### PR TITLE
Make DataUI's combobox display theme friendly.

### DIFF
--- a/FRBDK/Glue/Glue/Themes/Frb.Styles.xaml
+++ b/FRBDK/Glue/Glue/Themes/Frb.Styles.xaml
@@ -7,7 +7,8 @@
                     xmlns:themes="clr-namespace:FlatRedBall.Glue.Themes"
                     xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
                     xmlns:system="clr-namespace:System;assembly=System.Runtime"
-                    xmlns:converters="clr-namespace:FlatRedBall.Glue.Themes.Converters">
+                    xmlns:converters="clr-namespace:FlatRedBall.Glue.Themes.Converters"
+                    xmlns:wpfDataUi="clr-namespace:WpfDataUi;assembly=WpfDataUiCore">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Themes/Frb.Brushes.xaml"/>
@@ -1337,6 +1338,14 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type wpfDataUi:DataUiGrid}">
+        <Style.Resources>
+            <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Type ComboBox}}">
+                <Setter Property="Background" Value="{DynamicResource Frb.Brushes.Field.Background}"/>
+            </Style>
+        </Style.Resources>
     </Style>
 
 </ResourceDictionary>

--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/Controls/FileReferenceComboBox.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/Controls/FileReferenceComboBox.cs
@@ -22,7 +22,7 @@ namespace OfficialPlugins.VariableDisplay.Controls
             var grid = base.Grid;
 
             var columnDefinition = new ColumnDefinition();
-            columnDefinition.Width = new System.Windows.GridLength(36);
+            columnDefinition.Width = GridLength.Auto;
 
             // January 18, 2022
             // We allow this to be


### PR DESCRIPTION
- Use "safe" background on combobox instead of transparent
- Unset foreground instead of set to explicit black
- Change width to Auto instead of hardcoded pixels on "View" button in `FileReferenceCombobox`