### PR TITLE
Fixed stringcomparisons in the engine for non-US cultures

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
@@ -866,7 +866,7 @@ namespace FlatRedBall
 
         private static string TryFindAnyCased(string search, string[] arr, params string[] extensions)
         {
-            return arr.FirstOrDefault(s => extensions.Any(ext => s.ToLower() == (search.ToLower() + ext)));
+            return arr.FirstOrDefault(s => extensions.Any(ext => s.Equals(search + ext, StringComparison.OrdinalIgnoreCase)));
         }
 
 #if ASK_VIC //MDS_TODO ASK VIC

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/GraphicalEmumerations.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/GraphicalEmumerations.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 
@@ -128,19 +129,19 @@ namespace FlatRedBall.Graphics
                 return FlatRedBall.Graphics.BlendOperation.Regular;
             }
 
-            switch (op.ToLower())
+            switch(op)
             {
-                case "regular":
-                    return FlatRedBall.Graphics.BlendOperation.Regular;
-                case "add":
-                    return FlatRedBall.Graphics.BlendOperation.Add;
-                case "alphaadd":
-                    return FlatRedBall.Graphics.BlendOperation.Add;
-                case "modulate":
-                    return FlatRedBall.Graphics.BlendOperation.Modulate;
-                case "modulate2x":
-                    return FlatRedBall.Graphics.BlendOperation.Modulate2X;
-                case "nonpremultipliedalpha":
+                case var _ when String.Equals(op, "regular", StringComparison.OrdinalIgnoreCase):
+                    return BlendOperation.Regular;
+                case var _ when String.Equals(op, "add", StringComparison.OrdinalIgnoreCase):
+                    return BlendOperation.Add;
+                case var _ when String.Equals(op, "alphaadd", StringComparison.OrdinalIgnoreCase):
+                    return BlendOperation.Add;
+                case var _ when String.Equals(op, "modulate", StringComparison.OrdinalIgnoreCase):
+                    return BlendOperation.Modulate;
+                case var _ when String.Equals(op, "modulate2x", StringComparison.OrdinalIgnoreCase):
+                    return BlendOperation.Modulate2X;
+                case var _ when String.Equals(op, "nonpremultipliedalpha", StringComparison.OrdinalIgnoreCase):
                     return BlendOperation.NonPremultipliedAlpha;
                 default:
                     throw new NotImplementedException("Color Operation " + op + " not implemented");

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/Texture/AtlasLoader.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/Texture/AtlasLoader.cs
@@ -66,8 +66,8 @@ namespace FlatRedBall.Graphics.Texture
                     }
 
                     var isRotated = int.Parse(cols[1]) == 1;
