### PR TITLE
Added ImageLayer support for Tiled map import.

### DIFF
--- a/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
+++ b/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
@@ -432,6 +432,25 @@ namespace FlatRedBall.TileGraphics
 
             var tmxDirectory = FileManager.GetDirectory(fileName);
 
+            // add image layers
+            foreach (var imageLayer in tms.ImageLayers)
+            {
+                var imageLayerFile = tmxDirectory + imageLayer.imageobject.Source;
+                var texture = FlatRedBallServices.Load<Microsoft.Xna.Framework.Graphics.Texture2D>(imageLayerFile);
+
+                var newSprite = new Sprite
+                {
+                    Texture = texture,
+                    Width = imageLayer.imageobject.width,
+                    Height = imageLayer.imageobject.height
+                };
+
+                var mdb = new MapDrawableBatch(1, texture);
+                mdb.Paste(newSprite);
+                
+                toReturn.mMapLists.Add(mdb);
+            }
+
             var animationDictionary = new Dictionary<string, AnimationChain>();
 
             // add animations

--- a/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
+++ b/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
@@ -441,10 +441,10 @@ namespace FlatRedBall.TileGraphics
                 var newSprite = new Sprite
                 {
                     Texture = texture,
-                    Width = imageLayer.imageobject.width,
-                    Height = imageLayer.imageobject.height,
-                    X = imageLayer.imageobject.width/2 + imageLayer.offsetX,
-                    Y = -imageLayer.imageobject.height/2 + imageLayer.offsetY
+                    Width = imageLayer.ImageObject.Width,
+                    Height = imageLayer.ImageObject.Height,
+                    X = imageLayer.ImageObject.Width / 2 + imageLayer.OffsetX,
+                    Y = -imageLayer.ImageObject.Height / 2 + imageLayer.OffsetY
                 };
 
                 var mdb = new MapDrawableBatch(1, texture);

--- a/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
+++ b/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
@@ -443,8 +443,8 @@ namespace FlatRedBall.TileGraphics
                     Texture = texture,
                     Width = imageLayer.imageobject.width,
                     Height = imageLayer.imageobject.height,
-                    X = imageLayer.imageobject.width/2,
-                    Y = -imageLayer.imageobject.height/2
+                    X = imageLayer.imageobject.width/2 + imageLayer.offsetX,
+                    Y = -imageLayer.imageobject.height/2 + imageLayer.offsetY
                 };
 
                 var mdb = new MapDrawableBatch(1, texture);

--- a/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
+++ b/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
@@ -435,7 +435,7 @@ namespace FlatRedBall.TileGraphics
             // add image layers
             foreach (var imageLayer in tms.ImageLayers)
             {
-                var imageLayerFile = tmxDirectory + imageLayer.imageobject.Source;
+                var imageLayerFile = tmxDirectory + imageLayer.Imageobject.Source;
                 var texture = FlatRedBallServices.Load<Microsoft.Xna.Framework.Graphics.Texture2D>(imageLayerFile);
 
                 var newSprite = new Sprite

--- a/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
+++ b/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/LayeredTileMap.cs
@@ -442,12 +442,16 @@ namespace FlatRedBall.TileGraphics
                 {
                     Texture = texture,
                     Width = imageLayer.imageobject.width,
-                    Height = imageLayer.imageobject.height
+                    Height = imageLayer.imageobject.height,
+                    X = imageLayer.imageobject.width/2,
+                    Y = -imageLayer.imageobject.height/2
                 };
 
                 var mdb = new MapDrawableBatch(1, texture);
+                mdb.AttachTo(toReturn, false);
                 mdb.Paste(newSprite);
-                
+                mdb.Visible = imageLayer.Visible;
+
                 toReturn.mMapLists.Add(mdb);
             }
 

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/AbstractMapLayer.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/AbstractMapLayer.cs
@@ -7,6 +7,7 @@ namespace TMXGlueLib
     [Serializable]
 #endif
     [XmlInclude(typeof (MapLayer))]
