### PR TITLE
Bump AsepriteDotNet dependency version to 1.8.1

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall.FNA/FlatRedBall.FNA.csproj
+++ b/Engines/FlatRedBallXNA/FlatRedBall.FNA/FlatRedBall.FNA.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AsepriteDotNet" Version="1.7.4" />
+      <PackageReference Include="AsepriteDotNet" Version="1.8.1" />
     </ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\3rd Party Libraries\FNA\FNA.Core.csproj">

--- a/Engines/FlatRedBallXNA/FlatRedBallAndroid/FlatRedBallAndroid.csproj
+++ b/Engines/FlatRedBallXNA/FlatRedBallAndroid/FlatRedBallAndroid.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsepriteDotNet" Version="1.7.4" />
+    <PackageReference Include="AsepriteDotNet" Version="1.8.1" />
     <PackageReference Include="MonoGame.Framework.Android" Version="3.8.1.303" />
   </ItemGroup>
 

--- a/Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj
+++ b/Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj
@@ -16,7 +16,7 @@
   <Import Project="..\FlatRedBall\FlatRedBallShared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="AsepriteDotNet" Version="1.7.4" />
+    <PackageReference Include="AsepriteDotNet" Version="1.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/Engines/FlatRedBallXNA/FlatRedBalliOS/FlatRedBalliOS.csproj
+++ b/Engines/FlatRedBallXNA/FlatRedBalliOS/FlatRedBalliOS.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsepriteDotNet" Version="1.7.4" />
+    <PackageReference Include="AsepriteDotNet" Version="1.8.1" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="3.8.1.303" />
   </ItemGroup>
 

--- a/FRBDK/Glue/Glue/GlueFormsCore.csproj
+++ b/FRBDK/Glue/Glue/GlueFormsCore.csproj
@@ -164,7 +164,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AsepriteDotNet" Version="1.7.4" />
+		<PackageReference Include="AsepriteDotNet" Version="1.8.1" />
 		<PackageReference Include="CompareNETObjects" Version="4.72.0" />
 		<PackageReference Include="DotNetZip" Version="1.16.0" />
 		<PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.0" />

--- a/FRBDK/Glue/OfficialPlugins/OfficialPluginsCore.csproj
+++ b/FRBDK/Glue/OfficialPlugins/OfficialPluginsCore.csproj
@@ -108,7 +108,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="AsepriteDotNet" Version="1.7.4" />
+	  <PackageReference Include="AsepriteDotNet" Version="1.8.1" />
 	  <PackageReference Include="NAudio" Version="2.1.0" />
 	  <PackageReference Include="NAudio.Core" Version="2.1.0" />
 	  <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />


### PR DESCRIPTION
## Description
A critical bug was resolved in AsepriteDotNet concerning Aseprite files with linked cels.
- https://github.com/AristurtleDev/AsepriteDotNet/pull/31

This PR updates the version used by FlatRedBall to the latest 1.8.1