### PR TITLE
Use Parallel.ForEach for a small speedup when checking deleted files in wildcards

### DIFF
--- a/FRBDK/Glue/Glue/Managers/WildcardReferencedFileSaveLogic.cs
+++ b/FRBDK/Glue/Glue/Managers/WildcardReferencedFileSaveLogic.cs
@@ -301,36 +301,37 @@ public class WildcardReferencedFileSaveLogic
 
         var toRemove = new List<ProjectItem>();
 
-        foreach(var itemInVisualStudio in visualStudioProject.EvaluatedItems)
+        foreach (var itemInVisualStudio in visualStudioProject.EvaluatedItems)
+        //Parallel.ForEach(visualStudioProject.EvaluatedItems, itemInVisualStudio =>
         {
             var relativeFile = itemInVisualStudio.EvaluatedInclude;
 
-            if (relativeFile == null) continue;
-
-            FilePath absoluteFile = projectFile + relativeFile;
-
-
-            var isContent =
-                itemInVisualStudio.ItemType == "None" &&
-                !string.IsNullOrEmpty(absoluteFile.Extension) &&
-                absoluteFile.Extension != "cs" &&
-                _fileCommands.IsContent(absoluteFile);
-
-            if (isContent && absoluteFile.Exists() == false)
+            if (relativeFile != null)
             {
-                foreach(var pattern in glueProject.GlobalFileWildcards)
+                FilePath absoluteFile = projectFile + relativeFile;
+
+                var isContent =
+                    itemInVisualStudio.ItemType == "None" &&
+                    !string.IsNullOrEmpty(absoluteFile.Extension) &&
+                    absoluteFile.Extension != "cs" &&
+                    _fileCommands.IsContent(absoluteFile);
+
+                if (isContent && absoluteFile.Exists() == false)
                 {
-                    var absolutePattern = _glueCommands.GetAbsoluteFilePath(pattern);
-                    // does it match?
-                    if(IsMatch(absolutePattern, absoluteFile))
+                    foreach (var pattern in glueProject.GlobalFileWildcards)
                     {
-                        // remove it!
-                        toRemove.Add(itemInVisualStudio);
-                        break;
+                        var absolutePattern = _glueCommands.GetAbsoluteFilePath(pattern);
+                        // does it match?
+                        if (IsMatch(absolutePattern, absoluteFile))
+                        {
+                            // remove it!
+                            toRemove.Add(itemInVisualStudio);
+                            break;
+                        }
                     }
                 }
             }
-        }
+        }//);
 
         if(toRemove.Count > 0)
         {

--- a/FRBDK/Glue/Glue/Managers/WildcardReferencedFileSaveLogic.cs
+++ b/FRBDK/Glue/Glue/Managers/WildcardReferencedFileSaveLogic.cs
@@ -301,8 +301,8 @@ public class WildcardReferencedFileSaveLogic
 
         var toRemove = new List<ProjectItem>();
 
-        foreach (var itemInVisualStudio in visualStudioProject.EvaluatedItems)
-        //Parallel.ForEach(visualStudioProject.EvaluatedItems, itemInVisualStudio =>
+        //foreach (var itemInVisualStudio in visualStudioProject.EvaluatedItems)
+        Parallel.ForEach(visualStudioProject.EvaluatedItems, itemInVisualStudio =>
         {
             var relativeFile = itemInVisualStudio.EvaluatedInclude;
 
@@ -331,7 +331,7 @@ public class WildcardReferencedFileSaveLogic
                     }
                 }
             }
-        }//);
+        });
 
         if(toRemove.Count > 0)
         {


### PR DESCRIPTION
It's not much but if the number of files in a project keeps growing this should ensure performance will not degrade.