### PR TITLE
UseShellExecute launching .txt file in duplicate project entry code

### DIFF
--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -610,7 +610,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                         }
                         string whereToSave = FileManager.UserApplicationDataForThisApplication + "ProjectFileOutput.txt";
                         FileManager.SaveText(stringBuilder.ToString(), whereToSave);
-                        Process.Start(whereToSave);
+                        Process.Start(new ProcessStartInfo(whereToSave) { UseShellExecute = true });
 
 
                         mProject.RemoveItem(buildItem);


### PR DESCRIPTION
I am pretty sure (but can't guarantee) that you always have to UseShellExecute a .txt file (or anything else launched by association).  Regardless this failed on my system when I have duplicate project entry w/o UseShellExecute