### PR TITLE
Add per-frame color/tint support to AnimationFrame (.achx)

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Content/AnimationChain/AnimationFrameSave.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Content/AnimationChain/AnimationFrameSave.cs
@@ -12,6 +12,18 @@ using FlatRedBall.Content.Math.Geometry;
 
 namespace FlatRedBall.Content.AnimationChain
 {
+    /// <summary>
+    /// Per-frame color operation as stored in the .achx file format. This intentionally mirrors the
+    /// values produced by the FlatRedBall animation editor (Multiply, Add) rather than the engine's
+    /// richer FlatRedBall.Graphics.ColorOperation enum. It is mapped to a runtime ColorOperation
+    /// (Multiply -> Modulate, Add -> Add) when converted to an AnimationFrame.
+    /// </summary>
+    public enum AnimationFrameColorOperation
+    {
+        Multiply,
+        Add
+    }
+
     [Serializable]
     public class AnimationFrameSave
     {
@@ -104,6 +116,42 @@ namespace FlatRedBall.Content.AnimationChain
                 ShapeCollectionSave.SphereSaves.Count > 0 
             );
 
+        #region Color (optional, per-frame tint - added for .achx color support)
+
+        /// <summary>
+        /// Optional per-frame red tint channel, 0 - 255. Null means "unset" and is omitted from the .achx file.
+        /// Converted to the 0 - 1 range when applied to a Sprite.
+        /// </summary>
+        public int? Red;
+        public bool ShouldSerializeRed() => Red.HasValue;
+
+        /// <summary>
+        /// Optional per-frame green tint channel, 0 - 255. Null means "unset" and is omitted from the .achx file.
+        /// </summary>
+        public int? Green;
+        public bool ShouldSerializeGreen() => Green.HasValue;
+
+        /// <summary>
+        /// Optional per-frame blue tint channel, 0 - 255. Null means "unset" and is omitted from the .achx file.
+        /// </summary>
+        public int? Blue;
+        public bool ShouldSerializeBlue() => Blue.HasValue;
+
+        /// <summary>
+        /// Optional per-frame alpha (opacity) channel, 0 - 255. Null means "unset" and is omitted from the .achx file.
+        /// Alpha is independent of ColorOperation.
+        /// </summary>
+        public int? Alpha;
+        public bool ShouldSerializeAlpha() => Alpha.HasValue;
+
+        /// <summary>
+        /// Optional per-frame color operation. Null means "unset" (no tint operation) and is omitted from the .achx file.
+        /// </summary>
+        public AnimationFrameColorOperation? ColorOperation;
+        public bool ShouldSerializeColorOperation() => ColorOperation.HasValue;
+
+        #endregion
+
         [XmlIgnore]
         [ExternalInstance]
         internal Texture2D mTextureInstance;
@@ -127,6 +175,12 @@ namespace FlatRedBall.Content.AnimationChain
 
             RelativeX = template.RelativeX;
             RelativeY = template.RelativeY;
+
+            Red = ToColorByte(template.Red);
+            Green = ToColorByte(template.Green);
+            Blue = ToColorByte(template.Blue);
+            Alpha = ToColorByte(template.Alpha);
+            ColorOperation = ToSaveColorOperation(template.ColorOperation);
 
             TextureName = template.Texture.Name;
         }
@@ -202,6 +256,12 @@ namespace FlatRedBall.Content.AnimationChain
             frame.RelativeX = RelativeX;
             frame.RelativeY = RelativeY;
 
+            frame.Red = ToColorFloat(Red);
+            frame.Green = ToColorFloat(Green);
+            frame.Blue = ToColorFloat(Blue);
+            frame.Alpha = ToColorFloat(Alpha);
+            frame.ColorOperation = ToRuntimeColorOperation(ColorOperation);
+
             frame.ShapeCollectionSave = ShapeCollectionSave;
 
             #endregion
@@ -249,10 +309,68 @@ namespace FlatRedBall.Content.AnimationChain
                     case "RelativeY":
                         toReturn.RelativeY = SceneSave.AsFloat(subElement);
                         break;
+                    case "Red":
+                        toReturn.Red = SceneSave.AsInt(subElement);
+                        break;
+                    case "Green":
+                        toReturn.Green = SceneSave.AsInt(subElement);
+                        break;
+                    case "Blue":
+                        toReturn.Blue = SceneSave.AsInt(subElement);
+                        break;
+                    case "Alpha":
+                        toReturn.Alpha = SceneSave.AsInt(subElement);
+                        break;
+                    case "ColorOperation":
+                        if (Enum.TryParse<AnimationFrameColorOperation>(subElement.Value, out var parsedColorOperation))
+                        {
+                            toReturn.ColorOperation = parsedColorOperation;
+                        }
+                        break;
                 }
             }
 
             return toReturn;
+        }
+
+        private static float? ToColorFloat(int? colorByte) =>
+            colorByte.HasValue ? colorByte.Value / 255f : (float?)null;
+
+        private static int? ToColorByte(float? colorFloat)
+        {
+            if (!colorFloat.HasValue)
+            {
+                return null;
+            }
+
+            int asByte = (int)System.Math.Round(colorFloat.Value * 255f);
+            return System.Math.Max(0, System.Math.Min(255, asByte));
+        }
+
+        private static FlatRedBall.Graphics.ColorOperation? ToRuntimeColorOperation(AnimationFrameColorOperation? colorOperation)
+        {
+            switch (colorOperation)
+            {
+                case AnimationFrameColorOperation.Multiply:
+                    return FlatRedBall.Graphics.ColorOperation.Modulate;
+                case AnimationFrameColorOperation.Add:
+                    return FlatRedBall.Graphics.ColorOperation.Add;
+                default:
+                    return null;
+            }
+        }
+
+        private static AnimationFrameColorOperation? ToSaveColorOperation(FlatRedBall.Graphics.ColorOperation? colorOperation)
+        {
+            switch (colorOperation)
+            {
+                case FlatRedBall.Graphics.ColorOperation.Modulate:
+                    return AnimationFrameColorOperation.Multiply;
+                case FlatRedBall.Graphics.ColorOperation.Add:
+                    return AnimationFrameColorOperation.Add;
+                default:
+                    return null;
+            }
         }
 
         public override string ToString()

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/Animation/AnimationFrame.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/Animation/AnimationFrame.cs
@@ -107,6 +107,34 @@ namespace FlatRedBall.Graphics.Animation
         /// </summary>
         public ShapeCollectionSave ShapeCollectionSave;
 
