### PR TITLE
[Untested] Potential fix for SecondaryClick firing repeatedly

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Gui/Cursor.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Gui/Cursor.cs
@@ -2720,7 +2720,7 @@ namespace FlatRedBall.Gui
                 PrimaryDoublePush = PrimaryPush && (currentTime - mLastTimePrimaryPush) < .25;
 
                 PrimaryClick = PrimaryDown == false && mLastPrimaryDown == true;
-                SecondaryClick = !SecondaryDown && mLastMiddleDown;
+                SecondaryClick = !SecondaryDown && mLastSecondaryDown;
                 MiddleClick = !MiddleDown && mLastMiddleDown;
 
                 PrimaryDoubleClick = PrimaryClick && (currentTime - mLastTimePrimaryClick) < .25;


### PR DESCRIPTION
WARNING: I haven't even tried to build/run/test this!

In TownRaiser, I was seeing `SecondaryClick` being true for many frames (80-100). I don't know if this will fix it, but it doesn't seem right as it is when compared to other `*Click` properties.