### PR TITLE
Add style for radiobutton alignment

### DIFF
--- a/FRBDK/Glue/EntityInputMovementPlugin/Views/MainView.xaml
+++ b/FRBDK/Glue/EntityInputMovementPlugin/Views/MainView.xaml
@@ -9,6 +9,11 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
+        <Grid.Resources>
+            <Style TargetType="{x:Type RadioButton}">
+                <Setter Property="VerticalContentAlignment" Value="Center" />
+            </Style>
+        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition></RowDefinition>


### PR DESCRIPTION
- Adds a default style to the grid which styles all radiobutton's inside of it to center the content (which helps align the button itself)