### PR TITLE
Include generated event code in generated .gitignore

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/Git/MainPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/Git/MainPlugin.cs
@@ -82,6 +82,7 @@ namespace OfficialPlugins.Git
             yield return "*.tmp";
 
             yield return "*.Generated.cs";
+            yield return "*.Generated.Event.cs";
 
             yield return "*.cachefile";
 


### PR DESCRIPTION
This makes sure that "Add/Update .gitignore" includes the ignore pattern `*.Generated.Event.cs`.