### PR TITLE
Fixed bug where the CollisionManager.Self.Relationships.Clear() code …

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/CollisionPlugin/CollisionCodeGenerator.cs
+++ b/FRBDK/Glue/OfficialPlugins/CollisionPlugin/CollisionCodeGenerator.cs
@@ -13,9 +13,11 @@ namespace OfficialPlugins.CollisionPlugin
     {
         public override ICodeBlock GenerateDestroy(ICodeBlock codeBlock, IElement element)
         {
-            codeBlock.Line("FlatRedBall.Math.Collision.CollisionManager.Self.Relationships.Clear();");
-
-            return codeBlock;
+			if (element is ScreenSave)
+			{
+				codeBlock.Line("FlatRedBall.Math.Collision.CollisionManager.Self.Relationships.Clear();");
+			}
+			return codeBlock;
         }
     }
 }


### PR DESCRIPTION
…would be generated in all Element's rather than JUST Screens as intended.