### PR TITLE
Move PositionedObjectList instantiation to scene or entity constructors

### DIFF
--- a/FRBDK/Glue/Glue/CodeGeneration/CodeWriter.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/CodeWriter.cs
@@ -430,6 +430,8 @@ namespace FlatRedBallAddOns.Entities
 
         private static void GenerateConstructors(IElement element, ICodeBlock codeBlock)
         {
+            ICodeBlock constructor;
+
             var whatToInheritFrom = GetInheritance(element);
 
             var elementName = FileManager.RemovePath(element.Name);
@@ -440,7 +442,7 @@ namespace FlatRedBallAddOns.Entities
 
                 codeBlock.Constructor("public", elementName, "string contentManagerName", "this(contentManagerName, true)");
 
-                var constructor = codeBlock.Constructor("public", elementName, "string contentManagerName, bool addToManagers", "base()");
+                constructor = codeBlock.Constructor("public", elementName, "string contentManagerName, bool addToManagers", "base()");
                 constructor.Line("ContentManagerName = contentManagerName;");
 
                 // The base will handle this
@@ -462,7 +464,20 @@ namespace FlatRedBallAddOns.Entities
                     contentManagerName = "\"Global\"";
                 }
 
-                codeBlock.Constructor("public", elementName, "", $"base ({contentManagerName})");
+                constructor = codeBlock.Constructor("public", elementName, "", $"base ({contentManagerName})");
+            }
+
+            foreach (ElementComponentCodeGenerator codeGenerator in CodeGenerators)
+            {
+                try
+                {
+                    codeGenerator.GenerateConstructor(constructor, element);
+                }
+                catch (Exception e)
+                {
+                    GlueCommands.Self.PrintError(
+                        $"Error calling GenerateConstructor on {codeGenerator.GetType()}:\n{e}");
+                }
             }
         }
 

--- a/FRBDK/Glue/Glue/CodeGeneration/ElementComponentCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/ElementComponentCodeGenerator.cs
@@ -33,6 +33,11 @@ namespace FlatRedBall.Glue.CodeGeneration
             return codeBlock;
 
         }
+        public virtual ICodeBlock GenerateConstructor(ICodeBlock codeBlock, IElement element)
+        {
+            return codeBlock;
+
+        }
         public virtual ICodeBlock GenerateInitialize(ICodeBlock codeBlock, IElement element)
         {
             return codeBlock;

--- a/FRBDK/Glue/Glue/CodeGeneration/NamedObjectSaveCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/NamedObjectSaveCodeGenerator.cs
@@ -299,13 +299,23 @@ namespace FlatRedBall.Glue.CodeGeneration
 
             #region Perform instantiation
 
-            // Ensure that the nos is only instantiated where it should be. Since this method
-            // can be called for the constructor or Initialize() method, we need to check that
-            // we're in the proper place for generating the instantiation code.
-            if (!namedObject.InstantiatedByBase && inConstructor == instantiateInConstructor)
+            if (!namedObject.InstantiatedByBase)
             {
-                succeeded = GenerateInstantiationOrAssignment(
-                    namedObject, saveObject, codeBlock, overridingContainerName, referencedFilesAlreadyUsingFullFile);
+                // Ensure that the nos is only instantiated where it should be. Since this method
+                // can be called for the constructor or Initialize() method, we need to check that
+                // we're in the proper place for generating the instantiation code.
+                if (inConstructor == instantiateInConstructor)
+                {
+                    succeeded = GenerateInstantiationOrAssignment(
+                        namedObject, saveObject, codeBlock, overridingContainerName, referencedFilesAlreadyUsingFullFile);
+                }
+                // If the nos is a list, was instantiated in the constructor, and we aren't in the
+                // constructor, then we should clear any items out of it before anything new is
+                // added in. This isn't necessary for scenes, but it's needed for pooled entities.
+                if (namedObject.IsList && instantiateInConstructor && !inConstructor)
+                {
+                    codeBlock.Line($"{namedObject.FieldName}.Clear();");
+                }
             }
             #endregion
 

--- a/FRBDK/Glue/Glue/SaveClasses/NamedObjectSaveExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/NamedObjectSaveExtensionMethods.cs
@@ -899,6 +899,14 @@ namespace FlatRedBall.Glue.SaveClasses
 
                 namedObjectSave.SourceClassType?.StartsWith("CollisionRelationship<") == true;
         }
+
+        public static bool ShouldInstantiateInConstructor(this NamedObjectSave namedObjectSave)
+        {
+            return
+                namedObjectSave.SourceClassType?.StartsWith("FlatRedBall.Math.PositionedObjectList<") == true &&
+                namedObjectSave.Instantiate &&
+                !namedObjectSave.InstantiatedByBase;
+        }
     }
 
 

--- a/FRBDK/Glue/Glue/SaveClasses/NamedObjectSaveExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/NamedObjectSaveExtensionMethods.cs
@@ -903,7 +903,7 @@ namespace FlatRedBall.Glue.SaveClasses
         public static bool ShouldInstantiateInConstructor(this NamedObjectSave namedObjectSave)
         {
             return
-                namedObjectSave.SourceClassType?.StartsWith("FlatRedBall.Math.PositionedObjectList<") == true &&
+                namedObjectSave.IsList &&
                 namedObjectSave.Instantiate &&
                 !namedObjectSave.InstantiatedByBase;
         }


### PR DESCRIPTION
These changes add the ability to include code into scene and entity constructors via ElementComponentCodeGenerator-derived classes, and makes use of this to instantiate instances of PositionedObjectList<T> in scene and entity constructors similarly to how collision relationships are made to be initiated after everything else in a scene.

Fixes #138 