+    [XmlInclude(typeof  (mapImageLayer))]
     [XmlInclude(typeof (mapObjectgroup))]
     public abstract class AbstractMapLayer
     {

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/AbstractMapLayer.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/AbstractMapLayer.cs
@@ -7,7 +7,7 @@ namespace TMXGlueLib
     [Serializable]
 #endif
     [XmlInclude(typeof (MapLayer))]
-    [XmlInclude(typeof  (mapImageLayer))]
+    [XmlInclude(typeof  (MapImageLayer))]
     [XmlInclude(typeof (mapObjectgroup))]
     public abstract class AbstractMapLayer
     {

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/LayeredTileMap.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/LayeredTileMap.cs
@@ -441,10 +441,10 @@ namespace FlatRedBall.TileGraphics
                 var newSprite = new Sprite
                 {
                     Texture = texture,
-                    Width = imageLayer.imageobject.width,
-                    Height = imageLayer.imageobject.height,
-                    X = imageLayer.imageobject.width/2 + imageLayer.offsetX,
-                    Y = -imageLayer.imageobject.height/2 + imageLayer.offsetY
+                    Width = imageLayer.imageobject.Width,
+                    Height = imageLayer.imageobject.Height,
+                    X = imageLayer.imageobject.Width/2 + imageLayer.OffsetX,
+                    Y = -imageLayer.imageobject.Height/2 + imageLayer.OffsetY
                 };
 
                 var mdb = new MapDrawableBatch(1, texture);

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/LayeredTileMap.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/LayeredTileMap.cs
@@ -442,12 +442,16 @@ namespace FlatRedBall.TileGraphics
                 {
                     Texture = texture,
                     Width = imageLayer.imageobject.width,
-                    Height = imageLayer.imageobject.height
+                    Height = imageLayer.imageobject.height,
+                    X = imageLayer.imageobject.width/2 + imageLayer.offsetX,
+                    Y = -imageLayer.imageobject.height/2 + imageLayer.offsetY
                 };
 
                 var mdb = new MapDrawableBatch(1, texture);
+                mdb.AttachTo(toReturn, false);
                 mdb.Paste(newSprite);
-                
+                mdb.Visible = imageLayer.Visible;
+
                 toReturn.mMapLists.Add(mdb);
             }
 

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/LayeredTileMap.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/LayeredTileMap.cs
@@ -432,6 +432,25 @@ namespace FlatRedBall.TileGraphics
 
             var tmxDirectory = FileManager.GetDirectory(fileName);
 
+            // add image layers
+            foreach (var imageLayer in tms.ImageLayers)
+            {
+                var imageLayerFile = tmxDirectory + imageLayer.imageobject.Source;
+                var texture = FlatRedBallServices.Load<Microsoft.Xna.Framework.Graphics.Texture2D>(imageLayerFile);
+
+                var newSprite = new Sprite
+                {
+                    Texture = texture,
+                    Width = imageLayer.imageobject.width,
+                    Height = imageLayer.imageobject.height
+                };
+
+                var mdb = new MapDrawableBatch(1, texture);
+                mdb.Paste(newSprite);
+                
+                toReturn.mMapLists.Add(mdb);
+            }
+
             var animationDictionary = new Dictionary<string, AnimationChain>();
 
             // add animations

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/LayeredTileMap.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/LayeredTileMap.cs
@@ -441,10 +441,10 @@ namespace FlatRedBall.TileGraphics
                 var newSprite = new Sprite
                 {
                     Texture = texture,
-                    Width = imageLayer.imageobject.Width,
-                    Height = imageLayer.imageobject.Height,
-                    X = imageLayer.imageobject.Width/2 + imageLayer.OffsetX,
-                    Y = -imageLayer.imageobject.Height/2 + imageLayer.OffsetY
+                    Width = imageLayer.Imageobject.Width,
+                    Height = imageLayer.Imageobject.Height,
+                    X = imageLayer.Imageobject.Width/2 + imageLayer.OffsetX,
+                    Y = -imageLayer.Imageobject.Height/2 + imageLayer.OffsetY
                 };
 
                 var mdb = new MapDrawableBatch(1, texture);

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapSave.Serialization.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapSave.Serialization.cs
@@ -296,6 +296,9 @@ namespace TMXGlueLib
     {
         private mapImageLayerImage imageField;
 
+        private float _offsetX;
+        private float _offsetY;
+
         List<property> mProperties = new List<property>();
 
         public List<property> properties
@@ -346,6 +349,20 @@ namespace TMXGlueLib
         {
             get { return _visibleAsInt; }
             set { _visibleAsInt = value; }
+        }
+
+        [XmlAttribute("offsetx")]
+        public float offsetX
+        {
+            get { return _offsetX; }
+            set { _offsetX = value; }
+        }
+
+        [XmlAttribute("offsety")]
+        public float offsetY
+        {
+            get { return _offsetY; }
+            set { _offsetY = value; }
         }
 
         [XmlIgnore]

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapSave.Serialization.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapSave.Serialization.cs
@@ -97,11 +97,12 @@ namespace TMXGlueLib
 
         
         [XmlElement("layer", typeof(MapLayer))]
+        [XmlElement("imagelayer", typeof(mapImageLayer))]
         [XmlElement("objectgroup", typeof(mapObjectgroup))]
         public List<AbstractMapLayer> MapLayers { get; set; }
 
-            /// <remarks/>
-        
+        /// <remarks/>
+
 
         [XmlIgnore]
         public List<MapLayer> Layers => MapLayers.OfType<MapLayer>().ToList();
@@ -109,6 +110,9 @@ namespace TMXGlueLib
         /// <remarks/>
         [XmlIgnore]
         public List<mapObjectgroup> objectgroup => MapLayers.OfType<mapObjectgroup>().ToList();
+
+        [XmlIgnore]
+        public List<mapImageLayer> ImageLayers => MapLayers.OfType<mapImageLayer>().ToList();
 
         /// <remarks/>
         [XmlAttribute()]
@@ -284,6 +288,96 @@ namespace TMXGlueLib
         }
     }
     #endregion
