### PR TITLE
Add Tag property to positioned nodes

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/AI/Pathfinding/PositionedNode.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/AI/Pathfinding/PositionedNode.cs
@@ -170,6 +170,14 @@ namespace FlatRedBall.AI.Pathfinding
             get { return mActive; }
             set { mActive = value; }
         }
+
+        /// <summary>
+        /// Gets or sets a user-defined object associated with the current node.
+        /// </summary>
+        /// <remarks>This property can be used to attach custom data to the instance for
+        /// game-specific purposes. The value is not used or interpreted by the engine.</remarks>
+        public object? Tag { get; set; }
+
         #endregion
 
         #region Methods

--- a/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/EmbeddedCodeFiles/TileNodeNetworkCreator.cs
+++ b/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/EmbeddedCodeFiles/TileNodeNetworkCreator.cs
@@ -103,7 +103,7 @@ namespace FlatRedBall.AI.Pathfinding
             }
         }
 
-        public static void FillFromPredicate(this TileNodeNetwork nodeNetwork, LayeredTileMap layeredTileMap, Func<List<NamedValue>, bool> predicate, MapDrawableBatch layer = null, float offsetX = 0, float offsetY = 0)
+        public static void FillFromPredicate(this TileNodeNetwork nodeNetwork, LayeredTileMap layeredTileMap, Func<List<NamedValue>, bool> predicate, MapDrawableBatch layer = null, float offsetX = 0, float offsetY = 0, object? tagForAddedNodes = null)
         {
             var dimensionHalf = layeredTileMap.WidthPerTile.Value / 2.0f;
 
@@ -151,7 +151,8 @@ namespace FlatRedBall.AI.Pathfinding
                         var centerX = left + dimensionHalf + offsetX;
                         var centerY = bottom + dimensionHalf + offsetY;
 
-                        nodeNetwork.AddAndLinkTiledNodeWorld(centerX, centerY);
+                        var node = nodeNetwork.AddAndLinkTiledNodeWorld(centerX, centerY);
+                        node.Tag = tagForAddedNodes;
                     }
                 }
             }


### PR DESCRIPTION
Adds a Tag property to PositionedNode so the user can attach game-specific data to nodes.

Adds an optional parameter in TileNodeNetworkCreator.FillFromPredicate to ease adding user tags.