### PR TITLE
Attempt to reduce allocations on delay seconds calls

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
@@ -1255,6 +1255,12 @@ namespace FlatRedBall
                 // InstructionManager Update should happen *after* InputManager.Update 
                 // in case any instructions want to override input code.
                 InstructionManager.Update();
+                // Whether instructions come before or after Task.Delay calls is somewhat arbitrary, but we'll do it after
+                // Actually, Task'ed functions should happen at the same frame time (or nearly so) as the Update call. 
+                // I'm not sure why InstructionManager.Update is so early. Perhaps because internal methods use instructions?
+                // Anyway, if we delay a frame time, and then the frames adjust after, that can cause a Sprite to show its cycled
+                // state for 1 frame which is bad. Therefore, moving this to happen after all internal managers:
+                //TimeManager.DoScreenTimeDelayTaskLogic();
 
                 if (section != null)
                 {
@@ -1315,6 +1321,7 @@ namespace FlatRedBall
                     Section.EndContextAndTime();
                 }
 
+                TimeManager.DoScreenTimeDelayTaskLogic();
                 // Vic says = I think this needs to happen either at the very
                 // beginning of the frame or the very end of the frame. It will 
                 // contain custom user code, so we don't want this to fall in the

--- a/Engines/FlatRedBallXNA/FlatRedBall/TimeManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/TimeManager.cs
@@ -68,6 +68,7 @@ namespace FlatRedBall
         /// This value can be used to uniquely identify a frame.
         /// </remarks>
         public static double CurrentTime;
+        public static int CurrentFrame;
 
         static double mLastCurrentTime;
 
@@ -178,13 +179,7 @@ namespace FlatRedBall
         /// This value is the same as 
         /// Screens.ScreenManager.CurrentScreen.PauseAdjustedCurrentTime
         /// </remarks>
-        public static double CurrentScreenTime
-        {
-            get
-            {
-                return Screens.ScreenManager.CurrentScreen.PauseAdjustedCurrentTime;
-            }
-        }
+        public static double CurrentScreenTime => Screens.ScreenManager.CurrentScreen.PauseAdjustedCurrentTime;
 
         public static Dictionary<string, double> SumSectionDictionary
         {
@@ -604,6 +599,7 @@ namespace FlatRedBall
 
         }
 
+        static bool isFirstUpdate = false;
         /// <summary>
         /// Performs every-frame logic to update timing values such as CurrentTime and SecondDifference.  If this method is not called, CurrentTime will not advance.
         /// </summary>
@@ -650,7 +646,7 @@ namespace FlatRedBall
                 mCurrentTime = currentSystemTime;
                 */
 
-                if(SetNextFrameTimeTo0)
+                if (SetNextFrameTimeTo0)
                 {
                     elapsedTime = 0;
                     SetNextFrameTimeTo0 = false;
@@ -674,9 +670,22 @@ namespace FlatRedBall
 
             mSecondDifferenceSquaredDividedByTwo = (mSecondDifference * mSecondDifference) / 2.0f;
             mCurrentTimeForTimedSections = currentSystemTime;
-            
+
+            if (isFirstUpdate)
+            {
+                isFirstUpdate = false;
+            }
+            else
+            {
+                CurrentFrame++;
+            }
+        }
+
+        internal static void DoScreenTimeDelayTaskLogic()
+        {
+
             // Check if any delayed tasks should be completed
-            while (mScreenTimeDelayedTasks.Any())
+            while (mScreenTimeDelayedTasks.Count > 0)
             {
                 var first = mScreenTimeDelayedTasks.First();
                 if (first.Key <= CurrentScreenTime)


### PR DESCRIPTION
Previously, when you `await TimeManager.DelaySeconds()` the resulting task would be run every frame for every call.  This potentially created a new `Task` every frame, but also added needless work every frame.

Instead, only one task is created when delay seconds occurs, and the time manager tracks at what screen time that task should be woken up for, and wakes up that task only then.