### PR TITLE
Fix directory paths leaking into csproj Include items

### DIFF
--- a/.claude/skills/maintenance-mode-workflow/SKILL.md
+++ b/.claude/skills/maintenance-mode-workflow/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: maintenance-mode-workflow
+description: Gate checklist before fixing any FlatRedBall1 (engine + Glue) issue. Triggers: new bug report, "fix this issue", TDD, testability, before editing production code.
+---
+
+# Maintenance-Mode Issue Workflow
+
+FlatRedBall1 (engine + Glue) is maintenance-mode — no new features — but existing projects depend on it, so issues still get fixed. Every fix should also nudge the touched code toward testability, not just patch around it.
+
+Work through these gates in order before writing a fix:
+
+1. **Scan for skills.** Search `.claude/skills/` (repo-wide) and `FRBDK/Glue/.claude/skills/` for anything covering this area. Nothing found? Stop and propose a research task to produce a new skill file — written damped, per [skills-writer](../skills-writer/SKILL.md), not a full write-up.
+2. **Read the skill, discuss.** Once one exists (or was just written), read it and raise open questions with the user before touching code.
+3. **Testability gate.** Can the fix be pinned with a real unit test as it stands? If not, stop and propose a scoped refactor task first — see [REFACTORING.md](../../../FRBDK/Glue/REFACTORING.md) for the incremental-refactor philosophy and the transitional-injection pattern (`Xyz.Self` defaulting field with an internal setter) used to unstick static-singleton coupling. Do not write the fix until this gate passes.
+4. **Red.** Write a failing test for the fix.
+5. **Green.** Implement the fix.
+6. **Manual-test call-out.** If the tests don't cover the full user-facing path, say explicitly how to verify manually. If they do, say "no manual testing needed."
+
+This process is still being refined.

--- a/FRBDK/Glue/Glue/Glue.csproj
+++ b/FRBDK/Glue/Glue/Glue.csproj
@@ -743,6 +743,13 @@
     </Page>
   </ItemGroup>
 
-
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>GlueUnitTests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
 </Project>

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
@@ -1,4 +1,5 @@
-﻿using FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces;
+﻿using FlatRedBall.Glue.Plugins.ExportedInterfaces;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces;
 using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.IO;
 using System;
