### PR TITLE
Adds method that brute forces random points in a concave polygon

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Math/Geometry/Polygon.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Math/Geometry/Polygon.cs
@@ -1804,11 +1804,58 @@ namespace FlatRedBall.Math.Geometry
 
         }
 
+        /// <summary>
+        /// Gets a random point inside of a polygon which can be convex or concave.
+        /// However, concave polygons use a brute force approach, which can be slow
+        /// and may not find a valid point within the provided number of tries.
+        /// 
+        /// Convex polygons will always return a valid Vector3 on the first try.
+        /// </summary>
+        /// <param name="numberOfTries">The number of tries to get a point in concave polygon</param>
+        /// <returns>A random position in the polygon if possible.</returns>
+        public Vector3? GetRandomPositionInThisSlow(int numberOfTries = 100)
+        {
+            Vector3? result = null;
+            for(var i = 0; i < numberOfTries; i++)
+            {
+                var point = GetRandomPositionInThisWithOverride(true);
+                if(IsPointInside(ref point))
+                {
+                    result = point;
+                    break;
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Gets a random point inside of this polygon. This does
+        /// not support random points in a concave polygon.
+        /// 
+        /// For concave polygons, consider using GetRandomPositionInThisSlow.
+        /// </summary>
+        /// <returns>A random position in this shape.</returns>
+        /// <exception cref="NotImplementedException">This method cannot get random points in a concave Polygon.</exception>
+        /// <exception cref="InvalidOperationException">Cannot get random points in a Polygon with fewer than three vertices</exception>
         public Vector3 GetRandomPositionInThis()
         {
-            if (IsConcave())
+            return GetRandomPositionInThisWithOverride(false);
+        }
+
+        /// <summary>
+        /// This private method does the heavy lifting for finding points but has an internal-use-only
+        /// argument to force explicit overriding for concave polygons
+        /// </summary>
+        /// <param name="overrideConcaveWarning">Whether to get a point that may not actually be inside 
+        /// the polygon if the polygon is concave.</param>
+        /// <returns>A point which may not be inside if the polygon is concave</returns>
+        /// <exception cref="NotImplementedException">An exception thrown for concave polygons if the warning isn't overridden.</exception>
+        /// <exception cref="InvalidOperationException">An exception thrown when the polygon has insufficient vertices.</exception>
+        private Vector3 GetRandomPositionInThisWithOverride(bool overrideConcaveWarning = false)
+        {
+            if (IsConcave() && overrideConcaveWarning == false)
             {
-                throw new NotImplementedException("Cannot get random points inside a concave Polygon.");
+                throw new NotImplementedException("Cannot get random points inside a concave Polygon. Consider using GetRandomPositionInThisSlow.");
             }
 
             if (mPoints.Length < 4)
@@ -1873,8 +1920,6 @@ namespace FlatRedBall.Math.Geometry
             relativePoint += this.Position;
 
             return relativePoint.ToVector3();
-
-
         }
 
 


### PR DESCRIPTION
Right now, FlatRedBall prevents you from using its logic for finding points in a concave polygon with an exception in a way that's impossible to override. The algorithm to find random points in a concave polygon is fairly complex and would take significant effort to implement and test. However, there is a way to just brute force this, which might be sufficient for many games.

This PR:

1. Moves the guts of the `GetRandomPositionInThis` into a private method called `GetRandomPositionInThisWithOverride` which:
    a. Preserves the original public API endpoint and throws an exception for concave polygons
    b. Adds an argument that allows you to override the concave check
    c. Adds method docs explaining and warning about usage of the override
2. Adds another method that returns a `Vector3?` called `GetRandomPositionInThisSlow` which:
    a. Takes a `numberOfTries` argument with a default
    b. Brute forces generating random points using the new private method and checking whether the point is actually inside
    c. Has clear method docs explaining the usage of the method

I think this is an acceptable compromise between completely disallowing the dev to get random points in a concave polygon with a simple-but-inefficient method that allows developers to make their own choices and still leverage the same point-finding algorithm that already existed.