### PR TITLE
Don't run project plugins directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Templates/FlatRedBallCrossPlatformTemplate/.vs/
 FRBDK/AnimationEditor/.vs/
 FRBDK/NewProjectCreator/packages/
 .idea/
+.running*/

--- a/FRBDK/Glue/FlatRedBall.Plugin/PluginManagerBase.cs
+++ b/FRBDK/Glue/FlatRedBall.Plugin/PluginManagerBase.cs
@@ -348,7 +348,7 @@ namespace FlatRedBall.Glue.Plugins
             }
             else
             {
-                AddDirectoriesForInstance(pluginDirectories);
+                AddDirectoriesForInstance(pluginDirectories, absoluteFilePath);
             }
             return pluginDirectories;
         }
@@ -505,7 +505,7 @@ namespace FlatRedBall.Glue.Plugins
             return alreadyLoadedAssembly != null;
         }
 
-        protected virtual void AddDirectoriesForInstance(List<string> pluginDirectories)
+        protected virtual void AddDirectoriesForInstance(List<string> pluginDirectories, string searchPath)
         {
 
         }


### PR DESCRIPTION
Currently Glue runs project plugins in the project's own `Plugins\` directory.  This causes plugin assemblies to be locked, which prevents you from installing new plugins (usually via nuget upgrades or downgrades).

In order to fix this, every time Glue loads a project it will create a temporary project specific plugin directory and run the plugins from that temporary directory.  This allows plugins to be dynamically changed, and on a project reload the old plugins will be unloaded and the new plugins loaded.