-                    var slashIndex = cols[0].IndexOf("/");
-                    var name = cols[0].Substring(slashIndex + 1).ToLower();
+                    var slashIndex = cols[0].IndexOf("/", StringComparison.Ordinal);
+                    var name = cols[0].Substring(slashIndex + 1).ToLowerInvariant();
 
                     var sourceRectangle = new Microsoft.Xna.Framework.Rectangle(
                         int.Parse(cols[2]),

--- a/Engines/FlatRedBallXNA/FlatRedBall/IO/Csv/CsvFileManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/IO/Csv/CsvFileManager.cs
@@ -96,8 +96,9 @@ namespace FlatRedBall.IO.Csv
 
             T runtimeCsvRepresentation = null;
 
-            string extension = FileManager.GetExtension(fileName).ToLower();
-            if (extension == "csv" || extension == "txt")
+            var extension = FileManager.GetExtension(fileName);
+            if (string.Equals(extension, "csv", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(extension, "txt", StringComparison.OrdinalIgnoreCase))
             {
 #if MONOGAME
                 

--- a/Engines/FlatRedBallXNA/FlatRedBall/IO/FileManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/IO/FileManager.cs
@@ -74,15 +74,15 @@ namespace FlatRedBall.IO
 
 #else
         // Vic says - this used to be:
-        //static string mRelativeDirectory = (System.IO.Directory.GetCurrentDirectory() + "/").ToLower().Replace("\\", "/");
+        //static string mRelativeDirectory = (System.IO.Directory.GetCurrentDirectory() + "/").Replace("\\", "/");
         // But the current directory is the directory that launched the application, not the directory of the .exe.
         // We want to make sure that we use the .exe so that the game/tool can reference the proper path when loading
         // content.
         // Update: Made this per-thread so we can do multi-threaded loading.
-        // static string mRelativeDirectory = (System.Windows.Forms.Application.StartupPath + "/").ToLower().Replace("\\", "/");
+        // static string mRelativeDirectory = (System.Windows.Forms.Application.StartupPath + "/").Replace("\\", "/");
         // Update October 22, 2012 - Projects like Glue may be multi-threaded, but they want the default directory to be preset to
         // something specific.  But I think we only want this for tools (on the PC).
-        public static string DefaultRelativeDirectory = (System.Windows.Forms.Application.StartupPath + "/").ToLowerInvariant().Replace("\\", "/");
+        public static string DefaultRelativeDirectory = (System.Windows.Forms.Application.StartupPath + "/").Replace("\\", "/");
 
 #endif
 
@@ -696,21 +696,14 @@ namespace FlatRedBall.IO
             int i = fileName.LastIndexOf('.');
             if (i != -1)
             {
-                bool hasDotSlash = false;
-                if (i < fileName.Length - 1 && (fileName[i + 1] == '/' || fileName[i + 1] == '\\'))
-                {
-                    hasDotSlash = true;
-                }
+                bool hasDotSlash = i < fileName.Length - 1 && (fileName[i + 1] == '/' || fileName[i + 1] == '\\');
 
                 // Justin Johnson, 09/28/2017:
                 // Folders in the path might have a period in them. We need to make sure
                 // the period is after the last slash or we could end up with an "extension"
                 // that is a large chunk of the path
-                bool hasSlashAfterDot = false;
-                if(i < fileName.LastIndexOf("/") || i < fileName.LastIndexOf(@"\"))
-                {
-                    hasSlashAfterDot = true;
-                }
+                bool hasSlashAfterDot = i < fileName.LastIndexOf("/", StringComparison.OrdinalIgnoreCase) 
+                                        || i < fileName.LastIndexOf(@"\", StringComparison.OrdinalIgnoreCase);
 
                 if (hasDotSlash || hasSlashAfterDot)
                 {
@@ -1122,16 +1115,16 @@ namespace FlatRedBall.IO
                 if (!IsRelative(directory))
                 {
                     // just have to make sure that the filename includes the path
-                    fileName = fileName.ToLowerInvariant().Replace('\\', '/');
-                    directory = directory.ToLowerInvariant().Replace('\\', '/');
+                    fileName = fileName.Replace('\\', '/');
+                    directory = directory.Replace('\\', '/');
 
-                    if(directory.EndsWith("/") == false)
+                    if(directory.EndsWith("/", StringComparison.OrdinalIgnoreCase) == false)
                     {
                         // Do this to simplify the code below by allowing a "contains" call
                         directory += "/";
                     }
 
-                    return fileName.IndexOf(directory) == 0;
+                    return fileName.IndexOf(directory, StringComparison.OrdinalIgnoreCase) == 0;
                 }
             }
             else // fileName is relative
@@ -1152,7 +1145,7 @@ namespace FlatRedBall.IO
 
         public static bool IsUrl(string fileName)
         {
-            return fileName.IndexOf("http:") == 0 || fileName.IndexOf("https:") == 0;
+            return fileName.IndexOf("http:", StringComparison.OrdinalIgnoreCase) == 0 || fileName.IndexOf("https:", StringComparison.OrdinalIgnoreCase) == 0;
         }
 
 
@@ -1213,7 +1206,7 @@ namespace FlatRedBall.IO
                     // the string arrays.
                     //while (start < path.Length && start < relpath.Length && path[start] == relpath[start])
                     //while (path[start] == relpath[start])
-                    while (start < path.Length && start < relpath.Length && path[start].ToLower() == relpath[start].ToLower())
+                    while (start < path.Length && start < relpath.Length && String.Equals(path[start],relpath[start], StringComparison.OrdinalIgnoreCase))
                     {
                         start++;
                     }
@@ -1616,7 +1609,7 @@ namespace FlatRedBall.IO
             if (fileNameToFix == null)
                 return null;
 
-            bool isNetwork = fileNameToFix.StartsWith("\\\\");
+            bool isNetwork = fileNameToFix.StartsWith(@"\\");
 
             ReplaceSlashes(ref fileNameToFix);
 

--- a/Engines/FlatRedBallXNA/FlatRedBall/Instructions/GenericInstruction.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Instructions/GenericInstruction.cs
@@ -122,19 +122,9 @@ namespace FlatRedBall.Instructions
             }
         }
 
-        public override Type MemberType
-        {
-            get{ return typeof(ValueType);}
-        }
+        public override Type MemberType => typeof(ValueType);
 
-        public override string MemberTypeAsString
-        {
-            get 
-            { 
-                return typeof(ValueType).FullName; 
-            
-            }
-        }
+        public override string MemberTypeAsString => typeof(ValueType).FullName;
 
         public override string MemberValueAsString
         {
@@ -143,7 +133,7 @@ namespace FlatRedBall.Instructions
                 if (mValue != null)
                 {
                     if (mValue is bool)
-                        return mValue.ToString().ToLower();
+                        return mValue.ToString().ToLowerInvariant();
                     else
                         return mValue.ToString();
                 }
@@ -154,8 +144,8 @@ namespace FlatRedBall.Instructions
 
         public override object MemberValueAsObject
         {
-            get { return mValue; }
-			set { mValue = ((ValueType) value) ; }
+            get => mValue;
+            set { mValue = ((ValueType) value) ; }
         }
 
         public ValueType Value

--- a/Engines/FlatRedBallXNA/FlatRedBall/Instructions/Reflection/PropertyValuePair.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Instructions/Reflection/PropertyValuePair.cs
@@ -270,7 +270,7 @@ namespace FlatRedBall.Instructions.Reflection
                     }
 
                     // value could be upper case like "TRUE" or "True".  Make it lower
-                    value = value.ToLower();
+                    value = value.ToLowerInvariant();
 
                     toReturn = bool.Parse(value);
                     handled = true;
@@ -285,7 +285,7 @@ namespace FlatRedBall.Instructions.Reflection
                     }
                     else
                     {
-                        value = value.ToLower();
+                        value = value.ToLowerInvariant();
 
                         toReturn = bool.Parse(value);
                         handled = true;

--- a/Engines/FlatRedBallXNA/FlatRedBall/Math/AttachableList.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Math/AttachableList.cs
@@ -411,12 +411,10 @@ namespace FlatRedBall.Math
         /// <returns>The IAttachable with a name containing the argument string or null if none are found.</returns>
         public T FindWithNameContainingCaseInsensitive(string stringToSearchFor)
         {
-            string name;
             for (int i = 0; i < this.Count; i++)
             {
                 T t = this[i];
-                name = t.Name.ToLower();
-                if (name.Contains(stringToSearchFor.ToLower()))
+                if (t.Name.IndexOf(stringToSearchFor, StringComparison.OrdinalIgnoreCase) >= 0)
                     return t;
             }
 

--- a/Engines/FlatRedBallXNA/FlatRedBall/Utilities/StringBuilderExtensions.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Utilities/StringBuilderExtensions.cs
@@ -135,10 +135,10 @@ namespace FlatRedBall.Utilities
             {
                 for (int j = startIndex; j < num2; j++)
                 {
-                    if (char.ToLower(sb[j]) == char.ToLower(value[0]))
+                    if (char.ToLowerInvariant(sb[j]) == char.ToLowerInvariant(value[0]))
                     {
                         num3 = 1;
-                        while ((num3 < length) && (char.ToLower(sb[j + num3]) == char.ToLower(value[num3])))
+                        while ((num3 < length) && (char.ToLowerInvariant(sb[j + num3]) == char.ToLowerInvariant(value[num3])))
                         {
                             num3++;
                         }
@@ -160,7 +160,7 @@ namespace FlatRedBall.Utilities
         public static int LastIndexOf(this StringBuilder sb, string value)
         {
             // Eventually let's make this faster:
-            return sb.ToString().LastIndexOf(value);
+            return sb.ToString().LastIndexOf(value, StringComparison.OrdinalIgnoreCase);
 
         }
  

--- a/FRBDK/Glue/FlatRedBall.Plugin/PluginManagerBase.cs
+++ b/FRBDK/Glue/FlatRedBall.Plugin/PluginManagerBase.cs
@@ -353,8 +353,9 @@ namespace FlatRedBall.Glue.Plugins
             {
                 bool shouldProcessPlugin = true;
                 // GlueView is a special case, so we should skip that
-                string pluginToLower = plugin.ToLower().Replace("\\", "/");
-                if (pluginToLower.EndsWith("/glueview") || pluginToLower.EndsWith("/glueview/"))
+                string pluginToLower = plugin.Replace("\\", "/");
+                if (pluginToLower.EndsWith("/glueview", StringComparison.OrdinalIgnoreCase)
+                    || pluginToLower.EndsWith("/glueview/", StringComparison.OrdinalIgnoreCase))
                 {
                     shouldProcessPlugin = false;
                 }
@@ -363,7 +364,7 @@ namespace FlatRedBall.Glue.Plugins
                 {
                     // We had a && false here, so I don't think we use this ignored check, do we?
                     bool isIgnored = pluginsToIgnore != null && pluginsToIgnore.Any(item => 
-                        FileManager.Standardize(item.ToLowerInvariant()) == FileManager.Standardize(plugin.ToLowerInvariant()));
+                        FileManager.Standardize(item).Equals(FileManager.Standardize(plugin), StringComparison.OrdinalIgnoreCase));
 
                     if (!isIgnored)
                     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CodeGeneration/GlueCalls/GlueCallsCodeGenerator.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CodeGeneration/GlueCalls/GlueCallsCodeGenerator.cs
@@ -169,7 +169,7 @@ namespace GameCommunicationPlugin.GlueControl.CodeGeneration.GlueCalls
 
                     bldr.AppendLine($"          return await GlueCallsClassGenerationManager.ConvertToPropertyCallToGame(nameof({prop.Name}), typeof({prop.ReturnType}), parameter, new GlueCallsClassGenerationManager.CallPropertyParameters");
                     bldr.AppendLine($"          {{");
-                    bldr.AppendLine($"              ReturnToPropertyType = {prop.ReturnToPropertyType.ToString().ToLower()}");
+                    bldr.AppendLine($"              ReturnToPropertyType = {prop.ReturnToPropertyType.ToString().ToLowerInvariant()}");
                     bldr.AppendLine($"          }});");
                     bldr.AppendLine($"      }}");
                 }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Models/GlueProjectSaveExtensions.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Models/GlueProjectSaveExtensions.cs
@@ -38,7 +38,9 @@ namespace GlueControl.Models
 
 
 
-            foreach (var file in files.Where(item => item.ToLower().EndsWith(".generated.glux") || item.ToLower().EndsWith(".generated.gluj")))
+            foreach (var file in files.Where(item => 
+                         item.EndsWith(".generated.glux", StringComparison.OrdinalIgnoreCase) 
+                         || item.EndsWith(".generated.gluj", StringComparison.OrdinalIgnoreCase)))
             {
                 string withoutExtension = FileManager.RemoveExtension(file);
                 string withoutGenerated = FileManager.RemoveExtension(withoutExtension);

--- a/FRBDK/Glue/Glue/Build/BuildToolAssociationManager.cs
+++ b/FRBDK/Glue/Glue/Build/BuildToolAssociationManager.cs
@@ -7,175 +7,170 @@ using FlatRedBall.IO;
 using FlatRedBall.Glue.Controls;
 using System.Windows.Forms;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using L = Localization;
 
-namespace FlatRedBall.Glue.Managers
+namespace FlatRedBall.Glue.Managers;
+
+public class BuildToolAssociationManager
 {
-    public class BuildToolAssociationManager
+    #region Fields
+
+    static BuildToolAssociationManager mSelf;
+
+    #endregion
+
+    #region Properties
+
+    List<BuildToolAssociation> ProjectSpecificBuildTools => GlueState.Self.GlueSettingsSave.BuildToolAssociations;
+
+    public static BuildToolAssociationManager Self
     {
-        #region Fields
-
-        static BuildToolAssociationManager mSelf;
-
-        #endregion
-
-        #region Properties
-
-        List<BuildToolAssociation> ProjectSpecificBuildTools => GlueState.Self.GlueSettingsSave.BuildToolAssociations;
-
-        public static BuildToolAssociationManager Self
+        get
         {
-            get
+            if (mSelf == null)
             {
-                if (mSelf == null)
-                {
-                    mSelf = new BuildToolAssociationManager();
-                }
-                return mSelf;
+                mSelf = new BuildToolAssociationManager();
+            }
+            return mSelf;
+        }
+    }
+
+    #endregion
+
+    internal BuildToolAssociation GetBuilderToolAssociationForSourceExtension(string sourceExtension)
+    {
+        BuildToolAssociation buildToolAssociation = null;
+
+        foreach (BuildToolAssociation bta in ProjectSpecificBuildTools)
+        {
+            if (bta.SourceFileType != null && bta.SourceFileType.ToLowerInvariant() == sourceExtension.ToLowerInvariant())
+            {
+                buildToolAssociation = bta;
+                break;
+            }
+        }
+        return buildToolAssociation;
+    }
+
+    public BuildToolAssociation GetBuilderToolAssociationForDestinationExtension(string destinationExtension)
+    {
+        BuildToolAssociation buildToolAssociation = null;
+
+        foreach (BuildToolAssociation bta in ProjectSpecificBuildTools)
+        {
+            if (bta.DestinationFileType.ToLowerInvariant() == destinationExtension.ToLowerInvariant())
+            {
+                buildToolAssociation = bta;
+                break;
+            }
+        }
+        return buildToolAssociation;
+    }
+
+    public BuildToolAssociation GetBuilderToolAssociationForExtensions(string sourceExtension, string destinationExtension)
+    {
+        return ProjectSpecificBuildTools.FirstOrDefault(item =>
+            item.SourceFileType != null && 
+            item.SourceFileType.ToLowerInvariant() == sourceExtension.ToLowerInvariant() &&
+            item.DestinationFileType.ToLowerInvariant() == destinationExtension.ToLowerInvariant());
+    }
+
+    internal BuildToolAssociation GetBuilderToolAssociationByName(string name)
+    {
+        BuildToolAssociation buildToolAssociation = null;
+
+        foreach (var bta in ProjectSpecificBuildTools)
+        {
+            if (String.Equals(bta.ToString(), name, StringComparison.OrdinalIgnoreCase))
+            {
+                buildToolAssociation = bta;
+                break;
+            }
+        }
+        return buildToolAssociation;
+    }
+
+
+    public BuildToolAssociation GetBuildToolAssocationAndNameFor(string fileName, out bool userCancelled, out bool userPickedNone, out string rfsName, out string extraCommandLineArguments)
+    {
+        userCancelled = false;
+        userPickedNone = false;
+        rfsName = null;
+
+        BuildToolAssociation buildToolAssociation = null;
+
+        var sourceExtension = FileManager.GetExtension(fileName);
+
+        var btaList = new List<BuildToolAssociation>();
+        foreach (var bta in ProjectSpecificBuildTools)
+        {
+            if (bta.SourceFileType != null && String.Equals(bta.SourceFileType, sourceExtension, StringComparison.Ordinal))
+            {
+                btaList.Add(bta);
             }
         }
 
-        #endregion
+        NewFileWindow nfw = new NewFileWindow();
+        nfw.ComboBoxMessage = L.Texts.BuilderWhichForFile;
 
-        internal BuildToolAssociation GetBuilderToolAssociationForSourceExtension(string sourceExtension)
-        {
-            BuildToolAssociation buildToolAssociation = null;
-
-            foreach (BuildToolAssociation bta in ProjectSpecificBuildTools)
-            {
-                if (bta.SourceFileType != null && bta.SourceFileType.ToLowerInvariant() == sourceExtension.ToLowerInvariant())
-                {
-                    buildToolAssociation = bta;
-                    break;
-                }
-            }
-            return buildToolAssociation;
-        }
-
-        public BuildToolAssociation GetBuilderToolAssociationForDestinationExtension(string destinationExtension)
-        {
-            BuildToolAssociation buildToolAssociation = null;
-
-            foreach (BuildToolAssociation bta in ProjectSpecificBuildTools)
-            {
-                if (bta.DestinationFileType.ToLowerInvariant() == destinationExtension.ToLowerInvariant())
-                {
-                    buildToolAssociation = bta;
-                    break;
-                }
-            }
-            return buildToolAssociation;
-        }
-
-        public BuildToolAssociation GetBuilderToolAssociationForExtensions(string sourceExtension, string destinationExtension)
-        {
-            return ProjectSpecificBuildTools.FirstOrDefault(item =>
-                item.SourceFileType != null && 
-                item.SourceFileType.ToLowerInvariant() == sourceExtension.ToLowerInvariant() &&
-                item.DestinationFileType.ToLowerInvariant() == destinationExtension.ToLowerInvariant());
-        }
-
-        internal BuildToolAssociation GetBuilderToolAssociationByName(string name)
-        {
-            BuildToolAssociation buildToolAssociation = null;
-
-            foreach (BuildToolAssociation bta in ProjectSpecificBuildTools)
-            {
-                if (bta.ToString().ToLower() == name.ToLower())
-                {
-                    buildToolAssociation = bta;
-                    break;
-                }
-            }
-            return buildToolAssociation;
-        }
-
-
-        public BuildToolAssociation GetBuildToolAssocationAndNameFor(string fileName, out bool userCancelled, out bool userPickedNone, out string rfsName, out string extraCommandLineArguments)
-        {
-            userCancelled = false;
-            userPickedNone = false;
-            rfsName = null;
-
-            BuildToolAssociation buildToolAssociation = null;
-
-            string sourceExtension = FileManager.GetExtension(fileName);
-
-            List<BuildToolAssociation> btaList = new List<BuildToolAssociation>();
-            foreach (BuildToolAssociation bta in ProjectSpecificBuildTools)
-            {
-                if (bta.SourceFileType != null && bta.SourceFileType.ToLower() == sourceExtension.ToLower())
-                {
-                    btaList.Add(bta);
-                }
-            }
-
-
-
-            NewFileWindow nfw = new NewFileWindow();
-            nfw.ComboBoxMessage = "Which builder would you like to use for this file?";
-
-            int commandLineArgumentsId = nfw.AddTextBox("Enter extra command line arguments:");
+        int commandLineArgumentsId = nfw.AddTextBox(L.Texts.CliExtraArguments);
             
-            bool showNoneOption = Elements.AvailableAssetTypes.Self.AllAssetTypes
-                .Any(item => item.Extension == sourceExtension && string.IsNullOrEmpty(item.CustomBuildToolName));
+        bool showNoneOption = Elements.AvailableAssetTypes.Self.AllAssetTypes
+            .Any(item => item.Extension == sourceExtension && string.IsNullOrEmpty(item.CustomBuildToolName));
 
-            if(showNoneOption)
-            {
-                nfw.AddOption("<None>");
-            }
-
-            foreach (BuildToolAssociation bta in btaList)
-            {
-                nfw.AddOption(bta);
-            }
-
-            if (btaList.Count != 0)
-            {
-                nfw.SelectedItem = btaList[0];
-            }
-
-            nfw.ResultName = FileManager.RemoveExtension(FileManager.RemovePath(fileName));
-            //DialogResult result = cbmb.ShowDialog();
-            DialogResult result = nfw.ShowDialog();
-            extraCommandLineArguments = "";
-
-            if (result == DialogResult.OK)
-            {
-                buildToolAssociation = nfw.SelectedItem as BuildToolAssociation;
-                if (buildToolAssociation != null)
-                {
-                    rfsName = nfw.ResultName;
-                    extraCommandLineArguments = nfw.GetValueFromId(commandLineArgumentsId);
-                }
-                else
-                {
-                    userPickedNone = nfw.SelectedItem is string && (nfw.SelectedItem as string) == "<None>";
-                }
-            }
-            else
-            {
-                userCancelled = true;
-            }
-
-
-
-
-            return buildToolAssociation;
-        }
-
-        public bool GetIfIsBuiltFile(string fileName)
+        if(showNoneOption)
         {
+            nfw.AddOption($"<{L.Texts.None}>");
+        }
 
-            string sourceExtension = FileManager.GetExtension(fileName);
+        foreach (BuildToolAssociation bta in btaList)
+        {
+            nfw.AddOption(bta);
+        }
 
-            if (string.IsNullOrEmpty(sourceExtension))
+        if (btaList.Count != 0)
+        {
+            nfw.SelectedItem = btaList[0];
+        }
+
+        nfw.ResultName = FileManager.RemoveExtension(FileManager.RemovePath(fileName));
+        DialogResult result = nfw.ShowDialog();
+        extraCommandLineArguments = "";
+
+        if (result == DialogResult.OK)
+        {
+            buildToolAssociation = nfw.SelectedItem as BuildToolAssociation;
+            if (buildToolAssociation != null)
             {
-                return false;
+                rfsName = nfw.ResultName;
+                extraCommandLineArguments = nfw.GetValueFromId(commandLineArgumentsId);
             }
             else
             {
-                return GlueState.Self.GlueSettingsSave.BuildToolAssociations.Any(item => item.SourceFileType != null && item.SourceFileType.ToLower() == sourceExtension.ToLower());
+                userPickedNone = nfw.SelectedItem is string && (nfw.SelectedItem as string) == $"<{L.Texts.None}>";
             }
         }
+        else
+        {
+            userCancelled = true;
+        }
+
+
+
+
+        return buildToolAssociation;
+    }
+
+    public bool GetIfIsBuiltFile(string fileName)
+    {
+        var sourceExtension = FileManager.GetExtension(fileName);
+
+        if (String.IsNullOrEmpty(sourceExtension))
+        {
+            return false;
+        }
+
+        return GlueState.Self.GlueSettingsSave.BuildToolAssociations
+            .Any(item => String.Equals(item.SourceFileType, sourceExtension, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/FRBDK/Glue/Glue/CodeGeneration/CustomVariableCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/CustomVariableCodeGenerator.cs
@@ -261,8 +261,6 @@ namespace FlatRedBall.Glue.CodeGeneration
                 }
             }
 
-            string formatString = null;
-
             bool needsToBeProperty = (customVariable.SetByDerived && !customVariable.IsShared) || customVariable.CreatesProperty || customVariable.CreatesEvent
                 || IsVariableWholeNumberWithVelocity(customVariable);
 
@@ -282,14 +280,10 @@ namespace FlatRedBall.Glue.CodeGeneration
                 }
             }
 
-
             EventCodeGenerator.TryGenerateEventsForVariable(codeBlock, customVariable, element);
             
-
-            string memberType = GetMemberTypeFor(customVariable, element);
-
-            string scopeValue = customVariable.Scope.ToString().ToLower();
-
+            var memberType = GetMemberTypeFor(customVariable, element);
+            var scopeValue = customVariable.Scope.ToString().ToLowerInvariant();
 
 
             if (needsToBeProperty)
@@ -299,11 +293,11 @@ namespace FlatRedBall.Glue.CodeGeneration
                 // then it needs to have
                 // custom code (it can't be
                 // an automatic property).
-                bool isWholeNumberWithVelocity = IsVariableWholeNumberWithVelocity(customVariable);
+                var isWholeNumberWithVelocity = IsVariableWholeNumberWithVelocity(customVariable);
 
                 if (customVariable.CreatesEvent || isWholeNumberWithVelocity || customVariable.DefaultValue != null )
                 {
-                    string variableToAssignInProperty = "base." + customVariable.Name;
+                    var variableToAssignInProperty = "base." + customVariable.Name;
                     // create a field for this, unless it's defined by base - then the base creates a field for it
                     if (!isExposing && !customVariable.DefinedByBase)
                     {
@@ -318,9 +312,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                         codeBlock.Line(line);
                     }
 
-                    string propertyHeader = null;
-
-                    var scopeString = customVariable.Scope.ToString().ToLower();
+                    string propertyHeader;
 
                     if (isExposing)
                     {
@@ -398,7 +390,7 @@ namespace FlatRedBall.Glue.CodeGeneration
 
                     if(isStateDefinedInOtherEntity)
                     {
-                        var line = customVariable.Scope.ToString().ToLower() + " " + 
+                        var line = customVariable.Scope.ToString().ToLowerInvariant() + " " + 
                             StringHelper.Modifiers(Static: customVariable.IsShared, Type: memberType, Name: customVariable.Name) + ";";
 
                         codeBlock.Line(line);
@@ -413,7 +405,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                         // state variable for a
                         // disabled object, we still
                         // want to generate something:
-                        var line = scopeValue.ToString().ToLower() + " " +
+                        var line = scopeValue.ToLowerInvariant() + " " +
                             StringHelper.Modifiers(Static: customVariable.IsShared, Type: memberType, Name: customVariable.Name)
                             + ";";
 

--- a/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
@@ -810,15 +810,14 @@ namespace FlatRedBall.Glue.CodeGeneration
 
         public static string GetFileToLoadForRfs(ReferencedFileSave referencedFile, AssetTypeInfo ati = null)
         {
-            string referencedFileName = "content/" +  referencedFile.Name;
-            ati = ati ?? referencedFile.GetAssetTypeInfo();
+            var referencedFileName = "content/" +  referencedFile.Name;
+            ati ??= referencedFile.GetAssetTypeInfo();
             if (ati?.MustBeAddedToContentPipeline == true || referencedFile.UseContentPipeline)
             {
                 referencedFileName = FileManager.RemoveExtension(referencedFileName);
             }
             
-            referencedFileName = referencedFileName.ToLower();
-            return referencedFileName;
+            return referencedFileName.ToLowerInvariant();
         }
 
         public static void AppendAddUnloadMethod(ICodeBlock codeBlock, IElement element)
@@ -845,10 +844,9 @@ namespace FlatRedBall.Glue.CodeGeneration
                 var ati = referencedFile.GetAssetTypeInfo();
                 if (referencedFile.IsCsvOrTreatedAsCsv && referencedFile.CreatesDictionary)
                 {
-                    var fileName = ProjectBase.AccessContentDirectory + referencedFile.Name.ToLower().Replace("\\", "/");
+                    var fileName = ProjectBase.AccessContentDirectory + referencedFile.Name.ToLowerInvariant().Replace("\\", "/");
                     var instanceName = referencedFile.GetInstanceName();
-                    string line =
-                        $"FlatRedBall.IO.Csv.CsvFileManager.UpdateDictionaryValuesFromCsv({instanceName}, \"{fileName}\");";
+                    string line = $"FlatRedBall.IO.Csv.CsvFileManager.UpdateDictionaryValuesFromCsv({instanceName}, \"{fileName}\");";
                     codeBlock.Line(line);
                 }
                 else if (ati?.QualifiedRuntimeTypeName.QualifiedType == "Microsoft.Xna.Framework.Graphics.Texture2D")
@@ -919,7 +917,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                 }
                 else
                 {
-                    fileName = ReferencedFileSaveCodeGenerator.GetFileToLoadForRfs(referencedFile, referencedFile.GetAssetTypeInfo());
+                    fileName = GetFileToLoadForRfs(referencedFile, referencedFile.GetAssetTypeInfo());
 
                     project = ProjectManager.ProjectBase;
                 }
@@ -930,7 +928,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                     containerName = container.Name;
                 }
                 AddCodeforFileLoad(referencedFile, ref codeBlock, container,
-                    ref directives, isProjectSpecific, fileName, project, loadType, containerName);
+                    ref directives, isProjectSpecific, fileName, project, loadType);
             }
 
             if (directives == true)
@@ -971,7 +969,7 @@ namespace FlatRedBall.Glue.CodeGeneration
 
         private static void AddCodeforFileLoad(ReferencedFileSave referencedFile, ref ICodeBlock codeBlock, 
             IElement container, ref bool directives, bool isProjectSpecific, 
-            string fileName, ProjectBase project, LoadType loadType, string containerName)
+            string fileName, ProjectBase project, LoadType loadType)
         {
             if (project != null)
             {
@@ -1191,7 +1189,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                 typeName = "System.Collections.Generic.List<" + FileManager.RemovePath(FileManager.RemoveExtension(fileName)) + ">";
             }
 
-            if (typeName.ToLower().EndsWith("file"))
+            if (typeName.EndsWith("file", StringComparison.OrdinalIgnoreCase))
             {
                 typeName = typeName.Substring(0, typeName.Length - "file".Length);
             }

--- a/FRBDK/Glue/Glue/CodeGeneration/StateCodeGenerator.Interpolation.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/StateCodeGenerator.Interpolation.cs
@@ -249,7 +249,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                 // InterpolationEntityInstance.InterpolateToState(InterpolationEntity.VariableState.Small, secondsToTake);
                 //
                 string type = "VariableState";
-                if (variable != null && variable.Type.ToLower() != "string")
+                if (variable != null && !String.Equals(variable.Type, "string", StringComparison.OrdinalIgnoreCase))
                 {
                     type = variable.Type;
                 }
@@ -530,7 +530,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                                         if (stateContainingEntity != null)
                                         {
                                             string stateType = "VariableState";
-                                            if (customVariable != null && customVariable.Type.ToLower() != "string")
+                                            if (customVariable != null && !String.Equals(customVariable.Type, "string", StringComparison.OrdinalIgnoreCase))
                                             {
                                                 stateType = customVariable.Type;
                                                 if(stateType?.Contains('.') == true)

--- a/FRBDK/Glue/Glue/CodeGeneration/StateCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/StateCodeGenerator.cs
@@ -917,7 +917,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                 {
                     valueAsString = CustomVariableCodeGenerator.GetAssignmentToCsvItem(customVariable, element, valueAsString);
                 }
-                else if (customVariable != null && customVariable.Type == "Color")
+                else if (customVariable is { Type: "Color" })
                 {
                     valueAsString = "Color." + valueAsString.Replace("\"", "");
                 }
@@ -979,7 +979,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                 {
                     string variableType = "VariableState";
 
-                    if (customVariable != null && customVariable.Type.ToLower() != "string")
+                    if (customVariable != null && !String.Equals(customVariable.Type, "string", StringComparison.OrdinalIgnoreCase))
                     {
                         variableType = customVariable.Type;
                     }

--- a/FRBDK/Glue/Glue/ContentPipeline/ContentPipelineHelper.cs
+++ b/FRBDK/Glue/Glue/ContentPipeline/ContentPipelineHelper.cs
@@ -58,7 +58,7 @@ namespace FlatRedBall.Glue.ContentPipeline
 
                 for (int i = 0; i < filesInModifiedRfs.Count; i++)
                 {
-                    filesInModifiedRfs[i] = ProjectManager.MakeRelativeContent(filesInModifiedRfs[i].FullPath).ToLower();
+                    filesInModifiedRfs[i] = ProjectManager.MakeRelativeContent(filesInModifiedRfs[i].FullPath).ToLowerInvariant();
                 }
 
                 List<ReferencedFileSave> allReferencedFiles = ObjectFinder.Self.GetAllReferencedFiles();
@@ -283,11 +283,11 @@ namespace FlatRedBall.Glue.ContentPipeline
 
         private static void RemoveFilesFromListReferencedByRfses(List<FilePath> filesInModifiedRfs, List<ReferencedFileSave> allReferencedFiles)
         {
-            foreach (ReferencedFileSave possibleReferencer in allReferencedFiles)
+            foreach (var possibleReferencer in allReferencedFiles)
             {
                 if (!possibleReferencer.UseContentPipeline)
                 {
-                    string modifiedPossibleReferencerFile = possibleReferencer.Name.ToLower();
+                    string modifiedPossibleReferencerFile = possibleReferencer.Name.ToLowerInvariant();
                     if (filesInModifiedRfs.Contains(modifiedPossibleReferencerFile))
                     {
                         // There is a RFS referencing this guy

--- a/FRBDK/Glue/Glue/Elements/ObjectFinder.cs
+++ b/FRBDK/Glue/Glue/Elements/ObjectFinder.cs
@@ -51,9 +51,9 @@ public class ObjectFinder : IObjectFinder
 
     public List<ReferencedFileSave> GetReferencedFileSavesFromSource(string sourceFile)
     {
-        List<ReferencedFileSave> toReturn = new List<ReferencedFileSave>();
+        var toReturn = new List<ReferencedFileSave>();
 
-        sourceFile = sourceFile.ToLower();
+        sourceFile = sourceFile.ToLowerInvariant();
         if (GlueProject != null)
         {
             foreach (ScreenSave screenSave in GlueProject.Screens)

--- a/FRBDK/Glue/Glue/Extensions/GlueProjectSaveExtensions.cs
+++ b/FRBDK/Glue/Glue/Extensions/GlueProjectSaveExtensions.cs
@@ -521,7 +521,7 @@ namespace FlatRedBall.Glue.SaveClasses
 
 
 
-            foreach (var file in files.Where(item=>item.ToLower().EndsWith(".generated.glux") || item.ToLower().EndsWith(".generated.gluj")))
+            foreach (var file in files.Where(item=>item.EndsWith(".generated.glux", StringComparison.OrdinalIgnoreCase) || item.EndsWith(".generated.gluj", StringComparison.OrdinalIgnoreCase)))
             {
                 string withoutExtension = FileManager.RemoveExtension(file);
                 string withoutGenerated = FileManager.RemoveExtension(withoutExtension);

--- a/FRBDK/Glue/Glue/IO/ChangedFileGroup.cs
+++ b/FRBDK/Glue/Glue/IO/ChangedFileGroup.cs
@@ -257,11 +257,11 @@ namespace FlatRedBall.Glue.IO
             {
                 throw new Exception("File name should be absolute");
             }
-            string standardized = FileManager.Standardize(file, null, false).ToLower();
+            string standardized = FileManager.Standardize(file, null, false).ToLowerInvariant();
 
-            if (mChangesToIgnore.ContainsKey(standardized))
+            if (mChangesToIgnore.TryGetValue(standardized, out var change))
             {
-                return mChangesToIgnore[standardized];
+                return change;
             }
             else
             {
@@ -359,7 +359,7 @@ namespace FlatRedBall.Glue.IO
 
         bool TryIgnoreFileChange(string fileName)
         {
-            fileName = fileName.ToLower();
+            fileName = fileName.ToLowerInvariant();
             int changesToIgnore = 0;
 
             fileName = FileManager.Standardize(fileName, null, false);
@@ -383,7 +383,7 @@ namespace FlatRedBall.Glue.IO
                 {
                     throw new Exception("File name should be absolute");
                 }
-                string standardized = FileManager.Standardize(fileName, null, false).ToLower() ;
+                string standardized = FileManager.Standardize(fileName, null, false).ToLowerInvariant() ;
                 if (mChangesToIgnore.ContainsKey(standardized))
                 {
                     mChangesToIgnore[standardized] = 1 + mChangesToIgnore[standardized];

--- a/FRBDK/Glue/Glue/IO/FileWatchManager.cs
+++ b/FRBDK/Glue/Glue/IO/FileWatchManager.cs
@@ -361,7 +361,7 @@ namespace FlatRedBall.Glue.IO
                 isIgnored = true;
             }
 
-            if (!isIgnored && filePath.FullPath.ToLower().EndsWith(".generated.cs"))
+            if (!isIgnored && filePath.FullPath.EndsWith(".generated.cs", StringComparison.OrdinalIgnoreCase))
             {
                 reason = IgnoreReason.GeneratedCodeFile;
                 isIgnored = true;

--- a/FRBDK/Glue/Glue/IO/ProjectLoader.cs
+++ b/FRBDK/Glue/Glue/IO/ProjectLoader.cs
@@ -948,7 +948,9 @@ namespace FlatRedBall.Glue.IO
                         vsp.SaveAsAbsoluteSyncedProject = false;
                     }
 
-                    if (FileManager.GetDirectory(absoluteFileName).ToLower() == FileManager.GetDirectory(ProjectManager.ProjectBase.FullFileName.FullPath).ToLower())
+                    if (String.Equals(FileManager.GetDirectory(absoluteFileName),
+                            FileManager.GetDirectory(ProjectManager.ProjectBase.FullFileName.FullPath),
+                            StringComparison.OrdinalIgnoreCase))
                     {
                         vsp.SaveAsRelativeSyncedProject = false;
                         vsp.SaveAsAbsoluteSyncedProject = false;

--- a/FRBDK/Glue/Glue/IO/UpdateReactor.cs
+++ b/FRBDK/Glue/Glue/IO/UpdateReactor.cs
@@ -210,13 +210,14 @@ namespace FlatRedBall.Glue.IO
             var standardizedGluj = FileManager.RemoveExtension(FileManager.Standardize(projectFileName).ToLower()) + ".gluj";
             var partialGlux = FileManager.RemoveExtension(FileManager.Standardize(projectFileName).ToLower()) + @"\..*\.generated\.glux";
             var partialGluxRegex = new Regex(partialGlux);
-            var isGlueProjectFile = changedFile.ToLower() == standardizedGlux || partialGluxRegex.IsMatch(changedFile.ToLower()) || changedFile.ToLower() == standardizedGluj;
+            var isGlueProjectFile = String.Equals(changedFile, standardizedGlux, StringComparison.OrdinalIgnoreCase) || partialGluxRegex.IsMatch(changedFile.ToLowerInvariant()) ||
+                                    String.Equals(changedFile, standardizedGluj, StringComparison.OrdinalIgnoreCase);
             var isElementFile = false;
             if(!isGlueProjectFile)
             {
                 var extension = FileManager.GetExtension(changedFile);
 
-                if(extension == GlueProjectSave.ScreenExtension || extension == GlueProjectSave.EntityExtension)
+                if(extension is GlueProjectSave.ScreenExtension or GlueProjectSave.EntityExtension)
                 {
                     var projectDirectory = FileManager.GetDirectory(projectFileName);
 

--- a/FRBDK/Glue/Glue/Managers/DragDropManager.cs
+++ b/FRBDK/Glue/Glue/Managers/DragDropManager.cs
@@ -954,7 +954,7 @@ public class DragDropManager : Singleton<DragDropManager>
 
     private static void AskAndAddAllContainedRfsToGlobalContent(IElement element)
     {
-        string message = "Add all contained files in " + element.ToString() + " to Global Content Files?  Files will still be referenced by " + element.ToString();
+        string message = "Add all contained files in " + element + " to Global Content Files?  Files will still be referenced by " + element;
 
         DialogResult dialogResult = MessageBox.Show(message, "Add to Global Content?", MessageBoxButtons.YesNo);
 
@@ -970,7 +970,7 @@ public class DragDropManager : Singleton<DragDropManager>
                     screenOrEntity = "Entity";
                 }
 
-                DialogResult result = MessageBox.Show("The " + screenOrEntity + " " + element.ToString() +
+                DialogResult result = MessageBox.Show("The " + screenOrEntity + " " + element +
                     "does not UseGlobalContent.  Would you like " +
                     " to set UseGlobalContent to true?", "Set UseGlobalContent to true?", MessageBoxButtons.YesNo);
 
@@ -982,15 +982,8 @@ public class DragDropManager : Singleton<DragDropManager>
 
             foreach (ReferencedFileSave rfs in element.ReferencedFiles)
             {
-                bool alreadyExists = false;
-                foreach (ReferencedFileSave existingRfs in ObjectFinder.Self.GlueProject.GlobalFiles)
-                {
-                    if (existingRfs.Name.ToLower() == rfs.Name.ToLower())
-                    {
-                        alreadyExists = true;
-                        break;
-                    }
-                }
+                bool alreadyExists = ObjectFinder.Self.GlueProject.GlobalFiles
+                    .Any(existingRfs => String.Equals(existingRfs.Name, rfs.Name, StringComparison.CurrentCultureIgnoreCase));
 
                 if (!alreadyExists)
                 {

--- a/FRBDK/Glue/Glue/Managers/ErrorManager.cs
+++ b/FRBDK/Glue/Glue/Managers/ErrorManager.cs
@@ -99,7 +99,7 @@ namespace FlatRedBall.Glue.Managers
             #region  Loop through every .Generated.cs file to see if it has an associated object
             foreach (var buildItem in ProjectManager.ProjectBase.EvaluatedItems)
             {
-                if (buildItem.UnevaluatedInclude.ToLower().Contains(".generated.cs"))
+                if (buildItem.UnevaluatedInclude.Contains(".generated.cs", StringComparison.OrdinalIgnoreCase))
                 {
                     #region Prepare the "name" for checking
 

--- a/FRBDK/Glue/Glue/Managers/FileAssociation.cs
+++ b/FRBDK/Glue/Glue/Managers/FileAssociation.cs
@@ -56,9 +56,9 @@ namespace HQ.Util.Unmanaged
                 executablePath = "";
 
             // Ensure to not return the default OpenWith.exe associated executable in Windows 8 or higher
-            if (!string.IsNullOrEmpty(executablePath) && fileExists && !executablePath.ToLower().EndsWith(".dll"))
+            if (!String.IsNullOrEmpty(executablePath) && fileExists && !executablePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
             {
-                if (executablePath.ToLower().EndsWith("openwith.exe"))
+                if (executablePath.EndsWith("openwith.exe", StringComparison.OrdinalIgnoreCase))
                 {
                     return null; // 'OpenWith.exe' is th windows 8 or higher default for unknown extensions. I don't want to have it as associted file
                 }

--- a/FRBDK/Glue/Glue/Parsing/CodeParser.cs
+++ b/FRBDK/Glue/Glue/Parsing/CodeParser.cs
@@ -4,6 +4,7 @@ using System.IO;
 using FlatRedBall.IO;
 using FlatRedBall.Glue.SaveClasses;
 using System.Collections;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using L = Localization;
 
@@ -27,26 +28,16 @@ namespace FlatRedBall.Glue.Parsing
 
             // Okay, this is really cheap, but I'm in a hurry.  We should fix this for sure.
             if (File.Exists(FileManager.RelativeDirectory + generatedFile) &&
-                FileManager.MakeRelative(FileManager.GetDirectory(fileName)).StartsWith("Entities/"))
+                FileManager.MakeRelative(FileManager.GetDirectory(fileName)).StartsWith("Entities/", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
 
             // If we got here, it still might be an Entity, it just doesn't have its generated code yet
 
-            string modifiedFileName = FileManager.RemoveExtension(fileName).ToLower();
+            string modifiedFileName = FileManager.RemoveExtension(fileName);
 
-            for (int i = 0; i < ProjectManager.GlueProjectSave.Entities.Count; i++)
-            {
-                EntitySave es = ProjectManager.GlueProjectSave.Entities[i];
-
-                if (es.Name.ToLower() == modifiedFileName)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return ProjectManager.GlueProjectSave.Entities.Any(es => String.Equals(es.Name, modifiedFileName, StringComparison.OrdinalIgnoreCase));
         }
 
         public static bool IsScreen(string fileName)
@@ -66,19 +57,9 @@ namespace FlatRedBall.Glue.Parsing
                 return true;
             }
 
-            string modifiedFileName = FileManager.RemoveExtension(fileName).ToLower();
+            string modifiedFileName = FileManager.RemoveExtension(fileName);
 
-            for (int i = 0; i < ProjectManager.GlueProjectSave.Screens.Count; i++)
-            {
-                ScreenSave ss = ProjectManager.GlueProjectSave.Screens[i];
-
-                if (ss.Name.ToLower() == modifiedFileName)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return ProjectManager.GlueProjectSave.Screens.Any(ss => String.Equals(ss.Name, modifiedFileName, StringComparison.OrdinalIgnoreCase));
         }
 
         public static bool InheritsFrom(string fileName, string baseClass)
@@ -163,7 +144,7 @@ namespace FlatRedBall.Glue.Parsing
                 }
                 else
                 {
-                    value = value.ToLower();
+                    value = value.ToLowerInvariant();
                 }
             }
             else if (objectToParse is float || typeof(T) == typeof(float?))

--- a/FRBDK/Glue/Glue/Parsing/ContentParser.cs
+++ b/FRBDK/Glue/Glue/Parsing/ContentParser.cs
@@ -584,57 +584,54 @@ namespace EditorObjects.Parsing
         }
 
 		private static List<string> GetTextureReferencesInX(string fileName)
-		{
-			List<string> referencedFiles = new List<string>();
-			string contents = FileManager.FromFileText(fileName);
+        {
+            List<string> referencedFiles = new List<string>();
+            string contents = FileManager.FromFileText(fileName);
 
-			int currentIndex = 0;
-			//bool useCamel = false;
-			const string TextureFileNameString = "TextureFilename {";
-			string fileDirectory = FileManager.GetDirectory(fileName);
+            int currentIndex = 0;
+            //bool useCamel = false;
+            const string textureFileNameString = "TextureFilename {";
+            string fileDirectory = FileManager.GetDirectory(fileName);
 
-			int nextTextureFilename = contents.IndexOf(TextureFileNameString, currentIndex, StringComparison.OrdinalIgnoreCase);
+            int nextTextureFilename = contents.IndexOf(textureFileNameString, currentIndex, StringComparison.OrdinalIgnoreCase);
 
-			if (nextTextureFilename == -1)
-			{
+            if (nextTextureFilename == -1)
+            {
 
-				return referencedFiles;
-			}
-			// The first "TextureFilename" is garbage - it's the template definition.  Let's do the next
-			bool isFirstATemplate = false;
-			if (contents.IndexOf("template TextureFilename", StringComparison.OrdinalIgnoreCase) == nextTextureFilename - "template ".Length)
-			{
-				isFirstATemplate = true;
-			}
-			if (isFirstATemplate)
-			{
-				currentIndex = nextTextureFilename + 1;
-				nextTextureFilename = contents.IndexOf(TextureFileNameString, currentIndex, StringComparison.OrdinalIgnoreCase);
-			}
+                return referencedFiles;
+            }
+            // The first "TextureFilename" is garbage - it's the template definition.  Let's do the next
+            bool isFirstATemplate = contents.IndexOf("template TextureFilename", StringComparison.OrdinalIgnoreCase) == nextTextureFilename - "template ".Length;
 
-			while (nextTextureFilename != -1)
-			{
-				// read the file
+            if (isFirstATemplate)
+            {
+                currentIndex = nextTextureFilename + 1;
+                nextTextureFilename = contents.IndexOf(textureFileNameString, currentIndex, StringComparison.OrdinalIgnoreCase);
+            }
 
-				string texture = StringFunctions.GetWordAfter(TextureFileNameString, contents, nextTextureFilename, StringComparison.OrdinalIgnoreCase);
-				texture = fileDirectory + texture.Replace("\"", "").Replace(";", "").Replace(".\\\\", "").Replace("}", "");
+            while (nextTextureFilename != -1)
+            {
+                // read the file
 
-				if (!referencedFiles.Contains(texture))
-				{
-					referencedFiles.Add(texture);
-				}
+                string texture = StringFunctions.GetWordAfter(textureFileNameString, contents, nextTextureFilename, StringComparison.OrdinalIgnoreCase);
+                texture = fileDirectory + texture.Replace("\"", "").Replace(";", "").Replace(".\\\\", "").Replace("}", "");
 
-				currentIndex = nextTextureFilename + 1;
+                if (!referencedFiles.Contains(texture))
+                {
+                    referencedFiles.Add(texture);
+                }
 
-				nextTextureFilename = contents.IndexOf(TextureFileNameString, currentIndex, StringComparison.OrdinalIgnoreCase);
+                currentIndex = nextTextureFilename + 1;
 
-			}
+                nextTextureFilename = contents.IndexOf(textureFileNameString, currentIndex, StringComparison.OrdinalIgnoreCase);
+
+            }
 
 
 			
 
-			return referencedFiles;
-		}
+            return referencedFiles;
+        }
 
         public static void EliminateDuplicateSourceReferencingFiles(List<SourceReferencingFile> sourceReferencingFileList)
         {

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/UnreferencedFiles/UnreferencedFilesManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/UnreferencedFiles/UnreferencedFilesManager.cs
@@ -148,7 +148,7 @@ namespace FlatRedBall.Glue.Managers
                         // Added this here to make it easier to debug. This isn't necessary for function, as
                         // internally it does a IsContent check
                         var contentItems = ((VisualStudioProject)project.ContentProject).EvaluatedItems
-                            .Where(item => ProjectManager.IsContent(item.UnevaluatedInclude.ToLower().Replace(@"\", @"/")))
+                            .Where(item => GlueCommands.Self.FileCommands.IsContent(item.UnevaluatedInclude.Replace(@"\", @"/")))
                             .ToList();
 
                         foreach (var evaluatedItem in contentItems)
@@ -189,25 +189,20 @@ namespace FlatRedBall.Glue.Managers
         {
             bool isUnreferenced = false;
 
-            var link = item.GetLink();
-
-            string itemName;
-
-            itemName =  item.UnevaluatedInclude.ToLower().Replace(@"\", @"/");
+            string itemName =  item.UnevaluatedInclude.Replace(@"\", @"/");
             nameToInclude = item.UnevaluatedInclude;
 
             // no extensions are unsupported.  What do we do with the content pipeline?
-            if (!string.IsNullOrEmpty(FileManager.GetExtension(itemName)) && ProjectManager.IsContent(itemName) &&
+            if (!String.IsNullOrEmpty(FileManager.GetExtension(itemName)) && GlueCommands.Self.FileCommands.IsContent(itemName) &&
                 // If the project includes a reference to something like System.XML, then that reference
                 // will have an UnevaluatedInclude of "System.XML" which will be treated as an XML file.
                 // Therefore, ignore items with a Reference item type:
-                item.ItemType != "Reference")
+                !String.Equals(item.ItemType, "Reference", StringComparison.OrdinalIgnoreCase))
             {
                 FilePath filePath =
                     FileManager.RemoveDotDotSlash(FileManager.GetDirectory(project.ContentProject.FullFileName.FullPath) + nameToInclude);
 
-                isUnreferenced = 
-                    !referencedFiles.Contains(itemName);
+                isUnreferenced = !referencedFiles.Contains(itemName);
 
             }
             return isUnreferenced;

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
@@ -402,17 +402,15 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
         {
             string extension = filePath.Extension;
 
-            if (extension == "")
+            if (String.IsNullOrWhiteSpace(extension))
             {
                 return false;
             }
 
-            foreach (var ati in AvailableAssetTypes.Self.AllAssetTypes)
+            if (AvailableAssetTypes.Self.AllAssetTypes
+                .Any(ati => String.Equals(ati.Extension, extension, StringComparison.OrdinalIgnoreCase)))
             {
-                if (ati.Extension == extension)
-                {
-                    return true;
-                }
+                return true;
             }
 
             if (AvailableAssetTypes.Self.AdditionalExtensionsToTreatAsAssets.Contains(extension))
@@ -427,8 +425,8 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
             }
 
 
-            if (extension == "csv" ||
-                extension == "xml")
+            if (String.Equals(extension, "csv", StringComparison.OrdinalIgnoreCase) ||
+                String.Equals(extension, "xml", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -522,7 +520,7 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
                         var relativeExe = "";
                         if (GumFileExtensions.Contains(textExtension.ToLower()))
                             relativeExe = GlueState.Self.GlueExeDirectory + "../../../../../../Gum/Gum/bin/Debug/Data/Gum.exe";
-                        if (textExtension == "achx")
+                        if (String.Equals(textExtension, "achx", StringComparison.OrdinalIgnoreCase))
                             relativeExe = GlueState.Self.GlueExeDirectory + "../../../../AnimationEditor/PreviewProject/bin/Debug/AnimationEditor.exe";
                         if ((relativeExe != "") && (System.IO.File.Exists(relativeExe)))
                         {

--- a/FRBDK/Glue/Glue/ProjectManager.cs
+++ b/FRBDK/Glue/Glue/ProjectManager.cs
@@ -330,12 +330,6 @@ namespace FlatRedBall.Glue
             }
 
         }
-
-        [Obsolete("Use GlueCommands.Self.FileCommands.IsContent")]
-        public static bool IsContent(string file)
-        {
-            return GlueCommands.Self.FileCommands.IsContent(file);
-        }
         
         public static bool CollectionContains(ICollection collection, string itemToSearchFor)
         {

--- a/FRBDK/Glue/Glue/SaveClasses/CustomVariableExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/CustomVariableExtensionMethods.cs
@@ -451,7 +451,7 @@ namespace FlatRedBall.Glue.SaveClasses
             // removed when code was generated for it.  We
             // don't want this to happen so we're going to always
             // treat strings as non-files...for now at least.
-            if (typeName != null && typeName.ToLower() == "string")
+            if (String.Equals(typeName, "string", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/FRBDK/Glue/Glue/SaveClasses/NameVerifier.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/NameVerifier.cs
@@ -641,10 +641,8 @@ namespace FlatRedBall.Glue.SaveClasses
 
         public static bool IsEventNameValid(string name, IElement currentElement, out string failureMessage)
         {
-            bool didFailureOccur = false;
-
             string whyItIsntValid = "";
-            didFailureOccur = NameVerifier.IsCustomVariableNameValid(name, null, currentElement, ref whyItIsntValid) == false;
+            var didFailureOccur = NameVerifier.IsCustomVariableNameValid(name, null, currentElement, ref whyItIsntValid) == false;
             failureMessage = null;
             if (didFailureOccur)
             {
@@ -663,7 +661,7 @@ namespace FlatRedBall.Glue.SaveClasses
         private static void CheckForFileNameWindowsReserved(string name, out string whyNotValid)
         {
             whyNotValid = null;
-            if (InvalidWindowsFileNames.Contains(name?.ToLower()))
+            if (InvalidWindowsFileNames.Any(n => n.Equals(name, StringComparison.OrdinalIgnoreCase)))
             {
                 whyNotValid = String.Format(L.Texts.NameXReservedByWindows, name);
             }

--- a/FRBDK/Glue/Glue/SaveClasses/ReferencedFileSave.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/ReferencedFileSave.cs
@@ -194,10 +194,10 @@ namespace FlatRedBall.Glue.SaveClasses
         /// </summary>
         public string Name
         {
-            get { return mName; }
+            get => mName;
             set
             {
-                if (!String.IsNullOrEmpty(value) && value.ToLower().Replace("\\", "/").StartsWith("content/"))
+                if (!String.IsNullOrEmpty(value) && value.Replace("\\", "/").StartsWith("content/", StringComparison.OrdinalIgnoreCase))
                     value = value.Substring("content/".Length);
 
                 mName = value;

--- a/FRBDK/Glue/Glue/SaveClasses/ReferencedFileSaveExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/ReferencedFileSaveExtensionMethods.cs
@@ -121,20 +121,14 @@ namespace FlatRedBall.Glue.SaveClasses
         public static bool IsFileSourceForThis(this ReferencedFileSave instance, string fileName)
         {
             if (!string.IsNullOrEmpty(instance.SourceFile) &&
-                 FileManager.RemoveDotDotSlash( ObjectFinder.Self.MakeAbsoluteContent(instance.SourceFile) ).ToLower() == fileName)
+                 FileManager.RemoveDotDotSlash( ObjectFinder.Self.MakeAbsoluteContent(instance.SourceFile)).Equals(fileName, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
 
             if(instance.SourceFileCache != null)
             {
-                foreach (SourceReferencingFile srf in instance.SourceFileCache)
-                {
-                    if (srf.SourceFile == fileName)
-                    {
-                        return true;
-                    }
-                }
+                return instance.SourceFileCache.Any(srf => String.Equals(srf.SourceFile, fileName, StringComparison.OrdinalIgnoreCase));
             }
 
             return false;

--- a/FRBDK/Glue/Glue/SetProperty/ReferencedFileSaveSetPropertyManager.cs
+++ b/FRBDK/Glue/Glue/SetProperty/ReferencedFileSaveSetPropertyManager.cs
@@ -449,15 +449,15 @@ namespace FlatRedBall.Glue.SetVariable
                 // for both in case there are any older projects.
                 string rfsType = rfs.RuntimeType;
                 string rfsTypeUnqualified = rfsType;
-                if (rfsType != null && rfsType.Contains("."))
+                if (rfsType != null && rfsType.Contains('.'))
                 {
                     rfsTypeUnqualified = FileManager.GetExtension(rfsType);
                 }
 
                 var matches =
                     customVariable.Value is string && (customVariable.Value as string) == oldNameUnqualified && 
-                        (customVariable.Type.ToLower() == rfsType.ToLower() ||
-                            customVariable.Type.ToLower() == rfsTypeUnqualified.ToLower());
+                        (string.Equals(customVariable.Type, rfsType, StringComparison.OrdinalIgnoreCase) ||
+                         string.Equals(customVariable.Type, rfsTypeUnqualified, StringComparison.OrdinalIgnoreCase));
                 if (matches)
                 {
                     customVariable.Value = newNameUnqualified;
@@ -536,12 +536,12 @@ namespace FlatRedBall.Glue.SetVariable
                 // The item could be null if this file is excluded from the project
                 if (item != null)
                 {
-                    if (newName.ToLower().Replace("/", "\\").StartsWith("content\\"))
+                    if (newName.Replace("/", "\\").StartsWith(@"content\", StringComparison.OrdinalIgnoreCase))
                     {
-                        newName = newName.Substring("content\\".Length);
+                        newName = newName.Substring(@"content\".Length);
                     }
 
-                    var newNameWithContentPrefix = "content\\" + newName.ToLower().Replace("/", "\\");
+                    var newNameWithContentPrefix = "content\\" + newName.ToLowerInvariant().Replace("/", "\\");
                     item.UnevaluatedInclude = newNameWithContentPrefix;
 
                     string nameWithoutExtensions = FileManager.RemovePath(FileManager.RemoveExtension(newName));

--- a/FRBDK/Glue/Glue/Settings/FileAssociationSettings.cs
+++ b/FRBDK/Glue/Glue/Settings/FileAssociationSettings.cs
@@ -217,13 +217,12 @@ namespace FlatRedBall.Glue.Settings
         {
             string containsName = null;
 
-            oldName = oldName.ToLower().Replace("\\", "/");
+            oldName = oldName.Replace("\\", "/");
 
             for (int i = 0; i < mAvailableApplications.Count; i++)
             {
-                if (mAvailableApplications[i].ToLower().Replace("\\", "/") == oldName)
+                if (String.Equals(mAvailableApplications[i].Replace("\\", "/"), oldName, StringComparison.OrdinalIgnoreCase))
                 {
-
                     containsName = mAvailableApplications[i];
                     break;
                 }

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/AndroidProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/AndroidProject.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Build.Evaluation;
+﻿using System;
+using Microsoft.Build.Evaluation;
 using System.Collections.Generic;
 
 namespace FlatRedBall.Glue.VSHelpers.Projects
@@ -56,28 +57,24 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             {
 
                 // Android is case-sensitive
-                returnValue = returnValue.ToLower();
+                returnValue = returnValue.ToLowerInvariant();
 
-                if (returnValue.StartsWith("assets/") || returnValue.StartsWith("assets\\"))
+                if (returnValue.StartsWith("assets/", StringComparison.OrdinalIgnoreCase) || returnValue.StartsWith(@"assets\", StringComparison.OrdinalIgnoreCase))
                 {
                     // Assets folder is capitalized in FRB Android projects:
-                    returnValue = "A" + returnValue.Substring(1);
+                    returnValue = "A" + returnValue[1..];
                 }
 
-                if(returnValue.Contains("/"))
+                if(returnValue.Contains("/", StringComparison.OrdinalIgnoreCase))
                 {
-                    returnValue = returnValue.Replace("/", "\\");
-
+                    returnValue = returnValue.Replace("/", @"\");
                 }
             }
 
             return returnValue;
         }
 
-        public override string ContentDirectory
-        {
-            get { return "Assets/content/"; }
-        }
+        public override string ContentDirectory => "Assets/content/";
 
         public override List<string> LibraryDlls
         {

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/DesktopGlLinuxProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/DesktopGlLinuxProject.cs
@@ -28,7 +28,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         {
             var returnValue = base.ProcessLink(path);
             // Linux is case-sensitive
-            return returnValue.ToLower();
+            return returnValue.ToLowerInvariant();
         }
     }
 }

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/DesktopGlProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/DesktopGlProject.cs
@@ -65,7 +65,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         {
             var returnValue = base.ProcessLink(path);
             // Linux is case-sensitive
-            return returnValue.ToLower();
+            return returnValue.ToLowerInvariant();
         }
     }
 }

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/IosMonogameProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/IosMonogameProject.cs
@@ -74,7 +74,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         {
             var returnValue = base.ProcessLink(path);
             // iOS is case-sensitive
-            return returnValue.ToLower();
+            return returnValue.ToLowerInvariant();
         }
         // Is this valid?
         public override string NeededVisualStudioVersion

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -268,7 +268,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 {
                     // The items in the dictionary must be to-lower on some
                     // platforms, and ProcessPath takes care of this.
-                    mBuildItemDictionaries.Add(itemInclude.ToLower(), buildItem);
+                    mBuildItemDictionaries.Add(itemInclude.ToLowerInvariant(), buildItem);
                 }
                 catch
                 {
@@ -565,7 +565,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             {
                 ProjectItem buildItem = mProject.AllEvaluatedItems.ElementAt(i);
 
-                string includeToLower = buildItem.EvaluatedInclude.ToLower();
+                string includeToLower = buildItem.EvaluatedInclude.ToLowerInvariant();
 
                 if (buildItem.IsImported)
                 {
@@ -579,12 +579,13 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 }
                 else if (mBuildItemDictionaries.ContainsKey(includeToLower))
                 {
-                    wasChanged = ResolveDuplicateProjectEntry(wasChanged, buildItem);
+                    ResolveDuplicateProjectEntry(buildItem);
+                    wasChanged = true;
                 }
                 else
                 {
                     mBuildItemDictionaries.Add(
-                        buildItem.UnevaluatedInclude.ToLower(),
+                        buildItem.UnevaluatedInclude.ToLowerInvariant(),
                         buildItem);
                 }
             }
@@ -621,7 +622,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             }
         }
 
-        private bool ResolveDuplicateProjectEntry(bool wasChanged, ProjectItem buildItem)
+        private void ResolveDuplicateProjectEntry(ProjectItem buildItem)
         {
             var mbmb = new MultiButtonMessageBoxWpf();
 
@@ -668,8 +669,6 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 mProject.RemoveItem(buildItem);
                 mProject.ReevaluateIfNecessary();
             }
-            wasChanged = true;
-            return wasChanged;
         }
 
         public ProjectItem GetItem(string itemName)
@@ -690,7 +689,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             }
             else
             {
-                itemName = itemName.Replace("/", "\\").ToLower();
+                itemName = itemName.Replace("/", "\\").ToLowerInvariant();
             }
             if (!mBuildItemDictionaries.ContainsKey(itemName))
             {
@@ -703,7 +702,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 foreach (var item in values)
                 {
                     // This may be a link
-                    var foundLink = (string)item.Metadata.FirstOrDefault(metadata => metadata.ItemType == "Link")?.EvaluatedValue;
+                    var foundLink = item.Metadata.FirstOrDefault(metadata => String.Equals(metadata.ItemType, "Link", StringComparison.OrdinalIgnoreCase))?.EvaluatedValue;
 
                     if (!string.IsNullOrEmpty(foundLink) && foundLink.Equals(itemName, System.StringComparison.InvariantCultureIgnoreCase))
                     {
@@ -942,7 +941,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                     fileName = FileManager.MakeRelative(fileName, this.Directory);
                 }
 
-                string fileNameToLower = fileName.Replace('/', '\\').ToLower();
+                string fileNameToLower = fileName.Replace('/', '\\').ToLowerInvariant();
 
 
 
@@ -1059,7 +1058,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
         public bool RemoveItem(ProjectItem buildItem)
         {
-            string itemName = buildItem.EvaluatedInclude.Replace("/", "\\").ToLower();
+            string itemName = buildItem.EvaluatedInclude.Replace("/", "\\").ToLowerInvariant();
 
             return RemoveItem(itemName);
         }
@@ -1084,11 +1083,11 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
             ProjectItem itemToRemove = null;
 
-            itemName = itemName.Replace("/", "\\").ToLower();
+            itemName = itemName.Replace("/", "\\").ToLowerInvariant();
             bool removed = false;
-            if (mBuildItemDictionaries.ContainsKey(itemName))
+            if (mBuildItemDictionaries.TryGetValue(itemName, out var buildItem))
             {
-                itemToRemove = mBuildItemDictionaries[itemName];
+                itemToRemove = buildItem;
                 removed = true;
             }
 
@@ -1098,11 +1097,11 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
         public void RenameInDictionary(string oldName, string newName, ProjectItem item)
         {
-            mBuildItemDictionaries.Remove(oldName.Replace("/", "\\").ToLower());
+            mBuildItemDictionaries.Remove(oldName.Replace("/", "\\").ToLowerInvariant());
 
-            if (!mBuildItemDictionaries.ContainsKey(newName.Replace("/", "\\").ToLower()))
+            if (!mBuildItemDictionaries.ContainsKey(newName.Replace("/", "\\").ToLowerInvariant()))
             {
-                mBuildItemDictionaries.Add(newName.Replace("/", "\\").ToLower(), item);
+                mBuildItemDictionaries.Add(newName.Replace("/", "\\").ToLowerInvariant(), item);
             }
         }
 

--- a/FRBDK/Glue/Glue/VSHelpers/VSSolution.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/VSSolution.cs
@@ -142,7 +142,7 @@ namespace FlatRedBall.Glue.VSHelpers
                 //Add ones that don't already exist
                 foreach (var solutionConfiguration in solutionConfigurations)
                 {
-                    if (existingSolutionConfigurations.All(item => item.ToLower().Trim() != solutionConfiguration.ToLower().Trim()))
+                    if (existingSolutionConfigurations.All(item => !String.Equals(item.Trim(),solutionConfiguration.Trim(), StringComparison.OrdinalIgnoreCase)))
                     {
                         allLines.Insert(addLineHere.Value + 1, GetSolutionConfigurationText(solutionConfiguration));
                     }

--- a/FRBDK/Glue/GlueCommon/SaveClasses/NamedObjectSave.cs
+++ b/FRBDK/Glue/GlueCommon/SaveClasses/NamedObjectSave.cs
@@ -165,7 +165,7 @@ namespace FlatRedBall.Glue.SaveClasses
             get => mSourceFile;
             set
             {
-                if (!String.IsNullOrEmpty(value) && value.ToLower().Replace("\\", "/").StartsWith("content/"))
+                if (!String.IsNullOrEmpty(value) && value.Replace("\\", "/").StartsWith("content/", StringComparison.OrdinalIgnoreCase))
                     value = value.Substring(8);
 
                 mSourceFile = value;

--- a/FRBDK/Glue/GlueCommon/VSHelper/Projects/ProjectBase.cs
+++ b/FRBDK/Glue/GlueCommon/VSHelper/Projects/ProjectBase.cs
@@ -177,10 +177,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         {
             if (FileManager.IsRelative(relativePath))
             {
-                string lowerCase = relativePath.ToLower();
-
-                if (this.IsContentProject &&
-                    (lowerCase.StartsWith("content/") || lowerCase.StartsWith(@"content\")))
+                if (this.IsContentProject && (relativePath.StartsWith("content/", StringComparison.OrdinalIgnoreCase) || relativePath.StartsWith(@"content\", StringComparison.OrdinalIgnoreCase)))
                 {
                     relativePath = relativePath.Substring("content/".Length, relativePath.Length - "content/".Length);
                 }
@@ -191,8 +188,8 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 // Let's assume that if it has an extension it is not a directory
                 var extension = FileManager.GetExtension(returnValue);
                 if(string.IsNullOrEmpty(extension) && 
-                    !returnValue.EndsWith("/") &&
-                    !returnValue.EndsWith("\\"))
+                    !returnValue.EndsWith("/", StringComparison.OrdinalIgnoreCase) &&
+                    !returnValue.EndsWith("\\", StringComparison.OrdinalIgnoreCase))
                 {
                     if (// do the slow call last to early out
                         System.IO.Directory.Exists(returnValue)
@@ -233,7 +230,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
         public string StandardizeItemName(string itemName)
         {
-            itemName = itemName.ToLower().Replace("/", "\\");
+            itemName = itemName.Replace("/", "\\");
 
             if (!FileManager.IsRelative(itemName))
             {
@@ -241,7 +238,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 itemName = itemName.Replace("/", "\\");
             }
 
-            if (this.IsContentProject && itemName.StartsWith("content\\"))
+            if (this.IsContentProject && itemName.StartsWith("content\\", StringComparison.OrdinalIgnoreCase))
             {
                 itemName = itemName.Substring("content\\".Length);
             }
@@ -255,7 +252,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
             string fullName = FullFileName.GetDirectoryContainingThis().FullPath + relativeFileName;
 
-            if (FileManager.Standardize(fullName).ToLower() != FileManager.Standardize(sourceFileName).ToLower())
+            if (!String.Equals(FileManager.Standardize(fullName), FileManager.Standardize(sourceFileName), StringComparison.OrdinalIgnoreCase))
             {
                 try
                 {
@@ -276,10 +273,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
         }
 
-        protected virtual string ContentProjectDirectory
-        {
-            get { return Directory; }
-        }
+        protected virtual string ContentProjectDirectory => Directory;
 
 
         public virtual void LoadContentProject()

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
@@ -485,13 +485,13 @@ namespace GumPlugin.CodeGeneration
             if(state?.GetVariableSave("HasEvents") != null)
             {
                 bool hasEvents = state.GetValueOrDefault<bool>("HasEvents");
-                constructor.Line($"this.HasEvents = {hasEvents.ToString().ToLower()};");
+                constructor.Line($"this.HasEvents = {hasEvents.ToString().ToLowerInvariant()};");
             }
 
             if (state?.GetVariableSave("ExposeChildrenEvents") != null)
             {
                 bool exposeChildrenEvents = state.GetValueOrDefault<bool>("ExposeChildrenEvents");
-                constructor.Line($"this.ExposeChildrenEvents = {exposeChildrenEvents.ToString().ToLower()};");
+                constructor.Line($"this.ExposeChildrenEvents = {exposeChildrenEvents.ToString().ToLowerInvariant()};");
             }
 
             var ifStatement = constructor.If("fullInstantiation");
@@ -1016,7 +1016,7 @@ namespace GumPlugin.CodeGeneration
             }
             else if (variableSave.Type == "bool")
             {
-                variableValue = variableValue.ToLower();
+                variableValue = variableValue.ToLowerInvariant();
             }
 
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Managers/FileReferenceTracker.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Managers/FileReferenceTracker.cs
@@ -789,10 +789,10 @@ namespace GumPlugin.Managers
 
             bool IsFormsOrGumRuntime(ProjectItem projectItem)
             {
-                return projectItem.UnevaluatedInclude?.ToLower().EndsWith("runtime.generated.cs") == true ||
-                    projectItem.UnevaluatedInclude?.ToLower().EndsWith("runtime.cs") == true ||
-                    projectItem.UnevaluatedInclude?.ToLower().EndsWith("forms.generated.cs") == true ||
-                    projectItem.UnevaluatedInclude?.ToLower().EndsWith("forms.cs") == true;
+                return  projectItem.UnevaluatedInclude?.EndsWith("runtime.generated.cs", StringComparison.OrdinalIgnoreCase) ?? 
+                        projectItem.UnevaluatedInclude?.EndsWith("runtime.cs", StringComparison.OrdinalIgnoreCase) ??
+                        projectItem.UnevaluatedInclude?.EndsWith("forms.generated.cs", StringComparison.OrdinalIgnoreCase) ?? 
+                        projectItem.UnevaluatedInclude?.EndsWith("forms.cs", StringComparison.OrdinalIgnoreCase) ?? false;
             }
 
             var codeItemsMadeForGumObjects = project.EvaluatedItems.Where(IsFormsOrGumRuntime).ToArray();

--- a/FRBDK/Glue/NAudioPlugin/Managers/AssetTypeInfoManager.cs
+++ b/FRBDK/Glue/NAudioPlugin/Managers/AssetTypeInfoManager.cs
@@ -122,7 +122,7 @@ namespace NAudioPlugin.Managers
         {
             var instanceName = file.GetInstanceName();
 
-            var relativeFileName = file.Name.ToLower();
+            var relativeFileName = file.Name.ToLowerInvariant();
 
             var path = $"Content/{relativeFileName}";
 

--- a/FRBDK/Glue/NpcWpfLib/Managers/CommandLineManager.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/CommandLineManager.cs
@@ -35,19 +35,19 @@ namespace Npc.Managers
         {
             foreach (string arg in Environment.GetCommandLineArgs())
             {
-                if (arg.StartsWith("directory="))
+                if (arg.StartsWith("directory=", StringComparison.OrdinalIgnoreCase))
                 {
                     HandleDirectoryEquals(arg);
                 }
-                else if (arg.StartsWith("namespace="))
+                else if (arg.StartsWith("namespace=", StringComparison.OrdinalIgnoreCase))
                 {
                     HandleNamespaceEquals(arg);
                 }
-                else if (arg.ToLower().StartsWith("openedby="))
+                else if (arg.StartsWith("openedby=", StringComparison.OrdinalIgnoreCase))
                 {
                     HandleOpenedBy(arg);
                 }
-                else if(arg.ToLower() == "emptyprojects")
+                else if(String.Equals(arg, "emptyprojects", StringComparison.OrdinalIgnoreCase))
                 {
                     EmptyProjectsOnly = true;
                 }
@@ -61,7 +61,7 @@ namespace Npc.Managers
 
             string directory = arg.Substring(lengthOfDirectory, arg.Length - lengthOfDirectory);
 
-            if (directory.StartsWith("\"") && directory.EndsWith("\""))
+            if (directory.StartsWith("\"", StringComparison.OrdinalIgnoreCase) && directory.EndsWith("\"", StringComparison.OrdinalIgnoreCase))
             {
                 directory = directory.Substring(1, directory.Length - 2);
             }

--- a/FRBDK/Glue/NpcWpfLib/Managers/GuidLogic.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/GuidLogic.cs
@@ -81,11 +81,11 @@ namespace Npc.Managers
 
         private static void ReplaceAssemblyInfoGuids(string unpackDirectory, string newGuid)
         {
-            List<string> stringList = FileManager.GetAllFilesInDirectory(unpackDirectory, "cs");
+            var stringList = FileManager.GetAllFilesInDirectory(unpackDirectory, "cs");
 
             foreach (string s in stringList)
             {
-                if (s.ToLower().Contains("assemblyinfo.cs"))
+                if (s.Contains("assemblyinfo.cs", StringComparison.OrdinalIgnoreCase))
                 {
                     string contents = FileManager.FromFileText(s);
 

--- a/FRBDK/Glue/NpcWpfLib/Managers/ProjectCreationHelper.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/ProjectCreationHelper.cs
@@ -80,7 +80,7 @@ namespace Npc
 
             var generalResponse = GeneralResponse.SuccessfulResponse;
             
-            if (CommandLineManager.Self.OpenedBy != null && CommandLineManager.Self.OpenedBy.ToLower() == "glue")
+            if (CommandLineManager.Self.OpenedBy != null && CommandLineManager.Self.OpenedBy.Equals("glue", StringComparison.OrdinalIgnoreCase))
             {
                 var ppi = viewModel.SelectedProject;
 

--- a/FRBDK/Glue/OfficialPlugins/FRBDKUpdater/FrbdkUpdaterSettings.cs
+++ b/FRBDK/Glue/OfficialPlugins/FRBDKUpdater/FrbdkUpdaterSettings.cs
@@ -106,25 +106,17 @@ namespace OfficialPlugins.FrbdkUpdater
             int i = fileName.LastIndexOf('.');
             if (i != -1)
             {
-                bool hasDotSlash = false;
-                if (i < fileName.Length + 1 && (fileName[i + 1] == '/' || fileName[i + 1] == '\\'))
-                {
-                    hasDotSlash = true;
-                }
+                bool hasDotSlash = i < fileName.Length + 1 && (fileName[i + 1] == '/' || fileName[i + 1] == '\\');
 
                 if (hasDotSlash)
                 {
                     return "";
                 }
-                else
-                {
-                    return fileName.Substring(i + 1, fileName.Length - (i + 1)).ToLower();
-                }
+
+                return fileName.Substring(i + 1, fileName.Length - (i + 1)).ToLower();
             }
-            else
-            {
-                return ""; // This returns "" because calling the method with a string like "redball" should return no extension
-            }
+
+            return ""; // This returns "" because calling the method with a string like "redball" should return no extension
         }
 
         #region XML Docs

--- a/FRBDK/Glue/OfficialPlugins/GlobalContentManagerPlugin/PluginForm.cs
+++ b/FRBDK/Glue/OfficialPlugins/GlobalContentManagerPlugin/PluginForm.cs
@@ -94,15 +94,8 @@ namespace PluginTestbed.GlobalContentManagerPlugins
                     {
                         foreach (ReferencedFileSave rfs in element.ReferencedFiles)
                         {
-                            bool alreadyExists = false;
-                            foreach (ReferencedFileSave existingRfs in ProjectManager.GlueProjectSave.GlobalFiles)
-                            {
-                                if (existingRfs.Name.ToLower() == rfs.Name.ToLower())
-                                {
-                                    alreadyExists = true;
-                                    break;
-                                }
-                            }
+                            bool alreadyExists = ProjectManager.GlueProjectSave.GlobalFiles
+                                .Any(existingRfs => String.Equals(existingRfs.Name, rfs.Name, StringComparison.OrdinalIgnoreCase));
 
                             if (!alreadyExists)
                             {
@@ -113,13 +106,13 @@ namespace PluginTestbed.GlobalContentManagerPlugins
                     }
                     else
                     {
-                        foreach (ReferencedFileSave rfs in element.ReferencedFiles)
+                        foreach (var rfs in element.ReferencedFiles)
                         {
-                            for (int i = 0; i < ProjectManager.GlueProjectSave.GlobalFiles.Count; i++)
+                            for (var i = 0; i < ProjectManager.GlueProjectSave.GlobalFiles.Count; i++)
                             {
-                                ReferencedFileSave existingRfs = ProjectManager.GlueProjectSave.GlobalFiles[i];
+                                var existingRfs = ProjectManager.GlueProjectSave.GlobalFiles[i];
 
-                                if (existingRfs.Name.ToLower() == rfs.Name.ToLower())
+                                if (String.Equals(existingRfs.Name, rfs.Name, StringComparison.OrdinalIgnoreCase))
                                 {
                                     ProjectManager.GlueProjectSave.GlobalFiles.RemoveAt(i);
                                     break;
@@ -158,15 +151,8 @@ namespace PluginTestbed.GlobalContentManagerPlugins
 
             foreach (ReferencedFileSave rfs in element.ReferencedFiles)
             {
-                bool alreadyExists = false;
-                foreach (ReferencedFileSave existingRfs in ProjectManager.GlueProjectSave.GlobalFiles)
-                {
-                    if (existingRfs.Name.ToLower() == rfs.Name.ToLower())
-                    {
-                        alreadyExists = true;
-                        break;
-                    }
-                }
+                bool alreadyExists = ProjectManager.GlueProjectSave.GlobalFiles
+                    .Any(existingRfs => String.Equals(existingRfs.Name, rfs.Name, StringComparison.OrdinalIgnoreCase));
 
                 if (!alreadyExists)
                 {

--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/MainTreeViewViewModel.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/MainTreeViewViewModel.cs
@@ -560,11 +560,11 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
                 // Let's make the directories lower case
                 for (int i = 0; i < directories.Length; i++)
                 {
-                    directories[i] = FileManager.Standardize(directories[i]).ToLower();
+                    directories[i] = FileManager.Standardize(directories[i]);
 
-                    if (!directories[i].EndsWith("/") && !directories[i].EndsWith("\\"))
+                    if (!directories[i].EndsWith("/", StringComparison.OrdinalIgnoreCase) && !directories[i].EndsWith("\\", StringComparison.OrdinalIgnoreCase))
                     {
-                        directories[i] = directories[i] + "/";
+                        directories[i] += "/";
                     }
                 }
 
@@ -581,9 +581,9 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
 
                         string directory = GlueCommands.Self.GetAbsoluteFileName(treeNode.GetRelativeFilePath(), isGlobalContent);
 
-                        directory = FileManager.Standardize(directory.ToLower());
+                        directory = FileManager.Standardize(directory);
 
-                        if (!directories.Contains(directory))
+                        if (!directories.Contains(directory, StringComparer.OrdinalIgnoreCase))
                         {
                             parentTreeNode.Children.RemoveAt(i);
                         }
@@ -1090,7 +1090,7 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
             }
             else
             {
-                int indexOfSlash = containingDirection.IndexOf("/");
+                int indexOfSlash = containingDirection.IndexOf("/", StringComparison.OrdinalIgnoreCase);
 
                 string rootDirectory = containingDirection;
 
@@ -1103,7 +1103,7 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
                 {
                     var subNode = containingNode.Children[i];
 
-                    if (((ITreeNode)subNode).IsDirectoryNode() && subNode.Text.ToLower() == rootDirectory.ToLower())
+                    if (((ITreeNode)subNode).IsDirectoryNode() && String.Equals(subNode.Text, rootDirectory, StringComparison.OrdinalIgnoreCase))
                     {
                         // use the containingDirectory here
                         if (indexOfSlash == -1 || indexOfSlash == containingDirection.Length - 1)
@@ -1125,7 +1125,7 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
         {
             NodeViewModel containerTreeNode = nodeToStartAt;
 
-            if (rfs.Name.ToLower().StartsWith("globalcontent/") && nodeToStartAt == GlobalContentRootNode)
+            if (rfs.Name.StartsWith("globalcontent/", StringComparison.OrdinalIgnoreCase) && nodeToStartAt == GlobalContentRootNode)
             {
                 string directory = FileManager.GetDirectoryKeepRelative(rfs.Name);
 
@@ -1141,7 +1141,7 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
             }
 
 
-            if (rfs.Name.ToLower().StartsWith("content/globalcontent/") && nodeToStartAt == GlobalContentRootNode)
+            if (rfs.Name.StartsWith("content/globalcontent/", StringComparison.OrdinalIgnoreCase) && nodeToStartAt == GlobalContentRootNode)
             {
                 string directory = FileManager.GetDirectoryKeepRelative(rfs.Name);
 
@@ -1187,8 +1187,7 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
 
             // Let's see if this thing is really an Entity
 
-
-            string relativeToProject = FileManager.Standardize(containingDirectory.FullPath).ToLower();
+            string relativeToProject = FileManager.Standardize(containingDirectory.FullPath).ToLowerInvariant();
 
             if (FileManager.IsRelativeTo(relativeToProject, FileManager.RelativeDirectory))
             {
@@ -1199,8 +1198,8 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
                 relativeToProject = FileManager.MakeRelative(relativeToProject, ProjectManager.ContentProject.GetAbsoluteContentFolder());
             }
 
-            if (relativeToProject.StartsWith("content/globalcontent") || relativeToProject.StartsWith("globalcontent")
-                )
+            if (relativeToProject.StartsWith("content/globalcontent", StringComparison.OrdinalIgnoreCase) 
+                || relativeToProject.StartsWith("globalcontent", StringComparison.OrdinalIgnoreCase))
             {
                 isEntity = false;
             }

--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/NodeViewModel.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/NodeViewModel.cs
@@ -520,13 +520,13 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
                 else
                 {
                     // The RFS may be contained, but see if the file names match
-                    string rfsName = FileManager.Standardize(referencedFileSave.Name, null, false).ToLower();
-                    string treeNodeFile = FileManager.Standardize(treeNode.GetRelativeFilePath(), null, false).ToLower();
+                    string rfsName = FileManager.Standardize(referencedFileSave.Name, null, false);
+                    string treeNodeFile = FileManager.Standardize(treeNode.GetRelativeFilePath(), null, false);
 
                     // We first need to make sure that the file is part of GlobalContentFiles.
                     // If it is, then we may have tree node in the wrong folder, so let's get rid
                     // of it.  If it doesn't start with globalcontent/ then we shouldn't remove it here.
-                    if (rfsName.StartsWith("globalcontent/") && rfsName != treeNodeFile)
+                    if (rfsName.StartsWith("globalcontent/", StringComparison.OrdinalIgnoreCase) && !String.Equals(rfsName, treeNodeFile, StringComparison.OrdinalIgnoreCase))
                     {
                         treeNode.Parent.Remove(treeNode);
                     }

--- a/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/Controls/TiledToolbar.xaml.cs
+++ b/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/Controls/TiledToolbar.xaml.cs
@@ -307,9 +307,9 @@ namespace TiledPluginCore.Controls
 
             // Ensure to not return the default OpenWith.exe associated executable in Windows 8 or higher
             if (!string.IsNullOrEmpty(executablePath) && File.Exists(executablePath) &&
-                !executablePath.ToLower().EndsWith(".dll"))
+                !executablePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
             {
-                if (executablePath.ToLower().EndsWith("openwith.exe"))
+                if (executablePath.EndsWith("openwith.exe", StringComparison.OrdinalIgnoreCase))
                 {
                     return null; // 'OpenWith.exe' is th windows 8 or higher default for unknown extensions. I don't want to have it as associted file
                 }

--- a/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/Managers/TiledObjectTypeCreator.cs
+++ b/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/Managers/TiledObjectTypeCreator.cs
@@ -177,7 +177,7 @@ namespace TileGraphicsPlugin.Managers
         {
             if(type == "bool")
             {
-                return value?.ToLower();
+                return value?.ToLowerInvariant();
             }
             else
             {
@@ -187,7 +187,7 @@ namespace TileGraphicsPlugin.Managers
 
         private string GetTmxFriendlyType(string type)
         {
-            if(type == "double" || type == "decimal")
+            if(type is "double" or "decimal")
             {
                 return "float";
             }

--- a/FRBDK/Localization/Texts.Designer.cs
+++ b/FRBDK/Localization/Texts.Designer.cs
@@ -520,6 +520,15 @@ namespace Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Which builder would you like to use for this file?.
+        /// </summary>
+        public static string BuilderWhichForFile {
+            get {
+                return ResourceManager.GetString("BuilderWhichForFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Build Game.
         /// </summary>
         public static string BuildGame {
@@ -705,6 +714,15 @@ namespace Localization {
         public static string ClickToSetTile {
             get {
                 return ResourceManager.GetString("ClickToSetTile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        public static string CliExtraArguments {
+            get {
+                return ResourceManager.GetString("CliExtraArguments", resourceCulture);
             }
         }
         
@@ -1942,7 +1960,7 @@ namespace Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Could not create packaged file - likely because the file {0} contains files that are not relative..
         /// </summary>
         public static string ErrorCouldNotPackageFileRelative {
             get {
@@ -1956,6 +1974,15 @@ namespace Localization {
         public static string ErrorCouldntFindGameClass {
             get {
                 return ResourceManager.GetString("ErrorCouldntFindGameClass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to delete the target export directory: {0}.
+        /// </summary>
+        public static string ErrorDeleteDirectoryFailed {
+            get {
+                return ResourceManager.GetString("ErrorDeleteDirectoryFailed", resourceCulture);
             }
         }
         
@@ -2181,6 +2208,15 @@ namespace Localization {
         public static string Execute {
             get {
                 return ResourceManager.GetString("Execute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Can&apos;t export:.
+        /// </summary>
+        public static string ExportCant {
+            get {
+                return ResourceManager.GetString("ExportCant", resourceCulture);
             }
         }
         
@@ -2446,6 +2482,24 @@ namespace Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The file already exist {0}. Overwrite?.
+        /// </summary>
+        public static string FileXExistsOverwrite {
+            get {
+                return ResourceManager.GetString("FileXExistsOverwrite", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file {0} is not relative to the content folder for the element which is {1}.
+        /// </summary>
+        public static string FileXNotRelativeToContentFolder {
+            get {
+                return ResourceManager.GetString("FileXNotRelativeToContentFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fill Completely.
         /// </summary>
         public static string FillCompletely {
@@ -2595,6 +2649,15 @@ namespace Localization {
         public static string FolderRename {
             get {
                 return ResourceManager.GetString("FolderRename", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select folder to save exported file:.
+        /// </summary>
+        public static string FolderSelectExportedFile {
+            get {
+                return ResourceManager.GetString("FolderSelectExportedFile", resourceCulture);
             }
         }
         
@@ -2982,6 +3045,15 @@ namespace Localization {
         public static string GlueFileAssociation {
             get {
                 return ResourceManager.GetString("GlueFileAssociation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Glue Group.
+        /// </summary>
+        public static string GlueGroup {
+            get {
+                return ResourceManager.GetString("GlueGroup", resourceCulture);
             }
         }
         
@@ -6001,11 +6073,38 @@ namespace Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Export?.
+        /// </summary>
+        public static string QuestionExport {
+            get {
+                return ResourceManager.GetString("QuestionExport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This {0} contains files outside of its content folder. Glue will export this {0}, but all files will be referenced in the same content folder. This may break some file references. Do you want to export?.
+        /// </summary>
+        public static string QuestionFilesOutsideContent {
+            get {
+                return ResourceManager.GetString("QuestionFilesOutsideContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to fill all values in the {0} State from the default variable values?  All previous values will be lost.
         /// </summary>
         public static string QuestionFillValuesDefault {
             get {
                 return ResourceManager.GetString("QuestionFillValuesDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Overwrite?.
+        /// </summary>
+        public static string QuestionOverwrite {
+            get {
+                return ResourceManager.GetString("QuestionOverwrite", resourceCulture);
             }
         }
         

--- a/FRBDK/Localization/Texts.de.resx
+++ b/FRBDK/Localization/Texts.de.resx
@@ -2672,4 +2672,37 @@
 	<data name="ErrorCouldNotPackageFileRelative" xml:space="preserve">
 		<value>Die gepackte Datei konnte nicht erstellt werden – wahrscheinlich, weil die Datei {0} Dateien enthält, die nicht relativ sind.</value>
 	</data>
+	<data name="FileXNotRelativeToContentFolder" xml:space="preserve">
+		<value>Die Datei {0} ist nicht relativ zum Inhaltsordner für das Element {1}.</value>
+	</data>
+	<data name="ErrorDeleteDirectoryFailed" xml:space="preserve">
+		<value>Das Zielexportverzeichnis konnte nicht gelöscht werden: {0}</value>
+	</data>
+	<data name="GlueGroup" xml:space="preserve">
+		<value>Gluegruppe</value>
+	</data>
+	<data name="QuestionFilesOutsideContent" xml:space="preserve">
+		<value>Dieses {0} enthält Dateien außerhalb seines Inhaltsordners. Glue exportiert dieses {0}, aber alle Dateien werden im selben Inhaltsordner referenziert. Dadurch können einige Dateiverweise beschädigt werden. Möchten Sie exportieren?</value>
+	</data>
+	<data name="QuestionExport" xml:space="preserve">
+		<value>Export?</value>
+	</data>
+	<data name="FolderSelectExportedFile" xml:space="preserve">
+		<value>Wählen Sie den Ordner zum Speichern der exportierten Datei aus:</value>
+	</data>
+	<data name="QuestionOverwrite" xml:space="preserve">
+		<value>Überschreiben?</value>
+	</data>
+	<data name="FileXExistsOverwrite" xml:space="preserve">
+		<value>Die Datei existiert bereits {0}. Überschreiben?</value>
+	</data>
+	<data name="ExportCant" xml:space="preserve">
+		<value>Kann nicht exportiert werden:</value>
+	</data>
+	<data name="BuilderWhichForFile" xml:space="preserve">
+		<value>Welchen Builder möchten Sie für diese Datei verwenden?</value>
+	</data>
+	<data name="CliExtraArguments" xml:space="preserve">
+		<value>Geben Sie zusätzliche Befehlszeilenargumente ein:</value>
+	</data>
 </root>

--- a/FRBDK/Localization/Texts.fr.resx
+++ b/FRBDK/Localization/Texts.fr.resx
@@ -2672,4 +2672,37 @@
 	<data name="ErrorCouldNotPackageFileRelative" xml:space="preserve">
 		<value>Impossible de créer le fichier packagé, probablement parce que le fichier {0} contient des fichiers qui ne sont pas relatifs.</value>
 	</data>
+	<data name="FileXNotRelativeToContentFolder" xml:space="preserve">
+		<value>Le fichier {0} n'est pas relatif au dossier de contenu de l'élément qui est {1}</value>
+	</data>
+	<data name="ErrorDeleteDirectoryFailed" xml:space="preserve">
+		<value>Échec de la suppression du répertoire d'exportation cible : {0}</value>
+	</data>
+	<data name="GlueGroup" xml:space="preserve">
+		<value>Groupe de Glue</value>
+	</data>
+	<data name="QuestionFilesOutsideContent" xml:space="preserve">
+		<value>Ce {0} contient des fichiers en dehors de son dossier de contenu. Glue exportera ce {0}, mais tous les fichiers seront référencés dans le même dossier de contenu. Cela peut casser certaines références de fichiers. Vous souhaitez exporter ?</value>
+	</data>
+	<data name="QuestionExport" xml:space="preserve">
+		<value>Exporter?</value>
+	</data>
+	<data name="FolderSelectExportedFile" xml:space="preserve">
+		<value>Sélectionnez le dossier pour enregistrer le fichier exporté :</value>
+	</data>
+	<data name="QuestionOverwrite" xml:space="preserve">
+		<value>Écraser?</value>
+	</data>
+	<data name="FileXExistsOverwrite" xml:space="preserve">
+		<value>Le fichier existe déjà {0}. Écraser?</value>
+	</data>
+	<data name="ExportCant" xml:space="preserve">
+		<value>Impossible d'exporter :</value>
+	</data>
+	<data name="BuilderWhichForFile" xml:space="preserve">
+		<value>Quel constructeur souhaitez-vous utiliser pour ce fichier ?</value>
+	</data>
+	<data name="CliExtraArguments" xml:space="preserve">
+		<value>Entrez des arguments de ligne de commande supplémentaires :</value>
+	</data>
 </root>

--- a/FRBDK/Localization/Texts.nl.resx
+++ b/FRBDK/Localization/Texts.nl.resx
@@ -2675,4 +2675,37 @@
 	<data name="ErrorCouldNotPackageFileRelative" xml:space="preserve">
 		<value>Kon het verpakte bestand niet maken - waarschijnlijk omdat het bestand {0} bestanden bevat die niet relatief zijn.</value>
 	</data>
+	<data name="FileXNotRelativeToContentFolder" xml:space="preserve">
+		<value>Het bestand {0} is niet relatief ten opzichte van de inhoudsmap voor het element dat {1} is</value>
+	</data>
+	<data name="ErrorDeleteDirectoryFailed" xml:space="preserve">
+		<value>Kan de doelexportmap niet verwijderen: {0}</value>
+	</data>
+	<data name="GlueGroup" xml:space="preserve">
+		<value>Glue Groep</value>
+	</data>
+	<data name="QuestionFilesOutsideContent" xml:space="preserve">
+		<value>Deze {0} bevat bestanden buiten de inhoudsmap. Glue zal deze {0} exporteren, maar er zal naar alle bestanden verwezen worden in dezelfde inhoudsmap. Hierdoor kunnen sommige bestandsverwijzingen verbroken worden. Wilt u exporteren?</value>
+	</data>
+	<data name="QuestionExport" xml:space="preserve">
+		<value>Exporteren?</value>
+	</data>
+	<data name="FolderSelectExportedFile" xml:space="preserve">
+		<value>Selecteer de map om het geëxporteerde bestand op te slaan:</value>
+	</data>
+	<data name="QuestionOverwrite" xml:space="preserve">
+		<value>Overschrijven?</value>
+	</data>
+	<data name="FileXExistsOverwrite" xml:space="preserve">
+		<value>Het bestand bestaat al {0}. Overschrijven?</value>
+	</data>
+	<data name="ExportCant" xml:space="preserve">
+		<value>Kan niet exporteren:</value>
+	</data>
+	<data name="BuilderWhichForFile" xml:space="preserve">
+		<value>Welchen Builder möchten Sie für diese Datei verwenden?</value>
+	</data>
+	<data name="CliExtraArguments" xml:space="preserve">
+		<value>Voer extra opdrachtregelargumenten in:</value>
+	</data>
 </root>

--- a/FRBDK/Localization/Texts.resx
+++ b/FRBDK/Localization/Texts.resx
@@ -2675,4 +2675,37 @@
 	<data name="ErrorCouldNotPackageFileRelative" xml:space="preserve">
 		<value>Could not create packaged file - likely because the file {0} contains files that are not relative.</value>
 	</data>
+	<data name="FileXNotRelativeToContentFolder" xml:space="preserve">
+		<value>The file {0} is not relative to the content folder for the element which is {1}</value>
+	</data>
+	<data name="ErrorDeleteDirectoryFailed" xml:space="preserve">
+		<value>Failed to delete the target export directory: {0}</value>
+	</data>
+	<data name="GlueGroup" xml:space="preserve">
+		<value>Glue Group</value>
+	</data>
+	<data name="QuestionFilesOutsideContent" xml:space="preserve">
+		<value>This {0} contains files outside of its content folder. Glue will export this {0}, but all files will be referenced in the same content folder. This may break some file references. Do you want to export?</value>
+	</data>
+	<data name="QuestionExport" xml:space="preserve">
+		<value>Export?</value>
+	</data>
+	<data name="FolderSelectExportedFile" xml:space="preserve">
+		<value>Select folder to save exported file:</value>
+	</data>
+	<data name="QuestionOverwrite" xml:space="preserve">
+		<value>Overwrite?</value>
+	</data>
+	<data name="FileXExistsOverwrite" xml:space="preserve">
+		<value>The file already exist {0}. Overwrite?</value>
+	</data>
+	<data name="ExportCant" xml:space="preserve">
+		<value>Can't export:</value>
+	</data>
+	<data name="BuilderWhichForFile" xml:space="preserve">
+		<value>Which builder would you like to use for this file?</value>
+	</data>
+	<data name="CliExtraArguments" xml:space="preserve">
+		<value>Enter extra command line arguments:</value>
+	</data>
 </root>

--- a/Tiled/TMXGlueLib/TiledMapSave.Conversion.cs
+++ b/Tiled/TMXGlueLib/TiledMapSave.Conversion.cs
@@ -1114,7 +1114,7 @@ namespace TMXGlueLib
 
         private static bool IsName(string key)
         {
-            return property.GetStrippedName(key).ToLower() == "name";
+            return String.Equals(property.GetStrippedName(key), "name", StringComparison.OrdinalIgnoreCase);
         }
 
         public void CalculateWorldCoordinates(int layerIndex, int tileIndex, int tileWidth, int tileHeight, int layerWidth, out float x, out float y, out float z)


### PR DESCRIPTION
Stringcomparisons have many issues:

1) They're done without taking the user's culture into account, causing bugs (like auto-generated CS not working)
2) They allocate memory and take performance by creating new strings to compare rather than using _OrdinalIgnoreString_ methods
3) They often don't take into account if in a comparison A == B, A might be null. 

Fix intends to ensure all string comparisons are culture-insensistive and do not care about lowercase/uppercase. Exception: Android I/O.