### PR TITLE
Unloading of project specific plugins

### DIFF
--- a/FRBDK/Glue/FlatRedBall.Plugin/PluginManagerBase.cs
+++ b/FRBDK/Glue/FlatRedBall.Plugin/PluginManagerBase.cs
@@ -89,8 +89,7 @@ namespace FlatRedBall.Glue.Plugins
             get { return mPluginContainers; }
         }
 
-        public AssemblyLoadContext PluginAssemblies { get; set; } = new AssemblyLoadContext(null, true);
-
+        public AssemblyLoadContext AssemblyContext { get; set; }
 
         protected virtual void LoadReferenceLists()
         {
@@ -402,7 +401,7 @@ namespace FlatRedBall.Glue.Plugins
                     }
                     else
                     {
-                        assembly = PluginAssemblies.LoadFromAssemblyPath(assemblyName);
+                        assembly = AssemblyContext.LoadFromAssemblyPath(assemblyName);
                     }
                     
                     assemblies.Add(assembly);
@@ -500,7 +499,7 @@ namespace FlatRedBall.Glue.Plugins
                 return true;
             }
 
-            alreadyLoadedAssembly = PluginAssemblies.Assemblies
+            alreadyLoadedAssembly = AssemblyContext.Assemblies
                 .FirstOrDefault(x => FileManager.RemovePath(x.Location).Equals(strippedArgumentName));
 
             return alreadyLoadedAssembly != null;

--- a/FRBDK/Glue/FlatRedBall.Plugin/PluginManagerBase.cs
+++ b/FRBDK/Glue/FlatRedBall.Plugin/PluginManagerBase.cs
@@ -11,6 +11,7 @@ using System.CodeDom.Compiler;
 
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition;
+using System.Runtime.Loader;
 
 namespace FlatRedBall.Glue.Plugins
 {
@@ -31,7 +32,6 @@ namespace FlatRedBall.Glue.Plugins
         protected List<string> mReferenceListInternal = new List<string>();
         protected List<string> mReferenceListLoaded = new List<string>();
         protected List<string> mReferenceListExternal = new List<string>();
-
 
         protected Dictionary<IPlugin, PluginContainer> mPluginContainers = new Dictionary<IPlugin, PluginContainer>();
 
@@ -64,7 +64,6 @@ namespace FlatRedBall.Glue.Plugins
         }
 
 
-
         public static List<PluginManagerBase> GetInstances()
         {
             return mInstances;
@@ -90,7 +89,7 @@ namespace FlatRedBall.Glue.Plugins
             get { return mPluginContainers; }
         }
 
-
+        public AssemblyLoadContext PluginAssemblies { get; set; } = new AssemblyLoadContext(null, true);
 
 
         protected virtual void LoadReferenceLists()
@@ -403,7 +402,7 @@ namespace FlatRedBall.Glue.Plugins
                     }
                     else
                     {
-                        assembly = Assembly.LoadFrom(assemblyName);
+                        assembly = PluginAssemblies.LoadFromAssemblyPath(assemblyName);
                     }
                     
                     assemblies.Add(assembly);
@@ -492,8 +491,8 @@ namespace FlatRedBall.Glue.Plugins
         private bool IsAssemblyAlreadyReferenced(string assemblyName, out Assembly alreadyLoadedAssembly)
         {
             alreadyLoadedAssembly = null;
-            string strippedArgumentName = FileManager.RemovePath(assemblyName);
 
+            string strippedArgumentName = FileManager.RemovePath(assemblyName);
             string fileName = FileManager.RemovePath(assemblyName);
             
             if(mReferenceListInternal.Contains(fileName))
@@ -501,23 +500,10 @@ namespace FlatRedBall.Glue.Plugins
                 return true;
             }
 
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            alreadyLoadedAssembly = PluginAssemblies.Assemblies
+                .FirstOrDefault(x => FileManager.RemovePath(x.Location).Equals(strippedArgumentName));
 
-            foreach (Assembly assembly in assemblies)
-            {
-                if (!assembly.IsDynamic)
-                {
-                    string strippedName = FileManager.RemovePath(assembly.Location);
-
-                    if (strippedArgumentName == strippedName)
-                    {
-                        alreadyLoadedAssembly = assembly;
-                        return true;
-                    }
-                }
-            }
-
-            return false;
+            return alreadyLoadedAssembly != null;
         }
 
         protected virtual void AddDirectoriesForInstance(List<string> pluginDirectories)

