### PR TITLE
fix: default panel for node types

### DIFF
--- a/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
+++ b/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
@@ -70,7 +70,7 @@ namespace GlueFormsCore.ViewModels
 
             SelectedTab = TabsForTypes.TryGetValue(typeName, out PluginTab tab)
                 ? tab
-                : Tabs.OrderByDescending(item => !item.IsPreferredDisplayerForType(typeName))
+                : Tabs.OrderByDescending(item => item.IsPreferredDisplayerForType(typeName))
                     .ThenByDescending(item => item.LastTimeClicked)
                     .First();
         }


### PR DESCRIPTION
removed incorrect not operator from sorting comparison used to determine which tab to show
fixes: #1481 