### PR TITLE
Fixed Gum tool error when trying to get strong types and not properly…

### DIFF
--- a/FRBDK/Glue/Glue/FormHelpers/StringConverters/AvailableAnimationChainsStringConverter.cs
+++ b/FRBDK/Glue/Glue/FormHelpers/StringConverters/AvailableAnimationChainsStringConverter.cs
@@ -25,10 +25,10 @@ namespace FlatRedBall.Glue.GuiDisplay
     // so I'm inheriting from StringConverter.
     public class AvailableAnimationChainsStringConverter : StringConverter, IObjectsInFileConverter
     {
-        IElement element;
-        StateSave stateSave;
-        NamedObjectSave referencedNos;
-
+        IElement _element;
+        StateSave _stateSave;
+        NamedObjectSave _referencedNos;
+        private string? _variableName;
         string[] mAvailableChains;
 
         public string[] AvailableChains
@@ -79,16 +79,17 @@ namespace FlatRedBall.Glue.GuiDisplay
 
         }
 
-        public AvailableAnimationChainsStringConverter(IElement element, NamedObjectSave namedObjectSave)
+        public AvailableAnimationChainsStringConverter(IElement element, NamedObjectSave namedObjectSave, string? variableName = null)
         {
-            Initialize(element, namedObjectSave);
+            Initialize(element, namedObjectSave, variableName: variableName);
         }
 
-        void Initialize(IElement element, NamedObjectSave referencedNos, StateSave stateSave = null)
+        void Initialize(IElement element, NamedObjectSave referencedNos, StateSave stateSave = null, string? variableName = null)
         {
-            this.element = element;
-            this.stateSave = stateSave;
-            this.referencedNos = referencedNos;
+            _element = element;
+            _stateSave = stateSave;
+            _referencedNos = referencedNos;
+            _variableName = variableName;
 
 
             RefreshList();
@@ -101,12 +102,12 @@ namespace FlatRedBall.Glue.GuiDisplay
             AnimationChainListSave acls = null;
             try
             {
-                acls = GetAnimationChainListFile(element, referencedNos, stateSave);
+                acls = GetAnimationChainListFile(_element, _referencedNos, _stateSave, _variableName);
             }
             catch(Exception e)
             {
                 // file could be corrupt, don't crash the plugin if so, treat it as if it's empty and print output:
-                GlueCommands.Self.PrintError($"Error loading AnimationChains from {referencedNos} when attempting to get list of items:\n{e}");
+                GlueCommands.Self.PrintError($"Error loading AnimationChains from {_referencedNos} when attempting to get list of items:\n{e}");
             }
 
 
@@ -116,7 +117,7 @@ namespace FlatRedBall.Glue.GuiDisplay
             }
             else
             {
-                var referencedFile = element.ReferencedFiles.FirstOrDefault(item => ObjectFinder.Self.MakeAbsoluteContent(item.Name) == acls.FileName);
+                var referencedFile = _element.ReferencedFiles.FirstOrDefault(item => ObjectFinder.Self.MakeAbsoluteContent(item.Name) == acls.FileName);
 
                 this.ReferencedFileSave = referencedFile;
 
@@ -132,7 +133,7 @@ namespace FlatRedBall.Glue.GuiDisplay
             }
         }
 
-        public static AnimationChainListSave GetAnimationChainListFile(IElement element, NamedObjectSave referencedNos, StateSave stateSave)
+        static AnimationChainListSave GetAnimationChainListFile(IElement element, NamedObjectSave referencedNos, StateSave stateSave, string? variableName)
         {
             AnimationChainListSave acls = null;
 
@@ -167,6 +168,28 @@ namespace FlatRedBall.Glue.GuiDisplay
                     acls = foundAcls;
 
 
+                }
+                else if(referencedNos.SourceType == SourceType.Entity && variableName != null)
+                {
+                    // That means this variable is a tuneled variable, so we have to check what it is tunneling, find that sprite, and see what its default animation is
+                    var entity = ObjectFinder.Self.GetElement(referencedNos);
+
+                    if(entity != null)
+                    {
+                        CustomVariable innerVariable = entity.GetCustomVariable(variableName);
+
+                        // this variable should have a target NOS:
+                        if(innerVariable?.SourceObject != null)
+                        {
+                            NamedObjectSave? innerNamedObject = entity.GetNamedObjectRecursively(innerVariable.SourceObject);
+
+                            if(innerNamedObject != null)
+                            {
+                                return GetAnimationChainListFile(entity, innerNamedObject, null, innerVariable.Name);
+                            }
+                        }
+
+                    }
                 }
             }
             return acls;

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/TypeConverterPlugin/MainPlugin.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/TypeConverterPlugin/MainPlugin.cs
@@ -69,7 +69,7 @@ namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.TypeConverterPlugin
                 }
                 else if(variableDefinition.Name == "CurrentChainName")
                 {
-                    var converter = new AvailableAnimationChainsStringConverter(containerAsIElement, instance);
+                    var converter = new AvailableAnimationChainsStringConverter(containerAsIElement, instance, memberName);
                     typeConverter = converter;
                     handled = true;
                 }

