### PR TITLE
Segment performance improvement

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Math/Geometry/Segment.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Math/Geometry/Segment.cs
@@ -290,7 +290,7 @@ namespace FlatRedBall.Math.Geometry
 
         public float DistanceTo(double x, double y)
         {
-            if(Point1 == Point2)
+            if (Point1 == Point2)
             {
                 return (Point1 - new Point(x, y)).ToVector3().Length();
             }
@@ -298,21 +298,21 @@ namespace FlatRedBall.Math.Geometry
             {
                 float segmentLength = (float)this.GetLength();
 
-                Vector2 normalizedLine = new Vector2(
+                var normalizedLine = new Vector2(
                     (float)(Point2.X - Point1.X) / segmentLength,
                     (float)(Point2.Y - Point1.Y) / segmentLength);
 
-                Vector2 pointVector = new Vector2((float)(x - Point1.X), (float)(y - Point1.Y));
+                var pointVector = new Vector2((float)(x - Point1.X), (float)(y - Point1.Y));
 
-                float length = Vector2.Dot(pointVector, normalizedLine);
+                var length = Vector2.Dot(pointVector, normalizedLine);
 
                 if (length < 0)
                 {
-                    return (float)(new Segment(x, y, Point1.X, Point1.Y).GetLength());
+                    return (float)MathFunctions.Distance(x, y, Point1.X, Point1.Y);
                 }
                 else if (length > segmentLength)
                 {
-                    return (float)(new Segment(x, y, Point2.X, Point2.Y).GetLength());
+                    return (float)MathFunctions.Distance(x, y, Point2.X, Point2.Y);
                 }
                 else
                 {
@@ -328,7 +328,7 @@ namespace FlatRedBall.Math.Geometry
                     return (float)System.Math.Sqrt(xDistanceSquared + yDistanceSquared);
                 }
             }
-        }   
+        }
 
         public float DistanceTo(Point point, out Segment connectingSegment)
         {

--- a/Engines/FlatRedBallXNA/FlatRedBall/Math/MathFunctions.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Math/MathFunctions.cs
@@ -1440,6 +1440,13 @@ namespace FlatRedBall.Math
             return (X * X + Y * Y);
         }
 
+        public static double Distance(double x1, double y1, double x2, double y2)
+        {
+            double xDistance = x2 - x1;
+            double yDistance = y2 - y1;
+            return System.Math.Sqrt(xDistance * xDistance + yDistance * yDistance);
+        }
+
         public static Vector3 AngleToVector(float radians)
         {
             return new Vector3((float)System.Math.Cos((double)radians), (float)System.Math.Sin((double)radians), 0f);


### PR DESCRIPTION
Performance improvement by avoiding the creation of new segments in Segment.DistanceTo(double x, double y).
This method was called massively in my game and this brings a decent gain.