### PR TITLE
Create multi targeting FlatRedBall project

### DIFF
--- a/FRBDK/Glue/DialogTreePlugin/DialogTreePlugin.csproj
+++ b/FRBDK/Glue/DialogTreePlugin/DialogTreePlugin.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
     <ProjectReference Include="..\FlatRedBall.PropertyGrid\FlatRedBall.PropertyGrid.csproj" />
     <ProjectReference Include="..\GlueCommon\GlueCommon.csproj" />
     <ProjectReference Include="..\Glue\Glue.csproj" />

--- a/FRBDK/Glue/EntityInputMovementPlugin/EntityInputMovementPlugin.csproj
+++ b/FRBDK/Glue/EntityInputMovementPlugin/EntityInputMovementPlugin.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Gum\WpfDataUiCore\WpfDataUiCore.csproj" />
+    <ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
     <ProjectReference Include="..\Glue\Glue.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -15,7 +16,6 @@
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
     <ProjectReference Include="..\FlatRedBall.PropertyGrid\FlatRedBall.PropertyGrid.csproj" />
     <ProjectReference Include="..\GlueCommon\GlueCommon.csproj" />
     <ProjectReference Include="..\Glue\GlueFormsCore.csproj" />

--- a/FRBDK/Glue/EntityInputMovementPlugin/Views/MainView.xaml
+++ b/FRBDK/Glue/EntityInputMovementPlugin/Views/MainView.xaml
@@ -4,8 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:localization="clr-namespace:Localization;assembly=Localization"
-             xmlns:TopDownViews="clr-namespace:TopDownPlugin.Views;assembly=TopDownPlugin"
-             xmlns:PlatformerViews="clr-namespace:FlatRedBall.PlatformerPlugin.Views;assembly=PlatformerPlugin"
+             xmlns:topDownViews="clr-namespace:TopDownPlugin.Views;assembly=TopDownPlugin"
+             xmlns:platformerViews="clr-namespace:FlatRedBall.PlatformerPlugin.Views;assembly=PlatformerPlugin"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
@@ -64,7 +64,7 @@
                 </StackPanel>
             </GroupBox>
         </StackPanel>
-        <TopDownViews:MainEntityView Visibility="{Binding TopDownUiVisibility}" x:Name="TopDownView" Grid.Row="1"></TopDownViews:MainEntityView>
-        <PlatformerViews:MainControl Visibility="{Binding PlatformerUiVisibility}" x:Name="PlatformerView" Grid.Row="1"></PlatformerViews:MainControl>
+        <topDownViews:MainEntityView Visibility="{Binding TopDownUiVisibility}" x:Name="TopDownView" Grid.Row="1"></topDownViews:MainEntityView>
+        <platformerViews:MainControl Visibility="{Binding PlatformerUiVisibility}" x:Name="PlatformerView" Grid.Row="1"></platformerViews:MainControl>
     </Grid>
 </UserControl>

--- a/FRBDK/Glue/EntityPerformancePlugin/EntityPerformancePlugin/EntityPerformancePlugin.csproj
+++ b/FRBDK/Glue/EntityPerformancePlugin/EntityPerformancePlugin/EntityPerformancePlugin.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Platforms>AnyCPU</Platforms>
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\..\..\FlatRedBall\FlatRedBall.csproj" />
     <ProjectReference Include="..\..\FlatRedBall.PropertyGrid\FlatRedBall.PropertyGrid.csproj" />
     <ProjectReference Include="..\..\GlueCommon\GlueCommon.csproj" />
     <ProjectReference Include="..\..\Glue\Glue.csproj" />

--- a/FRBDK/Glue/FlatRedBall.Plugin/FlatRedBall.Plugin.csproj
+++ b/FRBDK/Glue/FlatRedBall.Plugin/FlatRedBall.Plugin.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
   </ItemGroup>
 
 </Project>

