### PR TITLE
Map Sprite Texture Camera Pan Crash Fix

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/SpritePlugin/Managers/CameraLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/SpritePlugin/Managers/CameraLogic.cs
@@ -89,7 +89,9 @@ namespace OfficialPlugins.SpritePlugin.Managers
         {
             var newPosition = args.GetPosition(View);
 
-            if(args.MiddleButton == MouseButtonState.Pressed && newPosition != LastMiddleMouseButtonPoint)
+            if(args.MiddleButton == MouseButtonState.Pressed
+               && LastMiddleMouseButtonPoint != null
+               && newPosition != LastMiddleMouseButtonPoint)
             {
                 var camera = Camera;
 


### PR DESCRIPTION
When in the Map SpriteTexture window, clicking the middle mouse button while moving the mouse would cause the events to fire in an undesirable order leading to a null reference.