### PR TITLE
Color Extensions for FlatRedBall

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/ExtensionMethods/ColorExtensionMethods.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/ExtensionMethods/ColorExtensionMethods.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+
+namespace FlatRedBall.ExtensionMethods;
+
+public static class ColorExtensionMethods
+{
+
+    /// <summary>
+    /// Tints a color by the provided percent, which can be
+    /// negative or positive.
+    /// 
+    /// A positive value will darken the color, a negative value will lighten it.
+    /// </summary>
+    /// <param name="color">The color to tint.</param>
+    /// <param name="percent">The tint amount as a percent from -1 to 1</param>
+    /// <returns>A tinted color</returns>
+    public static Color Tint(this Color color, float percent)
+    {
+        var newColor = new Color();
+        newColor.R = (byte)MathHelper.Clamp(color.R * (1f - percent), 0, 255);
+        newColor.G = (byte)MathHelper.Clamp(color.G * (1f - percent), 0, 255);
+        newColor.B = (byte)MathHelper.Clamp(color.B * (1f - percent), 0, 255);
+        newColor.A = color.A;
+        return newColor;
+    }
+
+    /// <summary>
+    /// Returns the inverse color (white minus color) for the
+    /// provided color
+    /// </summary>
+    /// <param name="color">The color to invert</param>
+    /// <returns>An inverted color</returns>
+    public static Color Inverse(this Color color)
+    {
+        return new Color(
+            255 - color.R,
+            255 - color.G,
+            255 - color.B,
+            color.A
+        );
+    }
+
+    /// <summary>
+    /// Returns a premultiplied alpha version of the source color.
+    /// </summary>
+    /// <param name="color">The source color.</param>
+    /// <param name="alpha">The alpha value (0.0 to 1.0).</param>
+    /// <returns>A Color with premultiplied alpha.</returns>
+    public static Color GetPremul(this Color color, float alpha)
+    {
+        // Clamp alpha to valid range [0.0, 1.0]
+        alpha = MathHelper.Clamp(alpha, 0f, 1f);
+
+        // Premultiply RGB values by alpha
+        byte r = (byte)(color.R * alpha);
+        byte g = (byte)(color.G * alpha);
+        byte b = (byte)(color.B * alpha);
+        byte a = (byte)(alpha * 255);
+
+        return new Color(r, g, b, a);
+    }
+
+    /// <summary>
+    /// Converts the provided color into a six-digit hexidecimal string
+    /// such as used in CSS and graphics programs.
+    /// </summary>
+    /// <param name="color">The color to convert</param>
+    /// <returns>A six-digit hex string with no prefix</returns>
+    public static string ToHexString(this Color color)
+    {
+        return $"{color.R.ToString("X2")}{color.G.ToString("X2")}{color.B.ToString("X2")}";
+    }
+
+    /// <summary>
+    /// Converts a 3 or 6 character hexidecimal string with no prefix to an RGB Color.
+    /// Does not support alpha as part of the hex string.
+    ///
+    /// Valid examples are "F90" (CSS shorthand) or "FF9900" (full hex string)
+    /// 
+    /// Will return black and debug assert if bad values are provided.
+    /// </summary>
+    /// <param name="str">A valid, 6-digit hex string</param>
+    /// <returns>The color from the provided string, will return pure black on error.</returns>
+    public static Color HexStringToColor(this string str)
+    {
+        Color outColor = Color.Black;
+
+        if (String.IsNullOrWhiteSpace(str) == false)
+        {
+            if (str.Length == 3)
+            {
+                var r = str.Substring(0, 1);
+                var g = str.Substring(1, 1);
+                var b = str.Substring(2, 1);
+                str = r + r + g + g + b + b;
+            }
+
+            if (str.Length == 6)
+            {
+                try
+                {
+                    var R = Convert.ToInt16(str.Substring(0, 2), 16);
+                    var G = Convert.ToInt16(str.Substring(2, 2), 16);
+                    var B = Convert.ToInt16(str.Substring(4, 2), 16);
+                    outColor = new Color(R, G, B);
+                }
+                catch (Exception e)
+                {
+                    System.Diagnostics.Debug.Assert(false, $"Bad values were provided to color conversion: {e.Message}");
+                }
+
+            }
+        }
+
+        return outColor;
+    }
+}

