### PR TITLE
Fixed reference issues causing OfficialPlugins to not load

### DIFF
--- a/FRBDK/Glue/Glue/Glue.csproj
+++ b/FRBDK/Glue/Glue/Glue.csproj
@@ -1175,6 +1175,10 @@
       <Project>{b941a93f-6093-4dc6-ad11-91a058b6c2cc}</Project>
       <Name>ToolsUtilities</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\Gum\WpfDataUi\WpfDataUi.csproj">
+      <Project>{47241002-7eb5-433b-b931-a530bb6b84ee}</Project>
+      <Name>WpfDataUi</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\Gum\XnaAndWinforms\XnaAndWinforms.csproj">
       <Project>{c39a973c-66d6-4a6c-82b5-ae0042f210f8}</Project>
       <Name>XnaAndWinforms</Name>

--- a/FRBDK/Glue/OfficialPlugins/OfficialPlugins.csproj
+++ b/FRBDK/Glue/OfficialPlugins/OfficialPlugins.csproj
@@ -103,9 +103,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="InteractiveInterface">
-      <HintPath>..\..\GlueView\GlueView\InteractiveInterface\bin\x86\Debug\InteractiveInterface.dll</HintPath>
-    </Reference>
     <Reference Include="Ionic.Zip, Version=1.7.2.26, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Glue\Libraries\Ionic.Zip.dll</HintPath>
@@ -224,6 +221,10 @@
     <ProjectReference Include="..\..\FRBDK Supporting Projects\EditorObjects\EditorObjectsXna4.csproj">
       <Project>{E1D670B6-AD42-4B84-AFF8-D568097BE03D}</Project>
       <Name>EditorObjectsXna4</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GlueView\GlueView\InteractiveInterface\InteractiveInterface.csproj">
+      <Project>{82fe0346-e86b-46de-ba29-93626d89c621}</Project>
+      <Name>InteractiveInterface</Name>
     </ProjectReference>
     <ProjectReference Include="..\FlatRedBall.Plugin\FlatRedBall.Plugin.csproj">
       <Project>{2C289A72-D6BD-4358-AFBC-B71F9D31B01E}</Project>


### PR DESCRIPTION
Fixed: removed and added reference to InteractiveInterface.dll in OfficialPlugins.csproj

Fixed: Added reference to the WpfDataUi.csproj into Glue.csproj. Without it, the WpfDataUi.dll was not making a local copy appropriately, which caused OfficialPlugins.dll to fail to load (as it referenced that project locally).