### PR TITLE
Error check suppressing fix

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/ErrorPlugin/MainErrorPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/ErrorPlugin/MainErrorPlugin.cs
@@ -119,7 +119,7 @@ public class MainErrorPlugin : PluginBase
     private void HandleLoadedGlux()
     {
         var glueProject = GlueState.Self.CurrentGlueProject;
-        if (glueProject != null && glueProject.IsSuppressingRefreshUnreferencedFiles == false)
+        if (glueProject != null && glueProject.IsSuppressingAutomaticErrorChecking == false)
         {
             RefreshLogic.RefreshAllErrors(errorListViewModel, errorListViewModel.IsOutputErrorCheckingDetailsChecked);
         }


### PR DESCRIPTION
Suppressing error checking at startup should depend on IsSuppressingAutomaticErrorChecking instead of IsSuppressingRefreshUnreferencedFiles.