### PR TITLE
Corrected spelling of "Finished" in messsage

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -911,7 +911,7 @@ namespace GameCommunicationPlugin.GlueControl
             PluginManager.CallPluginMethod("Compiler Plugin", "HandleOutput", "Waiting for tasks to finish...");
             await TaskManager.Self.WaitForAllTasksFinished();
 
-            PluginManager.CallPluginMethod("Compiler Plugin", "HandleOutput", "Finishined adding/generating code for GlueControlManager");
+            PluginManager.CallPluginMethod("Compiler Plugin", "HandleOutput", "Finished adding/generating code for GlueControlManager");
         }
 
         private static void AddNewtonsoft()


### PR DESCRIPTION
This fixes the spelling error in the `MainCompilerPlugin` as stated in 

Closes #1788 