### PR TITLE
Reset entity XAcceleration when required for movement type change

### DIFF
--- a/FRBDK/Glue/PlatformerPlugin/Generators/EntityCodeGenerator.cs
+++ b/FRBDK/Glue/PlatformerPlugin/Generators/EntityCodeGenerator.cs
@@ -369,6 +369,11 @@ namespace FlatRedBall.PlatformerPlugin.Generators
                 {
                     this.YAcceleration = -CurrentMovement.Gravity;
                 }
+
+                if(!CurrentMovement.UsesAcceleration)
+                {
+                    this.XAcceleration = 0;
+                }
             }
         }
 


### PR DESCRIPTION
This adds some code to the `UpdateCurrentMovement()` method added to entities from the platformer plugin that sets the entity's `XAcceleration` property back to 0 when the current movement type has been changed to one that doesn't support acceleration.

Fixes #133