--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallShared.projitems
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallShared.projitems
@@ -93,6 +93,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Entities\IDamageArea.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Entities\IEntity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Entities\ITiledTileMetadata.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\ColorExtensionMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\EnumerableExtensionMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\FloatExtensionMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\PointExtensionMethods.cs" />
@@ -111,6 +112,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\BitmapCharacterInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\BitmapFont.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\CustomEffectManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Graphics\HslColor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\IDrawableBatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\GenericEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\GraphicalEmumerations.cs" />

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/HslColor.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/HslColor.cs
@@ -151,7 +151,7 @@ public struct HSLColor
     /// </summary>
     /// <param name="color">The color to convert</param>
     /// <returns>An HSL color that approximates the RGB values</returns>
-    public static HSLColor FromRgb(this Color color)
+    public static HSLColor FromRgb(Color color)
     {
         return FromRgb(color.R, color.G, color.B);
     }

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/HslColor.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/HslColor.cs
@@ -1,0 +1,229 @@
+﻿using FlatRedBall.Math.Geometry;
+using Microsoft.Xna.Framework;
+
+namespace FlatRedBall.Graphics;
+
+/// <summary>
+/// HSL stands for Hue, Saturation, and Luminance.
+/// HSL may also referred to as HSB, where the B
+/// stands for Brightness. This color space makes
+/// it easier to do calculations that operate on
+/// these channels and is supported by most major
+/// graphics applications.
+///
+/// An example operation that can be done on HSL
+/// but not on RGB is finding the complement of
+/// a color. This is a hue operation that just
+/// requires adding 0.5 to the Hue channel (and
+/// wrapping overflow) in HSL but is impossible
+/// in RGB space.
+/// 
+/// Helpful color math can be found here:
+/// https://www.easyrgb.com/en/math.php
+/// </summary>
+public struct HSLColor
+{
+
+    /// <summary>
+    /// Hue, a value between 0 and 1. The center of major hues are
+    /// red: 0, orange: 0.5, yellow 0.15, green 0.35, blue 0.65,
+    /// purple, 0.75, and magenta 0.8.
+    /// </summary>
+    public float H;
+
+    /// <summary>
+    /// Saturation, a value between 0 and 1. A value of 0 will be black, white, or gray depending on Luminance.
+    /// A value of 1 will be fully saturated, displaying the color determined by Hue and Luminance.
+    /// </summary>
+    public float S;
+
+    /// <summary>
+    /// Luminance (brightness), a value between 0 and 1. A value of 0 is black. A value of 0.5 depends on
+    /// hue and saturation and represents a fully saturated color. A value of 1 is white.
+    /// </summary>
+    public float L;
+
+    /// <summary>
+    /// Gets this colors complementary color
+    /// </summary>
+    public HSLColor Complement
+    {
+        get
+        {
+            // complementary colors are across the color wheel
+            // which is 180 degrees or 50% of the way around the
+            // wheel. Add 50% to our hue (color) aspect of the
+            // HSL color
+            var h = H + 0.5f;
+            if (h > 1)
+            {
+                h -= 1;
+            }
+
+            return new HSLColor(h, S, L);
+        }
+    }
+
+    /// <summary>
+    /// Constructor for a new HSL color
+    /// </summary>
+    /// <param name="h">Hue parameter, 0 to 1</param>
+    /// <param name="s">Saturation parameter, 0 to 1</param>
+    /// <param name="l">Luminosity/Brightness parameter, 0 to 1</param>
+    public HSLColor(float h, float s, float l)
+    {
+        H = h;
+        S = s;
+        L = l;
+    }
+
+    /// <summary>
+    /// Gets an HSL color from an RGB color
+    /// </summary>
+    /// <param name="R">Red byte value</param>
+    /// <param name="G">Green byte value</param>
+    /// <param name="B">Blue byte value</param>
+    /// <returns>An HSL color that approximates the RGB values</returns>
+    public static HSLColor FromRgb(byte R, byte G, byte B)
+    {
+        var hsl = new HSLColor();
+
+        hsl.H = 0;
+        hsl.S = 0;
+        hsl.L = 0;
+
+        float r = R / 255f;
+        float g = G / 255f;
+        float b = B / 255f;
+        float min = System.Math.Min(System.Math.Min(r, g), b);
+        float max = System.Math.Max(System.Math.Max(r, g), b);
+        float delta = max - min;
+
+        // luminance is the ave of max and min
+        hsl.L = (max + min) / 2f;
+
+        if (delta > 0)
+        {
+            if (hsl.L < 0.5f)
+            {
+                hsl.S = delta / (max + min);
+            }
+            else
+            {
+                hsl.S = delta / (2 - max - min);
+            }
+
+            float deltaR = (((max - r) / 6f) + (delta / 2f)) / delta;
+            float deltaG = (((max - g) / 6f) + (delta / 2f)) / delta;
+            float deltaB = (((max - b) / 6f) + (delta / 2f)) / delta;
+
+            if (r == max)
+            {
+                hsl.H = deltaB - deltaG;
+            }
+            else if (g == max)
+            {
+                hsl.H = (1f / 3f) + deltaR - deltaB;
+            }
+            else if (b == max)
+            {
+                hsl.H = (2f / 3f) + deltaG - deltaR;
+            }
+
+            if (hsl.H < 0)
+            {
+                hsl.H += 1;
+            }
+
+            if (hsl.H > 1)
+            {
+                hsl.H -= 1;
+            }
+        }
+
+        return hsl;
+    }
+
+    /// <summary>
+    /// Gets an HSL color from an RGB color.
+    /// 
+    /// Wraps FromRgb for convenience.
+    /// </summary>
+    /// <param name="color">The color to convert</param>
+    /// <returns>An HSL color that approximates the RGB values</returns>
+    public static HSLColor FromRgb(this Color color)
+    {
+        return FromRgb(color.R, color.G, color.B);
+    }
+
+    /// <summary>
+    /// Gets an RGB color from an HSL color
+    /// </summary>
+    /// <returns>The RGB approximation of this HSL color</returns>
+    public Color ToRgb()
+    {
+        var hsl = this;
+        var c = new Color();
+
+        if (hsl.S == 0)
+        {
+            c.R = (byte)(hsl.L * 255f);
+            c.G = (byte)(hsl.L * 255f);
+            c.B = (byte)(hsl.L * 255f);
+        }
+        else
+        {
+            float v2 = (hsl.L + hsl.S) - (hsl.S * hsl.L);
+            if (hsl.L < 0.5f)
+            {
+                v2 = hsl.L * (1 + hsl.S);
+            }
+            float v1 = 2f * hsl.L - v2;
+
+            c.R = (byte)(255f * HueToRgb(v1, v2, hsl.H + (1f / 3f)));
+            c.G = (byte)(255f * HueToRgb(v1, v2, hsl.H));
+            c.B = (byte)(255f * HueToRgb(v1, v2, hsl.H - (1f / 3f)));
+        }
+
+        c.A = 255;
+
+        return c;
+    }
+
+    /// <summary>
+    /// Internal math function that is part of the conversion
+    /// process. For details see:
+    /// https://www.easyrgb.com/en/math.php
+    /// </summary>
+    private float HueToRgb(float v1, float v2, float vH)
+    {
+        vH += (vH < 0) ? 1 : 0;
+        vH -= (vH > 1) ? 1 : 0;
+        float returnValue = v1;
+
+        if ((6 * vH) < 1)
+        {
+            returnValue = (v1 + (v2 - v1) * 6 * vH);
+        }
+
+        else if ((2 * vH) < 1)
+        {
+            returnValue = (v2);
+        }
+
+        else if ((3 * vH) < 2)
+        {
+            returnValue = (v1 + (v2 - v1) * ((2f / 3f) - vH) * 6f);
+        }
+
+        returnValue = System.Math.Min(returnValue, 1);
+        returnValue = System.Math.Max(returnValue, 0);
+
+        return returnValue;
+    }
+
+    public override string ToString()
+    {
+        return $"H: {H}, S: {S}, L: {L}";
+    }
+}


### PR DESCRIPTION
This PR adds the HSL struct, which allows you to convert RGB colors to and from the HSL space. HSL color is commonly used in graphics programs because exposing the Hue channel allows you to do things like shift colors without changing their luminosity, find complementary colors, and similar tasks. It also makes it easier to partially desaturate colors without shifting the perceptual hue. The HSL struct was added in the Graphics folder as it seemed like the most logical space.

This PR also adds a `ColorExtensions` file that adds these utility methods to the `Color` struct:

- Tint: tints a color lighter or darker
- Invers: gets the inverse of a color (white minus the color)
- GetPremul: gets a version of the color with premultiplied alpha, required to colorize FRB geometry such as lines with alpha
- To/From Hex string: converts colors to and from a hex string, useful for displaying colors as a hex value when binding colors to UI