### PR TITLE
Add Brake Neck (Desktop GL) starter option

### DIFF
--- a/FRBDK/NewProjectCreator/NewProjectCreator/Content/StarterProjects.csv
+++ b/FRBDK/NewProjectCreator/NewProjectCreator/Content/StarterProjects.csv
@@ -1,6 +1,6 @@
 "FriendlyName (System.String, required)",Namespace (System.String),ZipName (System.String),Url (System.String),SupportedInGlue (bool)
 Anfloga (requires XNA),Anfloga,Anfloga.zip,https://github.com/vchelaru/Anfloga/archive/master.zip,TRUE
-Brake Neck (Desktop GL),BrakeNeckGL,BrakeNeckGL.zip,https://github.com/patridge/BrakeNeck-DesktopGL/archive/master.zip,TRUE
+Brake Neck (Desktop GL),BrakeNeck,BrakeNeckGL.zip,https://github.com/patridge/BrakeNeck-DesktopGL/archive/master.zip,TRUE
 Brake Neck (requires XNA),BrakeNeck,BrakeNeck.zip,https://github.com/vchelaru/BrakeNeck/archive/master.zip,TRUE
 Farseer Samples (requires XNA),FarseerProjectDesktop,FarseerSamples.zip,https://github.com/vchelaru/FarseerStarter/archive/master.zip,TRUE
 Legend of Dodgeball (requires XNA),Dodgeball,Dodgeball.zip,https://github.com/vchelaru/Dodgeball/archive/master.zip,TRUE

--- a/FRBDK/NewProjectCreator/NewProjectCreator/Content/StarterProjects.csv
+++ b/FRBDK/NewProjectCreator/NewProjectCreator/Content/StarterProjects.csv
@@ -1,5 +1,6 @@
 "FriendlyName (System.String, required)",Namespace (System.String),ZipName (System.String),Url (System.String),SupportedInGlue (bool)
 Anfloga (requires XNA),Anfloga,Anfloga.zip,https://github.com/vchelaru/Anfloga/archive/master.zip,TRUE
+Brake Neck (Desktop GL),BrakeNeckGL,BrakeNeckGL.zip,https://github.com/patridge/BrakeNeck-DesktopGL/archive/master.zip,TRUE
 Brake Neck (requires XNA),BrakeNeck,BrakeNeck.zip,https://github.com/vchelaru/BrakeNeck/archive/master.zip,TRUE
 Farseer Samples (requires XNA),FarseerProjectDesktop,FarseerSamples.zip,https://github.com/vchelaru/FarseerStarter/archive/master.zip,TRUE
 Legend of Dodgeball (requires XNA),Dodgeball,Dodgeball.zip,https://github.com/vchelaru/Dodgeball/archive/master.zip,TRUE


### PR DESCRIPTION
I ported the Brake Neck sample to Desktop GL. The only hiccup was the use of an unimplemented `Subtract` that didn't seem to be used.

I wasn't 100% sure on the various CSV values, so I took a guess. Feel free to push back or make edits.