### PR TITLE
Fix Glue crash: run TaskManager thread as STA

### DIFF
--- a/FRBDK/Glue/Glue/Tasks/TaskManager.cs
+++ b/FRBDK/Glue/Glue/Tasks/TaskManager.cs
@@ -265,10 +265,17 @@ namespace FlatRedBall.Glue.Managers
 
         public TaskManager()
         {
-            new Thread(StartDoTaskManagerLoop)
+            var thread = new Thread(StartDoTaskManagerLoop)
             {
                 IsBackground = true
-            }.Start();
+            };
+            // Some tasks (such as ProjectLoader's missing-custom-file check) create WPF
+            // controls (e.g. MultiButtonMessageBoxWpf), which require an STA thread. Without
+            // this, the thread defaults to MTA and those tasks throw
+            // "The calling thread must be STA" when they run off of file-watcher-triggered
+            // reloads instead of directly from the (STA) UI thread.
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
         }
 
         void StartDoTaskManagerLoop()


### PR DESCRIPTION
## Summary
- Glue's `TaskManager` background loop thread was created without an apartment state, defaulting to MTA.
- When a reload is triggered off the main UI thread (e.g. the file watcher noticing project files changed while an external process edits them), `ProjectLoader.PerformGluxLoad` → `CheckForMissingCustomFile` constructs a WPF `MultiButtonMessageBoxWpf` window on that thread, throwing `InvalidOperationException: The calling thread must be STA`.
- Fix: set `ApartmentState.STA` on the TaskManager thread before starting it, matching the apartment the main UI thread already runs under.

Verified no COM/EnvDTE automation or OS clipboard/drag-drop interop is reachable from TaskManager-queued work (project load/reload/codegen/save) — those calls are confined to UI event handlers on the main thread — so this only affects the WPF-dialog-creation path that was crashing.

## Test plan
- [x] \`dotnet build\` on \`Glue.csproj\` succeeds with no new errors
- [x] Manually reproduce: have an external process edit project JSON files while Glue is open, confirm the missing-custom-file dialog now shows instead of crashing