### PR TITLE
Fix for project reference

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Content/Aseprite/AsepriteFile.Extensions.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Content/Aseprite/AsepriteFile.Extensions.cs
@@ -22,7 +22,7 @@ namespace FlatRedBall.Content.Aseprite
         {
 
             //  Generate the Aseprite Spritesheet
-            AseSpriteSheet spriteSheet = SpriteSheetProcessor.Process(file);
+            AseSpriteSheet spriteSheet = SpriteSheetProcessor.Process(file, null);
             AseTexture aseTexture = spriteSheet.TextureAtlas.Texture;
 
             //  Create the MonoGame Texture2D from the Aseprite Spritesheet
@@ -57,7 +57,7 @@ namespace FlatRedBall.Content.Aseprite
 
         public static AnimationChainListSave ToAnimationChainListSave(this AsepriteFile file)
         {
-            AseSpriteSheet spriteSheet = SpriteSheetProcessor.Process(file);
+            AseSpriteSheet spriteSheet = SpriteSheetProcessor.Process(file, null);
 
             AnimationChainListSave list = new AnimationChainListSave();
             AseTexture aseTexture = spriteSheet.TextureAtlas.Texture;

--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallDesktopGL.sln
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallDesktopGL.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatRedBallDesktopGL", "Fla
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FlatRedBallShared", "FlatRedBallShared.shproj", "{0BB8CBE3-8503-46C1-9272-D98E153A230E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatRedBallDesktopGLNet5", "..\FlatRedBallDesktopGLNet5\FlatRedBallDesktopGLNet5.csproj", "{99FAA612-03E6-4622-806C-7CFCE7F04FA0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatRedBallDesktopGLNet6", "..\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj", "{99FAA612-03E6-4622-806C-7CFCE7F04FA0}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution

--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallDesktopGL.sln
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallDesktopGL.sln
@@ -1,20 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31129.286
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatRedBallDesktopGL", "FlatRedBallDesktopGL.csproj", "{10BDA06C-7269-4CCE-AE2A-D445F414520A}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FlatRedBallShared", "FlatRedBallShared.shproj", "{0BB8CBE3-8503-46C1-9272-D98E153A230E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatRedBallDesktopGLNet6", "..\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj", "{99FAA612-03E6-4622-806C-7CFCE7F04FA0}"
-EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		FlatRedBallShared.projitems*{0bb8cbe3-8503-46c1-9272-d98e153a230e}*SharedItemsImports = 13
-		FlatRedBallShared.projitems*{10bda06c-7269-4cce-ae2a-d445f414520a}*SharedItemsImports = 4
-		FlatRedBallShared.projitems*{99faa612-03e6-4622-806c-7cfce7f04fa0}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -24,15 +17,15 @@ Global
 		{10BDA06C-7269-4CCE-AE2A-D445F414520A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{10BDA06C-7269-4CCE-AE2A-D445F414520A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{10BDA06C-7269-4CCE-AE2A-D445F414520A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{99FAA612-03E6-4622-806C-7CFCE7F04FA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{99FAA612-03E6-4622-806C-7CFCE7F04FA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{99FAA612-03E6-4622-806C-7CFCE7F04FA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{99FAA612-03E6-4622-806C-7CFCE7F04FA0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E1E2CC39-9F68-4F78-9A5D-0431FBC2B13A}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		FlatRedBallShared.projitems*{0bb8cbe3-8503-46c1-9272-d98e153a230e}*SharedItemsImports = 13
+		FlatRedBallShared.projitems*{10bda06c-7269-4cce-ae2a-d445f414520a}*SharedItemsImports = 4
 	EndGlobalSection
 EndGlobal

--- a/Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj
+++ b/Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj
@@ -14,7 +14,7 @@
 	<Import Project="..\FlatRedBall\FlatRedBallShared.projitems" Label="Shared" />
 
 	<ItemGroup>
-		<PackageReference Include="AsepriteDotNet" Version="1.8.1" />
+		<PackageReference Include="AsepriteDotNet" Version="1.9.0" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Solution used outdated project reference. Updated .NET 6 aseprite reference to new version.

Notes:
1. Monogame 3.8.2 released just now, it's got a ton of stability features and little bugfixes as you probably already know, seems nice to integrate it a.s.a.p
2. New Aseprite updates provide stability and more options for handling their API, but at the cost of current usages becoming deprecated
3. I'll make a few small PR's in the coming weeks (for fun) with little QoL updates in the codebase, to aid documentation/Github Copilot and other AI tools. (XML summaries help those tools make more educated guesses in their probability machines)