### PR TITLE
Fix gum location

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Input/Mouse.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Input/Mouse.cs
@@ -242,6 +242,29 @@ namespace FlatRedBall.Input
             get { return mYVelocity; }
         }
 
+        List<MouseButtons> _buttonsPushedInternal = new List<MouseButtons>();
+
+        /// <summary>
+        /// Mouse buttons pushed this frame.
+        /// </summary>
+        public IReadOnlyCollection<MouseButtons> ButtonsPushed
+        {
+            get
+            {
+                _buttonsPushedInternal.Clear();
+
+                for (int i = 0; i < NumberOfButtons; i++)
+                {
+                    var button = (MouseButtons)i;
+
+                    if (ButtonPushed(button))
+                        _buttonsPushedInternal.Add(button);
+                }
+
+                return _buttonsPushedInternal;
+            }
+        }
+
         I2DInput IInputDevice.Default2DInput => Zero2DInput.Instance;
         IRepeatPressableInput IInputDevice.DefaultUpPressable => FalsePressableInput.Instance;
         IRepeatPressableInput IInputDevice.DefaultDownPressable => FalsePressableInput.Instance;

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
@@ -645,6 +645,11 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
 
                 if (absoluteExe?.Exists() == false)
                 {
+                    absoluteExe = GlueState.Self.GlueExeDirectory + "../../../../../../Gum/Gum/bin/Debug/Gum.exe";
+                }
+
+                if (absoluteExe?.Exists() == false)
+                {
                     absoluteExe = GlueState.Self.GlueExeDirectory + "Gum/Data/Gum.exe";
                 }
             }


### PR DESCRIPTION
Gum build location is no longer in Data folder. This fixed the file association problem when opening the Gum project via toolbar.