### PR TITLE
Fix GetRectangleAtPosition missing rectangles smaller than a full grid cell

### DIFF
--- a/Engines/FlatRedBallAddOns/FlatRedBall.TileCollisions/TileShapeCollection.cs
+++ b/Engines/FlatRedBallAddOns/FlatRedBall.TileCollisions/TileShapeCollection.cs
@@ -472,7 +472,7 @@ namespace FlatRedBall.TileCollisions
             int endExclusive = mShapes.AxisAlignedRectangles.GetFirstAfter(keyValueAfter, mSortAxis,
                 0, mShapes.AxisAlignedRectangles.Count);
 
-            AxisAlignedRectangle toReturn = GetRectangleAtPosition(middleOfTileX, middleOfTileY, startInclusive, endExclusive);
+            AxisAlignedRectangle toReturn = GetRectangleAtPosition(worldX, worldY, startInclusive, endExclusive);
 
             return toReturn;
         }


### PR DESCRIPTION
## Summary
`GetRectangleAtPosition` checked whether the grid-snapped tile-center point was inside the candidate rectangle instead of the actual query point. Harmless for full-cell rectangles, but an undersized/off-center rectangle (e.g. a half-height ledge tile) can have its tile center land exactly on its edge, failing the strict inside check even though the query point is genuinely inside.

One-line fix: pass `worldX, worldY` instead of `middleOfTileX, middleOfTileY`. Matches the already-correct `GlueView2` copy of this class.

Fixes #1890

## Test plan
- [x] No existing test coverage for this addon; verified by code inspection and cross-reference against the already-fixed GlueView2 copy of the same method.