--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -249,6 +249,11 @@ namespace FlatRedBall.Glue.Plugins
                 {
                     ShutDownPlugin(plugin, PluginShutDownReason.GlueShutDown);
                 }
+                
+                mProjectInstance.PluginAssemblies.Unload();
+                mProjectInstance.PluginAssemblies = null;
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
             }
 
             mProjectInstance = new PluginManager(false);

--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -25,6 +25,7 @@ using FlatRedBall.Glue.VSHelpers.Projects;
 using FlatRedBall.Glue.Events;
 using FlatRedBall.Glue.Reflection;
 using System.ComponentModel;
+using System.Runtime.Loader;
 using FlatRedBall.Instructions.Reflection;
 using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
 using FlatRedBall.Content.Instructions;
@@ -230,7 +231,21 @@ namespace FlatRedBall.Glue.Plugins
 
             if (mGlobalInstance == null)
             {
-                mGlobalInstance = new PluginManager(true);
+                mGlobalInstance = new PluginManager(true)
+                {
+                    // global assemblies must not be collectible for now (2nd argument == false).  This is because
+                    // some plugins (like Tiled) use the `XmlSerializer`, but as of now the XmlSerializer class
+                    // loads dynamic assemblies in the default assembly context, not the current/relevant one.  This
+                    // means code in a collectible assembly loads non-collectible assemblies, which isn't allowed and
+                    // causes a crash.  Right now the fix for this has been pushed back to .net 6, and it's not for
+                    // sure that it will actually be prioritized.  See https://github.com/dotnet/runtime/issues/1388.
+                    //
+                    // In the mean time, it is rare that global assemblies actually need to be unloaded without a 
+                    // Glue restart.  So to solve this for now we are making global plugins loaded in a non-collectible
+                    // context, so at least these plugins can still be used by glue, just not in a project specific
+                    // case.
+                    AssemblyContext = new AssemblyLoadContext(null, false),
+                };
                 mGlobalInstance.LoadPlugins(@"FRBDK\Plugins", pluginsToIgnore);
 
                 foreach (var output in mGlobalInstance.CompileOutput)
@@ -250,13 +265,23 @@ namespace FlatRedBall.Glue.Plugins
                     ShutDownPlugin(plugin, PluginShutDownReason.GlueShutDown);
                 }
                 
-                mProjectInstance.PluginAssemblies.Unload();
-                mProjectInstance.PluginAssemblies = null;
+                // Assembly loading only happens asynchronously when `Unload()` is called and all references
+                // to the context have been removed.  This means that they won't be fully cleaned up until the garbage
+                // collector runs.  Since we might end up re-loading a new version of the plugins that were previously
+                // loaded to be safe we want to pause for GC to occur to make sure the old project specific plugins
+                // are fully unloaded before we retry to load the new ones.
+                mProjectInstance.AssemblyContext.Unload();
+                mProjectInstance.AssemblyContext = null;
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
             }
 
-            mProjectInstance = new PluginManager(false);
+            mProjectInstance = new PluginManager(false)
+            {
+                // Project specific plugins should always be loaded in a collectible assembly, so they can be
+                // unloaded
+                AssemblyContext = new AssemblyLoadContext(null, true),
+            };
 
             if(FlatRedBall.Glue.Plugins.ExportedImplementations.GlueState.Self.CurrentGlueProject != null)
             {


### PR DESCRIPTION
Currently when Glue loads project specific plugins, those plugins are not unloaded when switching to a new project.  This means if you load a project that uses a different version of the same plugin then Glue will use the version of the plugin from the first project, and not the 2nd project.  Upon closing and reopening Glue it will then use the correct (2nd) plugin version.  This can lead to inconsistent behavior, confusion, and compatibility issues.

This PR fixes it by giving each `PluginManager` it's own `AssemblyLoadContext`, and allowing project specific plugins to be loaded in a collectible context.  When the project is unloaded then the project's assembly context is unloaded, thus allowing other versions of the plugins to be loaded in its way.  Now when switching projects, the new project will utilize the correct dlls based on which project is actually loaded.

Note that currently not all plugins will work.  This change prevents the Tiled plugin from being a project specific plugin, as the Tiled plugin relies on `XmlSerializer` which cannot be run in a collectible `AssemblyLoadContext` at this time (.net runtime bug that wont' be fixed until at least .net 6).  These plugins will throw an exception when loaded as a project specific plugin, but will work properly as global plugins.