### PR TITLE
Allow plugins to describe the owner and repository to their github repository

### DIFF
--- a/FRBDK/Glue/FlatRedBall.Plugin/IPlugin.cs
+++ b/FRBDK/Glue/FlatRedBall.Plugin/IPlugin.cs
@@ -18,6 +18,9 @@ namespace FlatRedBall.Glue.Plugins.Interfaces
     {
         string FriendlyName {get;}
         Version Version {get;}
+        string GithubRepoOwner { get; }
+        string GithubRepoName { get; }
+        bool CheckGithubForNewRelease { get; }
         void StartUp();
         bool ShutDown(PluginShutDownReason shutDownReason);
     }

--- a/FRBDK/Glue/FlatRedBall.Plugin/NotLoadedPlugin.cs
+++ b/FRBDK/Glue/FlatRedBall.Plugin/NotLoadedPlugin.cs
@@ -27,6 +27,10 @@ namespace FlatRedBall.Glue.Plugins
             get { return new Version(); }
         }
 
+        public string GithubRepoOwner => null;
+        public string GithubRepoName => null;
+        public bool CheckGithubForNewRelease => false;
+
         public void StartUp()
         {
 

--- a/FRBDK/Glue/Glue/Controls/PluginsWindow.cs
+++ b/FRBDK/Glue/Glue/Controls/PluginsWindow.cs
@@ -20,6 +20,7 @@ using Glue;
 using FlatRedBall.Glue.Plugins.EmbeddedPlugins;
 using FlatRedBall.Glue.Plugins.Rss;
 using System.Threading;
+using System.Windows.Navigation;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 
 namespace FlatRedBall.Glue.Controls
@@ -93,8 +94,10 @@ namespace FlatRedBall.Glue.Controls
                     toReturn.LoadOnStartup = IsLoadedOnStartup(SelectedPlugin);
                     toReturn.RequiredByProject = IsRequiredByProject(SelectedPlugin);
                     toReturn.LastUpdatedText = GetInfoForContainer(SelectedPlugin);
-
+                    toReturn.GithubRepoAddress = GetGithubAddress(SelectedPlugin);
+                   
                     toReturn.PropertyChanged += HandlePluginPropertyChanged;
+                    
 
                     
                     toReturn.BackingData = SelectedPlugin;
@@ -277,8 +280,20 @@ namespace FlatRedBall.Glue.Controls
                     text += container.FailureException.ToString();
 
                 }
+                
                 return text;
             }
+        }
+
+        private static string GetGithubAddress(PluginContainer container)
+        {
+            var plugin = container.Plugin;
+            if (string.IsNullOrWhiteSpace(plugin.GithubRepoName) || string.IsNullOrWhiteSpace(plugin.GithubRepoOwner))
+            {
+                return null;
+            }
+
+            return $"https://github.com/{plugin.GithubRepoOwner}/{plugin.GithubRepoName}";
         }
 
         private void UpdateViewToFeed()
@@ -506,7 +521,6 @@ namespace FlatRedBall.Glue.Controls
                 }
             }
         }
-
 
         void AfterDownload()
         {

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/ManagePlugins/PluginView.xaml
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/ManagePlugins/PluginView.xaml
@@ -15,5 +15,10 @@
         <CheckBox VerticalContentAlignment="Center" IsChecked="{Binding LoadOnStartup}">Load on startup</CheckBox>
         <CheckBox VerticalContentAlignment="Center" IsChecked="{Binding RequiredByProject}">Required by project</CheckBox>
         <TextBlock TextWrapping="Wrap" Text="{Binding LastUpdatedText}"></TextBlock>
+        <TextBlock TextWrapping="Wrap">
+            <Hyperlink NavigateUri="{Binding GithubRepoAddress}" RequestNavigate="Hyperlink_OnRequestNavigate">
+                <TextBlock Text="{Binding GithubRepoAddress}"></TextBlock>
+            </Hyperlink>
+        </TextBlock>
     </StackPanel>
 </UserControl>

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/ManagePlugins/PluginView.xaml.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/ManagePlugins/PluginView.xaml.cs
@@ -122,5 +122,13 @@ namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.ManagePlugins
                 System.Diagnostics.Process.Start(psi);
             }
         }
+
+        private void Hyperlink_OnRequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo(e.Uri.ToString())
+            {
+                UseShellExecute = true,
+            });
+        }
     }
 }

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/ManagePlugins/ViewModels/PluginViewModel.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/ManagePlugins/ViewModels/PluginViewModel.cs
@@ -44,6 +44,13 @@ namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.ManagePlugins.ViewModels
             }
         }
 
+        private string githubRepoAddress;
+        public string GithubRepoAddress
+        {
+            get => githubRepoAddress;
+            set => ChangeAndNotify(ref githubRepoAddress, value);
+        }
+
         bool requiredByProject;
         public bool RequiredByProject
         {

--- a/FRBDK/Glue/Glue/Plugins/Performance/PerformanceMeasurementPlugin.cs
+++ b/FRBDK/Glue/Glue/Plugins/Performance/PerformanceMeasurementPlugin.cs
@@ -83,6 +83,10 @@ namespace PluginTestbed.PerformanceMeasurement
             get { return new Version(1, 0); }
         }
 
+        public string GithubRepoOwner => null;
+        public string GithubRepoName => null;
+        public bool CheckGithubForNewRelease => false;
+
         public void StartUp()
         {
         }

--- a/FRBDK/Glue/Glue/Plugins/PluginBase.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginBase.cs
@@ -206,7 +206,9 @@ namespace FlatRedBall.Glue.Plugins
 
         public abstract string FriendlyName { get; }
         public abstract Version Version { get; }
-
+        public virtual string GithubRepoOwner => null;
+        public virtual string GithubRepoName => null;
+        public virtual bool CheckGithubForNewRelease => false;
 
         protected PluginTabPage PluginTab { get; private set; } // This is the tab that will hold our control
 

--- a/FRBDK/Glue/OfficialPlugins/FrbUpdater/FrbUpdaterPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/FrbUpdater/FrbUpdaterPlugin.cs
@@ -30,6 +30,10 @@ namespace OfficialPlugins.FrbUpdater
             get { return new Version(1, 0); }
         }
 
+        public string GithubRepoOwner => null;
+        public string GithubRepoName => null;
+        public bool CheckGithubForNewRelease => false;
+
         public void StartUp()
         {
             var settings = FrbUpdaterSettings.LoadSettings();

--- a/FRBDK/Glue/OfficialPlugins/GlobalContentManagerPlugin/GlobalContentManagerHelperPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/GlobalContentManagerPlugin/GlobalContentManagerHelperPlugin.cs
@@ -37,6 +37,10 @@ namespace PluginTestbed.GlobalContentManagerPlugins
             get { return new Version(1,0); }
         }
 
+        public string GithubRepoOwner => null;
+        public string GithubRepoName => null;
+        public bool CheckGithubForNewRelease => false;
+
         public void StartUp()
         {
             


### PR DESCRIPTION
The Glue UI will display the URL in the manage plugins view for easy access.

![image](https://user-images.githubusercontent.com/139393/173168088-d3e8461b-b2e8-41cd-a97a-85ed6c5dabae.png)
