### PR TITLE
Cancel any tasks waiting on delay seconds when we are clearing tasks.

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
@@ -1321,7 +1321,7 @@ namespace FlatRedBall
                     Section.EndContextAndTime();
                 }
 
-                TimeManager.DoScreenTimeDelayTaskLogic();
+                TimeManager.DoTaskLogic();
                 // Vic says = I think this needs to happen either at the very
                 // beginning of the frame or the very end of the frame. It will 
                 // contain custom user code, so we don't want this to fall in the

--- a/Engines/FlatRedBallXNA/FlatRedBall/Managers/SingleThreadSynchronizationContext.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Managers/SingleThreadSynchronizationContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace FlatRedBall.Managers
 {
@@ -64,7 +65,15 @@ namespace FlatRedBall.Managers
             while (thisFrameQueue.Count > 0)
             {
                 var actionToRun = thisFrameQueue.Dequeue();
-                actionToRun();
+                try
+                {
+                    actionToRun();
+                }
+                catch (TaskCanceledException)
+                {
+                    // Most likely the task was cancelled due to moving screens.
+                    // Nothing is to be done for cancelled tasks.
+                }
             }
         }
 

--- a/Engines/FlatRedBallXNA/FlatRedBall/TimeManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/TimeManager.cs
@@ -587,6 +587,10 @@ namespace FlatRedBall
 
         public static Task DelaySeconds(double seconds)
         {
+            if(seconds <= 0)
+            {
+                return Task.CompletedTask;
+            }
             var time = CurrentScreenTime + seconds;
             var taskSource = new TaskCompletionSource<object>();
 
@@ -607,6 +611,10 @@ namespace FlatRedBall
 
         public static Task DelayUntil(Func<bool> predicate)
         {
+            if(predicate())
+            {
+                return Task.CompletedTask;
+            }
             var taskSource = new TaskCompletionSource<object>();
             predicateTasks.Add(new PredicateTask { Predicate = predicate, TaskCompletionSource = taskSource });
             return taskSource.Task;
@@ -614,6 +622,10 @@ namespace FlatRedBall
 
         public static Task DelayFrames(int frameCount)
         {
+            if(frameCount < = 0)
+            {
+                return Task.CompletedTask;
+            }
             var taskSource = new TaskCompletionSource<object>();
             var index = frameTasks.Count;
             var absoluteFrame = TimeManager.CurrentFrame + frameCount;

--- a/Engines/FlatRedBallXNA/FlatRedBall/TimeManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/TimeManager.cs
@@ -720,6 +720,11 @@ namespace FlatRedBall
 
         internal static void ClearTasks()
         {
+            foreach (var timedTasks in mScreenTimeDelayedTasks)
+            {
+                timedTasks.TaskCompletionSource.SetCanceled();
+            }
+            
             mScreenTimeDelayedTasks.Clear();
         }
 


### PR DESCRIPTION
When moving from one screen to the other, time manager will clear all saved TCS objects.  However, the tasks that `DelaySeconds()` callers are waiting for still exist and will stay in the task scheduler forever.

This now sets the tasks to a cancelled state, and tells the synchronization context to ignore any `TaskCancellationException` that get raised by closing tasks.