### PR TITLE
Fix GumPlugin build + add agent skills (skills-writer, achx-format)

### DIFF
--- a/.claude/skills/achx-format/SKILL.md
+++ b/.claude/skills/achx-format/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: achx-format
+description: The .achx animation file format and its save/runtime split. Triggers: .achx, AnimationChainListSave, AnimationChainSave, AnimationFrameSave, ToAnimationChainList, FromXElement.
+---
+
+# .achx Animation File Format
+
+`.achx` is the XML serialization of an `AnimationChainListSave`. It describes texture-flip animations: a list of chains, each a list of frames, each frame naming a texture + UV/pixel coordinates + timing (and, more recently, optional per-frame color). See the [AnimationChainList file docs](https://docs.flatredball.com/flatredball/glue-reference/files/file-types/glue-reference-animationchainlist) and the [runtime API](https://docs.flatredball.com/flatredball/api/flatredball/graphics/animation/flatredball-graphics-animationchainlist).
+
+## The save ↔ runtime split (the core thing to internalize)
+
+There are **two parallel class trees** — a serialized "Save" tree and a runtime tree — and you convert between them. Don't confuse the two.
+
+| Save (`.achx`, `Content/AnimationChain/`) | Runtime (`Graphics/Animation/`) |
+|---|---|
+| `AnimationChainListSave` (`[XmlType("AnimationChainArraySave")]`) | `AnimationChainList` |
+| `AnimationChainSave` (`[XmlRoot("AnimationChain")]`) | `AnimationChain` |
+| `AnimationFrameSave` | `AnimationFrame` |
+
+- **Load:** `AnimationChainListSave.FromFile(fileName)` → `ToAnimationChainList(...)` → per chain `ToAnimationChain(...)` → per frame `AnimationFrameSave.ToAnimationFrame(...)`.
+- **Save:** the `AnimationFrameSave(AnimationFrame template)` ctor copies runtime → save.
+- **Apply to a Sprite:** runtime frames are pushed onto a `Sprite` in `Sprite.UpdateToAnimationFrame` (called from `UpdateToCurrentAnimationFrame` / `AnimateSelf`). That method is the single hook where per-frame texture/coords/flip/color land on the Sprite.
+
+## Landmines
+
+- **Two deserialization paths, kept in sync by hand.** Desktop uses reflection-based `FileManager.XmlDeserialize<AnimationChainListSave>`. Android/iOS use a hand-written manual path (`AnimationChainListSave.DeserializeManually` / `LoadFromElement`, and `AnimationFrameSave.FromXElement` — a `switch` on element local-name). **Any new serialized element must be added to BOTH**, or it loads on desktop and silently vanishes on mobile.
+- **`ShouldSerializeXxx()` controls XML output.** Save-class fields use `ShouldSerializeXxx()` methods so defaults/nulls are omitted from the `.achx`. New optional fields follow this pattern to stay backward-compatible (old files just lack the element).
+- **Coordinate + time units differ from runtime.** `AnimationChainListSave.CoordinateType` is UV *or* Pixel — `ToAnimationFrame` converts Pixel→UV by dividing by texture width/height. `TimeMeasurementUnit` (seconds vs. milliseconds) makes `ToAnimationChain` divide `FrameLength` by 1000. The runtime is always UV + seconds.
+
+## Per-frame color (signpost)
+
+Frames carry optional nullable tint: `Red/Green/Blue/Alpha` and a color operation. The `.achx`/Save side stores 0–255 ints and an editor-flavored op enum; the runtime side stores 0–1 floats and `FlatRedBall.Graphics.ColorOperation`, with mapping done in `AnimationFrameSave.ToAnimationFrame`. Applied to the Sprite in `Sprite.UpdateToAnimationFrame` (`ApplyAnimationFrameColor`). Read the source there for the exact channels, identity-on-null rules, and op mapping.
+
+## Key files
+
+| File (`Engines/FlatRedBallXNA/FlatRedBall/`) | Purpose |
+|---|---|
+| `Content/AnimationChain/AnimationChainListSave.cs` | `.achx` root; `FromFile`, `ToAnimationChainList`, manual load |
+| `Content/AnimationChain/AnimationChainSave.cs` | one chain; `ToAnimationChain`, `FromXElement` |
+| `Content/AnimationChain/AnimationFrameSave.cs` | one frame; `ToAnimationFrame`, `FromXElement`, color map |
+| `Graphics/Animation/AnimationFrame.cs` | runtime frame |
+| `Sprite.cs` | `UpdateToAnimationFrame` — where a frame is applied to a Sprite |

--- a/.claude/skills/skills-writer/SKILL.md
+++ b/.claude/skills/skills-writer/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: skills-writer
+description: Creates and updates skill files (.claude/skills/*/SKILL.md). Triggers: creating/updating a skill, documenting a subsystem for agent context.
+---
+
+# Skills Writer
+
+## Mental Model
+
+A skill is **a map and a list of landmines**, not an encyclopedia. It points an agent at the right code and docs and warns about what isn't obvious from reading them. If a fact already lives in source or the docs site, **link, don't restate**.
+
+A good skill answers three things and stops: **where** the relevant code/docs live, **what gotchas** aren't obvious from reading them, and **what patterns** recur. Default to prose-free pointers and tables; include code only when the snippet is a pattern that can't be conveyed by pointing at a file. Every line is re-read into context on every load, so a skill that says *less* but points *accurately* beats a thorough one.
+
+## Growing a Skill — Damped Response
+
+A skill is rarely written whole; it grows as questions pull on it. **Don't answer a question 100% inside the skill.** Treat demand as an elastic pull and the skill as an object resting in sand: a question pulls toward a fuller answer, the skill responds **damped** (moves part-way, not all the way), and **retains** its new position — the sand means it doesn't snap back. Over many questions this settles the skill at the best *average* of real demand without overfitting to any one question. It's a leaky integrator of demand, not a transcript of the last conversation.
+
+**Default: a 100% pull moves ~20%.** When a question *could* be answered in full inside the skill, add only its broad orienting fifth — a concrete signpost plus a one-sentence shape of the answer — not the whole walkthrough. Because the position is retained, a genuinely recurring question reaches full coverage in a few pulls, while a one-off never bloats the skill past its signpost. This is also why creating a thin, broad skill is cheap and reversible: easy to add, easy to delete if demand never returns.
+
+Why damped: chasing every specific detail down into the skill bloats it, scatters its focus, rots, and front-loads context future agents won't need. Most questions are one-offs. Let the skill grow only where demand actually, repeatedly pulls.
+
+**Two exceptions — place these by hand, at full strength, not through the elastic:**
+
+1. **Landmines.** A non-obvious, expensive-to-rediscover gotcha that *isn't* evident from the source you point at is a sharp fact, not a sample to be averaged. Damping it smears a precise truth into a vague gesture — the worst outcome. State it fully and firmly. (This is the "list of landmines" half of the mental model above.)
+2. **Bimodal pull.** When a skill is dragged toward a low-density middle between two genuinely distinct sub-topics, don't settle in the valley — it serves neither. Split into two skills, each with its own focus. A pull toward the empty middle *is* the signal to fission.
+
+**Signpost quality bar.** A nudge must name *where to look* — a file, class, or relationship — not merely assert that something exists. "Animation frames interact with the Sprite" raises a question without reducing search cost; "see `Sprite.UpdateToAnimationFrame` — color is applied there, gated on null per-frame channels" reduces it. A vague signpost is worse than none: it costs context and resolves nothing.
+
+## Authoritative Sources (do not duplicate)
+
+Before writing anything, identify where the ground truth already lives:
+
+- **Source code** — class outlines, property lists, method signatures, call sites.
+- **The docs site** ([docs.flatredball.com](https://docs.flatredball.com)) — user-facing behavior, engine APIs, Glue reference, tutorials. If a topic has a docs page, link to it rather than restating it. (The docs are hosted GitBook, not checked into this repo.)
+- **Other skills** — cross-reference instead of copying. When two skills cover a shallow-vs-deep split of the same topic, point between them rather than duplicating the overlap.
+
+## Process
+
+1. Read the relevant source files.
+2. Check [docs.flatredball.com](https://docs.flatredball.com) for an existing user-facing page on the topic — link it instead of restating.
+3. Skim a few existing skills in `.claude/skills/` to match style and depth.
+4. Write only the non-obvious distillation.
+
+## Skill File Rules
+
+- **Length**: aim under 100 lines. Hard ceiling 500. Bloat costs agent context on every load.
+- **Naming**: kebab-case noun phrases (e.g., `sprite-animation`, `glue-codegen`).
+- **Frontmatter**: `name` and `description`. **The description is loaded into every session's skill listing** — it pays for itself in context tokens forever. Keep it brutally short. See "Writing the description" below.
+- **Structure**: `##` sections. Tables for file maps. Prose for relationships and gotchas.
+- **Progressive disclosure**: keep SKILL.md to high-level architecture; spill advanced content into sibling files (e.g., `[advanced-topic.md](advanced-topic.md)`) only when it's bulky enough to justify a second file.
+
+## Writing the description
+
+The description's **only job** is to tell future-Claude *when this skill is relevant*. It is a trigger, not a summary.
+
+**Hard rules:**
+- **One sentence. Under ~250 chars.** Ideally under 200. The skill body covers the rest.
+- **Drop boilerplate.** No "Reference guide for…", no "Load this when working on…", no "Covers FlatRedBall's…". The fact that this is a skill is implicit — these phrases are dead weight on every entry.
+- **Lead with the topic, then trigger identifiers.** Format: `<Topic> — <one-line hook>. Triggers: <distinctive identifiers, file paths, or scenarios>.`
+- **Pick the 3–8 most distinctive triggers, not all of them.** Generic words ("file", "system", "behavior") don't help; specific class names, file paths, and method names do. The rest belong inside the file.
+- **No multi-line YAML (`description: >`).** Keep it on one line. It folds anyway, and one line is easier to scan when auditing.
+
+**Example.** Same triggers, ~40% fewer tokens:
+
+Good:
+```
+description: FlatRedBall sprite texture-flip animation. Triggers: AnimationChain, AnimationFrame, .achx, Sprite.AnimationChains, UpdateToCurrentAnimationFrame.
+```
+
+Bad (boilerplate, padded):
+```
+description: Reference guide for FlatRedBall's sprite animation system. Load this when working on animation behavior, AnimationChains, AnimationFrame, .achx files, Sprite.AnimationChains, or UpdateToCurrentAnimationFrame.
+```
+
+## Include
+
+- Architecture: how major pieces fit together and why.
+- Gotchas: surprising behavior, ordering dependencies, naming mismatches, "looks like X but actually Y."
+- Key file map: one-line table of file → purpose.
+- Pointers: links to relevant docs pages, key source files, and related skills.
+- Specific identifiers only when the name itself is misleading or the behavior is surprising.
+
+## Exclude
+
+- Anything already on the docs site — link instead of restating.
+- Full class outlines or property lists — read source directly.
+- Code examples unless the snippet captures an irreplaceable pattern.
+- **In-flight migration / refactor STATE** — what's done *now*, what currently blocks what, what's left, "X is already converted," "Y can't move until Z." This **inverts to false the moment the work lands**, turning the skill into an active liar that every future agent re-reads as fact. Skills hold *timeless* structure only. Transient progress belongs in the ephemeral working ledger, not the skill — and that includes versions and dates, any time-sensitive fact.
+- Anything Claude already knows from general C# or .NET knowledge.
+
+## Output
+
+Write to `.claude/skills/<skill-name>/SKILL.md`. Create the directory if needed. Add sibling detail files only when content is too large for the main file.

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/SaveObjectExtensionMethods.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/SaveObjectExtensionMethods.cs
@@ -1,7 +1,7 @@
 ﻿using FlatRedBall.IO;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
-using StateAnimationPlugin.SaveClasses;
+using Gum.StateAnimation.SaveClasses;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.Animation.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.Animation.cs
@@ -10,7 +10,7 @@ using FlatRedBall.IO;
 using Gum.DataTypes;
 using GumPlugin.Managers;
 using GumPlugin.Managers;
-using StateAnimationPlugin.SaveClasses;
+using Gum.StateAnimation.SaveClasses;
 
 namespace GumPlugin.CodeGeneration;
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/GumPlugin.csproj
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/GumPlugin.csproj
@@ -183,12 +183,6 @@
     <EmbeddedResource Include="..\..\..\..\..\Gum\RenderingLibrary\Math\MathFunctions.cs" Link="Embedded\LibraryFiles\RenderingLibrary\MathFunctions.cs" />
     <EmbeddedResource Include="..\..\..\..\..\Gum\RenderingLibrary\SystemManagers.cs" Link="Embedded\LibraryFiles\RenderingLibrary\SystemManagers.cs" />
     <Compile Include="..\..\..\..\..\Gum\GumRuntime\BbCodeParser.cs" Link="BbCodeParser.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\AnimatedStateSave.cs" Link="Animation\AnimatedStateSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\AnimationReferenceSave.cs" Link="Animation\AnimationReferenceSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\AnimationSave.cs" Link="Animation\AnimationSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\ElementAnimationReferenceSave.cs" Link="Animation\ElementAnimationReferenceSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\ElementAnimationsSave.cs" Link="Animation\ElementAnimationsSave.cs" />
-    <Compile Include="..\..\..\..\..\Gum\Gum\StateAnimationPlugin\SaveClasses\NamedEventSave.cs" Link="Animation\NamedEventSave.cs" />
     <EmbeddedResource Include="..\..\..\..\..\Gum\ToolsUtilities\FileManager.cs" Link="Embedded\LibraryFiles\ToolsUtilities\FileManager.cs" />
     <EmbeddedResource Include="..\..\..\..\..\Gum\ToolsUtilities\ReflectionManager.cs" Link="Embedded\LibraryFiles\ToolsUtilities\ReflectionManager.cs" />
     <EmbeddedResource Include="..\..\..\..\..\Gum\ToolsUtilities\StringFunctions.cs" Link="Embedded\LibraryFiles\ToolsUtilities\StringFunctions.cs" />

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Managers/AnimationLogic.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Managers/AnimationLogic.cs
@@ -2,7 +2,7 @@
 using FlatRedBall.IO;
 using Gum.DataTypes;
 using GumPlugin.Managers;
-using StateAnimationPlugin.SaveClasses;
+using Gum.StateAnimation.SaveClasses;
 using System;
 using System.Collections.Generic;
 using System.Text;


### PR DESCRIPTION
## Summary
Two changes that share this branch:

1. **Fix GumPlugin build** (`6e64383b`, pre-existing) after Gum moved its animation SaveClasses to GumDataTypes.
2. **Add two agent skills** under `.claude/skills/`:
   - **`skills-writer`** — ported from Gum's `skills-writer` skill, with Gum-specific paths genericized for FRB: external docs site (docs.flatredball.com) instead of an in-repo `docs/` tree, no ADR/`Direction` path, and FRB-flavored naming/description examples. The generic guidance (20%/damped-response model, landmines, signpost bar, description rules) is unchanged.
   - **`achx-format`** — a thin (20%-rule) orienting skill for the `.achx` save↔runtime class split, the two deserialization paths (XmlSerializer + manual `FromXElement`), and the coordinate/time-unit landmines.

> Note: the two changes are logically independent but were committed to the same branch per the original request. Happy to split the skills onto their own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)