### PR TITLE
Get tilemap parallax values from Tiled layer properties

### DIFF
--- a/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/MapDrawableBatch.cs
+++ b/Engines/FlatRedBallAddOns/FlatRedBall.TileGraphics/FlatRedBall.TileGraphics/MapDrawableBatch.cs
@@ -609,6 +609,9 @@ namespace FlatRedBall.TileGraphics
                 toReturn.RegisterName(quad.Name, tileIndex);
             }
 
+            toReturn.ParallaxMultiplierX = reducedLayerInfo.ParallaxMultiplierX;
+            toReturn.ParallaxMultiplierY = reducedLayerInfo.ParallaxMultiplierY;
+
             return toReturn;
         }
 

--- a/Tiled/TMXGlueLib/AbstractMapLayer.cs
+++ b/Tiled/TMXGlueLib/AbstractMapLayer.cs
@@ -29,5 +29,33 @@ namespace TMXGlueLib
         }
 
         public bool IsVisible => visibleField == null || visibleField == 1;
+
+        private float? parallaxxField;
+        [XmlAttribute("parallaxx")]
+        public float ParallaxX
+        {
+            get
+            {
+                return this.parallaxxField.HasValue ? this.parallaxxField.Value : 1f;
+            }
+            set
+            {
+                this.parallaxxField = value;
+            }
+        }
+
+        private float? parallaxyField;
+        [XmlAttribute("parallaxy")]
+        public float ParallaxY
+        {
+            get
+            {
+                return this.parallaxyField.HasValue ? this.parallaxyField.Value : 1f;
+            }
+            set
+            {
+                this.parallaxyField = value;
+            }
+        }
     }
 }

--- a/Tiled/TMXGlueLib/AbstractMapLayer.cs
+++ b/Tiled/TMXGlueLib/AbstractMapLayer.cs
@@ -11,6 +11,9 @@ namespace TMXGlueLib
     [XmlInclude(typeof (mapObjectgroup))]
     public abstract class AbstractMapLayer
     {
+        private float _offsetX;
+        private float _offsetY;
+
         [XmlAttribute("name")]
         public string Name { get; set; }
 
@@ -56,6 +59,20 @@ namespace TMXGlueLib
             {
                 this.parallaxyField = value;
             }
+        }
+
+        [XmlAttribute("offsetx")]
+        public float OffsetX
+        {
+            get { return _offsetX; }
+            set { _offsetX = value; }
+        }
+
+        [XmlAttribute("offsety")]
+        public float OffsetY
+        {
+            get { return _offsetY; }
+            set { _offsetY = value; }
         }
     }
 }

--- a/Tiled/TMXGlueLib/DataTypes/ReducedTileMapInfo.TiledMapSave.cs
+++ b/Tiled/TMXGlueLib/DataTypes/ReducedTileMapInfo.TiledMapSave.cs
@@ -168,6 +168,8 @@ namespace TMXGlueLib.DataTypes
                     Name = tiledLayer.Name,
                     TileWidth = tileWidth,
                     TileHeight = tileHeight,
+                    ParallaxMultiplierX = tiledLayer.ParallaxX,
+                    ParallaxMultiplierY = tiledLayer.ParallaxY,
                 };
 
                 reducedTileMapInfo.Layers.Add(reducedLayerInfo);

--- a/Tiled/TMXGlueLib/DataTypes/ReducedTileMapInfo.cs
+++ b/Tiled/TMXGlueLib/DataTypes/ReducedTileMapInfo.cs
@@ -105,6 +105,13 @@ namespace TMXGlueLib.DataTypes
         // Version 2:
         public int TextureId;
 
+        // Version 3:
+        public float ParallaxMultiplierX = 1f;
+        public float ParallaxMultiplierY = 1f;
+
+        public float CameraOffsetX = 0f;
+        public float CameraOffsetY = 0f;
+
 
         public static ReducedLayerInfo ReadFrom(BinaryReader reader, int version)
         {
@@ -126,6 +133,15 @@ namespace TMXGlueLib.DataTypes
             if(version >= 2)
             {
                 toReturn.TextureId = reader.ReadInt32();
+            }
+
+            if (version >= 3)
+            {
+                toReturn.ParallaxMultiplierX = reader.ReadSingle();
+                toReturn.ParallaxMultiplierY = reader.ReadSingle();
+
+                toReturn.CameraOffsetX = reader.ReadSingle();
+                toReturn.CameraOffsetY = reader.ReadSingle();
             }
 
             return toReturn;
@@ -150,6 +166,15 @@ namespace TMXGlueLib.DataTypes
             if (version >= 2)
             {
                 writer.Write(TextureId);
+            }
+
+            if (version >= 3)
+            {
+                writer.Write(ParallaxMultiplierX);
+                writer.Write(ParallaxMultiplierY);
+
+                writer.Write(CameraOffsetX);
+                writer.Write(CameraOffsetY);
             }
         }
 

--- a/Tiled/TMXGlueLib/TiledMapSave.Serialization.cs
+++ b/Tiled/TMXGlueLib/TiledMapSave.Serialization.cs
@@ -322,9 +322,6 @@ namespace TMXGlueLib
     {
         private MapImageLayerImage imageField;
 
-        private float _offsetX;
-        private float _offsetY;
-
         List<property> mProperties = new List<property>();
 
         public List<property> properties
@@ -375,20 +372,6 @@ namespace TMXGlueLib
             get;
             set;
         } = 1.0f;
-
-        [XmlAttribute("offsetx")]
-        public float OffsetX
-        {
-            get { return _offsetX; }
-            set { _offsetX = value; }
-        }
-
-        [XmlAttribute("offsety")]
-        public float OffsetY
-        {
-            get { return _offsetY; }
-            set { _offsetY = value; }
-        }
 
     }
 


### PR DESCRIPTION
This PR adds support for Tiled's per-layer parallax properties, using them to set the ParallaxMultiplierX and ParallaxMultiplierY values for the drawable instances of the layers. This also moves the offset properties for Tiled layers from MapImageLayer to AbstractMapLayer as these properties exist for all layer types and not just image layers in particular.