### PR TITLE
Reduced number of tabs shown for entities by default

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/PluginBase.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginBase.cs
@@ -76,6 +76,7 @@ namespace FlatRedBall.Glue.Plugins
     public class PluginTab : ViewModel
     {
         public event EventHandler AfterHide;
+        public event EventHandler Closed;
 
         public string Title
         {
@@ -141,6 +142,12 @@ namespace FlatRedBall.Glue.Plugins
 
         public event Action TabShown;
 
+        public void Close()
+        {
+            Hide();
+            Closed?.Invoke(this, EventArgs.Empty);
+        }
+
         public void Hide()
         {
             ParentContainer?.Remove(this);
@@ -174,7 +181,7 @@ namespace FlatRedBall.Glue.Plugins
         public PluginTab()
         {
             CanClose = true;
-            CloseCommand = new (Hide, nameof(CanClose), this);
+            CloseCommand = new (Close, nameof(CanClose), this);
             MoveTabCommand = new (MoveTab, nameof(CanMoveTo), nameof(CurrentLocation), this);
         }
 

--- a/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
+++ b/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
@@ -61,8 +61,14 @@ namespace GlueFormsCore.ViewModels
                 return;
             }
 
-            SelectedTab = Tabs.OrderByDescending(item => item.LastTimeClicked)
-                    .ThenByDescending(item => item.IsPreferredDisplayerForType(typeName))
+            // removing remembering of last tabs clicked
+            // https://github.com/vchelaru/FlatRedBall/issues/1593
+            //SelectedTab =
+            //    Tabs.OrderByDescending(item => item.LastTimeClicked)
+            //        .ThenByDescending(item => item.IsPreferredDisplayerForType(typeName))
+            //        .First();
+            SelectedTab =
+                Tabs.OrderByDescending(item => item.IsPreferredDisplayerForType(typeName))
                     .First();
         }
     }

--- a/FRBDK/Glue/RacingPlugin/MainPlugin.cs
+++ b/FRBDK/Glue/RacingPlugin/MainPlugin.cs
@@ -74,9 +74,15 @@ namespace RacingPlugin
 
         private void HandleItemSelected(ITreeNode selectedTreeNode)
         {
-            bool shouldShow = GlueState.Self.CurrentEntitySave != null &&
+            // October 26, 2024
+            // The racing plugin has not been updated in a long time. IT is likely
+            // not working well with the new FRB so we are going to hide this until
+            // it can get proper attention.
+            bool shouldShow =
+                false;
+                //GlueState.Self.CurrentEntitySave != null &&
                 // So this only shows if the entity itself is selected:
-                selectedTreeNode?.Tag == GlueState.Self.CurrentEntitySave;
+                //selectedTreeNode?.Tag == GlueState.Self.CurrentEntitySave;
 
 
             if (shouldShow)


### PR DESCRIPTION
Performance tab only shows if it's been turned on by right-click option. Removed remembering of previously-selected tab.