### PR TITLE
Fix GumPlugin build after Gum moved animation SaveClasses to GumDataTypes

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/SaveObjectExtensionMethods.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/SaveObjectExtensionMethods.cs
@@ -1,7 +1,7 @@
 ﻿using FlatRedBall.IO;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
-using StateAnimationPlugin.SaveClasses;
+using Gum.StateAnimation.SaveClasses;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.Animation.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.Animation.cs
@@ -10,7 +10,7 @@ using FlatRedBall.IO;
 using Gum.DataTypes;
 using GumPlugin.Managers;
 using GumPlugin.Managers;
-using StateAnimationPlugin.SaveClasses;
+using Gum.StateAnimation.SaveClasses;
 
 namespace GumPlugin.CodeGeneration;
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/GumPlugin.csproj
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/GumPlugin.csproj
@@ -183,12 +183,6 @@
     <EmbeddedResource Include="..\..\..\..\..\Gum\RenderingLibrary\Math\MathFunctions.cs" Link="Embedded\LibraryFiles\RenderingLibrary\MathFunctions.cs" />
     <EmbeddedResource Include="..\..\..\..\..\Gum\RenderingLibrary\SystemManagers.cs" Link="Embedded\LibraryFiles\RenderingLibrary\SystemManagers.cs" />
     <Compile Include="..\..\..\..\..\Gum\GumRuntime\BbCodeParser.cs" Link="BbCodeParser.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\AnimatedStateSave.cs" Link="Animation\AnimatedStateSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\AnimationReferenceSave.cs" Link="Animation\AnimationReferenceSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\AnimationSave.cs" Link="Animation\AnimationSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\ElementAnimationReferenceSave.cs" Link="Animation\ElementAnimationReferenceSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\ElementAnimationsSave.cs" Link="Animation\ElementAnimationsSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\NamedEventSave.cs" Link="Animation\NamedEventSave.cs" />
     <EmbeddedResource Include="..\..\..\..\..\Gum\ToolsUtilities\FileManager.cs" Link="Embedded\LibraryFiles\ToolsUtilities\FileManager.cs" />
     <EmbeddedResource Include="..\..\..\..\..\Gum\ToolsUtilities\ReflectionManager.cs" Link="Embedded\LibraryFiles\ToolsUtilities\ReflectionManager.cs" />
     <EmbeddedResource Include="..\..\..\..\..\Gum\ToolsUtilities\StringFunctions.cs" Link="Embedded\LibraryFiles\ToolsUtilities\StringFunctions.cs" />

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Managers/AnimationLogic.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Managers/AnimationLogic.cs
@@ -2,7 +2,7 @@
 using FlatRedBall.IO;
 using Gum.DataTypes;
 using GumPlugin.Managers;
-using StateAnimationPlugin.SaveClasses;
+using Gum.StateAnimation.SaveClasses;
 using System;
 using System.Collections.Generic;
 using System.Text;


### PR DESCRIPTION
## Problem

Building `GlueWithAll.sln` against latest Gum fails with six `CS2001` "source file could not be found" errors in **GumPlugin**:

```
...\Gum\Gum\StateAnimationPlugin\SaveClasses\AnimationSave.cs could not be found
...and AnimatedStateSave, AnimationReferenceSave, ElementAnimationReferenceSave, ElementAnimationsSave, NamedEventSave
```

## Root cause

Gum relocated its six animation save-classes out of the editor's `StateAnimationPlugin` and into the core **GumDataTypes** library, consolidating what used to be two duplicate copies into one. As part of that move the namespace changed:

`StateAnimationPlugin.SaveClasses` → `Gum.StateAnimation.SaveClasses`

GumPlugin linked those files by relative path (`<Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\*.cs">`) — a *source-level* coupling, not an assembly reference. When Gum deleted the old physical location, those hardcoded paths went stale.

## Fix

GumPlugin already has a `ProjectReference` to **GumCommon**, and GumCommon now compiles these six classes (namespace `Gum.StateAnimation.SaveClasses`). So the linked source is redundant — and repointing it would compile the types *into* GumPlugin while also importing them from GumCommon, producing duplicate-type errors. Instead:

- Removed the six stale `<Compile Include>` entries from `GumPlugin.csproj`.
- Updated the three `using StateAnimationPlugin.SaveClasses;` directives (`AnimationLogic.cs`, `SaveObjectExtensionMethods.cs`, `StateCodeGenerator.Animation.cs`) to `using Gum.StateAnimation.SaveClasses;`.

## Scope

**Tool-only.** GumPlugin is a Glue editor plugin. The `StateAnimationPlugin.SaveClasses` namespace only ever existed in tool-side code (the Gum editor and this plugin). The runtime libraries (MonoGameGum / GumCore) have always used `Gum.StateAnimation.SaveClasses`, so **games are unaffected** and need no changes.

## Verification

`dotnet build GumPlugin.csproj` — C# compilation succeeds with **0 errors** (was 6× CS2001), `GumPlugin.dll` produced. The only remaining build error is the post-build copy step, which depends on `$(SolutionDir)` and only resolves when building via the solution (`GlueWithAll.sln`); it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
