### PR TITLE
Tiled object class

### DIFF
--- a/Tiled/TMXGlueLib/TiledMapSave.Serialization.cs
+++ b/Tiled/TMXGlueLib/TiledMapSave.Serialization.cs
@@ -878,6 +878,12 @@ namespace TMXGlueLib
             get; set;
         }
 
+        [XmlAttribute(AttributeName = "class")]
+        public string Class {
+            get { return Type; }
+            set { Type = value; }
+        }
+
         [XmlIgnore]
         public uint? gid { get; set; }
 


### PR DESCRIPTION
Setting the Tiled object class wasn't working unless setting it in the tileset - i.e. adding a tile object and setting it's class there wasn't eventually setting the frb type or overriding the tileset class that frb originally picked up