--- a/FRBDK/Glue/Glue/SaveClasses/NamedObjectSaveExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/NamedObjectSaveExtensionMethods.cs
@@ -900,7 +900,7 @@ namespace FlatRedBall.Glue.SaveClasses
         /// <param name="namedObjectContainer"></param>
         /// <param name="namedObjectName"></param>
         /// <returns></returns>
-        public static NamedObjectSave GetNamedObjectRecursively(this INamedObjectContainer namedObjectContainer, string namedObjectName)
+        public static NamedObjectSave? GetNamedObjectRecursively(this INamedObjectContainer namedObjectContainer, string namedObjectName)
         {
             ////////////////////////early out////////////////////////
             if(string.IsNullOrEmpty(namedObjectName))

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
@@ -306,23 +306,31 @@ namespace GumPlugin.CodeGeneration
             GenerateCustomVariableProperties(elementSave, currentBlock);
         }
 
-        public string GetQualifiedRuntimeTypeFor(InstanceSave instance, ElementSave container, bool includeGlobalPrefix = true)
+        public string GetQualifiedRuntimeTypeFor(InstanceSave instance, ElementSave instanceOwner, bool includeGlobalPrefix = true)
         {
-            var element = ObjectFinder.Self.GetElementSave(instance);
-            if(element == null)
+            var instanceElement = ObjectFinder.Self.GetElementSave(instance);
+            if(instanceElement == null)
             {
                 return "UnknownType";
             }
             else
             {
-                var qualifiedRuntimeType = GetQualifiedRuntimeTypeFor(element, includeGlobalPrefix);
+                var qualifiedRuntimeType = GetQualifiedRuntimeTypeFor(instanceElement, includeGlobalPrefix);
 
-                var isContainer = element is StandardElementSave && element.Name == "Container";
+                var isInstanceContainer = instanceElement is StandardElementSave && instanceElement.Name == "Container";
 
-                if(isContainer)
+                if(isInstanceContainer)
                 {
-                    var genericType = (string)container.DefaultState.GetValueRecursive(instance.Name + ".ContainedType") ??
-                        (string)container.DefaultState.GetValueRecursive(instance.Name + ".Contained Type");
+                    var instanceOwnerDefaultState = instanceOwner.DefaultState;
+
+                    if(instanceOwnerDefaultState.ParentContainer == null)
+                    {
+                        throw new InvalidOperationException("Did you forget to initialize the Gum project after loading it?");
+                    }
+
+                    var genericType =
+                        (string)instanceOwnerDefaultState.GetValueRecursive(instance.Name + ".ContainedType") ??
+                        (string)instanceOwnerDefaultState.GetValueRecursive(instance.Name + ".Contained Type");
 
                     if(!string.IsNullOrEmpty(genericType))
                     {

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Managers/ContainedObjectsManager.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Managers/ContainedObjectsManager.cs
@@ -10,12 +10,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+using GumObjectFinder= Gum.Managers.ObjectFinder; 
+
 namespace GumPlugin.Managers
 {
     public class ContainedObjectsManager : Singleton<ContainedObjectsManager>
     {
         public bool HandleTryAddContainedObjects(string absoluteFile, List<string> availableObjects)
         {
+            var elementFilePath = new FilePath(absoluteFile);
+
             string extension = FileManager.GetExtension(absoluteFile);
             bool isEitherScreenOrComponent = extension == GumProjectSave.ComponentExtension ||
                 extension == GumProjectSave.ScreenExtension;
@@ -48,9 +52,33 @@ namespace GumPlugin.Managers
 
             }
 
-            ElementSave element = null;
-            if (isEitherScreenOrComponent && System.IO.File.Exists(absoluteFile))
+            ElementSave? element = null;
+
+            // August 9, 2025
+            // Loading from file
+            // seems unnecessary since
+            // we already have the Gum project
+            // loaded. Can we rely on that?
+            if(GumObjectFinder.Self.GumProjectSave != null && isEitherScreenOrComponent)
             {
+                var directory = new FilePath(GumObjectFinder.Self.GumProjectSave.FullFileName).GetDirectoryContainingThis();
+
+                var relative = elementFilePath.RemoveExtension().RelativeTo(directory);
+                if(relative.StartsWith("Screens/"))
+                {
+                    relative = relative.Substring("Screens/".Length);
+                }
+                else if(relative.StartsWith("Components/"))
+                {
+                    relative = relative.Substring("Components/".Length);
+                }
+                element = GumObjectFinder.Self.GetElementSave(relative);
+            }
+
+
+            if (element == null && isEitherScreenOrComponent && System.IO.File.Exists(absoluteFile))
+            {
+
                 try
                 {
                     if (extension == GumProjectSave.ComponentExtension)
@@ -63,10 +91,12 @@ namespace GumPlugin.Managers
                         element =
                             FileManager.XmlDeserialize<Gum.DataTypes.ScreenSave>(absoluteFile);
                     }
+                    // we could initialize more deeply, but this should handle common cases.
+                    element.DefaultState.ParentContainer = element;
                 }
                 catch (Exception ex)
                 {
-                    GlueCommands.Self.PrintOutput("Error trying to load element {} for filling available contained objects: \n" + ex.ToString());
+                    GlueCommands.Self.PrintOutput($"Error trying to load element {absoluteFile} for filling available contained objects: \n" + ex.ToString());
                 }
             }
 

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Content/Entities/TunneledVariableEntity/AnimationChainListFile.achx
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Content/Entities/TunneledVariableEntity/AnimationChainListFile.achx
@@ -1,10 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <AnimationChainArraySave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <FileRelativeTextures>false</FileRelativeTextures>
   <TimeMeasurementUnit>Undefined</TimeMeasurementUnit>
+  <CoordinateType>Pixel</CoordinateType>
   <AnimationChain>
     <Name>asdf</Name>
-    <ColorKey>0</ColorKey>
   </AnimationChain>
-  <FileName>C:/FlatRedBallProjects/FrbTests/GlueTestProject/GlueTestProject/GlueTestProjectContent/Entities/TunneledVariableEntity/AnimationChainListFile.achx</FileName>
+  <AnimationChain>
+    <Name>Animation1</Name>
+  </AnimationChain>
+  <AnimationChain>
+    <Name>Animation2</Name>
+  </AnimationChain>
+  <AnimationChain>
+    <Name>Animation3</Name>
+  </AnimationChain>
 </AnimationChainArraySave>

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Content/Entities/TunneledVariableEntity/AnimationChainListFile2.achx
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Content/Entities/TunneledVariableEntity/AnimationChainListFile2.achx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AnimationChainArraySave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <FileRelativeTextures>true</FileRelativeTextures>
+  <TimeMeasurementUnit>Undefined</TimeMeasurementUnit>
+  <CoordinateType>UV</CoordinateType>
+  <ProjectFile>..\..\..\testprojectdesktopnet6.gluj</ProjectFile>
+</AnimationChainArraySave>

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Content/Entities/TunneledVariableEntity/AnimationChainListFile3.achx
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Content/Entities/TunneledVariableEntity/AnimationChainListFile3.achx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AnimationChainArraySave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <FileRelativeTextures>true</FileRelativeTextures>
+  <TimeMeasurementUnit>Undefined</TimeMeasurementUnit>
+  <CoordinateType>UV</CoordinateType>
+  <ProjectFile>..\..\..\testprojectdesktopnet6.gluj</ProjectFile>
+</AnimationChainArraySave>

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Content/Screens/TunneledVariableScreen/AchxInScreen.achx
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Content/Screens/TunneledVariableScreen/AchxInScreen.achx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AnimationChainArraySave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <FileRelativeTextures>true</FileRelativeTextures>
+  <TimeMeasurementUnit>Undefined</TimeMeasurementUnit>
+  <CoordinateType>UV</CoordinateType>
+  <ProjectFile>..\..\..\testprojectdesktopnet6.gluj</ProjectFile>
+</AnimationChainArraySave>

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Entities/TunneledVariableEntity.glej
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Entities/TunneledVariableEntity.glej
@@ -8,6 +8,19 @@
     {
       "Name": "Entities/TunneledVariableEntity/AnimationChainListFile.achx",
       "IsSharedStatic": true,
+      "HasPublicProperty": true,
+      "ProjectsToExcludeFrom": []
+    },
+    {
+      "Name": "Entities/TunneledVariableEntity/AnimationChainListFile2.achx",
+      "IsSharedStatic": true,
+      "RuntimeType": "FlatRedBall.Graphics.Animation.AnimationChainList",
+      "ProjectsToExcludeFrom": []
+    },
+    {
+      "Name": "Entities/TunneledVariableEntity/AnimationChainListFile3.achx",
+      "IsSharedStatic": true,
+      "RuntimeType": "FlatRedBall.Graphics.Animation.AnimationChainList",
       "ProjectsToExcludeFrom": []
     }
   ],
@@ -202,6 +215,25 @@
       "Name": "SpriteObjectTexture",
       "SourceObject": "SpriteObject",
       "SourceObjectProperty": "Texture"
+    },
+    {
+      "Properties": [
+        {
+          "Name": "Type",
+          "Value": "string",
+          "Type": "String"
+        },
+        {
+          "Name": "Category",
+          "Value": "Animation",
+          "Type": "String"
+        }
+      ],
+      "Name": "SpriteObjectCurrentChainName",
+      "SetByDerived": true,
+      "SourceObject": "SpriteObject",
+      "SourceObjectProperty": "CurrentChainName",
+      "Category": "Animation"
     }
   ],
   "States": [

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Screens/TunneledVariableScreen.glsj
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Screens/TunneledVariableScreen.glsj
@@ -4,6 +4,14 @@
   ],
   "Source": "GLUE",
   "NextScreen": "Screens\\ScreenBeforeAsyncScreen",
+  "ReferencedFiles": [
+    {
+      "Name": "Screens/TunneledVariableScreen/AchxInScreen.achx",
+      "IsSharedStatic": true,
+      "RuntimeType": "FlatRedBall.Graphics.Animation.AnimationChainList",
+      "ProjectsToExcludeFrom": []
+    }
+  ],
   "NamedObjects": [
     {
       "InstanceName": "TunneledVariableEntityInstance",
@@ -15,6 +23,12 @@
         }
       ],
       "InstructionSaves": [
+        {
+          "Type": "string",
+          "Member": "SpriteObjectCurrentChainName",
+          "Value": "Animation2",
+          "Time": 0.0
+        },
         {
           "Type": "string",
           "Member": "TextObjectDisplayText",

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/TestProjectDesktopNet6.csproj
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/TestProjectDesktopNet6.csproj
@@ -414,6 +414,14 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Name>AnimationChainListFile</Name>
     </None>
+    <None Include="Content\Entities\TunneledVariableEntity\AnimationChainListFile2.achx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Name>AnimationChainListFile2</Name>
+    </None>
+    <None Include="Content\Entities\TunneledVariableEntity\AnimationChainListFile3.achx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Name>AnimationChainListFile3</Name>
+    </None>
     <None Include="Content\Entities\VariableEntity\SceneFileForSourceFileSet.scnx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Name>SceneFileForSourceFileSet</Name>
@@ -1253,6 +1261,10 @@
     <None Include="Content\Screens\TransparencyRenderingScreen\ColorTest.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Name>ColorTest</Name>
+    </None>
+    <None Include="Content\Screens\TunneledVariableScreen\AchxInScreen.achx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Name>AchxInScreen</Name>
     </None>
     <None Include="Content\Screens\XmlScreen\XmlFileWithNoBackingObject.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
… initializing

Sprites with Tunneled variables can now set CurrentChainName for internal .achx. Sped up loading of Gum types when getting internal object names. Added sample project to test ^^