### PR TITLE
Fix: TreeViewListItem Selected Visual

### DIFF
--- a/FRBDK/Glue/Glue/Themes/Frb.Styles.xaml
+++ b/FRBDK/Glue/Glue/Themes/Frb.Styles.xaml
@@ -575,8 +575,7 @@
                         <Border.Style>
                             <Style TargetType="{x:Type Border}">
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
-
+                                    <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource TemplatedParent}}" Value="True">
                                         <Setter Property="BorderBrush" Value="{DynamicResource Frb.Brushes.Primary}"/>
                                     </DataTrigger>
                                 </Style.Triggers>

--- a/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/Views/AchxPreviewView.xaml
+++ b/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/Views/AchxPreviewView.xaml
@@ -41,21 +41,7 @@
                 SelectedItem="{Binding SelectedItem}"
                 MouseDoubleClick="TreeListBox_MouseDoubleClick"
                 PreviewKeyDown="TreeListBox_PreviewKeyDown"
-                >
-
-                            <pt:TreeListBox.ItemTemplate>
-
-                                <DataTemplate>
-                                    <Grid x:Name="ItemGrid">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Grid.Column="1" Text="{Binding Text}" />
-                                    </Grid>
-                                </DataTemplate>
-                            </pt:TreeListBox.ItemTemplate>
-
-                        </pt:TreeListBox>
+                />
                         <GridSplitter Height="5" VerticalAlignment="Center" HorizontalAlignment="Stretch" Grid.Row="1"/>
                         <ScrollViewer Grid.Row="2">
                             <wpfdataui:DataUiGrid x:Name="PropertyGrid"></wpfdataui:DataUiGrid>


### PR DESCRIPTION
- Selection Visual was incorrectly binding to the datacontext, rather than the templated parent.