### PR TITLE
Compile Gum's Cursor event-failure diagnostic into Forms

### DIFF
--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Shared/FlatRedBall.Forms.Shared.projitems
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Shared/FlatRedBall.Forms.Shared.projitems
@@ -111,6 +111,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\IListExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FrameworkElementTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CursorExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\..\Gum\MonoGameGum\Input\CursorExtensions.cs">
+      <Link>Input\CursorEventFailureExtensions.cs</Link>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)GumExtensions\GraphicalUiElementExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Input\KeyEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Managers\FrameworkElementManager.cs" />


### PR DESCRIPTION
Paired with vchelaru/Gum#3697.

Compiles Gum's `MonoGameGum/Input/CursorExtensions.cs` (the `Cursor.GetEventFailureReason` click diagnostic) into `FlatRedBall.Forms` via the shared `.projitems`, under the existing `#if FRB` sharing. The diagnostic logic lives in the Gum repo; this is only the `<Compile Include>` so FRB picks it up.

Merge alongside the Gum PR — the projitems `Include` points at Gum source that must exist for FRB to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
