### PR TITLE
Ignore Properties in CSV Data Classes

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/IO/Csv/RuntimeCsvRepresentation.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/IO/Csv/RuntimeCsvRepresentation.cs
@@ -8,6 +8,7 @@ using System.Xml.Serialization;
 using FlatRedBall.Utilities;
 using System.Linq;
 using System.Diagnostics;
+using System.Runtime.Serialization;
 
 namespace FlatRedBall.IO.Csv
 {
@@ -793,6 +794,9 @@ namespace FlatRedBall.IO.Csv
 
             var fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
             var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            fields = fields.Where(fi => fi.GetCustomAttribute<IgnoreDataMemberAttribute>() == null).ToArray();
+            properties = properties.Where(pi => pi.GetCustomAttribute<IgnoreDataMemberAttribute>() == null).ToArray();
 
             foreach(var newKvp in newDictionary)
             {


### PR DESCRIPTION
Allows you to add stuff like computed properties to data classes with the IgnoreDataMember attribute
![image](https://user-images.githubusercontent.com/6179393/226411696-04502fd8-69f1-49fc-ba3b-ba2ef92b4e41.png)