+        /// <summary>
+        /// Optional per-frame red tint channel in the 0 - 1 range. Loaded from the .achx file (stored there as 0 - 255).
+        /// When non-null this is applied to the Sprite during animation playback; null means "unset".
+        /// </summary>
+        public float? Red;
+
+        /// <summary>
+        /// Optional per-frame green tint channel in the 0 - 1 range. Applied to the Sprite when non-null.
+        /// </summary>
+        public float? Green;
+
+        /// <summary>
+        /// Optional per-frame blue tint channel in the 0 - 1 range. Applied to the Sprite when non-null.
+        /// </summary>
+        public float? Blue;
+
+        /// <summary>
+        /// Optional per-frame alpha (opacity) in the 0 - 1 range. Applied to the Sprite when non-null.
+        /// Independent of ColorOperation.
+        /// </summary>
+        public float? Alpha;
+
+        /// <summary>
+        /// Optional per-frame color operation. Applied to the Sprite when non-null, gating how the
+        /// Red/Green/Blue channels combine with the texture.
+        /// </summary>
+        public FlatRedBall.Graphics.ColorOperation? ColorOperation;
+
         #endregion
 
         #region Properties

--- a/Engines/FlatRedBallXNA/FlatRedBall/Sprite.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Sprite.cs
@@ -1647,12 +1647,49 @@ namespace FlatRedBall
                 RelativePosition.Y = frame.RelativeY;
             }
 
+            ApplyAnimationFrameColor(frame);
+
             foreach (var instruction in frame.Instructions)
             {
                 instruction.Execute();
             }
 
             UpdateScale();
+        }
+
+        /// <summary>
+        /// Applies the optional per-frame color values (tint, alpha, color operation) from the AnimationFrame
+        /// to this Sprite. Frames which carry no color data leave the Sprite's color completely untouched, so
+        /// existing animations are unaffected.
+        /// </summary>
+        private void ApplyAnimationFrameColor(AnimationFrame frame)
+        {
+            // Alpha is independent of the color operation - apply it whenever the frame specifies it.
+            if (frame.Alpha.HasValue)
+            {
+                this.Alpha = frame.Alpha.Value;
+            }
+
+            if (frame.ColorOperation.HasValue)
+            {
+                this.ColorOperation = frame.ColorOperation.Value;
+
+                // Unset channels resolve to the operation's identity value so a partially-specified tint
+                // behaves predictably: Modulate (multiply) leaves a channel unchanged at 1, Add at 0.
+                float identity = frame.ColorOperation.Value == Graphics.ColorOperation.Add ? 0f : 1f;
+
+                this.Red = frame.Red ?? identity;
+                this.Green = frame.Green ?? identity;
+                this.Blue = frame.Blue ?? identity;
+            }
+            else
+            {
+                // No color operation specified: apply only the channels that are set, leaving the Sprite's
+                // current ColorOperation and unspecified channels alone.
+                if (frame.Red.HasValue) this.Red = frame.Red.Value;
+                if (frame.Green.HasValue) this.Green = frame.Green.Value;
+                if (frame.Blue.HasValue) this.Blue = frame.Blue.Value;
+            }
         }
 
         public void ClearTimeRelatedStates()


### PR DESCRIPTION
## Summary
Adds per-frame color/tint support to `AnimationFrame` and `AnimationFrameSave`, matching the new color fields in the `.achx` file format.

## What changed
- **`AnimationFrameSave`** (`.achx` serialized form): new nullable `Red/Green/Blue/Alpha` (0–255) and an `AnimationFrameColorOperation` enum (`{Multiply, Add}`), each omitted from XML when null via `ShouldSerialize…` (backward-compatible — old files simply lack the elements). Wired through the `AnimationFrameSave(AnimationFrame)` ctor, `ToAnimationFrame`, and the manual `FromXElement` path used on Android/iOS.
- **`AnimationFrame`** (runtime): nullable `float? Red/Green/Blue/Alpha` (0–1) and `FlatRedBall.Graphics.ColorOperation?`. Mapped at load: `Multiply → Modulate`, `Add → Add`; channels divided by 255.
- **`Sprite.UpdateToAnimationFrame`**: new `ApplyAnimationFrameColor` applies color during playback. Alpha is applied independently; when a color operation is set, unset RGB channels resolve to the op's identity (Modulate→1, Add→0); **frames carrying no color data leave the Sprite's color untouched**, so existing animations are unaffected.

## Notes
- The `.achx` element names (`Red/Green/Blue/Alpha/ColorOperation`) assume the new authoring tool emits FRB2's `AnimationFrameSave` property names — worth confirming against a real tool-produced `.achx`.
- Sprite's existing DEBUG guard throws for `ColorOperation.Add` on iOS/Android/WinRT; a `.achx` using `Add` becomes reachable there.
- Builds clean (net6 DesktopGL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)