### PR TITLE
Fix incorrect syntax for nullable Invoke()

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Entities/IDamageable.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Entities/IDamageable.cs
@@ -128,8 +128,8 @@ namespace FlatRedBall.Entities
 
             if (healthBefore > 0 && damageable.CurrentHealth <= 0)
             {
-                damageable.Died?(modifiedByDamageable, null);
-                //damageArea.KilledDamageable?(modifiedByBoth, damageable);
+                damageable.Died?.Invoke(modifiedByDamageable, null);
+                //damageArea.KilledDamageable?.Invoke(modifiedByBoth, damageable);
             }
         }
 


### PR DESCRIPTION
Can't just go `?(params...)` yet, maybe next C# language version?