### PR TITLE
Allow copy from log tabs

### DIFF
--- a/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
+++ b/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
@@ -258,7 +258,7 @@ namespace GlueFormsCore.Controls
             // If this is coming from a text box, don't try to apply hotkeys
             // Maybe in the future we want to be selective, like only apply certain
             // hotkeys (ctrl+f) but not others (delete)?
-            var isTextBox = e.OriginalSource is TextBox;
+            var isTextBox = e.OriginalSource is TextBox || e.OriginalSource is RichTextBox;
 
             if (HotkeyManager.Self.TryHandleKeys(e, isTextBox))
             {

--- a/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
+++ b/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
@@ -258,7 +259,7 @@ namespace GlueFormsCore.Controls
             // If this is coming from a text box, don't try to apply hotkeys
             // Maybe in the future we want to be selective, like only apply certain
             // hotkeys (ctrl+f) but not others (delete)?
-            var isTextBox = e.OriginalSource is TextBox || e.OriginalSource is RichTextBox;
+            var isTextBox = e.OriginalSource is TextBoxBase;
 
             if (HotkeyManager.Self.TryHandleKeys(e, isTextBox))
             {


### PR DESCRIPTION
Potential solution that fixes #510.

The logic for allowing Ctrl+ keyboard shortcuts only allows it when a `TextBox` is focused. The output tabs are `RichTextBox`. Originally, I did an `||` between the two types, but they both inherit from `TextBoxBase`. So, I did that type check so that all implementations of that would all be eligible for copy/cut/paste use, which seems theoretically correct.