### PR TITLE
Fix: 1465 - A Tab Should Always Be Shown

### DIFF
--- a/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
+++ b/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
@@ -68,20 +68,11 @@ namespace GlueFormsCore.ViewModels
                 return;
             }
 
-            if (!TabsForTypes.TryGetValue(typeName, out PluginTab tab)) 
-            { 
-                List<PluginTab> ordered = Tabs
-                    .OrderBy(item => !item.IsPreferredDisplayerForType(typeName))
+            SelectedTab = TabsForTypes.TryGetValue(typeName, out PluginTab tab)
+                ? tab
+                : Tabs.OrderByDescending(item => !item.IsPreferredDisplayerForType(typeName))
                     .ThenByDescending(item => item.LastTimeClicked)
-                    .ToList();
-
-                if (ordered[0].LastTimeClicked != ordered[1].LastTimeClicked)
-                {
-                    tab = ordered[0];
-                }
-            }
-
-            SelectedTab = tab;
+                    .First();
         }
     }
 


### PR DESCRIPTION
Fixes: #1465 

[This commit](https://github.com/vchelaru/FlatRedBall/commit/9de62745238b9d66c0cdbe352da8cc356f982c44) had a [method](https://github.com/vchelaru/FlatRedBall/blob/9de62745238b9d66c0cdbe352da8cc356f982c44/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs#L60) refactor that was allowing `null` to slip by as a recent tab.