### PR TITLE
Minor UI improvements

### DIFF
--- a/FRBDK/Glue/Glue/Controls/InitializationWindowWpf.xaml
+++ b/FRBDK/Glue/Glue/Controls/InitializationWindowWpf.xaml
@@ -6,8 +6,16 @@
              xmlns:localization="clr-namespace:Localization;assembly=Localization"
              mc:Ignorable="d" 
              Height="240" Width="550" WindowStartupLocation="CenterScreen">
-    <StackPanel Margin="12,0,12,12">
-        <TextBlock x:Name="TopLevelLabel" TextWrapping="Wrap" FontSize="22" Text="{x:Static localization:Texts.PleaseWait}" />
-        <TextBlock Margin="0,8,0,0" x:Name="SubLabel" TextWrapping="Wrap"></TextBlock>
-    </StackPanel>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="1*" />
+            <ColumnDefinition Width="5*" />
+        </Grid.ColumnDefinitions>
+        <Image Source="/Content/Icons/GlueIcon.png" VerticalAlignment="Top" />
+        <Rectangle Width="1" Fill="DarkGray" Margin="0,7" HorizontalAlignment="Left" Grid.Column="1" />
+        <StackPanel Margin="12,2,12,12" Grid.Column="1">
+            <TextBlock x:Name="TopLevelLabel" TextWrapping="Wrap" FontSize="22" Text="{x:Static localization:Texts.PleaseWait}" />
+            <TextBlock Margin="0,8,0,0" x:Name="SubLabel" TextWrapping="Wrap"></TextBlock>
+        </StackPanel>
+    </Grid>
 </Window>

--- a/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml
+++ b/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml
@@ -50,16 +50,16 @@
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
                 <ColumnDefinition Width="290"></ColumnDefinition>
             </Grid.ColumnDefinitions>
-            <TabControl x:Name="LeftTabControl" Padding="0"></TabControl>
+            <TabControl x:Name="LeftTabControl" Padding="0" Margin="4,2,2,2"></TabControl>
             <GridSplitter Width="4" HorizontalAlignment="Center" VerticalAlignment="Stretch" Grid.Column="1"></GridSplitter>
-            <TabControl x:Name="CenterTabControl" Grid.Column="2" Padding="0"></TabControl>
+            <TabControl x:Name="CenterTabControl" Grid.Column="2" Padding="0" Margin="2"></TabControl>
             <GridSplitter Width="4" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Stretch"></GridSplitter>
-            <TabControl x:Name="RightTabControl" Grid.Column="4" Padding="0"></TabControl>
+            <TabControl x:Name="RightTabControl" Grid.Column="4" Padding="0" Margin="2,2,4,2"></TabControl>
         </Grid>
 
         <GridSplitter Height="4" HorizontalAlignment="Stretch" VerticalAlignment="Center" Grid.Row="4"></GridSplitter>
 
-        <TabControl Grid.Row="5" x:Name="BottomTabControl" Padding="0"></TabControl>
+        <TabControl Grid.Row="5" x:Name="BottomTabControl" Padding="0" Margin="2"></TabControl>
         
     </Grid>
 </UserControl>

--- a/FRBDK/Glue/Glue/Program.cs
+++ b/FRBDK/Glue/Glue/Program.cs
@@ -27,8 +27,7 @@ namespace Glue
             // Add proper exception handling so we can handle plugin exceptions:
             CreateExceptionHandlingEvents();
 
-			Application.EnableVisualStyles();
-			Application.SetCompatibleTextRenderingDefault(false);
+            ApplicationConfiguration.Initialize();
             //bool succeededToObtainMutex;
 
             // Only open one instance of Glue


### PR DESCRIPTION
- Updated the XAML for the main editor to add a bit of spacing around the inside so objects aren't lined up against the window edge
- Property grid items have a little bit of padding at the bottom. This prevents the items from running too close together and adds visual spacing
- Loading screen has the icon, so it doesn't look like an arctic blizzard and has some substance 😁 
- WinForms startup uses the new .NET 6 init method. This method is generated on compile and contains options that are set in the config. By default it does the exact same things that the replaced code did. Visual Studio 2022 reads this generated method to configure the WinForms designer.