### PR TITLE
[Git plugin] Add TiledObjects.Generated.xml to project gitignore files

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/Git/MainPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/Git/MainPlugin.cs
@@ -84,6 +84,8 @@ namespace OfficialPlugins.Git
             yield return "*.Generated.cs";
             yield return "*.Generated.Event.cs";
 
+            yield return "TiledObjects.Generated.xml";
+
             yield return "*.cachefile";
 
             yield return "*.csvSettings";


### PR DESCRIPTION
This automatically generated and updated file can be safely ignored as Glue will recreate it whenever necessary.