### PR TITLE
Font loading speedup

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapCharacterInfo.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapCharacterInfo.cs
@@ -65,7 +65,7 @@ namespace FlatRedBall.Graphics
         public int PageNumber;
 
 
-        public Dictionary<int, int> SecondLetterKearning;
+        public Dictionary<int, int> SecondLetterKerning;
 
         #endregion
 

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapFont.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapFont.cs
@@ -292,9 +292,9 @@ namespace FlatRedBall.Graphics
             else
             {
                 // index is -1, but let's try a regular IndexOf:
-                int forwardIndexOf = fontPattern.IndexOf("char id=");
+                int forwardIndexOf = fontPattern.IndexOf("char id=", StringComparison.Ordinal);
 
-                if(forwardIndexOf != -1 && index == -1)
+                if (forwardIndexOf != -1 && index == -1)
                 {
                     throw new Exception("How is this possible? LastIndexOf \"char id=\" is returning a value of -1, while IndexOf for the same string is returning an index value)");
 

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapFont.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapFont.cs
@@ -255,7 +255,7 @@ namespace FlatRedBall.Graphics
                 // Right now we'll assume that the pages come in order and they're sequential
                 // If this isn' the case then the logic may need to be modified to support this
                 // instead of just returning a string[].
-                int page = StringFunctions.GetIntAfter("page id=", fontPattern, currentIndexIntoFile);
+                int page = StringFunctions.GetIntAfter("page id=", fontPattern, currentIndexIntoFile, StringComparison.Ordinal);
 
                 int openingQuotesIndex = fontPattern.IndexOf('"', currentIndexIntoFile);
 
@@ -285,7 +285,7 @@ namespace FlatRedBall.Graphics
             int index = fontPattern.LastIndexOf("char id=", fontPattern.Length, StringComparison.Ordinal);
             if (index != -1)
             {
-                int ID = StringFunctions.GetIntAfter("char id=", fontPattern, index);
+                int ID = StringFunctions.GetIntAfter("char id=", fontPattern, index, StringComparison.Ordinal);
 
                 sizeOfArray = System.Math.Max(sizeOfArray, ID + 1);
 
@@ -315,7 +315,7 @@ namespace FlatRedBall.Graphics
             mCharacterInfo = new BitmapCharacterInfo[sizeOfArray];
             mLineHeightInPixels =
                 StringFunctions.GetIntAfter(
-                "lineHeight=", fontPattern);
+                "lineHeight=", fontPattern, 0, StringComparison.Ordinal);
 
             // This font may not reference any textures at all - if it doesn't have any
             // characters set in the .bmfc.  I don't think we should crash here if so:
@@ -338,7 +338,7 @@ namespace FlatRedBall.Graphics
                 while (index != -1)
                 {
 
-                    int ID = StringFunctions.GetIntAfter("char id=", fontPattern, index);
+                    int ID = StringFunctions.GetIntAfter("char id=", fontPattern, index, StringComparison.Ordinal);
 
                     if (ID == -1)
                     {
@@ -393,9 +393,9 @@ namespace FlatRedBall.Graphics
 
                     while (index != -1)
                     {
-                        int ID = StringFunctions.GetIntAfter("first=", fontPattern, index);
-                        int secondCharacter = StringFunctions.GetIntAfter("second=", fontPattern, index);
-                        int kearningAmount = StringFunctions.GetIntAfter("amount=", fontPattern, index);
+                        int ID = StringFunctions.GetIntAfter("first=", fontPattern, index, StringComparison.Ordinal);
+                        int secondCharacter = StringFunctions.GetIntAfter("second=", fontPattern, index, StringComparison.Ordinal);
+                        int kearningAmount = StringFunctions.GetIntAfter("amount=", fontPattern, index, StringComparison.Ordinal);
 
                         if(mCharacterInfo[ID].SecondLetterKearning == null)
                         {
@@ -569,14 +569,14 @@ namespace FlatRedBall.Graphics
 
             if (indexOfID != -1)
             {
-                var x = StringFunctions.GetIntAfter("x=", fontString, ref indexOfID);
-                var y = StringFunctions.GetIntAfter("y=", fontString, ref indexOfID);
-                var width = StringFunctions.GetIntAfter("width=", fontString, ref indexOfID);
-                var height = StringFunctions.GetIntAfter("height=", fontString, ref indexOfID);
-                var xOffset = StringFunctions.GetIntAfter("xoffset=", fontString, ref indexOfID);
-                var yOffset = StringFunctions.GetIntAfter("yoffset=", fontString, ref indexOfID);
-                var xAdvance = StringFunctions.GetIntAfter("xadvance=", fontString, ref indexOfID);
-                var page = StringFunctions.GetIntAfter("page=", fontString, ref indexOfID);
+                var x = StringFunctions.GetIntAfter("x=", fontString, ref indexOfID, StringComparison.Ordinal);
+                var y = StringFunctions.GetIntAfter("y=", fontString, ref indexOfID, StringComparison.Ordinal);
+                var width = StringFunctions.GetIntAfter("width=", fontString, ref indexOfID, StringComparison.Ordinal);
+                var height = StringFunctions.GetIntAfter("height=", fontString, ref indexOfID, StringComparison.Ordinal);
+                var xOffset = StringFunctions.GetIntAfter("xoffset=", fontString, ref indexOfID, StringComparison.Ordinal);
+                var yOffset = StringFunctions.GetIntAfter("yoffset=", fontString, ref indexOfID, StringComparison.Ordinal);
+                var xAdvance = StringFunctions.GetIntAfter("xadvance=", fontString, ref indexOfID, StringComparison.Ordinal);
+                var page = StringFunctions.GetIntAfter("page=", fontString, ref indexOfID, StringComparison.Ordinal);
 
                 var textureWidthF = (float)textureWidth;
                 var textureHeightF = (float)textureHeight;

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapFont.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapFont.cs
@@ -397,11 +397,19 @@ namespace FlatRedBall.Graphics
                         int secondCharacter = StringFunctions.GetIntAfter("second=", fontPattern, index, StringComparison.Ordinal);
                         int kearningAmount = StringFunctions.GetIntAfter("amount=", fontPattern, index, StringComparison.Ordinal);
 
-                        if(mCharacterInfo[ID].SecondLetterKearning == null)
+                        var characterInfo = mCharacterInfo[ID];
+
+                        if (characterInfo.SecondLetterKearning == null)
                         {
-                            mCharacterInfo[ID].SecondLetterKearning = new Dictionary<int, int>();
+                            characterInfo.SecondLetterKearning = new Dictionary<int, int>();
                         }
-                        mCharacterInfo[ID].SecondLetterKearning.Add(secondCharacter, kearningAmount);
+
+                        // Some fonts may contain duplicated kerning pairs, avoid the
+                        // crash by checking if the key is has already been added.
+                        if (!characterInfo.SecondLetterKearning.ContainsKey(secondCharacter))
+                        {
+                            characterInfo.SecondLetterKearning.Add(secondCharacter, kearningAmount);
+                        }
 
                         index = fontPattern.IndexOf("first=", index + 1, StringComparison.Ordinal);
                     }

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapFont.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/BitmapFont.cs
@@ -283,19 +283,17 @@ namespace FlatRedBall.Graphics
             // index, so we can just find the last one
             // and save some time.
             int index = fontPattern.LastIndexOf("char id=", fontPattern.Length, StringComparison.Ordinal);
+
             if (index != -1)
             {
                 int ID = StringFunctions.GetIntAfter("char id=", fontPattern, index, StringComparison.Ordinal);
-
                 sizeOfArray = System.Math.Max(sizeOfArray, ID + 1);
-
-
-
             }
             else
             {
                 // index is -1, but let's try a regular IndexOf:
                 int forwardIndexOf = fontPattern.IndexOf("char id=");
+
                 if(forwardIndexOf != -1 && index == -1)
                 {
                     throw new Exception("How is this possible? LastIndexOf \"char id=\" is returning a value of -1, while IndexOf for the same string is returning an index value)");
@@ -308,9 +306,8 @@ namespace FlatRedBall.Graphics
                     throw new Exception(message);
                 }
             }
+
             #endregion
-
-
 
             mCharacterInfo = new BitmapCharacterInfo[sizeOfArray];
             mLineHeightInPixels =
@@ -321,7 +318,6 @@ namespace FlatRedBall.Graphics
             // characters set in the .bmfc.  I don't think we should crash here if so:
             if (mTextures.Length != 0)
             {
-
                 BitmapCharacterInfo space = FillBitmapCharacterInfo(' ', fontPattern,
                    mTextures[0].Width, mTextures[0].Height, mLineHeightInPixels, 0);
 
@@ -335,9 +331,9 @@ namespace FlatRedBall.Graphics
                 mCharacterInfo['t'].Spacing = space.Spacing * 4;
 
                 index = fontPattern.IndexOf("char id=", 0, StringComparison.Ordinal);
+
                 while (index != -1)
                 {
-
                     int ID = StringFunctions.GetIntAfter("char id=", fontPattern, index, StringComparison.Ordinal);
 
                     if (ID == -1)
@@ -368,47 +364,48 @@ namespace FlatRedBall.Graphics
                         }
 #endif
 
-
                         mCharacterInfo[ID] = FillBitmapCharacterInfo(ID, fontPattern, mTextures[0].Width,
                             mTextures[0].Height, mLineHeightInPixels, index);
 
                         int indexOfID = fontPattern.IndexOf("char id=", index, StringComparison.Ordinal);
+
                         if (indexOfID != -1)
                         {
                             index = indexOfID + ID.ToString().Length;
                         }
                         else
+                        {
                             index = -1;
+                        }
                     }
                 }
 
-                #region Get Kearning Info
+                #region Get kerning info
 
                 index = fontPattern.IndexOf("kerning ", 0, StringComparison.Ordinal);
 
                 if (index != -1)
                 {
-
                     index = fontPattern.IndexOf("first=", index, StringComparison.Ordinal);
 
                     while (index != -1)
                     {
                         int ID = StringFunctions.GetIntAfter("first=", fontPattern, index, StringComparison.Ordinal);
                         int secondCharacter = StringFunctions.GetIntAfter("second=", fontPattern, index, StringComparison.Ordinal);
-                        int kearningAmount = StringFunctions.GetIntAfter("amount=", fontPattern, index, StringComparison.Ordinal);
+                        int kerningAmount = StringFunctions.GetIntAfter("amount=", fontPattern, index, StringComparison.Ordinal);
 
                         var characterInfo = mCharacterInfo[ID];
 
-                        if (characterInfo.SecondLetterKearning == null)
+                        if (characterInfo.SecondLetterKerning == null)
                         {
-                            characterInfo.SecondLetterKearning = new Dictionary<int, int>();
+                            characterInfo.SecondLetterKerning = new Dictionary<int, int>();
                         }
 
                         // Some fonts may contain duplicated kerning pairs, avoid the
                         // crash by checking if the key is has already been added.
-                        if (!characterInfo.SecondLetterKearning.ContainsKey(secondCharacter))
+                        if (!characterInfo.SecondLetterKerning.ContainsKey(secondCharacter))
                         {
-                            characterInfo.SecondLetterKearning.Add(secondCharacter, kearningAmount);
+                            characterInfo.SecondLetterKerning.Add(secondCharacter, kerningAmount);
                         }
 
                         index = fontPattern.IndexOf("first=", index + 1, StringComparison.Ordinal);
@@ -417,7 +414,6 @@ namespace FlatRedBall.Graphics
 
                 #endregion
             }
-            //mCharacterInfo[32].ScaleX = .23f;
         }
 
         public void SetFontPatternFromFile(string fntFileName)

--- a/Engines/FlatRedBallXNA/FlatRedBall/Utilities/StringFunctions.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Utilities/StringFunctions.cs
@@ -20,9 +20,7 @@ namespace FlatRedBall.Utilities
 
         static HashSet<char> sValidNumericalChars = new HashSet<char> { '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ',' };
 
-
         #endregion
-
 
         public static bool IsAscii(string stringToCheck)
         {
@@ -105,7 +103,6 @@ namespace FlatRedBall.Utilities
 
         }
 
-        #region XML Docs
         /// <summary>
         /// Returns the number of non-whitespace characters in the argument stringInQuestion.
         /// </summary>
@@ -115,7 +112,6 @@ namespace FlatRedBall.Utilities
         /// </remarks>
         /// <param name="stringInQuestion">The string to have its non-witespace counted.</param>
         /// <returns>The number of non-whitespace characters counted.</returns>
-        #endregion
         public static int CharacterCountWithoutWhitespace(string stringInQuestion)
         {
             int characterCount = 0;
@@ -127,7 +123,6 @@ namespace FlatRedBall.Utilities
             return characterCount;
         }
 
-        #region XML Docs
         /// <summary>
         /// Returns a string of the float with the argument decimalsAfterPoint digits of resolution after the point.
         /// </summary>
@@ -135,7 +130,6 @@ namespace FlatRedBall.Utilities
         /// <param name="decimalsAfterPoint">The number of decimals after the point.  For example, 3.14159 becomes "3.14" if the
         /// decimalsAfterPoint is 2.  This method will not append extra decimals to reach the argument decimalsAfterPoint.</param>
         /// <returns>The string representation of the argument float.</returns>
-        #endregion
         public static string FloatToString(float floatToConvert, int decimalsAfterPoint)
         {
             if (decimalsAfterPoint == 0)
@@ -149,7 +143,6 @@ namespace FlatRedBall.Utilities
             }
         }
 
-        #region XML Docs
         /// <summary>
         /// Returns the character that can be found after a particular sequence of characters.
         /// </summary>
@@ -160,7 +153,6 @@ namespace FlatRedBall.Utilities
         /// <param name="stringToSearchFor">The string to search for.</param>
         /// <param name="whereToSearch">The string to search in.</param>
         /// <returns>Returns the character found or the null character '\0' if the string is not found.</returns>
-        #endregion
         public static char GetCharAfter(string stringToSearchFor, string whereToSearch)
         {
             int indexOf = whereToSearch.IndexOf(stringToSearchFor);
@@ -219,7 +211,6 @@ namespace FlatRedBall.Utilities
             return count;
         }
 
-        #region XML Docs
         /// <summary>
         /// Returns the float that can be found after a particular sequence of characters.
         /// </summary>
@@ -230,7 +221,6 @@ namespace FlatRedBall.Utilities
         /// <param name="stringToSearchFor">The string to search for.</param>
         /// <param name="whereToSearch">The string to search in.</param>
         /// <returns>Returns the float value found or float.NaN if the string is not found.</returns>
-        #endregion
         public static float GetFloatAfter(string stringToSearchFor, string whereToSearch)
         {
             return GetFloatAfter(stringToSearchFor, whereToSearch, 0);
@@ -308,7 +298,6 @@ namespace FlatRedBall.Utilities
             return float.NaN;
         }
 
-        #region XML Docs
         /// <summary>
         /// Returns the first integer found after the argument stringToSearchFor in whereToSearch.
         /// </summary>
@@ -320,13 +309,11 @@ namespace FlatRedBall.Utilities
         /// <param name="stringToSearchFor">The string pattern to search for.</param>
         /// <param name="whereToSearch">The string that will be searched.</param>
         /// <returns>The integer value found after the argument stringToSearchFor.</returns>
-        #endregion
         public static int GetIntAfter(string stringToSearchFor, string whereToSearch)
         {
             return GetIntAfter(stringToSearchFor, whereToSearch, 0, StringComparison.CurrentCulture);
         }
 
-        #region XML Docs
         /// <summary>
         /// Returns the first integer found after the argument stringToSearchFor.  The search begins
         /// at the argument startIndex.
@@ -337,13 +324,11 @@ namespace FlatRedBall.Utilities
         /// will ignore any instances of stringToSearchFor which begin at an index smaller
         /// than the argument startIndex.</param>
         /// <returns></returns>
-        #endregion
         public static int GetIntAfter(string stringToSearchFor, string whereToSearch, int startIndex)
         {
             return GetIntAfter(stringToSearchFor, whereToSearch, startIndex, StringComparison.CurrentCulture);
         }
 
-        #region XML Docs
         /// <summary>
         /// Returns the first integer found after the argument stringToSearchFor.  The search begins
         /// at the argument startIndex.
@@ -356,7 +341,6 @@ namespace FlatRedBall.Utilities
         /// <param name="stringComparison">String comparison mode to use. Some modes may affect
         /// performance.</param>
         /// <returns></returns>
-        #endregion
         public static int GetIntAfter(string stringToSearchFor, string whereToSearch, int startIndex, StringComparison stringComparison)
         {
             int startOfNumber = -1;
@@ -550,14 +534,12 @@ namespace FlatRedBall.Utilities
 
 
 
-        #region XML Docs
         /// <summary>
         /// Returns the number of lines in a given string.  Newlines '\n' increase the 
         /// line count.
         /// </summary>
         /// <param name="stringInQuestion">The string that will have its lines counted.</param>
         /// <returns>The number of lines in the argument.  "Hello" will return a value of 1, "Hello\nthere" will return a value of 2.</returns>
-        #endregion
         public static int GetLineCount(string stringInQuestion)
         {
             if (string.IsNullOrEmpty(stringInQuestion))
@@ -577,7 +559,6 @@ namespace FlatRedBall.Utilities
             return lines;
         }
 
-        #region XML Docs
         /// <summary>
         /// Returns the number found at the end of the argument stringToGetNumberFrom or throws an
         /// ArgumentException if no number is found.
@@ -589,7 +570,6 @@ namespace FlatRedBall.Utilities
         /// <exception cref="System.ArgumentException">Throws ArgumentException if no number is found at the end of the argument string.</exception>
         /// <param name="stringToGetNumberFrom">The number found at the end.</param>
         /// <returns>The integer value found at the end of the stringToGetNumberFrom.</returns>
-        #endregion
         public static int GetNumberAtEnd(string stringToGetNumberFrom)
         {
             int letterChecking = stringToGetNumberFrom.Length;
@@ -682,7 +662,6 @@ namespace FlatRedBall.Utilities
         }
         
 
-        #region XML Docs
         /// <summary>
         /// Inserts spaces before every capital letter in a camel-case
         /// string.  Ignores the first letter.
@@ -693,7 +672,6 @@ namespace FlatRedBall.Utilities
         /// </remarks>
         /// <param name="originalString">The string in which to insert spaces.</param>
         /// <returns>The string with spaces inserted.</returns>
-        #endregion
         public static string InsertSpacesInCamelCaseString(string originalString)
         {
             // Normally in reverse loops you go til i > -1, but 
@@ -942,14 +920,12 @@ namespace FlatRedBall.Utilities
             strings.AddRange(finalList);
         }
 
-        #region XML Docs
         /// <summary>
         /// Removes the number found at the end of the argument originalString and returns the resulting
         /// string, or returns the original string if no number is found.
         /// </summary>
         /// <param name="originalString">The string that will have the number at its end removed.</param>
         /// <returns>The string after the number has been removed.</returns>
-        #endregion
         public static string RemoveNumberAtEnd(string originalString)
         {
             // start at the end of the string and move backwards until reacing a non-Digit.
@@ -968,13 +944,11 @@ namespace FlatRedBall.Utilities
             return originalString.Remove(letterChecking + 1, originalString.Length - letterChecking - 1);
         }
 
-        #region XML Docs
         /// <summary>
         /// Removes all whitespace found in the argument stringToRemoveWhitespaceFrom.
         /// </summary>
         /// <param name="stringToRemoveWhitespaceFrom">The string that will have its whitespace removed.</param>
         /// <returns>The string resulting from removing whitespace from the argument string.</returns>
-        #endregion
         public static string RemoveWhitespace(string stringToRemoveWhitespaceFrom)
         {
             return stringToRemoveWhitespaceFrom.Replace(" ", "").Replace("\t", "").Replace("\n", "").Replace("\r", "");

--- a/Engines/FlatRedBallXNA/FlatRedBall/Utilities/StringFunctions.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Utilities/StringFunctions.cs
@@ -323,7 +323,7 @@ namespace FlatRedBall.Utilities
         #endregion
         public static int GetIntAfter(string stringToSearchFor, string whereToSearch)
         {
-            return GetIntAfter(stringToSearchFor, whereToSearch, 0);
+            return GetIntAfter(stringToSearchFor, whereToSearch, 0, StringComparison.CurrentCulture);
         }
 
         #region XML Docs
@@ -340,13 +340,32 @@ namespace FlatRedBall.Utilities
         #endregion
         public static int GetIntAfter(string stringToSearchFor, string whereToSearch, int startIndex)
         {
+            return GetIntAfter(stringToSearchFor, whereToSearch, startIndex, StringComparison.CurrentCulture);
+        }
+
+        #region XML Docs
+        /// <summary>
+        /// Returns the first integer found after the argument stringToSearchFor.  The search begins
+        /// at the argument startIndex.
+        /// </summary>
+        /// <param name="stringToSearchFor">The string pattern to search for.</param>
+        /// <param name="whereToSearch">The string that will be searched.</param>
+        /// <param name="startIndex">The index to begin searching at.  This method
+        /// will ignore any instances of stringToSearchFor which begin at an index smaller
+        /// than the argument startIndex.</param>
+        /// <param name="stringComparison">String comparison mode to use. Some modes may affect
+        /// performance.</param>
+        /// <returns></returns>
+        #endregion
+        public static int GetIntAfter(string stringToSearchFor, string whereToSearch, int startIndex, StringComparison stringComparison)
+        {
             int startOfNumber = -1;
             int endOfNumber = -1;
             string substring = string.Empty;
 
             try
             {
-                int indexOf = whereToSearch.IndexOf(stringToSearchFor, startIndex);
+                int indexOf = whereToSearch.IndexOf(stringToSearchFor, startIndex, stringComparison);
 
                 if (indexOf != -1)
                 {
@@ -384,7 +403,7 @@ namespace FlatRedBall.Utilities
             return 0;
         }
 
-        public static int GetIntAfter(string stringToSearchFor, string whereToSearch, ref int startIndex)
+        public static int GetIntAfter(string stringToSearchFor, string whereToSearch, ref int startIndex, StringComparison stringComparison)
         {
             int startOfNumber = -1;
             int endOfNumber = -1;
@@ -397,7 +416,7 @@ namespace FlatRedBall.Utilities
 
             try
             {
-                int indexOf = whereToSearch.IndexOf(stringToSearchFor, startIndex);
+                int indexOf = whereToSearch.IndexOf(stringToSearchFor, startIndex, stringComparison);
 
                 if (indexOf != -1)
                 {

--- a/FRBDK/Glue/Glue/ContentPipeline/ContentPipelineHelper.cs
+++ b/FRBDK/Glue/Glue/ContentPipeline/ContentPipelineHelper.cs
@@ -219,11 +219,11 @@ namespace FlatRedBall.Glue.ContentPipeline
                     var filesReferencedByAsset =
                         _fileReferenceManager.GetFilesReferencedBy(absoluteName, EditorObjects.Parsing.TopLevelOrRecursive.Recursive);
 
-                    for (int i = 0; i < filesReferencedByAsset.Count; i++)
+                    foreach(var file in filesReferencedByAsset)
                     {
-                        if (!filesInModifiedRfs.Contains(filesReferencedByAsset[i]))
+                        if (!filesInModifiedRfs.Contains(file))
                         {
-                            filesInModifiedRfs.Add(filesReferencedByAsset[i]);
+                            filesInModifiedRfs.Add(file);
                         }
                     }
                 }

--- a/FRBDK/Glue/Glue/ContentPipeline/ContentPipelineHelper.cs
+++ b/FRBDK/Glue/Glue/ContentPipeline/ContentPipelineHelper.cs
@@ -301,9 +301,9 @@ namespace FlatRedBall.Glue.ContentPipeline
                         filesInModifiedRfs.Remove(modifiedPossibleReferencerFile);
                     }
 
-                    string absoluteFileName = GlueCommands.Self.GetAbsoluteFileName(possibleReferencer);
+                    var absoluteFileName = GlueCommands.Self.GetAbsoluteFilePath(possibleReferencer);
 
-                    if (File.Exists(absoluteFileName))
+                    if (absoluteFileName.Exists())
                     {
                         var filesInPossibleReferencer =
                             _fileReferenceManager.GetFilesReferencedBy(absoluteFileName, TopLevelOrRecursive.Recursive);

--- a/FRBDK/Glue/Glue/IO/FileHelper.cs
+++ b/FRBDK/Glue/Glue/IO/FileHelper.cs
@@ -92,14 +92,10 @@ namespace FlatRedBall.Glue.IO
 
 
             // We also need to copy all of the other content files.
-            var referencedFiles = new List<FilePath>();
+            var referencedFiles = FileReferenceManager.Self.GetFilesReferencedBy(sourceFile);
 
-            referencedFiles = FileReferenceManager.Self.GetFilesReferencedBy(sourceFile);
-
-            for (int i = 0; i < referencedFiles.Count; i++)
+            foreach(var file in referencedFiles)
             {
-                var file = referencedFiles[i];
-
                 RecursivelyCopyContentTo(file.FullPath, sourceDirectory, directoryThatFileShouldBeRelativeTo);
 
             }

--- a/FRBDK/Glue/Glue/IO/ProjectLoader.cs
+++ b/FRBDK/Glue/Glue/IO/ProjectLoader.cs
@@ -384,8 +384,6 @@ namespace FlatRedBall.Glue.IO
 
                 //AddEmptyTreeItems();
 
-                Section.EndContextAndTime();
-                Section.GetAndStartContextAndTime("RefreshSourceFileCache");
 
                 // This has to be done before the tree nodes are created.  The reason is because a user
                 // may create a ReferencedFileSave using a source type, but not check in the built file.

--- a/FRBDK/Glue/Glue/Managers/FileReferenceManager.cs
+++ b/FRBDK/Glue/Glue/Managers/FileReferenceManager.cs
@@ -122,6 +122,9 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
                 {
                     var referenceInfo = new FileReferenceInformation
                     {
+                        // Although it might be faster to use DateTime.Now for the last write time, this would only work
+                        // if we were to do a > check. However, users can revert files in Git and that should mark the file
+                        // as out of date. To support that, we have to do strict equality and use the actual file
                         LastWriteTime = absoluteName.Exists() ? File.GetLastWriteTime(absoluteName.FullPath) : DateTime.MinValue,
                         References = topLevelOnly
                     };
@@ -137,10 +140,8 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
                 {
                     FilesWithFailedGetReferenceCalls[absoluteName] = response;
 
-                    // todo - need to raise an event here on parse error:
                     PluginManager.HandleFileReadError(absoluteName, response);
                 }
-
             }
         }
         

--- a/FRBDK/Glue/Glue/Managers/FileReferenceManager.cs
+++ b/FRBDK/Glue/Glue/Managers/FileReferenceManager.cs
@@ -10,6 +10,7 @@ using FlatRedBall.Glue.IO;
 using FlatRedBall.Glue.Errors;
 using GeneralResponse = ToolsUtilities.GeneralResponse;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using System.Collections.Concurrent;
 
 namespace FlatRedBall.Glue.Managers;
 
@@ -21,7 +22,7 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
     class FileReferenceInformation
     {
         public DateTime LastWriteTime;
-        public List<FilePath> References = new List<FilePath>();
+        public HashSet<FilePath> References = new ();
 
         public override string ToString()
         {
@@ -31,7 +32,7 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
 
     #endregion
 
-    Dictionary<FilePath, FileReferenceInformation> fileReferences = new Dictionary<FilePath, FileReferenceInformation>();
+    ConcurrentDictionary<FilePath, FileReferenceInformation> fileReferences = new ConcurrentDictionary<FilePath, FileReferenceInformation>();
 
     Dictionary<FilePath, FileReferenceInformation> filesNeededOnDisk = new Dictionary<FilePath, FileReferenceInformation>();
 
@@ -50,7 +51,7 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
     {
         if (fileReferences.ContainsKey(absoluteName))
         {
-            fileReferences.Remove(absoluteName);
+            fileReferences.Remove(absoluteName, out _);
         }
 
         if(filesNeededOnDisk.ContainsKey(absoluteName))
@@ -59,18 +60,18 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
         }
     }
 
-    public List<FilePath> GetFilesReferencedBy(FilePath absoluteName, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive = TopLevelOrRecursive.Recursive)
+    public HashSet<FilePath> GetFilesReferencedBy(FilePath absoluteName, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive = TopLevelOrRecursive.Recursive)
     {
-        var toReturn = new List<FilePath>();
+        var toReturn = new HashSet<FilePath>();
 
         GetFilesReferencedBy(absoluteName, topLevelOrRecursive, listToFill: toReturn);
 
         return toReturn;
     }
 
-    public void GetFilesReferencedBy(FilePath absoluteName, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive, List<FilePath> listToFill)
+    public void GetFilesReferencedBy(FilePath absoluteName, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive, ICollection<FilePath> listToFill)
     { 
-        List<FilePath> topLevelOnly = null;
+        HashSet<FilePath> topLevelOnly = null;
         bool handledByCache = false;
 
         if(fileReferences.ContainsKey(absoluteName))
@@ -99,7 +100,7 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
             bool succeeded = false;
             try
             {
-                topLevelOnly = ContentParser.GetFilesReferencedByAsset(absoluteName, TopLevelOrRecursive.TopLevel);
+                topLevelOnly = ContentParser.GetFilesReferencedByAsset(absoluteName, TopLevelOrRecursive.TopLevel).ToHashSet();
                 succeeded = true;
             }
             // August 26, 2017
@@ -126,7 +127,7 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
                         // if we were to do a > check. However, users can revert files in Git and that should mark the file
                         // as out of date. To support that, we have to do strict equality and use the actual file
                         LastWriteTime = absoluteName.Exists() ? File.GetLastWriteTime(absoluteName.FullPath) : DateTime.MinValue,
-                        References = topLevelOnly
+                        References = topLevelOnly.ToHashSet()
                     };
 
                     fileReferences[absoluteName] = referenceInfo;
@@ -149,7 +150,10 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
         if(topLevelOnly != null)
         {
             var newFiles = topLevelOnly.Except(listToFill).ToList();
-            listToFill.AddRange(newFiles);
+            foreach(var item in newFiles)
+            {
+                listToFill.Add(item);
+            }
 
             if (topLevelOrRecursive == TopLevelOrRecursive.Recursive)
             {
@@ -177,9 +181,9 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
         return false;
     }
 
-    public List<FilePath> GetFilesNeededOnDiskBy(FilePath absoluteName, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive)
+    public HashSet<FilePath> GetFilesNeededOnDiskBy(FilePath absoluteName, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive)
     {
-        List<FilePath> topLevelOnly = null;
+        HashSet<FilePath> topLevelOnly = null;
         bool handledByCache = false;
 
         if (filesNeededOnDisk.ContainsKey(absoluteName))
@@ -212,12 +216,12 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
             filesNeededOnDisk[absoluteName] = new FileReferenceInformation
             {
                 LastWriteTime = absoluteName.Exists() ? File.GetLastWriteTime(absoluteName.FullPath) : DateTime.MinValue,
-                References = topLevelOnly
+                References = topLevelOnly.ToHashSet()
             };
         }
 
 
-        var toReturn = new List<FilePath>();
+        var toReturn = new HashSet<FilePath>();
         toReturn.AddRange(topLevelOnly);
 
         if (topLevelOrRecursive == TopLevelOrRecursive.Recursive)

--- a/FRBDK/Glue/Glue/Managers/FileReferenceManager.cs
+++ b/FRBDK/Glue/Glue/Managers/FileReferenceManager.cs
@@ -76,10 +76,16 @@ public class FileReferenceManager : Singleton<FileReferenceManager>
         if(fileReferences.ContainsKey(absoluteName))
         {
             // compare dates:
-            bool isOutOfDate = absoluteName.Exists() && 
-                //File.GetLastWriteTime(standardized) > fileReferences[standardized].LastWriteTime;
-                // Do a != in case the user reverts a file
-                File.GetLastWriteTime(absoluteName.FullPath) != fileReferences[absoluteName].LastWriteTime;
+            bool isOutOfDate = false;
+
+            if(ObjectsForcingTrustedCache.Count == 0)
+            {
+                isOutOfDate = absoluteName.Exists() && 
+                    //File.GetLastWriteTime(standardized) > fileReferences[standardized].LastWriteTime;
+                    // Do a != in case the user reverts a file
+                    File.GetLastWriteTime(absoluteName.FullPath) != fileReferences[absoluteName].LastWriteTime;
+            }
+
 
             if(!isOutOfDate)
             {

--- a/FRBDK/Glue/Glue/Parsing/ContentParser.cs
+++ b/FRBDK/Glue/Glue/Parsing/ContentParser.cs
@@ -25,6 +25,7 @@ using FlatRedBall.Content.Scene;
 using FlatRedBall.Content.SpriteFrame;
 
 using Color = Microsoft.Xna.Framework.Color;
+using System.Collections.Concurrent;
 
 namespace EditorObjects.Parsing
 {
@@ -166,22 +167,22 @@ namespace EditorObjects.Parsing
         }
 
 
-        public static List<FilePath> GetFilesReferencedByAsset(FilePath filePath)
+        public static HashSet<FilePath> GetFilesReferencedByAsset(FilePath filePath)
 		{
 
             return GetFilesReferencedByAsset(filePath, TopLevelOrRecursive.TopLevel);
 		}
 
-        public static List<FilePath> GetFilesReferencedByAsset(FilePath filePath, TopLevelOrRecursive topLevelOrRecursive)
+        public static HashSet<FilePath> GetFilesReferencedByAsset(FilePath filePath, TopLevelOrRecursive topLevelOrRecursive)
 		{
             var referencedFiles = new List<FilePath>();
 
             GetFilesReferencedByAsset(filePath, topLevelOrRecursive, referencedFiles);
 
-            return referencedFiles.Distinct().ToList();
+            return referencedFiles.ToHashSet();
         }
 
-        public static void GetFilesReferencedByAsset(FilePath filePath, TopLevelOrRecursive topLevelOrRecursive, List<FilePath> referencedFiles)
+        public static void GetFilesReferencedByAsset(FilePath filePath, TopLevelOrRecursive topLevelOrRecursive, ICollection<FilePath> referencedFiles)
         {
             var newReferencedFiles = new List<FilePath>();
             if (!CanFileReferenceOtherFiles(filePath))
@@ -285,7 +286,10 @@ namespace EditorObjects.Parsing
 
                 }
 
-                referencedFiles.AddRange(newReferencedFiles);
+                foreach(var item in newReferencedFiles)
+                {
+                    referencedFiles.Add(item);
+                }
 
                 if (didErrorOccur)
                 {

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/MenuStripPlugin/MainMenuStripPlugin.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/MenuStripPlugin/MainMenuStripPlugin.cs
@@ -179,7 +179,7 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.MenuStripPlugin
 
                     if (File.Exists(absoluteFileName))
                     {
-                        List<FilePath> referencedFiles = null;
+                        HashSet<FilePath> referencedFiles = null;
 
                         try
                         {

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Particle/ParticleFileReferenceManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Particle/ParticleFileReferenceManager.cs
@@ -23,7 +23,7 @@ namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.Particle
 
         public bool CanFileReferenceContent(string file) => FileManager.GetExtension(file) == "emix";
 
-        internal GeneralResponse FillWithReferencedFiles(FilePath file, List<FilePath> referencedFiles)
+        internal GeneralResponse FillWithReferencedFiles(FilePath file, HashSet<FilePath> referencedFiles)
         {
             if (CanFileReferenceContent(file.FullPath))
             {

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/TaskDisplayer/TaskDisplayerControl.xaml
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/TaskDisplayer/TaskDisplayerControl.xaml
@@ -14,6 +14,7 @@
     <CheckBox IsChecked="{Binding LogGameToFrbCommands}" VerticalContentAlignment="Center">Log Game->FRB Commands</CheckBox>
     <Button Content="Copy Task List to Clipboard" Width="200" HorizontalAlignment="Left" Click="Button_Click" Margin="0,2" />
     <Button Content="Add temp tasks" Width="200" HorizontalAlignment="Left" Click="AddTempTasksClicked" Margin="0,0,0,2"/>
+    <Button Content="Refresh File Membership" Width="200" HorizontalAlignment="Left" Click="HandleRefreshFileMembership" />
 
 
     <Label Content="{Binding CurrentTaskText}"></Label>

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
@@ -133,7 +133,7 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
 
                 if (File.Exists(filePath.FullPath))
                 {
-                    List<FilePath> referencedFiles = null;
+                    HashSet<FilePath> referencedFiles = null;
 
                     if (projectOrFile == ProjectOrDisk.Project)
                     {

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
@@ -264,7 +264,7 @@ class ProjectCommands : IProjectCommands
 
         bool isFileAlreadyPartOfProject = false;
 
-        bool needsToBeInContentProject = ShouldFileBeInContentProject(fileToAddAbsolute);
+        bool needsToBeInContentProject = ShouldFileBeInContentProject(fileName);
 
         BuildItemMembershipType bimt = BuildItemMembershipType.CopyIfNewer;
 
@@ -289,9 +289,7 @@ class ProjectCommands : IProjectCommands
             isFileAlreadyPartOfProject = project.IsFilePartOfProject(fileName.FullPath, BuildItemMembershipType.CompileOrContentPipeline);
         }
 
-        string fileRelativeToContent = FileManager.MakeRelative(
-            fileToAddAbsolute,
-            project.ContentProject.FullFileName.GetDirectoryContainingThis().FullPath);
+        string fileRelativeToContent = fileName.RelativeTo(project.ContentProject.FullFileName.GetDirectoryContainingThis());
         fileRelativeToContent = fileRelativeToContent.Replace("/", "\\");
 
         if (!isFileAlreadyPartOfProject && needsToBeInContentProject)
@@ -366,10 +364,10 @@ class ProjectCommands : IProjectCommands
         var listOfReferencedFiles = new List<string>();
 
         // Glue is going to assume .cs files can't reference content:
-        if (!fileToAddAbsolute.EndsWith(".cs"))
+        if (fileName.Extension != ".cs")
         {
             var inner = new List<FilePath>();
-            FileReferenceManager.Self.GetFilesReferencedBy(fileToAddAbsolute, TopLevelOrRecursive.TopLevel, inner);
+            FileReferenceManager.Self.GetFilesReferencedBy(fileName, TopLevelOrRecursive.TopLevel, inner);
             listOfReferencedFiles.AddRange(inner.Select(item => item.StandardizedCaseSensitive));
             if (alreadyReferencedFiles != null)
             {
@@ -440,7 +438,7 @@ class ProjectCommands : IProjectCommands
         return useContentPipeline;
     }
 
-    private static bool ShouldFileBeInContentProject(string fileToAddAbsolute)
+    private static bool ShouldFileBeInContentProject(FilePath filePath)
     {
         var mainContentProject = GlueState.Self.CurrentMainContentProject;
         var mainProject = GlueState.Self.CurrentMainProject;
@@ -451,10 +449,10 @@ class ProjectCommands : IProjectCommands
         {
             var contentFolder = mainContentProject.GetAbsoluteContentFolder();
 
-            toReturn = FileManager.IsRelativeTo(fileToAddAbsolute, contentFolder);
+            toReturn = filePath.IsRelativeTo(contentFolder);
 
             // If this is a .cs file and the content project is the same project as the main project, then it's actually a code file
-            if (toReturn && mainContentProject.FullFileName == mainProject.FullFileName && FileManager.GetExtension(fileToAddAbsolute) == "cs")
+            if (toReturn && mainContentProject.FullFileName == mainProject.FullFileName && filePath.Extension == "cs")
             {
                 toReturn = false;
             }

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
@@ -148,8 +148,23 @@ class ProjectCommands : IProjectCommands
         Managers.TaskManager.Self.Add(() =>
         {
 
+            // We can parallel for to update the cache using all threads. We'll do top-level. This won't
+            // catch everything, but will take care of many of the top level files including .achx files which
+            // might be causing slowdown in games like Deadvivors.
+            var filePaths = allReferencedFileSaves.Select(item => GlueCommands.Self.GetAbsoluteFilePath(item))
+                .ToHashSet()
+                .ToArray();
+
+
             _fileReferenceManager.ObjectsForcingTrustedCache.Add(this);
             GlueCommands.Self.GluxCommands.RequestFileCache(this);
+            var fileCommands = GlueCommands.Self.FileCommands;
+            var fileReferenceManager = FileReferenceManager.Self;
+
+            Parallel.ForEach(filePaths, filePath =>
+            {
+                fileReferenceManager.GetFilesReferencedBy(filePath, TopLevelOrRecursive.TopLevel);
+            });
 
             try
             {

--- a/FRBDK/Glue/Glue/Plugins/PluginBase.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginBase.cs
@@ -487,14 +487,14 @@ namespace FlatRedBall.Glue.Plugins
         /// This should return GeneralResponse.Succeeded if either the parse succeeded, or if the file
         /// is ignored by this plugin. This should not return a failure if the file is ignored by the plugin.
         /// </summary>
-        public Func<FilePath, List<FilePath>, GeneralResponse> FillWithReferencedFiles { get; protected set; }
+        public Func<FilePath, HashSet<FilePath>, GeneralResponse> FillWithReferencedFiles { get; protected set; }
         public Action<FilePath, GeneralResponse> ReactToFileReadError { get; protected set; }
 
         /// <summary>
         /// Returns all files needed on disk by the argument file. Files on disk include built files such as content pipeline, or files 
         /// built by command line tools such as .csv files built from .ods files.
         /// </summary>
-        public Action<string, List<FilePath>> GetFilesNeededOnDiskBy { get; protected set; }
+        public Action<string, HashSet<FilePath>> GetFilesNeededOnDiskBy { get; protected set; }
 
         public Action ResolutionChanged { get; protected set; }
 

--- a/FRBDK/Glue/Glue/Plugins/PluginBase.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginBase.cs
@@ -481,8 +481,6 @@ namespace FlatRedBall.Glue.Plugins
 
         public AdjustDisplayedEntityDelegate AdjustDisplayedEntity { get; protected set; }
 
-        [Obsolete("Use FillWithReferencedFiles instead", error: true)]
-        public Action<string, EditorObjects.Parsing.TopLevelOrRecursive, List<string>> GetFilesReferencedBy { get; protected set; }
 
         /// <summary>
         /// Fills the argument List<FilePath> with files referenced by the argument FilePath.

--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -768,7 +768,7 @@ namespace FlatRedBall.Glue.Plugins
 
         }
 
-        internal static GeneralResponse GetFilesReferencedBy(string absoluteName, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive, List<FilePath> listToFill)
+        internal static GeneralResponse GetFilesReferencedBy(FilePath filePath, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive, List<FilePath> listToFill)
         {
             GeneralResponse generalResponse =  GeneralResponse.SuccessfulResponse;
             SaveRelativeDirectory();
@@ -778,7 +778,7 @@ namespace FlatRedBall.Glue.Plugins
                 {
                     if(plugin.FillWithReferencedFiles != null)
                     {
-                        var response = plugin.FillWithReferencedFiles(absoluteName, listToFill);
+                        var response = plugin.FillWithReferencedFiles(filePath, listToFill);
 
                         if(!response.Succeeded)
                         {
@@ -788,7 +788,7 @@ namespace FlatRedBall.Glue.Plugins
                 },
                 nameof(GetFilesReferencedBy));
 
-            ResumeRelativeDirectory($"GetFilesReferencedBy for {absoluteName}");
+            ResumeRelativeDirectory($"GetFilesReferencedBy for {filePath}");
 
             return generalResponse;
         }

--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -768,7 +768,7 @@ namespace FlatRedBall.Glue.Plugins
 
         }
 
-        internal static GeneralResponse GetFilesReferencedBy(FilePath filePath, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive, List<FilePath> listToFill)
+        internal static GeneralResponse GetFilesReferencedBy(FilePath filePath, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive, HashSet<FilePath> listToFill)
         {
             GeneralResponse generalResponse =  GeneralResponse.SuccessfulResponse;
             SaveRelativeDirectory();
@@ -793,7 +793,7 @@ namespace FlatRedBall.Glue.Plugins
             return generalResponse;
         }
 
-        internal static void GetFilesNeededOnDiskBy(string absoluteName, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive, List<FilePath> listToFill)
+        internal static void GetFilesNeededOnDiskBy(string absoluteName, EditorObjects.Parsing.TopLevelOrRecursive topLevelOrRecursive, HashSet<FilePath> listToFill)
         {
             SaveRelativeDirectory();
             CallMethodOnPluginNotUiThread(
@@ -805,7 +805,7 @@ namespace FlatRedBall.Glue.Plugins
                     }
                     else if (plugin.FillWithReferencedFiles != null)
                     {
-                        List<FilePath> innerList = new List<FilePath>();
+                        HashSet<FilePath> innerList = new ();
                         plugin.FillWithReferencedFiles(absoluteName, innerList);
                         listToFill.AddRange(innerList);
 

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -1025,7 +1025,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
             else
             {
-                List<FilePath> listOfReferencedFiles;
+                HashSet<FilePath> listOfReferencedFiles;
 
                 if (FileHelper.DoesFileReferenceContent(sourceFileName))
                 {
@@ -1033,7 +1033,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 }
                 else
                 {
-                    listOfReferencedFiles = new List<FilePath>();
+                    listOfReferencedFiles = new HashSet<FilePath>();
                 }
 
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Managers/FileReferenceTracker.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Managers/FileReferenceTracker.cs
@@ -571,7 +571,7 @@ namespace GumPlugin.Managers
             }
         }
         
-        internal GeneralResponse HandleFillWithReferencedFiles(FilePath filePath, List<FilePath> listToFill)
+        internal GeneralResponse HandleFillWithReferencedFiles(FilePath filePath, HashSet<FilePath> listToFill)
         {
             ProjectOrDisk projectOrDisk = ProjectOrDisk.Project;
 

--- a/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/MainAnimationChainPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/MainAnimationChainPlugin.cs
@@ -101,21 +101,24 @@ namespace OfficialPlugins.AnimationChainPlugin
                 if (path.Exists())
                 {
                     var directory = path.GetDirectoryContainingThis();
-                    using (StreamReader reader = new StreamReader(path.FullPath))
+
+                    // might be faster to read the entire file:
+                    var contents = System.IO.File.ReadAllText(path.FullPath);
+
+                    var splitContents = contents.Split(new[] { '\n' }, StringSplitOptions.None);
+
+                    var textureNameLength = "<TextureName>".Length;
+                    foreach(var line in splitContents)
                     {
-                        string line;
-                        var textureNameLength = "<TextureName>".Length;
-                        while ((line = reader.ReadLine()) != null)
+                        if(line.Contains("<TextureName>"))
                         {
-                            if(line.Contains("<TextureName>"))
-                            {
-                                var startIndex = line.IndexOf("<TextureName>") + textureNameLength;
-                                var endIndex = line.IndexOf("</TextureName>");
-                                var textureName = line.Substring(startIndex, endIndex - startIndex);
-                                list.Add(directory + textureName);
-                            }
+                            var startIndex = line.IndexOf("<TextureName>") + textureNameLength;
+                            var endIndex = line.IndexOf("</TextureName>");
+                            var textureName = line.Substring(startIndex, endIndex - startIndex);
+                            list.Add(directory + textureName);
                         }
                     }
+
                     return ToolsUtilities.GeneralResponse.SuccessfulResponse;
                 }
                 else

--- a/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/MainAnimationChainPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/MainAnimationChainPlugin.cs
@@ -94,7 +94,7 @@ namespace OfficialPlugins.AnimationChainPlugin
         // from 0.7 seconds to 0.2 seconds. This is a little less flexible
         // since it assumes TextureName rather than relying on reusable reference
         // tracking, but modern .achx files only use this.
-        private ToolsUtilities.GeneralResponse HandleFillWithReferencedFilesNew(FilePath path, List<FilePath> list)
+        private ToolsUtilities.GeneralResponse HandleFillWithReferencedFilesNew(FilePath path, HashSet<FilePath> list)
         {
             if (path.Extension == "achx")
             {

--- a/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/MainAnimationChainPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/MainAnimationChainPlugin.cs
@@ -103,12 +103,10 @@ namespace OfficialPlugins.AnimationChainPlugin
                     var directory = path.GetDirectoryContainingThis();
 
                     // might be faster to read the entire file:
-                    var contents = System.IO.File.ReadAllText(path.FullPath);
-
-                    var splitContents = contents.Split(new[] { '\n' }, StringSplitOptions.None);
+                    var contents = System.IO.File.ReadAllLines(path.FullPath);
 
                     var textureNameLength = "<TextureName>".Length;
-                    foreach(var line in splitContents)
+                    foreach(var line in contents)
                     {
                         if(line.Contains("<TextureName>"))
                         {

--- a/FRBDK/Glue/OfficialPlugins/ContentPipelinePlugin/MainContentPipelinePlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/ContentPipelinePlugin/MainContentPipelinePlugin.cs
@@ -133,7 +133,7 @@ namespace OfficialPlugins.MonoGameContent
             this.GetFilesNeededOnDiskBy += HandleGetFilesNeededOnDiskBy;
         }
 
-        private void HandleGetFilesNeededOnDiskBy(string fileName, List<FilePath> list)
+        private void HandleGetFilesNeededOnDiskBy(string fileName, HashSet<FilePath> list)
         {
             var filePath = new FilePath(fileName);
             var rfs = GlueCommands.Self.GluxCommands.GetReferencedFileSaveFromFile(filePath);

--- a/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/Managers/FileReferenceManager.cs
+++ b/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/Managers/FileReferenceManager.cs
@@ -45,7 +45,7 @@ namespace TileGraphicsPlugin.Managers
         }
 
 
-        public GeneralResponse HandleGetFilesReferencedBy(FilePath filePath, List<FilePath> listToFill)
+        public GeneralResponse HandleGetFilesReferencedBy(FilePath filePath, HashSet<FilePath> listToFill)
         {
             GeneralResponse generalResponse = GeneralResponse.SuccessfulResponse;
 
@@ -67,7 +67,7 @@ namespace TileGraphicsPlugin.Managers
             return generalResponse;
         }
 
-        private GeneralResponse GetTsxFileReferences(FilePath tsxFile, List<FilePath> referencedFiles)
+        private GeneralResponse GetTsxFileReferences(FilePath tsxFile, HashSet<FilePath> referencedFiles)
         {
             ExternalTileSet external = null;
 
@@ -106,7 +106,7 @@ namespace TileGraphicsPlugin.Managers
             return response;
         }
 
-        private GeneralResponse GetTmxFileReferences(FilePath fileName, List<FilePath> listToFill)
+        private GeneralResponse GetTmxFileReferences(FilePath fileName, HashSet<FilePath> listToFill)
         {
             TiledMapSave tms = null;
             GeneralResponse response = GeneralResponse.SuccessfulResponse;
@@ -158,7 +158,7 @@ namespace TileGraphicsPlugin.Managers
             return response;
         }
 
-        private static void GetTilbFileReferences(FilePath fileName, List<FilePath> listToFill)
+        private static void GetTilbFileReferences(FilePath fileName, HashSet<FilePath> listToFill)
         {
             try
             {


### PR DESCRIPTION
Huge fonts like Noto Sans took around 20 seconds to initializate. I fixed this by making sure all string comparisons while reading the Angel Code font file are made using StringComparison.Ordinal instead of StringComparison.CurrentCulture (default value). After some testing this loading time was reduced to less than a second.