+
+#if !UWP
+    [Serializable]
+#endif
+    public partial class mapImageLayer : AbstractMapLayer
+    {
+        private mapImageLayerImage imageField;
+
+        List<property> mProperties = new List<property>();
+
+        public List<property> properties
+        {
+            get { return mProperties; }
+            set
+            {
+                mProperties = value;
+            }
+        }
+
+        private IDictionary<string, string> propertyDictionaryField = null;
+        private int _visibleAsInt = 1;
+
+        [XmlIgnore]
+        public IDictionary<string, string> PropertyDictionary
+        {
+            get
+            {
+                lock (this)
+                {
+                    if (propertyDictionaryField == null)
+                    {
+                        propertyDictionaryField = TiledMapSave.BuildPropertyDictionaryConcurrently(properties);
+                    }
+                    return propertyDictionaryField;
+                }
+            }
+        }
+
+        /// <remarks/>
+        [XmlElement("image", Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
+        public mapImageLayerImage imageobject
+        {
+            get
+            {
+                return this.imageField;
+            }
+            set
+            {
+                this.imageField = value;
+            }
+        }
+
+
+        [XmlAttribute("visible")]
+        public int VisibleAsInt
+        {
+            get { return _visibleAsInt; }
+            set { _visibleAsInt = value; }
+        }
+
+        [XmlIgnore]
+        public bool Visible
+        {
+            get
+            {
+                return VisibleAsInt != 0;
+            }
+        }
+    }
+
+    public partial class mapImageLayerImage
+    {
+        private string _source;
+
+        [XmlAttributeAttribute(AttributeName = "source")]
+        public string Source
+        {
+            get { return _source; }
+            set { _source = value; }
+        }
+
+        /// <remarks/>
+        [XmlAttributeAttribute(AttributeName = "width")]
+        public float width { get; set; }
+
+        /// <remarks/>
+        [XmlAttributeAttribute(AttributeName = "height")]
+        public float height { get; set; }
+    }
+
 
     /// <remarks/>
     [XmlType(AnonymousType = true)]

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapSave.Serialization.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapSave.Serialization.cs
@@ -97,7 +97,7 @@ namespace TMXGlueLib
 
         
         [XmlElement("layer", typeof(MapLayer))]
-        [XmlElement("imagelayer", typeof(mapImageLayer))]
+        [XmlElement("imagelayer", typeof(MapImageLayer))]
         [XmlElement("objectgroup", typeof(mapObjectgroup))]
         public List<AbstractMapLayer> MapLayers { get; set; }
 
@@ -112,7 +112,7 @@ namespace TMXGlueLib
         public List<mapObjectgroup> objectgroup => MapLayers.OfType<mapObjectgroup>().ToList();
 
         [XmlIgnore]
-        public List<mapImageLayer> ImageLayers => MapLayers.OfType<MapImageLayer>().ToList();
+        public List<MapImageLayer> ImageLayers => MapLayers.OfType<MapImageLayer>().ToList();
 
         /// <remarks/>
         [XmlAttribute()]

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapSave.Serialization.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapSave.Serialization.cs
@@ -112,7 +112,7 @@ namespace TMXGlueLib
         public List<mapObjectgroup> objectgroup => MapLayers.OfType<mapObjectgroup>().ToList();
 
         [XmlIgnore]
-        public List<mapImageLayer> ImageLayers => MapLayers.OfType<mapImageLayer>().ToList();
+        public List<mapImageLayer> ImageLayers => MapLayers.OfType<MapImageLayer>().ToList();
 
         /// <remarks/>
         [XmlAttribute()]
@@ -292,10 +292,8 @@ namespace TMXGlueLib
 #if !UWP
     [Serializable]
 #endif
-    public partial class mapImageLayer : AbstractMapLayer
+    public partial class MapImageLayer : AbstractMapLayer
     {
-        private mapImageLayerImage imageField;
-
         private float _offsetX;
         private float _offsetY;
 
@@ -329,21 +327,6 @@ namespace TMXGlueLib
             }
         }
 
-        /// <remarks/>
-        [XmlElement("image", Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
-        public mapImageLayerImage imageobject
-        {
-            get
-            {
-                return this.imageField;
-            }
-            set
-            {
-                this.imageField = value;
-            }
-        }
-
-
         [XmlAttribute("visible")]
         public int VisibleAsInt
         {
@@ -352,14 +335,14 @@ namespace TMXGlueLib
         }
 
         [XmlAttribute("offsetx")]
-        public float offsetX
+        public float OffsetX
         {
             get { return _offsetX; }
             set { _offsetX = value; }
         }
 
         [XmlAttribute("offsety")]
-        public float offsetY
+        public float OffsetY
         {
             get { return _offsetY; }
             set { _offsetY = value; }
@@ -388,11 +371,11 @@ namespace TMXGlueLib
 
         /// <remarks/>
         [XmlAttributeAttribute(AttributeName = "width")]
-        public float width { get; set; }
+        public float Width { get; set; }
 
         /// <remarks/>
         [XmlAttributeAttribute(AttributeName = "height")]
-        public float height { get; set; }
+        public float Height { get; set; }
     }
 
 

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapToShapeCollectionConverter.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapToShapeCollectionConverter.cs
@@ -75,25 +75,35 @@ namespace TMXGlueLib
                             }
                         }
 
-                       
-
                         if (@object.polygon == null && @object.polyline == null)
                         {
-                            PolygonSave p = tiledMapSave.ConvertTmxObjectToFrbPolygonSave(@object.Name, @object.x, @object.y, @object.width, @object.height, @object.Rotation, @object.ellipse);
-                            if (p != null)
+                            if (@object.Rotation == 0 && @object.ellipse == null)
                             {
-                                shapes.PolygonSaves.Add(p);
+                                var aar = new AxisAlignedRectangleSave()
+                                {
+                                    Name = @object.Name,
+                                    X = (float)@object.x,
+                                    Y = (float)@object.y,
+                                    ScaleX = @object.width / 2,
+                                    ScaleY = @object.height / 2,
+                                };
+
+                                shapes.AxisAlignedRectangleSaves.Add(aar);
+                            }
+                            else
+                            {
+                                PolygonSave p = tiledMapSave.ConvertTmxObjectToFrbPolygonSave(@object.Name, @object.x, @object.y, @object.width, @object.height, @object.Rotation, @object.ellipse);
+                                if (p != null)
+                                {
+                                    shapes.PolygonSaves.Add(p);
+                                }
                             }
                         }
-
-                        
                     }
                 }
             }
             return shapes;
         }
-
-
 
         private static PolygonSave ConvertTmxObjectToFrbPolygonSave(this TiledMapSave tiledMapSave, string name, double x, double y, double w, double h, double rotation, mapObjectgroupObjectEllipse ellipse)
         {

--- a/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapToShapeCollectionConverter.cs
+++ b/Tests/GlueTestProject/GlueTestProject/GlueTestProject/TileGraphics/TiledMapToShapeCollectionConverter.cs
@@ -82,8 +82,8 @@ namespace TMXGlueLib
                                 var aar = new AxisAlignedRectangleSave()
                                 {
                                     Name = @object.Name,
-                                    X = (float)@object.x,
-                                    Y = (float)@object.y,
+                                      X = (float)@object.x + (@object.width /2),
+                                      Y = (float)-@object.y - (@object.height / 2),
                                     ScaleX = @object.width / 2,
                                     ScaleY = @object.height / 2,
                                 };


### PR DESCRIPTION
I added support for the ImageLayer tags to the tiled map XML conversion, then add a new MapDrawableBatch for each of these layers, and paste a Sprite into them.  I considered skipping the MDB and just using a Sprite, but then I'd have to add support for all the LayeredTileMap operations which MDB already covers (scale, visibility, etc).