### PR TITLE
Add comments to update-all BAT file

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/Git/MainGitPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/Git/MainGitPlugin.cs
@@ -67,18 +67,21 @@ namespace OfficialPlugins.Git
             if(GlueState.Self.CurrentGlueProject != null)
             {
                 var contents =
-@"git fetch
-git pull
-cd..
-cd Gum
+@":: Get the latest code for your project
 git fetch
 git pull
-cd..
-cd FlatRedBall
+:: Get the latest Gum
+cd ..\Gum
 git fetch
 git pull
+:: Get the latest FlatRedBall
+cd ..\FlatRedBall
+git fetch
+git pull
+:: Build Glue with All solution
 cd FRBDK\Glue
 dotnet build ""Glue with All.sln""
+:: Run the newly built Glue
 cd Glue\bin\x86\Debug\netcoreapp3.0\
 start GlueFormsCore.exe";
                 var locationToSave = new FilePath(GlueState.Self.CurrentGlueProjectDirectory).GetDirectoryContainingThis();


### PR DESCRIPTION
Adding some comments to the various sections to describe what the various chunks of the BAT file are doing.

I also combined some `cd` commands. If those were split intentionally, that can be reverted for sure.

For what it's worth, I picked the `::` comment instead of `REM`, which seems common but I personally find harder to read as a non-expert on batch files. Not sure if that has any side-effects, though.