### PR TITLE
Animation Chain plugin: tolerate invalid enum values in .achx files

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/ViewModels/AchxViewModel.cs
+++ b/FRBDK/Glue/OfficialPlugins/AnimationChainPlugin/ViewModels/AchxViewModel.cs
@@ -563,7 +563,14 @@ internal class AchxViewModel : ViewModel
             }
             else
             {
-                animationChainListSave = AnimationChainListSave.FromFile(filePath.FullPath);
+                try
+                {
+                    animationChainListSave = AnimationChainListSave.FromFile(filePath.FullPath);
+                }
+                catch (Exception ex)
+                {
+                    GlueCommands.Self.PrintError($"Error loading .achx file {filePath.FullPath}:\n{ex.Message}");
+                }
             }
 
             if(animationChainListSave != null )


### PR DESCRIPTION
## Summary
- `AnimationChainListSave.FromFile` throws `InvalidOperationException` when an .achx contains an invalid enum value (e.g. bad `AnimationFrameColorOperation`), crashing the plugin's file-watch reload.
- Wraps the deserialization in a try/catch; on failure, prints an informative error via `GlueCommands.Self.PrintError` instead of throwing. Downstream code already null-tolerates a missing load result.

## Test plan
- [ ] Point an .achx's enum field to an invalid value, trigger a file-watch reload, confirm Glue shows an error instead of crashing