@@ -28,6 +29,11 @@ class ProjectCommands : IProjectCommands
 {
     private FileReferenceManager _fileReferenceManager;
 
+    // Transitional pattern (see REFACTORING.md): defaults to the real singleton in production, so this
+    // is a zero-behavior-change substitution for the ~30 previous GlueState.Self reads in this class.
+    // Tests can override via this internal field to avoid needing a live GlueState.Self.
+    internal IGlueState _glueState = GlueState.Self;
+
     public void Initialize(FileReferenceManager fileReferenceManager)
     {
         _fileReferenceManager = fileReferenceManager;
@@ -47,7 +53,7 @@ class ProjectCommands : IProjectCommands
     public void SaveProjectsImmediately()
     {
         TaskManager.Self.WarnIfNotInTask();
-        var toLock = GlueState.Self.CurrentMainProject;
+        var toLock = _glueState.CurrentMainProject;
 
         ///////////////////////early out///////////////////////
         if (toLock == null)
@@ -62,7 +68,7 @@ class ProjectCommands : IProjectCommands
             // been updated to the "evaluated" list, not if it needs to
             // be saved.
             //if (mProjectBase != null && mProjectBase.IsDirty)
-            var mainProject = GlueState.Self.CurrentMainProject;
+            var mainProject = _glueState.CurrentMainProject;
             // toList to reduce the chance of having a collection modified exception:
             var projects = ProjectManager.SyncedProjects.ToList();
             if (mainProject != null)
@@ -124,7 +130,7 @@ class ProjectCommands : IProjectCommands
     public void CreateAndAddPartialFile(IElement element, string partialName, string code)
     {
         var fileName = element.Name + ".Generated." + partialName + ".cs";
-        var fullFileName = GlueState.Self.CurrentMainProject.Directory + fileName;
+        var fullFileName = _glueState.CurrentMainProject.Directory + fileName;
 
         var save = false; // we'll be doing manual saving after it's created
         ProjectManager.CodeProjectHelper.CreateAndAddPartialGeneratedCodeFile(fileName, save);
@@ -135,7 +141,7 @@ class ProjectCommands : IProjectCommands
 
     public void AddContentFileToProject(string absoluteFileName, bool saveProjects = true)
     {
-        GlueCommands.Self.ProjectCommands.UpdateFileMembershipInProject(GlueState.Self.CurrentMainProject, absoluteFileName, false, false, null);
+        GlueCommands.Self.ProjectCommands.UpdateFileMembershipInProject(_glueState.CurrentMainProject, absoluteFileName, false, false, null);
         if (saveProjects)
         {
             SaveProjects();
@@ -180,8 +186,8 @@ class ProjectCommands : IProjectCommands
 
                 if (wasAnythingModified)
                 {
-                    GlueState.Self.CurrentMainProject.ReevaluateItems();
-                    foreach (var item in GlueState.Self.SyncedProjects)
+                    _glueState.CurrentMainProject.ReevaluateItems();
+                    foreach (var item in _glueState.SyncedProjects)
                     {
                         (item as VisualStudioProject)?.ReevaluateItems();
                     }
@@ -226,12 +232,12 @@ class ProjectCommands : IProjectCommands
                     useContentPipeline = false;
                 }
             }
-            var projectName = GlueState.Self.CurrentMainProject.Name;
+            var projectName = _glueState.CurrentMainProject.Name;
             var isExcludedFromProject = referencedFileSave.ProjectsToExcludeFrom.Contains(projectName);
             if (!isExcludedFromProject)
             {
                 var absoluteFilePath = GlueCommands.Self.GetAbsoluteFilePath(referencedFileSave);
-                wasAnythingAdded = UpdateFileMembershipInProject(GlueState.Self.CurrentMainProject, absoluteFilePath,
+                wasAnythingAdded = UpdateFileMembershipInProject(_glueState.CurrentMainProject, absoluteFilePath,
                     useContentPipeline, false,
                     fileRfs: referencedFileSave,
                     reEvaluateAfterAdd: reEvaluateAfterAdd,
@@ -273,10 +279,12 @@ class ProjectCommands : IProjectCommands
     {
         bool wasProjectModified = false;
         ///////////////////Early Out/////////////////////
-        if (project == null || GlueState.Self.CurrentMainProject == null) return wasProjectModified;
+        if (project == null || _glueState.CurrentMainProject == null) return wasProjectModified;
+
+        if (ShouldSkipBecauseDirectory(fileName)) return wasProjectModified;
 
         /////////////////End Early Out//////////////////
-        bool preserveCase = GlueState.Self.CurrentGlueProject.FileVersion >= (int)GlueProjectSave.GluxVersions.CaseSensitiveLoading;
+        bool preserveCase = _glueState.CurrentGlueProject.FileVersion >= (int)GlueProjectSave.GluxVersions.CaseSensitiveLoading;
 
         string fileToAddAbsolute = fileName.FullPath;
 
@@ -436,6 +444,16 @@ class ProjectCommands : IProjectCommands
         return wasProjectModified;
     }
 
+    /// <summary>
+    /// Whether <paramref name="fileName"/> should be skipped by UpdateFileMembershipInProject because it
+    /// refers to a directory rather than a file. Directories can reach this method via FileSystemWatcher
+    /// Created/Renamed events (which fire for folders too, not just files) or via the recursive "referenced
+    /// files" walk. A directory's path always ends with a path separator, and MSBuild rejects that as an
+    /// Include value ("A file item cannot end with a path separator."), so callers must bail out before any
+    /// Include gets written.
+    /// </summary>
+    internal static bool ShouldSkipBecauseDirectory(FilePath fileName) => fileName.IsDirectory;
+
     private static bool GetIfShouldUseContentPipeline(FilePath filePath, ReferencedFileSave rfs = null)
     {
         // grab the RFS and see if the rfs forces it
@@ -460,10 +478,10 @@ class ProjectCommands : IProjectCommands
         return useContentPipeline;
     }
 
-    private static bool ShouldFileBeInContentProject(FilePath filePath)
+    private bool ShouldFileBeInContentProject(FilePath filePath)
     {
-        var mainContentProject = GlueState.Self.CurrentMainContentProject;
-        var mainProject = GlueState.Self.CurrentMainProject;
+        var mainContentProject = _glueState.CurrentMainContentProject;
+        var mainProject = _glueState.CurrentMainProject;
 
         bool toReturn = false;
 
@@ -538,14 +556,14 @@ class ProjectCommands : IProjectCommands
     {
         //////////////Early Out///////////////////
         // Just in case this is called when the project is unloaded:
-        if (GlueState.Self.CurrentGlueProject == null)
+        if (_glueState.CurrentGlueProject == null)
         {
             return;
         }
         ////////////End Early Out////////////////
 
         // see if the file exists. If not, create it:
-        FilePath filePath = GlueState.Self.CurrentGlueProjectDirectory + relativeFileName;
+        FilePath filePath = _glueState.CurrentGlueProjectDirectory + relativeFileName;
 
         CreateAndAddCodeFile(filePath);
     }
@@ -569,7 +587,7 @@ class ProjectCommands : IProjectCommands
 
         ProjectItem added = null;
 
-        var mainProject = GlueState.Self.CurrentMainProject;
+        var mainProject = _glueState.CurrentMainProject;
 
         if (mainProject?.CodeProject == null)
         {
@@ -593,7 +611,7 @@ class ProjectCommands : IProjectCommands
     {
         await TaskManager.Self.AddAsync(() =>
         {
-            var mainProject = GlueState.Self.CurrentMainProject;
+            var mainProject = _glueState.CurrentMainProject;
             if (mainProject.CodeProject.IsFilePartOfProject(codeFilePath.FullPath) == false)
             {
                 ((VisualStudioProject)mainProject.CodeProject).AddCodeBuildItem(codeFilePath.FullPath);
@@ -605,7 +623,7 @@ class ProjectCommands : IProjectCommands
 
     public void CopyToBuildFolder(ReferencedFileSave rfs)
     {
-        FilePath source = GlueState.Self.ContentDirectory + rfs.Name;
+        FilePath source = _glueState.ContentDirectory + rfs.Name;
 
         CopyToBuildFolder(source);
     }
@@ -631,23 +649,23 @@ class ProjectCommands : IProjectCommands
         {
             // This is the location when running from Glue
             // Maybe eventually I'll fix glue build to build to the same location as the project...
-            if (absoluteSource.Exists() && GlueState.Self.CurrentMainProject != null)
+            if (absoluteSource.Exists() && _glueState.CurrentMainProject != null)
             {
-                var fileToCopyItem = GlueState.Self.CurrentMainProject.GetItem(absoluteSource);
+                var fileToCopyItem = _glueState.CurrentMainProject.GetItem(absoluteSource);
 
 
                 if (fileToCopyItem != null)
                 {
-                    var outputDirectory = GlueState.Self.CurrentMainProject.GetOutputDirectory() + "Content/";
+                    var outputDirectory = _glueState.CurrentMainProject.GetOutputDirectory() + "Content/";
 
-                    FilePath destination = outputDirectory + FileManager.MakeRelative(absoluteSource.FullPath, GlueState.Self.ContentDirectory);
+                    FilePath destination = outputDirectory + FileManager.MakeRelative(absoluteSource.FullPath, _glueState.ContentDirectory);
 
                     var link = fileToCopyItem.GetLink();
                     if (!string.IsNullOrEmpty(link))
                     {
                         // it seems that links have Content already appended so we should not have content
 
-                        destination = GlueState.Self.CurrentMainProject.GetOutputDirectory() + link;
+                        destination = _glueState.CurrentMainProject.GetOutputDirectory() + link;
                     }
 
                     try
@@ -673,10 +691,10 @@ class ProjectCommands : IProjectCommands
         }, CopyToBuildFolderTaskIdFor(absoluteSource), taskExecutionPreference);
     }
 
-    private static void CopyToBuildFolder(FilePath absoluteSource, string outputPathRelativeToCsProj)
+    private void CopyToBuildFolder(FilePath absoluteSource, string outputPathRelativeToCsProj)
     {
-        string buildFolder = FileManager.GetDirectory(GlueState.Self.CurrentCodeProjectFileName.FullPath) + outputPathRelativeToCsProj + "Content/";
-        string destination = buildFolder + FileManager.MakeRelative(absoluteSource.FullPath, GlueState.Self.ContentDirectory);
+        string buildFolder = FileManager.GetDirectory(_glueState.CurrentCodeProjectFileName.FullPath) + outputPathRelativeToCsProj + "Content/";
+        string destination = buildFolder + FileManager.MakeRelative(absoluteSource.FullPath, _glueState.ContentDirectory);
 
         string destinationFolder = FileManager.GetDirectory(destination);
 
@@ -721,14 +739,14 @@ class ProjectCommands : IProjectCommands
         }
         else if (treeNodeToAddTo.IsRootEntityNode())
         {
-            string directory = GlueState.Self.CurrentGlueProjectDirectory + "Entities/" +
+            string directory = _glueState.CurrentGlueProjectDirectory + "Entities/" +
                 folderName;
 
             Directory.CreateDirectory(directory);
         }
         else if (treeNodeToAddTo.IsRootScreenNode())
         {
-            string directory = GlueState.Self.CurrentGlueProjectDirectory + "Screens/" + folderName;
+            string directory = _glueState.CurrentGlueProjectDirectory + "Screens/" + folderName;
 
             Directory.CreateDirectory(directory);
         }
@@ -786,14 +804,14 @@ class ProjectCommands : IProjectCommands
             var isGlobalContentDirectory = treeNodeToAddTo.IsFolderForGlobalContentFiles();
             if (isGlobalContentDirectory)
             {
-                directory = GlueState.Self.ContentDirectory +
+                directory = _glueState.ContentDirectory +
                     treeNodeToAddTo.GetRelativeFilePath() +
                     folderName;
             }
             else
             {
 
-                directory = GlueState.Self.CurrentGlueProjectDirectory +
+                directory = _glueState.CurrentGlueProjectDirectory +
                         treeNodeToAddTo.GetRelativeFilePath() +
                         folderName;
             }
@@ -845,7 +863,7 @@ class ProjectCommands : IProjectCommands
 
     public void MakeGeneratedCodeItemsNestedImmediately()
     {
-        foreach (var bi in GlueState.Self.CurrentMainProject.EvaluatedItems)
+        foreach (var bi in _glueState.CurrentMainProject.EvaluatedItems)
         {
 
             string biInclude = bi.UnevaluatedInclude;
@@ -865,9 +883,9 @@ class ProjectCommands : IProjectCommands
                     // make sure there is an object to nest under in this directory
                     string whatToNextUnderWithPath = FileManager.GetDirectory(bi.UnevaluatedInclude, RelativeType.Relative) + whatToNestUnder;
 
-                    if (GlueState.Self.CurrentMainProject.GetItem(whatToNextUnderWithPath) != null)
+                    if (_glueState.CurrentMainProject.GetItem(whatToNextUnderWithPath) != null)
                     {
-                        GlueState.Self.CurrentMainProject.MakeBuildItemNested(bi, whatToNestUnder);
+                        _glueState.CurrentMainProject.MakeBuildItemNested(bi, whatToNestUnder);
 
                         foreach (VisualStudioProject project in ProjectManager.SyncedProjects)
                         {
@@ -920,7 +938,7 @@ class ProjectCommands : IProjectCommands
     {
         //////////////Early Out///////////////////
         // Just in case this is called when the project is unloaded:
-        if (GlueState.Self.CurrentGlueProject == null)
+        if (_glueState.CurrentGlueProject == null)
         {
             return null;
         }
@@ -935,14 +953,14 @@ class ProjectCommands : IProjectCommands
             throw new ArgumentException(nameof(versionNumber));
         }
 
-        var hasNugetsEmbeddedInCsproj = GlueState.Self.CurrentGlueProject.FileVersion >= (int)GlueProjectSave.GluxVersions.NugetPackageInCsproj;
+        var hasNugetsEmbeddedInCsproj = _glueState.CurrentGlueProject.FileVersion >= (int)GlueProjectSave.GluxVersions.NugetPackageInCsproj;
         // If not....do we fail silently?
         // So far this is for adding Newtonsoft json, and if we don't have it the user will get a compile error so maybe that's enough to guide them?
         if (hasNugetsEmbeddedInCsproj)
         {
             return await TaskManager.Self.AddAsync(() =>
             {
-                var mainProject = GlueState.Self.CurrentMainProject;
+                var mainProject = _glueState.CurrentMainProject;
 
                 if (mainProject?.CodeProject == null)
                 {
@@ -971,7 +989,7 @@ class ProjectCommands : IProjectCommands
 
     public void AddAssemblyBinding(string name, string publicKeyToken, string oldVersion, string newVersion)
     {
-        string appConfig = FileManager.GetDirectory(GlueState.Self.CurrentCodeProjectFileName.FullPath) + "app.config";
+        string appConfig = FileManager.GetDirectory(_glueState.CurrentCodeProjectFileName.FullPath) + "app.config";
 
         if (File.Exists(appConfig))
         {
@@ -1036,14 +1054,14 @@ class ProjectCommands : IProjectCommands
 
         ProjectBase syncedProject = null;
 
-        if (GlueState.Self.CurrentMainProject.FullFileName == filePath)
+        if (_glueState.CurrentMainProject.FullFileName == filePath)
         {
             doesProjectAlreadyExist = true;
         }
 
         if (!doesProjectAlreadyExist)
         {
-            foreach (var project in GlueState.Self.SyncedProjects)
+            foreach (var project in _glueState.SyncedProjects)
             {
                 var existingFileName = project.FullFileName;
                 if (existingFileName == filePath)
@@ -1058,12 +1076,14 @@ class ProjectCommands : IProjectCommands
         {
             syncedProject = ProjectCreator.CreateProject(filePath.FullPath).Project;
 
-            syncedProject.OriginalProjectBaseIfSynced = GlueState.Self.CurrentMainProject;
+            syncedProject.OriginalProjectBaseIfSynced = _glueState.CurrentMainProject;
 
             syncedProject.Load(filePath.FullPath);
 
             lock (ProjectManager.SyncedProjects)
             {
+                // IGlueState.SyncedProjects is intentionally read-only (IEnumerable<ProjectBase>); the
+                // mutable concrete list lives on the singleton, so mutation goes through it directly.
                 GlueState.Self.SyncedProjects.Add(syncedProject);
             }
 

--- a/FRBDK/Glue/Glue/Plugins/ExportedInterfaces/IGlueState.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedInterfaces/IGlueState.cs
@@ -3,6 +3,7 @@ using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.Glue.VSHelpers.Projects;
 using FlatRedBall.Glue.Events;
 using FlatRedBall.Glue.FormHelpers;
+using FlatRedBall.IO;
 using System.Linq;
 
 namespace FlatRedBall.Glue.Plugins.ExportedInterfaces
@@ -73,6 +74,8 @@ namespace FlatRedBall.Glue.Plugins.ExportedInterfaces
         }
 
         string CurrentGlueProjectDirectory { get; }
+
+        FilePath CurrentCodeProjectFileName { get; }
 
         string ContentDirectory
         {
@@ -205,6 +208,8 @@ namespace FlatRedBall.Glue.Plugins.ExportedInterfaces
 
         public string CurrentGlueProjectDirectory { get; set; }
 
+        public FilePath CurrentCodeProjectFileName { get; set; }
+
         public bool IsReferencingFrbSource { get; set; }
 
         public int? EngineDllSyntaxVersion { get; private set; }
@@ -254,6 +259,8 @@ namespace FlatRedBall.Glue.Plugins.ExportedInterfaces
                 this.ProjectSpecificSettingsFolder = glueState.ProjectSpecificSettingsFolder;
 
                 this.CurrentGlueProjectDirectory = glueState.CurrentGlueProjectDirectory;
+
+                this.CurrentCodeProjectFileName = glueState.CurrentCodeProjectFileName;
             }
         }
 

--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -285,9 +285,65 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
 
 ## Known Areas Needing Improvement
 
-<!-- Add notes here as problem areas are identified -->
+- **`ProjectCommands.UpdateFileMembershipInProject`** is a ~170-line method with no seams — it touches
+  a concrete `VisualStudioProject` (abstract, but its constructor requires a live MSBuild `Project`, so
+  it can't be constructed in a unit test), `FileReferenceManager`, and `PluginManager` all inline. The
+  `GlueState.Self` dependency was removed (see below), but `VisualStudioProject` remains the blocker.
+  Fully unit-testing this method would require extracting an `IVisualStudioProject`-style seam around
+  the MSBuild-backed project type — out of scope until a feature actually needs to touch this method
+  again.
 
 ## Completed Refactors
+
+### 2026-07-12 — Inject `IGlueState` into `ProjectCommands`
+
+Follow-up to the directory-path fix below. `ProjectCommands` had ~40 direct `GlueState.Self` reads
+across the class (not just the bug's method) — the largest concentration of static-singleton coupling
+of any class touched by that fix. Converted it to the same transitional pattern already used for
+`SelectionLogic.Current`/`ReferenceService.Self` elsewhere in this doc:
+
+- Added `internal IGlueState _glueState = GlueState.Self;` to `ProjectCommands`, defaulting to the real
+  singleton (zero behavior change in production) with an internal setter tests can override.
+- Replaced all reads of `GlueState.Self.*` in `ProjectCommands.cs` with `_glueState.*`, **except** one:
+  `AddSyncedProject`'s `GlueState.Self.SyncedProjects.Add(syncedProject)` mutates the list, and
+  `IGlueState.SyncedProjects` is intentionally read-only (`IEnumerable<ProjectBase>`) — that one call
+  stays on the concrete singleton rather than widening the interface's mutation surface for one caller.
+- `IGlueState` was missing `CurrentCodeProjectFileName` (used by `ProjectCommands` but never previously
+  exposed on the interface, only the concrete `GlueState` class) — added it to `IGlueState`, to
+  `GlueStateSnapshot`'s implementation, and to `GlueStateSnapshot.SetFrom` (per its own "STOP! if adding
+  more properties" comment).
+- Two `private static` helper methods (`ShouldFileBeInContentProject`, and an unused 2-arg
+  `CopyToBuildFolder(FilePath, string)` overload — dead code, no call sites found anywhere in the repo)
+  read `_glueState` internally, so both had `static` removed. Safe: both are `private`.
+- Added `InternalsVisibleTo("GlueUnitTests")` / `("DynamicProxyGenAssembly2")` to `Glue.csproj` (it only
+  existed on `OfficialPlugins.csproj` before), since `ProjectCommands` is `internal` and tests need to
+  reach it and its new `_glueState` field.
+
+This unlocks unit-testing any `ProjectCommands` logic that only depends on `IGlueState` — the
+`VisualStudioProject` construction problem noted above is the next, harder blocker.
+
+### 2026-07-12 — Fix directory paths leaking into csproj Include items, pin with a unit test
+
+Bug: Glue was occasionally adding directory paths (e.g. `Content\Entities\Bosses\ResonatorCoil\`) as
+`<Content Include="...">` items in the target project, which MSBuild rejects with "A file item cannot
+end with a path separator." Root cause: `FileSystemWatcher` in `ChangedFileGroup.cs` watches with
+`NotifyFilters.DirectoryName`, so folder `Created`/`Renamed` events flow through
+`UpdateReactor.UpdateFile` → plugins → `ProjectCommands.UpdateFileMembershipInProject` the same as file
+events, and that method never checked whether the incoming `FilePath` was a directory before handing it
+to `VisualStudioProject.AddContentBuildItem` → `mProject.AddItem`.
+
+`UpdateFileMembershipInProject` itself can't be unit-tested directly: it depends on `GlueState.Self` and
+a concrete `VisualStudioProject`, and `VisualStudioProject`'s constructor requires a live MSBuild
+`Project` (dereferenced immediately in `GetDotNetVersion()`), so it can't be instantiated or mocked in a
+test without loading a real `.csproj` from disk. Rather than take on that larger extraction to add one
+test, the directory check itself — the actual fix — was pulled out into a standalone, pure, testable
+method: `internal static bool ShouldSkipBecauseDirectory(FilePath fileName)`. `UpdateFileMembershipInProject`
+calls it as an early-out; `ProjectCommandsTests.cs` (new, `Tests/GlueUnitTests/CommandInterfaces/`) pins
+it directly against the exact path shape from the bug report (trailing separator, both `\` and `/`) plus
+ordinary file paths that must NOT be skipped.
+
+See "Known Areas Needing Improvement" above for the larger `VisualStudioProject` testability gap this
+left unaddressed.
 
 ### 2026-03-04 — Reference-finding centralization
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/ProjectCommandsTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/ProjectCommandsTests.cs
@@ -1,0 +1,28 @@
+using FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces;
+using FlatRedBall.IO;
+using Shouldly;
+
+namespace GlueUnitTests.CommandInterfaces;
+
+public class ProjectCommandsTests
+{
+    // Regression test for a bug where Glue added directory paths (e.g. from a FileSystemWatcher folder
+    // Created/Renamed event) as csproj <Content Include="..."> items. Since directory paths end with a
+    // path separator, MSBuild rejected them with "A file item cannot end with a path separator."
+    [Theory]
+    [InlineData(@"C:\MyProject\Content\Entities\Bosses\ResonatorCoil\")]
+    [InlineData(@"C:\MyProject\Content\Entities\Bosses\ResonatorCoil")]
+    [InlineData(@"C:/MyProject/Content/Entities/Bosses/ResonatorCoil/")]
+    public void ShouldSkipBecauseDirectory_ShouldReturnTrue_ForDirectoryPath(string path)
+    {
+        ProjectCommands.ShouldSkipBecauseDirectory(new FilePath(path)).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(@"C:\MyProject\Content\Entities\Bosses\ResonatorCoil\ResonatorCoil.achx")]
+    [InlineData(@"C:\MyProject\Content\Entities\Bosses\ResonatorCoil\Idle.png")]
+    public void ShouldSkipBecauseDirectory_ShouldReturnFalse_ForFilePath(string path)
+    {
+        ProjectCommands.ShouldSkipBecauseDirectory(new FilePath(path)).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes a bug where Glue occasionally added directory paths (e.g. `Content\Entities\Bosses\ResonatorCoil\`) as `<Content Include="...">` items in the target project, which MSBuild rejects with "A file item cannot end with a path separator." Root cause: `FileSystemWatcher` fires folder `Created`/`Renamed` events too, and `ProjectCommands.UpdateFileMembershipInProject` never checked for that before writing an Include.
- The fix logic is pinned with a new unit test (`ProjectCommandsTests`). Since `UpdateFileMembershipInProject` itself can't be unit-tested directly (it takes a concrete `VisualStudioProject` whose constructor requires a live MSBuild `Project`), followed up with a scoped testability improvement: injected `IGlueState` into `ProjectCommands`, replacing ~40 `GlueState.Self` reads with a transitional `_glueState` field (defaults to the real singleton, zero prod behavior change, mockable in tests).
- Adds a `maintenance-mode-workflow` skill documenting the skill-scan → testability-gate → TDD process to use for future FlatRedBall1 fixes.

## Test plan
- [x] `dotnet test` on `GlueUnitTests` — new `ProjectCommandsTests` (5 tests) pass; full suite is 91/96 passing, the 5 failures are pre-existing (`RightClickDescriptorTests`, confirmed unrelated via stash-and-rerun against unmodified `NetStandard`)
- [x] `Glue.csproj` and `OfficialPlugins.csproj` build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)