### PR TITLE
Set IGumScreenOwner.GumScreen so it is not null

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GumPluginCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GumPluginCodeGenerator.cs
@@ -70,13 +70,15 @@ class GumPluginCodeGenerator : ElementComponentCodeGenerator
             var gumScreenRfs = GetGumScreenRfs(element);
             var ati = gumScreenRfs.GetAssetTypeInfo();
 
+            var gumScreenObjectName = GumScreenObjectNameFor(element);
+
             if (ati?.RuntimeTypeName == "GumIdb")
             {
-                codeBlock.Line("global::Gum.Wireframe.GraphicalUiElement FlatRedBall.Gum.IGumScreenOwner.GumScreen => GumScreen.Element;");
+                codeBlock.Line($"global::Gum.Wireframe.GraphicalUiElement FlatRedBall.Gum.IGumScreenOwner.GumScreen => {gumScreenObjectName}.Element;");
             }
             else
             {
-                codeBlock.Line("global::Gum.Wireframe.GraphicalUiElement FlatRedBall.Gum.IGumScreenOwner.GumScreen => GumScreen;");
+                codeBlock.Line($"global::Gum.Wireframe.GraphicalUiElement FlatRedBall.Gum.IGumScreenOwner.GumScreen => {gumScreenObjectName};");
             }
 
             codeBlock.Line("void FlatRedBall.Gum.IGumScreenOwner.RefreshLayout() => RefreshLayoutInternal(null, null);");

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GumPluginCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GumPluginCodeGenerator.cs
@@ -67,7 +67,17 @@ class GumPluginCodeGenerator : ElementComponentCodeGenerator
         // It's possible to have a Gum screen in derived but not base, but that's rare so I'm not going to handle that case until someone complains
         if(ShouldGenerateGumScreenOwner(element) && !HasBaseWithGumScreen(element as GlueElement))
         {
-            codeBlock.Line("global::Gum.Wireframe.GraphicalUiElement FlatRedBall.Gum.IGumScreenOwner.GumScreen { get; }");
+            var gumScreenRfs = GetGumScreenRfs(element);
+            var ati = gumScreenRfs.GetAssetTypeInfo();
+
+            if (ati?.RuntimeTypeName == "GumIdb")
+            {
+                codeBlock.Line("global::Gum.Wireframe.GraphicalUiElement FlatRedBall.Gum.IGumScreenOwner.GumScreen => GumScreen.Element;");
+            }
+            else
+            {
+                codeBlock.Line("global::Gum.Wireframe.GraphicalUiElement FlatRedBall.Gum.IGumScreenOwner.GumScreen => GumScreen;");
+            }
 
             codeBlock.Line("void FlatRedBall.Gum.IGumScreenOwner.RefreshLayout() => RefreshLayoutInternal(null, null);");
         }

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Screens/GumScreen.cs
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Screens/GumScreen.cs
@@ -5,13 +5,13 @@ using GlueTestProject.GumRuntimes;
 using System.Linq;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
+using FlatRedBall.Gum;
 
 
 namespace GlueTestProject.Screens;
 
 public partial class GumScreen
 {
-
     void CustomInitialize()
     {
         if (this.TopButton.Width < 149 || this.TopButton.Width > 151)
@@ -95,8 +95,15 @@ public partial class GumScreen
         CustomVariables_ShouldMatchInstanceValues();
 
         AnimatedSprites_ShouldDisplayCorrectFrame_WhenMadeNewlyVisible();
+
+        GumScreen_ShouldNotBeNull();
     }
 
+    private void GumScreen_ShouldNotBeNull()
+    {
+        this.GumScreen_.ShouldNotBe(null);
+        ((IGumScreenOwner)this).GumScreen.ShouldNotBe(null);
+    }
     private void AnimatedSprites_ShouldDisplayCorrectFrame_WhenMadeNewlyVisible()
     {
         var sprite = new SpriteRuntime();


### PR DESCRIPTION
IGumScreenOwner.GumScreen was always null before but this property can be useful in code. Enabled the code generator to return the value.