### PR TITLE
Different interface method name

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Entities/ITiledTileMetadata.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Entities/ITiledTileMetadata.cs
@@ -9,7 +9,7 @@ namespace FlatRedBall.Entities {
     }
 
     public interface ITiledTileMetadata {
-        void SetTileTextureCoordinates(TiledTileMetadata TextureCoords);
+        void SetTileMetadata(TiledTileMetadata tileMetadata);
     }
 
 }

--- a/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/EmbeddedCodeFiles/TileEntityInstantiator.cs
+++ b/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/EmbeddedCodeFiles/TileEntityInstantiator.cs
@@ -353,7 +353,7 @@ namespace FlatRedBall.TileEntities
                                                 RightTextureCoordinate = tx + (tileSize / layer.Texture.Width),
                                                 BottomTextureCoordinate = ty + (tileSize / layer.Texture.Height)
                                             };
-                                            asEntity.SetTileTextureCoordinates(ttm);
+                                            asEntity.SetTileMetadata(ttm);
                                         }
 #endif
                                     }


### PR DESCRIPTION
Was adjusting something in game and realized we genericized the interface w/ a struct but the method name was still targeting specifically texture coordinates.