### PR TITLE
1487- Add persistence for right and bottom tabs

### DIFF
--- a/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
+++ b/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
@@ -305,9 +305,19 @@ namespace GlueFormsCore.Controls
 
         internal void ApplyGlueSettings(GlueSettingsSave glueSettingsSave)
         {
-            if(glueSettingsSave.LeftTabWidthPixels > 1)
+            if(glueSettingsSave.LeftTabWidthPixels is > 0)
             {
-                ViewModel.LeftPanelWidth = new GridLength(glueSettingsSave.LeftTabWidthPixels.Value);
+                ViewModel.LeftPanelWidth = new(glueSettingsSave.LeftTabWidthPixels.Value);
+            }
+
+            if (glueSettingsSave.RightTabWidthPixels is > 0)
+            {
+                ViewModel.RightPanelWidth = new(glueSettingsSave.RightTabWidthPixels.Value);
+            }
+
+            if (glueSettingsSave.BottomTabHeightPixels is > 0)
+            {
+                ViewModel.BottomPanelHeight = new(glueSettingsSave.BottomTabHeightPixels.Value);
             }
 
         }

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueCommands.cs
@@ -330,6 +330,25 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations
             {
                 save.LeftTabWidthPixels = null;
             }
+
+            if (MainPanelControl.ViewModel.RightPanelWidth.GridUnitType == System.Windows.GridUnitType.Pixel)
+            {
+                save.RightTabWidthPixels = MainPanelControl.ViewModel.RightPanelWidth.Value;
+            }
+            else
+            {
+                save.RightTabWidthPixels = null;
+            }
+
+            if (MainPanelControl.ViewModel.BottomPanelHeight.GridUnitType == System.Windows.GridUnitType.Pixel)
+            {
+                save.BottomTabHeightPixels = MainPanelControl.ViewModel.BottomPanelHeight.Value;
+            }
+            else
+            {
+                save.BottomTabHeightPixels = null;
+            }
+
             // do we care about the other panels?
 
 

--- a/FRBDK/Glue/Glue/SaveClasses/GlueSettingsSave.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/GlueSettingsSave.cs
@@ -121,6 +121,8 @@ namespace FlatRedBall.Glue.SaveClasses
         public List<string> BottomTabs { get; set; } = new List<string>();
 
         public double? LeftTabWidthPixels { get; set; }
+        public double? RightTabWidthPixels { get; set; }
+        public double? BottomTabHeightPixels { get; set; }
 
         public ExternalSeparatingList<BuildToolAssociation> BuildToolAssociations = new ExternalSeparatingList<BuildToolAssociation>();
 

--- a/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
+++ b/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
@@ -146,13 +146,15 @@ namespace GlueFormsCore.ViewModels
 
             if (args.NewItems is not null && tab.Count == 1)
             {
-                double length = tab.Location switch
+                double? length = tab.Location switch
                 {
-                    TabLocation.Left => GlueState.Self.GlueSettingsSave.LeftTabWidthPixels ?? 230,
-                    _ => 230
+                    TabLocation.Left => GlueState.Self.GlueSettingsSave.LeftTabWidthPixels,
+                    TabLocation.Right => GlueState.Self.GlueSettingsSave.RightTabWidthPixels,
+                    TabLocation.Bottom => GlueState.Self.GlueSettingsSave.BottomTabHeightPixels,
+                    _ => null
                 };
 
-                gridLength = new GridLength(length, GridUnitType.Pixel);
+                gridLength = new GridLength(length ?? 220, GridUnitType.Pixel);
             }
             else if (tab.Count == 0)
             {


### PR DESCRIPTION
fixes #1487 

@vchelaru 
The issue for this has a title which conflicts with criteria. `all` vs `right/bottom`. I've implemented the right and bottom.

**There are some things to take note:** 
- Currently (despite properties existing in the save settings for it), there is no window size persistence. This means that likely if the user was previously full screen (or larger than default), and edge tabs were expanded rather large, it can set up for potentially odd tab sizes upon app launch.
- It also appears like there is some code trying to persist open tabs and their locations? But this isn't working (or hasn't worked for me since contributing to the project), this means currently we can save left/right/bottom tab sizes safely and why I'm ok with leaving `top` out of this PR, because they are always populated on app launch, but if that ever gets implemented in the future, then this may need revisited so we aren't blowing empty tab controls open.