### PR TITLE
Added code to check ATI for ImplementsICollidable and hide the ImplementsICollidable property if the base type has an ATI defined that sets this value to false (it defaults to true).

### DIFF
--- a/FRBDK/Glue/Glue/Elements/AssetTypeInfo.cs
+++ b/FRBDK/Glue/Glue/Elements/AssetTypeInfo.cs
@@ -160,6 +160,7 @@ namespace FlatRedBall.Glue.Elements
         public string AttachToNullOnlyMethod;
         public bool HasCursorIsOn;
         public bool HasVisibleProperty;
+        public bool HasImplementsIColladableProperty = true;
         public string ContentImporter;
         public string ContentProcessor;
 

--- a/FRBDK/Glue/Glue/Elements/AssetTypeInfo.cs
+++ b/FRBDK/Glue/Glue/Elements/AssetTypeInfo.cs
@@ -160,7 +160,7 @@ namespace FlatRedBall.Glue.Elements
         public string AttachToNullOnlyMethod;
         public bool HasCursorIsOn;
         public bool HasVisibleProperty;
-        public bool HasImplementsIColladableProperty = true;
+        public bool ImplementsICollidable;
         public string ContentImporter;
         public string ContentProcessor;
 

--- a/FRBDK/Glue/Glue/FormHelpers/PropertyGrids/EntitySavePropertyGridDisplayer.cs
+++ b/FRBDK/Glue/Glue/FormHelpers/PropertyGrids/EntitySavePropertyGridDisplayer.cs
@@ -43,6 +43,11 @@ namespace FlatRedBall.Glue.FormHelpers.PropertyGrids
                 IncludeMember("ImplementsIVisible", typeof(EntitySave), null, base.ReadOnlyAttribute());
             }
 
+            if (!string.IsNullOrEmpty(instance.BaseEntity) && !instance.GetHasImplementsCollidableProperty())
+            {
+                ExcludeMember("ImplementsICollidable");
+            }
+
 
             if (!instance.CreatedByOtherEntities)
             {

--- a/FRBDK/Glue/Glue/SaveClasses/EntitySaveExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/EntitySaveExtensionMethods.cs
@@ -72,6 +72,34 @@ namespace FlatRedBall.Glue.SaveClasses
         }
 
         /// <summary>
+        /// Returns whether the calling Entity inherits from another class that implements ICollidable.
+        /// Whether the calling Entity itself implements ICollidable doesn't matter.
+        /// </summary>
+        /// <param name="instance">The calling Entity</param>
+        /// <returns>Whether the implementation is found in a base Entity.</returns>
+        public static bool GetHasImplementsCollidableProperty(this EntitySave instance)
+        {
+            if (string.IsNullOrEmpty(instance.BaseEntity))
+            {
+                return true;
+            }
+            else
+            {
+                if (instance.InheritsFromFrbType())
+                {
+
+                    AssetTypeInfo ati = AvailableAssetTypes.Self.GetAssetTypeFromRuntimeType(instance.BaseEntity);
+
+                    if (ati != null)
+                    {
+                        return ati.HasImplementsIColladableProperty;
+                    }
+                }
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Returns whether the calling Entity inherits from another Entity that implements IVisible.
         /// Whether the calling Entity itself implements IVisible doesn't matter.
         /// </summary>

--- a/FRBDK/Glue/Glue/SaveClasses/EntitySaveExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/EntitySaveExtensionMethods.cs
@@ -92,7 +92,7 @@ namespace FlatRedBall.Glue.SaveClasses
 
                     if (ati != null)
                     {
-                        return ati.HasImplementsIColladableProperty;
+                        return !ati.ImplementsICollidable;
                     }
                 }
                 return true;

--- a/FRBDK/Glue/Glue/SetVariable/EntitySaveSetVariableLogic.cs
+++ b/FRBDK/Glue/Glue/SetVariable/EntitySaveSetVariableLogic.cs
@@ -249,6 +249,7 @@ namespace FlatRedBall.Glue.SetVariable
 
                 AskToPreserveVariables(entitySave, variablesBefore);
             }
+            PropertyGridHelper.UpdateEntitySaveDisplay();
         }
 
         private static bool GetIfCurrentEntityBaseIsValid(EntitySave entitySave)


### PR DESCRIPTION
(cherry picked from commit b32a30dbe483e964231541b3f50b2e431e3fcec2)

# Conflicts:
#	FRBDK/Glue/GumPlugin/GumPlugin/Managers/AssetTypeInfoManager.cs (file diff removed from change)