--- a/FRBDK/Glue/Glue with All.sln
+++ b/FRBDK/Glue/Glue with All.sln
@@ -11,8 +11,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Plugins", "Plugins", "{EC6F
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared Libraries", "Shared Libraries", "{07985C4C-B3CF-432C-8A27-36FDD006231F}"
 EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FlatRedBallShared", "..\..\Engines\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.shproj", "{0BB8CBE3-8503-46C1-9272-D98E153A230E}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GumCoreProjects", "GumCoreProjects", "{1D66D67D-064B-4AAC-94E1-AF754D281FA0}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "GumCoreShared", "..\..\..\Gum\GumCoreShared.shproj", "{F919C045-EAC7-4806-9A1F-CE421F923E97}"
@@ -22,8 +20,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tiled Plugin", "Tiled Plugin", "{DABAF6E1-1075-4CD2-959A-78FFB46B868D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GlueCommon", "GlueCommon\GlueCommon.csproj", "{9403B27A-6E3A-4083-8A42-0EB62B699246}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlatRedBallStandard", "..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj", "{26DD17AA-55AE-46AB-9394-A2319728869A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Glue", "Glue\Glue.csproj", "{C953AF0B-B890-40CE-888D-8F60579CD03E}"
 EndProject
@@ -93,6 +89,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Plugin Base Libraries", "Pl
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{60818A85-E5BC-4B05-97F9-24402B4B0CCE}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{58B4F9F1-EC0A-4DCB-BCAD-EAAABABFE4B8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlatRedBall", "..\..\FlatRedBall\FlatRedBall.csproj", "{70A4BE37-617A-4B58-ACB9-9FBF62CB38A9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Frb", "Frb", "{69D428BA-766B-491B-8256-F0B68425B7DD}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FlatRedBallShared", "..\..\Engines\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.shproj", "{0BB8CBE3-8503-46C1-9272-D98E153A230E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -107,10 +111,6 @@ Global
 		{9403B27A-6E3A-4083-8A42-0EB62B699246}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9403B27A-6E3A-4083-8A42-0EB62B699246}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9403B27A-6E3A-4083-8A42-0EB62B699246}.Release|Any CPU.Build.0 = Release|Any CPU
-		{26DD17AA-55AE-46AB-9394-A2319728869A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{26DD17AA-55AE-46AB-9394-A2319728869A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{26DD17AA-55AE-46AB-9394-A2319728869A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{26DD17AA-55AE-46AB-9394-A2319728869A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C953AF0B-B890-40CE-888D-8F60579CD03E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C953AF0B-B890-40CE-888D-8F60579CD03E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C953AF0B-B890-40CE-888D-8F60579CD03E}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -223,6 +223,10 @@ Global
 		{82348794-B260-45E4-AC62-68BD68E76A10}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82348794-B260-45E4-AC62-68BD68E76A10}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82348794-B260-45E4-AC62-68BD68E76A10}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70A4BE37-617A-4B58-ACB9-9FBF62CB38A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70A4BE37-617A-4B58-ACB9-9FBF62CB38A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70A4BE37-617A-4B58-ACB9-9FBF62CB38A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70A4BE37-617A-4B58-ACB9-9FBF62CB38A9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -230,12 +234,10 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5FE94178-9907-4878-AFAC-8F347CA86B50} = {60818A85-E5BC-4B05-97F9-24402B4B0CCE}
 		{3DDD0995-4B47-47A2-82A4-F0A6367C9FF2} = {EC6FC7AF-EDDF-4DC2-93C8-95EE34CD8CD8}
-		{0BB8CBE3-8503-46C1-9272-D98E153A230E} = {07985C4C-B3CF-432C-8A27-36FDD006231F}
 		{1D66D67D-064B-4AAC-94E1-AF754D281FA0} = {3DDD0995-4B47-47A2-82A4-F0A6367C9FF2}
 		{F919C045-EAC7-4806-9A1F-CE421F923E97} = {1D66D67D-064B-4AAC-94E1-AF754D281FA0}
 		{728151F0-03E0-4253-94FE-46B9C77EDEA6} = {3DDD0995-4B47-47A2-82A4-F0A6367C9FF2}
 		{DABAF6E1-1075-4CD2-959A-78FFB46B868D} = {EC6FC7AF-EDDF-4DC2-93C8-95EE34CD8CD8}
-		{26DD17AA-55AE-46AB-9394-A2319728869A} = {07985C4C-B3CF-432C-8A27-36FDD006231F}
 		{D784E25F-320D-47F5-9397-63E33B81A64F} = {1D05DDEE-051E-4280-A9E5-5F343B7084BC}
 		{C5D613DF-0E6A-4BE5-BEAC-E5524DC1EC93} = {EC6FC7AF-EDDF-4DC2-93C8-95EE34CD8CD8}
 		{6F58A8DD-C47E-4157-85BE-70E5371293FA} = {DABAF6E1-1075-4CD2-959A-78FFB46B868D}
@@ -267,14 +269,16 @@ Global
 		{48261027-DFD2-4571-948E-129136A6E6BE} = {07985C4C-B3CF-432C-8A27-36FDD006231F}
 		{74CBDCBC-7458-4668-8D11-56867CA62E94} = {07985C4C-B3CF-432C-8A27-36FDD006231F}
 		{82348794-B260-45E4-AC62-68BD68E76A10} = {3DDD0995-4B47-47A2-82A4-F0A6367C9FF2}
+		{70A4BE37-617A-4B58-ACB9-9FBF62CB38A9} = {69D428BA-766B-491B-8256-F0B68425B7DD}
+		{0BB8CBE3-8503-46C1-9272-D98E153A230E} = {69D428BA-766B-491B-8256-F0B68425B7DD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {878CCBB8-EADE-4F25-9DE7-D55D999D414A}
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\..\Engines\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.projitems*{0bb8cbe3-8503-46c1-9272-d98e153a230e}*SharedItemsImports = 13
-		..\..\Engines\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.projitems*{26dd17aa-55ae-46ab-9394-a2319728869a}*SharedItemsImports = 5
 		StateInterpolationPlugin\StateInterpolationPlugin\StateInterpolationShared.projitems*{48261027-dfd2-4571-948e-129136a6e6be}*SharedItemsImports = 5
+		..\..\Engines\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.projitems*{70a4be37-617a-4b58-acb9-9fbf62cb38a9}*SharedItemsImports = 5
 		..\..\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.Shared\FlatRedBall.Forms.Shared.projitems*{728151f0-03e0-4253-94fe-46b9c77edea6}*SharedItemsImports = 13
 		StateInterpolationPlugin\StateInterpolationPlugin\StateInterpolationShared.projitems*{d00d287d-385b-42fb-bf5f-04401e7d37d0}*SharedItemsImports = 13
 		..\..\..\Gum\GumCoreShared.projitems*{f919c045-eac7-4806-9a1f-ce421f923e97}*SharedItemsImports = 13

--- a/FRBDK/Glue/Glue/Glue.csproj
+++ b/FRBDK/Glue/Glue/Glue.csproj
@@ -152,7 +152,7 @@
 		<ProjectReference Include="..\..\..\..\Gum\SkiaGumMonogame\SkiaGumMonogame.csproj" />
 		<ProjectReference Include="..\..\..\..\Gum\ToolsUtilities\ToolsUtilitiesStandard.csproj" />
 		<ProjectReference Include="..\..\..\..\Gum\WpfDataUiCore\WpfDataUiCore.csproj" />
-		<ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+		<ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
 		<ProjectReference Include="..\..\..\Tiled\TMXGlueLib\TMXGlueLib.csproj" />
 		<ProjectReference Include="..\..\FRBDKUpdater\UpdaterWpf\UpdaterWpf\UpdaterWpf.csproj" />
 		<ProjectReference Include="..\..\Localization\Localization.csproj" />

--- a/FRBDK/Glue/GlueCommon/GlueCommon.csproj
+++ b/FRBDK/Glue/GlueCommon/GlueCommon.csproj
@@ -20,8 +20,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
+
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
   </ItemGroup>
 
 </Project>

--- a/FRBDK/Glue/GumPlugin/GumPlugin/GumPlugin.csproj
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/GumPlugin.csproj
@@ -377,7 +377,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\Gum\GumCommon\GumCommon.csproj" />
-    <ProjectReference Include="..\..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\..\..\FlatRedBall\FlatRedBall.csproj" />
     <ProjectReference Include="..\..\GlueCommon\GlueCommon.csproj" />
     <ProjectReference Include="..\..\Glue\Glue.csproj" />
     <ProjectReference Include="..\..\StateInterpolationPlugin\StateInterpolationNet6\StateInterpolationNet6.csproj" />

--- a/FRBDK/Glue/NAudioPlugin/NAudioPlugin.csproj
+++ b/FRBDK/Glue/NAudioPlugin/NAudioPlugin.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
     <ProjectReference Include="..\GlueCommon\GlueCommon.csproj" />
     <ProjectReference Include="..\Glue\Glue.csproj" />
   </ItemGroup>

--- a/FRBDK/Glue/PlatformerPlugin/PlatformerPlugin.csproj
+++ b/FRBDK/Glue/PlatformerPlugin/PlatformerPlugin.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Platforms>AnyCPU</Platforms>
     <TargetFramework>net6.0-windows</TargetFramework>
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Gum\WpfDataUiCore\WpfDataUiCore.csproj" />
-    <ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
     <ProjectReference Include="..\FlatRedBall.PropertyGrid\FlatRedBall.PropertyGrid.csproj" />
     <ProjectReference Include="..\GlueCommon\GlueCommon.csproj" />
     <ProjectReference Include="..\Glue\Glue.csproj" />

--- a/FRBDK/Glue/PluginLibraries/PluginLibraries.csproj
+++ b/FRBDK/Glue/PluginLibraries/PluginLibraries.csproj
@@ -12,7 +12,7 @@
 		<ProjectReference Include="..\..\..\..\Gum\SkiaGum.Wpf.NetCore3_0\SkiaGum.Wpf.Net6.csproj" />
 		<ProjectReference Include="..\..\..\..\Gum\SkiaGumMonogame\SkiaGumMonogame.csproj" />
 		<ProjectReference Include="..\..\..\..\Gum\WpfDataUiCore\WpfDataUiCore.csproj" />
-		<ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+		<ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
 		<ProjectReference Include="..\FlatRedBall.PropertyGrid\FlatRedBall.PropertyGrid.csproj" />
 		<ProjectReference Include="..\GlueCommon\GlueCommon.csproj" />
 		<ProjectReference Include="..\Glue\Glue.csproj" />

--- a/FRBDK/Glue/RacingPlugin/RacingPlugin.csproj
+++ b/FRBDK/Glue/RacingPlugin/RacingPlugin.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+		<ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
 		<ProjectReference Include="..\GlueCommon\GlueCommon.csproj" />
 		<ProjectReference Include="..\Glue\Glue.csproj" />
 	</ItemGroup>

--- a/FRBDK/Glue/StateInterpolationPlugin/StateInterpolationNet6/StateInterpolationNet6.csproj
+++ b/FRBDK/Glue/StateInterpolationPlugin/StateInterpolationNet6/StateInterpolationNet6.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\StateInterpolationPlugin\StateInterpolationShared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\..\..\FlatRedBall\FlatRedBall.csproj" />
   </ItemGroup>
 
 </Project>

--- a/FRBDK/Glue/StateInterpolationPlugin/StateInterpolationPluginCore/StateInterpolationPlugin.csproj
+++ b/FRBDK/Glue/StateInterpolationPlugin/StateInterpolationPluginCore/StateInterpolationPlugin.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\..\..\FlatRedBall\FlatRedBall.csproj" />
     <ProjectReference Include="..\..\GlueCommon\GlueCommon.csproj" />
     <ProjectReference Include="..\..\Glue\Glue.csproj" />
     <ProjectReference Include="..\StateInterpolationNet6\StateInterpolationNet6.csproj" />

--- a/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/TiledPlugin.csproj
+++ b/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/TiledPlugin.csproj
@@ -85,7 +85,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+		<ProjectReference Include="..\..\..\..\FlatRedBall\FlatRedBall.csproj" />
 		<ProjectReference Include="..\..\..\..\Tiled\TMXGlueLib\TMXGlueLib.csproj" />
 		<ProjectReference Include="..\..\GlueCommon\GlueCommon.csproj" />
 		<ProjectReference Include="..\..\Glue\Glue.csproj">

--- a/FRBDK/Glue/TopDownPlugin/TopDownPlugin.csproj
+++ b/FRBDK/Glue/TopDownPlugin/TopDownPlugin.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Gum\WpfDataUiCore\WpfDataUiCore.csproj" />
+    <ProjectReference Include="..\..\..\FlatRedBall\FlatRedBall.csproj" />
     <ProjectReference Include="..\Glue\Glue.csproj" />
   </ItemGroup>
 
@@ -32,10 +33,8 @@
 
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
     <ProjectReference Include="..\FlatRedBall.PropertyGrid\FlatRedBall.PropertyGrid.csproj" />
     <ProjectReference Include="..\GlueCommon\GlueCommon.csproj" />
-    <ProjectReference Include="..\Glue\GlueFormsCore.csproj" />
   </ItemGroup>
 
 

--- a/FlatRedBall/FlatRedBall.csproj
+++ b/FlatRedBall/FlatRedBall.csproj
@@ -1,0 +1,105 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Global Properties -->
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net8.0-ios;net8.0-android;netstandard2.0;net6.0;</TargetFrameworks>
+    <MonoGameVersion>3.8.1.303</MonoGameVersion>
+    <FNA>false</FNA>
+    <DefineConstants>FRB_XNA;XNA4;</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Define properties for TargetFramework checks -->
+    <IsNet8 Condition="'$(TargetFramework)' == 'net8.0'">true</IsNet8>
+    <IsNet6 Condition="'$(TargetFramework)' == 'net6.0'">true</IsNet6>
+    <IsNetStandard20 Condition="'$(TargetFramework)' == 'netstandard2.0'">true</IsNetStandard20>
+    <IsNet8Windows Condition="'$(TargetFramework)' == 'net8.0-windows'">true</IsNet8Windows>
+    <IsAndroid Condition="'$(TargetFramework)' == 'net8.0-android'">true</IsAndroid>
+    <IsIOS Condition="'$(TargetFramework)' == 'net8.0-ios'">true</IsIOS>
+  </PropertyGroup>
+
+  <!-- Pre-emptively remove platform all specific files, to be later included by the platform itself -->
+  <ItemGroup>
+    <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Input\InputManager.Android.cs" />
+    <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Input\Keyboard.Android.cs" />
+    <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\IO\FileManager.IsolatedStorage.cs" />
+  </ItemGroup>
+
+  <!--Troubled Files-->
+  <ItemGroup>
+    <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Graphics\Renderer.SpriteBatch.cs" />
+    <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Instructions\Reflection\HashSet.cs" />
+    <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Input\JoystickState.cs" />
+    <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Graphics\PostProcessing\*" />
+  </ItemGroup>
+
+  <!-- For DesktopGL, without KNI -->
+  <PropertyGroup Condition="$(IsNet8) == 'true'">
+    <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;DESKTOP_GL;</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(IsNet8) == 'true'">
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- For DesktopGL, without KNI -->
+  <PropertyGroup Condition="$(IsNet6) == 'true'">
+    <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;DESKTOP_GL;</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(IsNet6) == 'true'">
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
+  </ItemGroup>
+
+  <!-- For WindowsDX -->
+  <PropertyGroup Condition="$(IsNet8Windows) == 'true'">
+    <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;WINDOWS;</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(IsNet8Windows) == 'true'">
+    <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
+  </ItemGroup>
+
+  <!--For NetStandard20-->
+  <PropertyGroup Condition="$(IsNetStandard20) == 'true'">
+    <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;NETSTANDARD;NO_CODE_EMIT;STANDARD;WINDOWS;DESKTOP_GL</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(IsNetStandard20) == 'true'">
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+  </ItemGroup>
+
+  <!-- For Android -->
+  <PropertyGroup Condition="$(IsAndroid) == 'true'">
+    <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;ANDROID;USE_ISOLATED_STORAGE</DefineConstants>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(IsAndroid) == 'true'">
+    <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
+    <Compile Include="..\Engines\FlatRedBallXNA\FlatRedBall\Input\AndroidGamePad.cs" Link="Input\AndroidGamePad.cs" />
+    <Compile Include="..\Engines\FlatRedBallXNA\FlatRedBall\Input\InputManager.Android.cs" Link="Input\InputManager.Android.cs" />
+    <Compile Include="..\Engines\FlatRedBallXNA\FlatRedBall\Input\Keyboard.Android.cs" Link="Input\Keyboard.Android.cs" />
+    <Compile Include="..\Engines\FlatRedBallXNA\FlatRedBall\IO\FileManager.IsolatedStorage.cs" Link="IO\FileManager.IsolatedStorage.cs" />
+  </ItemGroup>
+
+  <!-- For iOS -->
+  <PropertyGroup Condition="$(IsIOS) == 'true'">
+    <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;IOS;USE_ISOLATED_STORAGE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(IsIOS) == 'true'">
+    <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
+    <Compile Include="..\Engines\FlatRedBallXNA\FlatRedBall\IO\FileManager.IsolatedStorage.cs" Link="IO\FileManager.IsolatedStorage.cs" />
+  </ItemGroup>
+  
+  <!-- Additional package reference for AsepriteDotNet -->
+  <ItemGroup Condition="$(IsNetStandard20) == ''">
+    <PackageReference Include="AsepriteDotNet" Version="1.8.1" />
+  </ItemGroup>
+  <Import Project="..\Engines\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.projitems" Label="Shared" />
+
+</Project>

--- a/FlatRedBall/FlatRedBall.csproj
+++ b/FlatRedBall/FlatRedBall.csproj
@@ -4,12 +4,11 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net8.0-ios;net8.0-android;netstandard2.0;net6.0;</TargetFrameworks>
     <MonoGameVersion>3.8.1.303</MonoGameVersion>
-    <FNA>false</FNA>
     <DefineConstants>FRB_XNA;XNA4;</DefineConstants>
   </PropertyGroup>
-
+  
+  <!-- These just make condition checks less verbose -->
   <PropertyGroup>
-    <!-- Define properties for TargetFramework checks -->
     <IsNet8 Condition="'$(TargetFramework)' == 'net8.0'">true</IsNet8>
     <IsNet6 Condition="'$(TargetFramework)' == 'net6.0'">true</IsNet6>
     <IsNetStandard20 Condition="'$(TargetFramework)' == 'netstandard2.0'">true</IsNetStandard20>
@@ -18,14 +17,18 @@
     <IsIOS Condition="'$(TargetFramework)' == 'net8.0-ios'">true</IsIOS>
   </PropertyGroup>
 
-  <!-- Pre-emptively remove platform all specific files, to be later included by the platform itself -->
+  <!-- Reference shared code until we migrate everything to this project -->
+  <Import Project="..\Engines\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.projitems" Label="Shared" />
+
+  <!-- Pre-emptively remove all platform-specific files, to be later be conditionally included by platform -->
   <ItemGroup>
+    <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Input\AndroidGamePad.cs" />
     <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Input\InputManager.Android.cs" />
     <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Input\Keyboard.Android.cs" />
     <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\IO\FileManager.IsolatedStorage.cs" />
   </ItemGroup>
 
-  <!--Troubled Files-->
+  <!-- Remove troubled files (ones which are causing build issues, possibly obsolete?) -->
   <ItemGroup>
     <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Graphics\Renderer.SpriteBatch.cs" />
     <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Instructions\Reflection\HashSet.cs" />
@@ -33,7 +36,7 @@
     <Compile Remove="..\Engines\FlatRedBallXNA\FlatRedBall\Graphics\PostProcessing\*" />
   </ItemGroup>
 
-  <!-- For DesktopGL, without KNI -->
+  <!-- DesktopGL Net8-->
   <PropertyGroup Condition="$(IsNet8) == 'true'">
     <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;DESKTOP_GL;</DefineConstants>
   </PropertyGroup>
@@ -44,7 +47,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- For DesktopGL, without KNI -->
+  <!-- DesktopGL Net6-->
   <PropertyGroup Condition="$(IsNet6) == 'true'">
     <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;DESKTOP_GL;</DefineConstants>
   </PropertyGroup>
@@ -53,7 +56,7 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
   </ItemGroup>
 
-  <!-- For WindowsDX -->
+  <!-- WindowsDX Net8-->
   <PropertyGroup Condition="$(IsNet8Windows) == 'true'">
     <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;WINDOWS;</DefineConstants>
   </PropertyGroup>
@@ -62,7 +65,7 @@
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
   </ItemGroup>
 
-  <!--For NetStandard20-->
+  <!-- DesktopGL NetStandard20 -->
   <PropertyGroup Condition="$(IsNetStandard20) == 'true'">
     <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;NETSTANDARD;NO_CODE_EMIT;STANDARD;WINDOWS;DESKTOP_GL</DefineConstants>
   </PropertyGroup>
@@ -72,7 +75,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
-  <!-- For Android -->
+  <!-- Android Net8 -->
   <PropertyGroup Condition="$(IsAndroid) == 'true'">
     <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;ANDROID;USE_ISOLATED_STORAGE</DefineConstants>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -86,7 +89,7 @@
     <Compile Include="..\Engines\FlatRedBallXNA\FlatRedBall\IO\FileManager.IsolatedStorage.cs" Link="IO\FileManager.IsolatedStorage.cs" />
   </ItemGroup>
 
-  <!-- For iOS -->
+  <!-- iOS Net8-->
   <PropertyGroup Condition="$(IsIOS) == 'true'">
     <DefineConstants>$(DefineConstants);MONOGAME;MONOGAME_381;IOS;USE_ISOLATED_STORAGE</DefineConstants>
   </PropertyGroup>
@@ -96,10 +99,9 @@
     <Compile Include="..\Engines\FlatRedBallXNA\FlatRedBall\IO\FileManager.IsolatedStorage.cs" Link="IO\FileManager.IsolatedStorage.cs" />
   </ItemGroup>
   
-  <!-- Additional package reference for AsepriteDotNet -->
+  <!-- Additional package references -->
   <ItemGroup Condition="$(IsNetStandard20) == ''">
     <PackageReference Include="AsepriteDotNet" Version="1.8.1" />
-  </ItemGroup>
-  <Import Project="..\Engines\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.projitems" Label="Shared" />
+  </ItemGroup>  
 
 </Project>

--- a/Tiled/TMXGlueLib/TMXGlueLib.csproj
+++ b/Tiled/TMXGlueLib/TMXGlueLib.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Engines\FlatRedBallXNA\Standard\FlatRedBallStandard\FlatRedBallStandard\FlatRedBallStandard.csproj" />
+    <ProjectReference Include="..\..\FlatRedBall\FlatRedBall.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The idea here is to eventually replace the many single platform projects referencing the shared-code-library with a one-stop-shop:
- Simplified repo/project structure
- Consistency/simplification in build, nuget packaging, and versioning
- Reduced redundancy
- Better/faster development experience
- Cleaner conditional compilation (conditions are maintained here rather than spread across multiple projects)
- Reduced complication for third parties (just reference this and forget about target platforms/frameworks _for the most part_)

Implementing KNI and FNA will want a little extra time/consideration to start on a good path forward. 

As far as I can tell MonoGame is entirely implemented in this PR (as far as pre-existing targets go). As a first step in migration, all projects in the Glue solution have swapped their references to this new library.

Since a full replacement and path forward for using it isn't here yet, we are referencing the shared-code-library to maintain sync between the existing projects which are being used outside of Glue, with the intent to (hopefully) eventually move the code into this project directly.