### PR TITLE
 Improve foreach performance

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Math/AttachableList.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Math/AttachableList.cs
@@ -723,6 +723,10 @@ namespace FlatRedBall.Math
             return mName + ": " + this.Count;
         }
 
+        public List<T>.Enumerator GetEnumerator()
+        {
+            return mInternalList.GetEnumerator();
+        }
 
         #endregion
 
@@ -775,13 +779,9 @@ namespace FlatRedBall.Math
 
         #region IEnumerable<T> Members
 
-        public IEnumerator<T> GetEnumerator()
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
         {
-            for (int i = 0; i < mInternalList.Count; i++)
-            {
-                yield return mInternalList[i];
-            }
-            //return mInternalList.GetEnumerator();
+            return mInternalList.GetEnumerator();
         }
 
         #endregion


### PR DESCRIPTION
Since `AttachableList` only exposed a `GetEnumerator()` method that returns `IEnumerator<T>`, this caused boxing of the enumerator, creating garbage and GC pauses during loop iteration.

This PR adds a `GetEnumerator()` method that returns a concrete enumerator type.  Since `List<T>`'s enumerator is a `struct`, this means a `foreach` loop no longer generates garbage, and is about 6x  faster.