### PR TITLE
Add TaskManager sync-mode + UI-thread-marshaller seams for Wizard testability

### DIFF
--- a/FRBDK/Glue/Glue/Managers/IUiThreadMarshaller.cs
+++ b/FRBDK/Glue/Glue/Managers/IUiThreadMarshaller.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+
+namespace FlatRedBall.Glue.Managers
+{
+    /// <summary>
+    /// Abstraction over marshalling work onto Glue's UI thread. The default implementation
+    /// (<see cref="WinFormsUiThreadMarshaller"/>) wraps <c>MainGlueWindow.Self.Invoke</c>/<c>BeginInvoke</c>,
+    /// which requires a live <c>Form</c> with a running WinForms message loop. Test hosts can supply an
+    /// inline implementation that just runs the delegate on the calling thread, so code that goes through
+    /// <see cref="TaskManager.UiThreadMarshaller"/> (directly, or via <c>TaskManager.OnUiThread</c>/
+    /// <c>BeginOnUiThread</c> or a <c>GlueTask</c> with <c>DoOnUiThread = true</c>) doesn't require a real window.
+    /// </summary>
+    public interface IUiThreadMarshaller
+    {
+        void Invoke(Action action);
+        T Invoke<T>(Func<T> func);
+        Task Invoke(Func<Task> func);
+        Task<T> Invoke<T>(Func<Task<T>> func);
+        void BeginInvoke(Action action);
+    }
+}

--- a/FRBDK/Glue/Glue/Managers/WinFormsUiThreadMarshaller.cs
+++ b/FRBDK/Glue/Glue/Managers/WinFormsUiThreadMarshaller.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+
+namespace FlatRedBall.Glue.Managers
+{
+    /// <summary>
+    /// Default production implementation of <see cref="IUiThreadMarshaller"/> - forwards straight to
+    /// <c>global::Glue.MainGlueWindow.Self</c>'s real WinForms Invoke/BeginInvoke overloads. Zero behavior
+    /// change from the code this was extracted from.
+    /// </summary>
+    public class WinFormsUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => global::Glue.MainGlueWindow.Self.Invoke(action);
+
+        public T Invoke<T>(Func<T> func) => global::Glue.MainGlueWindow.Self.Invoke(func);
+
+        public Task Invoke(Func<Task> func) => global::Glue.MainGlueWindow.Self.Invoke(func);
+
+        public Task<T> Invoke<T>(Func<Task<T>> func) => global::Glue.MainGlueWindow.Self.Invoke(func);
+
+        public void BeginInvoke(Action action) => global::Glue.MainGlueWindow.Self.BeginInvoke(action);
+    }
+}

--- a/FRBDK/Glue/Glue/Tasks/GlueTask.cs
+++ b/FRBDK/Glue/Glue/Tasks/GlueTask.cs
@@ -70,7 +70,7 @@ public class GlueTask : GlueTaskBase
     {
         if (DoOnUiThread && !TaskManager.Self.IsOnUiThread)
         {
-            global::Glue.MainGlueWindow.Self.Invoke(Action);
+            TaskManager.UiThreadMarshaller.Invoke(Action);
         }
         else
         {
@@ -89,7 +89,7 @@ public class GlueTask<T> : GlueTaskBase
     {
         if (DoOnUiThread && !TaskManager.Self.IsOnUiThread)
         {
-            Result =  global::Glue.MainGlueWindow.Self.Invoke(() => Result = Func());
+            Result =  TaskManager.UiThreadMarshaller.Invoke(() => Result = Func());
         }
         else
         {
@@ -109,7 +109,7 @@ public class GlueAsyncTask : GlueTaskBase
     {
         if (DoOnUiThread && !TaskManager.Self.IsOnUiThread)
         {
-            await global::Glue.MainGlueWindow.Self.Invoke(() => Func());
+            await TaskManager.UiThreadMarshaller.Invoke(() => Func());
         }
         else
         {
@@ -127,7 +127,7 @@ public class GlueAsyncTask<T> : GlueTaskBase
     {
         if (DoOnUiThread && !TaskManager.Self.IsOnUiThread)
         {
-            Result = await global::Glue.MainGlueWindow.Self.Invoke(() => Func());
+            Result = await TaskManager.UiThreadMarshaller.Invoke(() => Func());
         }
         else
         {

--- a/FRBDK/Glue/Glue/Tasks/TaskManager.cs
+++ b/FRBDK/Glue/Glue/Tasks/TaskManager.cs
@@ -255,6 +255,25 @@ namespace FlatRedBall.Glue.Managers
             }
         }
 
+        /// <summary>
+        /// When true, tasks added via Add/AddAsync/AddOrRunIfTasked run inline and synchronously on the
+        /// calling thread instead of being enqueued to the background task-processing thread. Intended
+        /// for test hosts (e.g. xunit) that don't want to spin up, or wait on, TaskManager's dedicated
+        /// STA thread. Must be set before the first access to <see cref="Self"/> for the constructor to
+        /// also skip spinning that thread; the Add methods honor it regardless of when it's set. Defaults
+        /// to false, so production behavior is unchanged.
+        /// </summary>
+        public static bool SynchronousMode { get; set; }
+
+        /// <summary>
+        /// Marshals actions/functions onto Glue's UI thread. Defaults to a wrapper around
+        /// <see cref="global::Glue.MainGlueWindow"/>'s real WinForms Invoke/BeginInvoke, which requires a
+        /// live window with a running message loop. Tests can replace this with an inline passthrough
+        /// (see <see cref="SynchronousMode"/>) so <see cref="OnUiThread(Action)"/>/<see cref="BeginOnUiThread(Action)"/>
+        /// don't require a real window.
+        /// </summary>
+        public static IUiThreadMarshaller UiThreadMarshaller { get; set; } = new WinFormsUiThreadMarshaller();
+
         #endregion
 
         #region Events
@@ -265,6 +284,15 @@ namespace FlatRedBall.Glue.Managers
 
         public TaskManager()
         {
+            if (SynchronousMode)
+            {
+                // Tests run everything inline on the calling thread rather than a dedicated
+                // background thread; treat the calling thread as the "task" thread so
+                // IsInTask()/AddOrRunIfTasked behave the same way they do in production.
+                SyncTaskThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+                return;
+            }
+
             var thread = new Thread(StartDoTaskManagerLoop)
             {
                 IsBackground = true
@@ -419,7 +447,14 @@ namespace FlatRedBall.Glue.Managers
             glueTask.DisplayInfo = displayInfo;
             glueTask.CustomId = customId;
 
-            AddInternal(glueTask);
+            if (SynchronousMode)
+            {
+                RunSynchronously(glueTask);
+            }
+            else
+            {
+                AddInternal(glueTask);
+            }
             return glueTask;
         }
 
@@ -431,7 +466,14 @@ namespace FlatRedBall.Glue.Managers
             glueTask.TaskExecutionPreference = executionPreference;
             glueTask.DisplayInfo = displayInfo;
             glueTask.CustomId=customId;
-            AddInternal(glueTask);
+            if (SynchronousMode)
+            {
+                RunSynchronously(glueTask);
+            }
+            else
+            {
+                AddInternal(glueTask);
+            }
             return glueTask;
         }
 
@@ -446,8 +488,32 @@ namespace FlatRedBall.Glue.Managers
             glueTask.TaskExecutionPreference = executionPreference;
             glueTask.DisplayInfo = displayInfo;
             glueTask.CustomId = customId;
-            AddInternal(glueTask);
+            if (SynchronousMode)
+            {
+                RunSynchronously(glueTask);
+            }
+            else
+            {
+                AddInternal(glueTask);
+            }
             return glueTask;
+        }
+
+        /// <summary>
+        /// Runs a task inline on the calling thread, bypassing the queue entirely. Used by the Add
+        /// overloads when <see cref="SynchronousMode"/> is enabled.
+        /// </summary>
+        private void RunSynchronously(GlueTaskBase glueTask)
+        {
+            // TaskManager is a process-wide singleton (see Singleton<T>), so whichever thread happens to
+            // construct it first (e.g. in a parallel test run) is the one that gets recorded as
+            // SyncTaskThreadId in the constructor. Re-stamp it here on every synchronous run so
+            // IsInTask()/AddOrRunIfTasked correctly treat *this* calling thread as "in a task",
+            // regardless of construction order.
+            SyncTaskThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+
+            TaskAddedOrRemoved?.Invoke(TaskEvent.Queued, glueTask);
+            RunTask(glueTask, markAsCurrent: true).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -794,7 +860,7 @@ namespace FlatRedBall.Glue.Managers
             }
             else
             {
-                global::Glue.MainGlueWindow.Self.Invoke(() => action.Invoke().Wait());
+                UiThreadMarshaller.Invoke(() => action.Invoke().Wait());
             }
         }
 
@@ -806,7 +872,7 @@ namespace FlatRedBall.Glue.Managers
             }
             else
             {
-                global::Glue.MainGlueWindow.Self.Invoke(action);
+                UiThreadMarshaller.Invoke(action);
             }
         }
 
@@ -818,7 +884,7 @@ namespace FlatRedBall.Glue.Managers
             }
             else
             {
-                global::Glue.MainGlueWindow.Self.BeginInvoke(action);
+                UiThreadMarshaller.BeginInvoke(action);
             }
         }
 

--- a/FRBDK/Glue/OfficialPlugins/Wizard/Managers/WizardProjectLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/Wizard/Managers/WizardProjectLogic.cs
@@ -33,6 +33,23 @@ namespace OfficialPlugins.Wizard.Managers
         }
         #endregion
 
+        // Not covered by an end-to-end unit test - see GitHub issue #1894 and GlueUnitTests.Wizard.WizardProjectLogicTests
+        // for what *is* covered and why.
+        //
+        // #1894 added test seams for the two couplings it identified (TaskManager's background thread and
+        // MainGlueWindow's Invoke/BeginInvoke - see TaskManager.SynchronousMode/UiThreadMarshaller). Those
+        // seams are real and tested directly. But driving Apply() itself - even for the plugin-free
+        // "bare AddGameScreen" step suggested as a fallback - turns out to be blocked by a *deeper*
+        // coupling than plugins: HandleAddGameScreen -> GluxCommands.ScreenCommands.AddScreen ->
+        // ProjectCommands.CreateAndAddCodeFile, which throws NullReferenceException("Main Project") unless
+        // GlueState.CurrentMainProject is a real, MSBuild-backed VisualStudioProject (abstract, no fake-able
+        // interface). That's the same blocker already called out in REFACTORING.md's "Known Areas Needing
+        // Improvement" section for ProjectCommands - out of scope here, since fully addressing it means
+        // building an IVisualStudioProject seam, a separate and much larger refactor.
+        //
+        // What's genuinely unit tested instead: the pure, side-effect-free decision logic inside each step
+        // that doesn't touch GlueState/TaskManager/plugins - e.g. GetDisplaySettingsFor (the
+        // CameraResolution -> width/height/aspect-ratio mapping used by ApplyMainCameraSettings).
         public async Task Apply(WizardViewModel vm)
         {
             ///////////////////Early Out/////////////////////
@@ -1035,20 +1052,25 @@ namespace OfficialPlugins.Wizard.Managers
             await ApplyMainCameraSettings(vm);
         }
 
-        private static async Task ApplyMainCameraSettings(WizardViewModel vm)
+        /// <summary>
+        /// Pure resolution -> display-settings mapping used by <see cref="ApplyMainCameraSettings"/>.
+        /// Extracted so this decision logic can be unit tested without the TaskManager/GlueState side
+        /// effects it's normally wrapped in - see GlueUnitTests.Wizard.WizardProjectLogicTests.
+        /// </summary>
+        internal static (int Width, int Height, decimal AspectRatioWidth, decimal AspectRatioHeight, int ScalePercent) GetDisplaySettingsFor(
+            CameraResolution resolution, int scalePercent)
         {
             int width = 800;
             int height = 600;
             decimal aspectRatioWidth = 4;
             decimal aspectRatioHeight = 3;
 
-            int scalePercent = vm.ScalePercent;
             if (scalePercent <= 0)
             {
                 scalePercent = 100;
             }
 
-            switch (vm.SelectedCameraResolution)
+            switch (resolution)
             {
                 case CameraResolution._256x224:
                     width = 256;
@@ -1095,17 +1117,24 @@ namespace OfficialPlugins.Wizard.Managers
 
             }
 
+            return (width, height, aspectRatioWidth, aspectRatioHeight, scalePercent);
+        }
+
+        private static async Task ApplyMainCameraSettings(WizardViewModel vm)
+        {
+            var settings = GetDisplaySettingsFor(vm.SelectedCameraResolution, vm.ScalePercent);
+
             await TaskManager.Self.AddAsync(() =>
             {
                 var displaySettings = GlueState.Self.CurrentGlueProject.DisplaySettings;
-                displaySettings.ResolutionWidth = width;
-                displaySettings.ResolutionHeight = height;
+                displaySettings.ResolutionWidth = settings.Width;
+                displaySettings.ResolutionHeight = settings.Height;
 
-                displaySettings.AspectRatioWidth = aspectRatioWidth;
-                displaySettings.AspectRatioHeight = aspectRatioHeight;
+                displaySettings.AspectRatioWidth = settings.AspectRatioWidth;
+                displaySettings.AspectRatioHeight = settings.AspectRatioHeight;
                 displaySettings.AspectRatioBehavior = AspectRatioBehavior.FixedAspectRatio;
 
-                displaySettings.Scale = scalePercent;
+                displaySettings.Scale = settings.ScalePercent;
 
             }, "Setting display settings");
         }

--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -307,6 +307,41 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
 
 ## Completed Refactors
 
+### 2026-07-23 — Wizard apply-engine test seams (issue #1894)
+
+Follow-up to #1892: applied the same seam pattern to the Wizard's apply-engine (`WizardProjectLogic.Apply`),
+which was untestable because it runs through `TaskManager`'s real background thread and
+`MainGlueWindow`'s real WinForms `Invoke`/`BeginInvoke`.
+
+- **`TaskManager.SynchronousMode`** (static bool, default `false`) - when set, `Add`/`Add<T>`/
+  `Add(Func<Task>)` run the task inline on the calling thread (via a new `RunSynchronously` helper)
+  instead of enqueueing to the background STA thread; the constructor also skips spinning that thread
+  when the flag is already set. `AddAsync`/`AddOrRunIfTasked` needed no changes - they already delegate
+  to `Add` in the non-reentrant case. Zero behavior change when unset.
+- **`IUiThreadMarshaller`** (`Glue/Managers/IUiThreadMarshaller.cs`) - abstraction over
+  Invoke/BeginInvoke, injected via `TaskManager.UiThreadMarshaller` (static, defaults to
+  `WinFormsUiThreadMarshaller`, which forwards to `MainGlueWindow.Self.Invoke`/`BeginInvoke` exactly as
+  before). `TaskManager.OnUiThread`/`BeginOnUiThread`, and all four `GlueTask*.Do_Action_Internal()`
+  variants (`GlueTask`, `GlueTask<T>`, `GlueAsyncTask`, `GlueAsyncTask<T>`), now go through this instead of
+  referencing `MainGlueWindow.Self` directly - the latter four were a coupling #1894 hadn't
+  originally identified (only `TaskManager.OnUiThread`/`BeginOnUiThread` were flagged), found because any
+  `GlueTask` with `DoOnUiThread = true` would otherwise still NRE in a test host with no live window.
+
+Both seams are pinned directly in `GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs`.
+
+**`WizardProjectLogic.Apply` itself is not covered end-to-end.** The issue's fallback plan was to start
+with a plugin-free step (bare `AddGameScreen`) if full coverage wasn't practical. That step turned out to
+be blocked by something deeper than plugins: `HandleAddGameScreen` -> `GluxCommands.ScreenCommands.AddScreen`
+-> `ProjectCommands.CreateAndAddCodeFile`, which throws `NullReferenceException("Main Project")` unless
+`GlueState.CurrentMainProject` is a real, MSBuild-backed `VisualStudioProject` - the same
+`VisualStudioProject` construction blocker already documented above under "Known Areas Needing
+Improvement". Building an `IVisualStudioProject` seam to unblock that is a separate, larger refactor.
+Instead, extracted and tested the one piece of `Apply` that's pure decision logic with no
+GlueState/TaskManager/plugin coupling: `WizardProjectLogic.GetDisplaySettingsFor` (the `CameraResolution`
+-> width/height/aspect-ratio mapping used by `ApplyMainCameraSettings`), pinned in
+`GlueUnitTests/Wizard/WizardProjectLogicTests.cs`. The scoping-out is documented directly above
+`WizardProjectLogic.Apply` in a code comment pointing back here.
+
 ### 2026-07-23 — Make new-project creation (NPC) testable (issue #1892)
 
 `ProjectCreationHelper` (the New Project Creator in `NpcWpfLib`) was untested despite being one of the

--- a/FRBDK/Glue/Tests/GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs
@@ -1,0 +1,179 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Managers;
+using Shouldly;
+
+namespace GlueUnitTests.Tasks;
+
+// TaskManager is a process-wide singleton (see Singleton<T>) and TaskManager.SynchronousMode /
+// UiThreadMarshaller are process-wide static state. Both test classes in this file mutate that state,
+// so they share a non-parallel xunit collection to avoid interleaving with each other.
+[CollectionDefinition(nameof(TaskManagerSequentialCollection), DisableParallelization = true)]
+public class TaskManagerSequentialCollection { }
+
+// Pins the synchronous-execution-mode seam added for GitHub issue #1894: with TaskManager.SynchronousMode
+// enabled, Add/AddAsync run the task inline on the calling thread instead of enqueueing it to
+// TaskManager's dedicated background thread. This is what lets tests (like WizardProjectLogicTests) drive
+// code that goes through TaskManager without needing to wait on, or even spin up, that background thread.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class TaskManagerSynchronousModeTests : System.IDisposable
+{
+    private readonly bool _originalSynchronousMode;
+
+    public TaskManagerSynchronousModeTests()
+    {
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        TaskManager.SynchronousMode = true;
+    }
+
+    public void Dispose()
+    {
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+    }
+
+    [Fact]
+    public void Add_Action_ShouldRunInline_OnCallingThread()
+    {
+        var callingThreadId = Thread.CurrentThread.ManagedThreadId;
+        var ranOnThreadId = -1;
+
+        TaskManager.Self.Add(() => ranOnThreadId = Thread.CurrentThread.ManagedThreadId, "test action");
+
+        ranOnThreadId.ShouldBe(callingThreadId);
+    }
+
+    [Fact]
+    public void Add_Func_ShouldRunInlineAndPopulateResult()
+    {
+        var glueTask = TaskManager.Self.Add(() => 42, "test func");
+
+        ((int)glueTask.Result).ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task AddAsync_Action_ShouldRunBeforeAwaitCompletes()
+    {
+        var ran = false;
+
+        await TaskManager.Self.AddAsync(() => ran = true, "test async action");
+
+        ran.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AddAsync_Func_ShouldRunInline()
+    {
+        var ran = false;
+
+        await TaskManager.Self.AddAsync(async () =>
+        {
+            ran = true;
+            await Task.CompletedTask;
+        }, "test async func");
+
+        ran.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task WaitForAllTasksFinished_ShouldReturnImmediately_SinceTasksAlreadyRanInline()
+    {
+        TaskManager.Self.Add(() => { }, "already done by the time we get here");
+
+        // AreAllAsyncTasksDone should already be true - RunSynchronously blocks until the task completes -
+        // so this shouldn't need to poll/wait at all.
+        var didWait = await TaskManager.Self.WaitForAllTasksFinished();
+
+        didWait.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Add_ShouldNotRequireALiveMainGlueWindow()
+    {
+        // This test host never constructs a MainGlueWindow. If some code path regressed to touching
+        // MainGlueWindow.Self directly (instead of going through TaskManager.UiThreadMarshaller), this
+        // would NullReferenceException.
+        Should.NotThrow(() => TaskManager.Self.Add(() => { }, "no live window needed"));
+    }
+}
+
+// Pins the UI-thread-marshaller seam added for GitHub issue #1894: TaskManager.OnUiThread/BeginOnUiThread,
+// and GlueTask's DoOnUiThread handling, now go through the injectable TaskManager.UiThreadMarshaller
+// instead of calling global::Glue.MainGlueWindow.Self.Invoke/BeginInvoke directly. That means tests can
+// supply an inline marshaller and never need a real WinForms window with a running message loop.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class TaskManagerUiThreadMarshallerTests : System.IDisposable
+{
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly bool _originalSynchronousMode;
+
+    public TaskManagerUiThreadMarshallerTests()
+    {
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+    }
+
+    public void Dispose()
+    {
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+    }
+
+    private class RecordingInlineMarshaller : IUiThreadMarshaller
+    {
+        public int InvokeActionCallCount;
+        public int BeginInvokeCallCount;
+
+        public void Invoke(System.Action action) { InvokeActionCallCount++; action(); }
+        public T Invoke<T>(System.Func<T> func) => func();
+        public Task Invoke(System.Func<Task> func) => func();
+        public Task<T> Invoke<T>(System.Func<Task<T>> func) => func();
+        public void BeginInvoke(System.Action action) { BeginInvokeCallCount++; action(); }
+    }
+
+    [Fact]
+    public void OnUiThread_Action_ShouldRouteThroughMarshaller_WhenNotOnUiThread()
+    {
+        var marshaller = new RecordingInlineMarshaller();
+        TaskManager.UiThreadMarshaller = marshaller;
+        var ran = false;
+
+        // The xunit test thread is never MainGlueWindow's UI thread, so IsOnUiThread is false here,
+        // exercising the marshaller branch.
+        TaskManager.Self.IsOnUiThread.ShouldBeFalse();
+        TaskManager.Self.OnUiThread(() => ran = true);
+
+        ran.ShouldBeTrue();
+        marshaller.InvokeActionCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void BeginOnUiThread_ShouldRouteThroughMarshaller_WhenNotOnUiThread()
+    {
+        var marshaller = new RecordingInlineMarshaller();
+        TaskManager.UiThreadMarshaller = marshaller;
+        var ran = false;
+
+        TaskManager.Self.BeginOnUiThread(() => ran = true);
+
+        ran.ShouldBeTrue();
+        marshaller.BeginInvokeCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GlueTask_WithDoOnUiThread_ShouldRouteThroughMarshaller_NotMainGlueWindowDirectly()
+    {
+        var marshaller = new RecordingInlineMarshaller();
+        TaskManager.UiThreadMarshaller = marshaller;
+        TaskManager.SynchronousMode = true;
+        var ran = false;
+
+        // Block-bodied lambda: unambiguously resolves to the Add(Action, ...) overload rather than
+        // the Add<T>(Func<T>, ...) overload (an expression-bodied `() => ran = true` is convertible to
+        // both, since assignment is a valid expression *and* statement, so it would otherwise resolve to
+        // Add<bool> and route through UiThreadMarshaller.Invoke<T> instead of Invoke(Action)).
+        TaskManager.Self.Add(() => { ran = true; }, "ui thread task", doOnUiThread: true);
+
+        ran.ShouldBeTrue();
+        marshaller.InvokeActionCallCount.ShouldBe(1);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicTests.cs
@@ -1,0 +1,59 @@
+using OfficialPlugins.Wizard.Managers;
+using OfficialPlugins.Wizard.Models;
+using Shouldly;
+
+namespace GlueUnitTests.Wizard;
+
+// GitHub issue #1894 asked for unit coverage of WizardProjectLogic.Apply, using the TaskManager
+// synchronous-mode / UI-thread-marshaller seams added in this same change (see
+// GlueUnitTests.Tasks.TaskManagerSynchronousModeTests). Those seams are real and directly tested.
+//
+// But driving Apply() itself - even for the plugin-free "bare AddGameScreen" step suggested as a
+// fallback - turns out to be blocked by a deeper coupling than plugins: HandleAddGameScreen ends up in
+// ProjectCommands.CreateAndAddCodeFile, which throws NullReferenceException("Main Project") unless
+// GlueState.CurrentMainProject is a real, MSBuild-backed VisualStudioProject (abstract, no fakeable
+// interface) - the same blocker already called out in REFACTORING.md's "Known Areas Needing Improvement"
+// section. Building an IVisualStudioProject seam to unblock that is a separate, larger refactor, out of
+// scope here.
+//
+// What's covered instead: the pure, side-effect-free decision logic inside an Apply step that doesn't
+// touch GlueState/TaskManager/plugins - GetDisplaySettingsFor, extracted from ApplyMainCameraSettings.
+public class WizardProjectLogicTests
+{
+    [Theory]
+    [InlineData(CameraResolution._256x224, 256, 224, 8, 7)]
+    [InlineData(CameraResolution._360x240, 360, 240, 3, 2)]
+    [InlineData(CameraResolution._480x360, 480, 360, 4, 3)]
+    [InlineData(CameraResolution._640x480, 640, 480, 4, 3)]
+    [InlineData(CameraResolution._800x600, 800, 600, 4, 3)]
+    [InlineData(CameraResolution._1024x768, 1024, 768, 4, 3)]
+    [InlineData(CameraResolution._1920x1080, 1920, 1080, 16, 9)]
+    public void GetDisplaySettingsFor_ShouldMapResolutionToWidthHeightAndAspectRatio(
+        CameraResolution resolution, int expectedWidth, int expectedHeight, decimal expectedAspectWidth, decimal expectedAspectHeight)
+    {
+        var settings = WizardProjectLogic.GetDisplaySettingsFor(resolution, scalePercent: 100);
+
+        settings.Width.ShouldBe(expectedWidth);
+        settings.Height.ShouldBe(expectedHeight);
+        settings.AspectRatioWidth.ShouldBe(expectedAspectWidth);
+        settings.AspectRatioHeight.ShouldBe(expectedAspectHeight);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-10)]
+    public void GetDisplaySettingsFor_ShouldDefaultScalePercentTo100_WhenNotPositive(int scalePercent)
+    {
+        var settings = WizardProjectLogic.GetDisplaySettingsFor(CameraResolution._800x600, scalePercent);
+
+        settings.ScalePercent.ShouldBe(100);
+    }
+
+    [Fact]
+    public void GetDisplaySettingsFor_ShouldPassThroughScalePercent_WhenPositive()
+    {
+        var settings = WizardProjectLogic.GetDisplaySettingsFor(CameraResolution._800x600, scalePercent: 150);
+
+        settings.ScalePercent.ShouldBe(150);
+    }
+}


### PR DESCRIPTION
Part of #1894 (not fully closing it — Apply() end-to-end coverage still open, see Deviation below). Follow-up to #1892/#1893, same seam pattern applied to the Wizard apply-engine.

## Findings
- `TaskManager.Add`/`AddAsync` always enqueue to a dedicated background STA thread - no sync mode existed.
- `TaskManager.OnUiThread`/`BeginOnUiThread` called `MainGlueWindow.Self.Invoke`/`BeginInvoke` directly, requiring a live window.
- Not called out in #1894, but found along the way: all four `GlueTask*.Do_Action_Internal()` variants (`GlueTask`, `GlueTask<T>`, `GlueAsyncTask`, `GlueAsyncTask<T>`) *also* call `MainGlueWindow.Self.Invoke` directly when `DoOnUiThread = true` - a second coupling that needed the same seam.
- `WizardProjectLogic.Apply`'s "bare AddGameScreen" fallback step (suggested in #1894 as the plugin-free path to unit test) is blocked by something deeper than plugins: `HandleAddGameScreen` → `GluxCommands.ScreenCommands.AddScreen` → `ProjectCommands.CreateAndAddCodeFile`, which throws `NullReferenceException("Main Project")` unless `GlueState.CurrentMainProject` is a real, MSBuild-backed `VisualStudioProject` (abstract, no fakeable interface). Same blocker already flagged in REFACTORING.md's "Known Areas Needing Improvement" for `ProjectCommands`.

## What's done
- `TaskManager.SynchronousMode` (static bool, default false) - `Add`/`Add<T>`/`Add(Func<Task>)` run inline on the calling thread instead of enqueueing; constructor skips spinning the background thread when set. `AddAsync`/`AddOrRunIfTasked` needed no changes (they delegate to `Add`).
- `IUiThreadMarshaller` + `TaskManager.UiThreadMarshaller` (static, defaults to `WinFormsUiThreadMarshaller` wrapping `MainGlueWindow.Self`). `TaskManager.OnUiThread`/`BeginOnUiThread` and all four `GlueTask*` variants route through it instead of touching `MainGlueWindow.Self` directly.
- Both seams pinned in `GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs`.
- Extracted `WizardProjectLogic.GetDisplaySettingsFor` (the pure `CameraResolution` → width/height/aspect-ratio mapping inside `ApplyMainCameraSettings`) and tested it in `GlueUnitTests/Wizard/WizardProjectLogicTests.cs`.

## Deviation from the issue's plan
`WizardProjectLogic.Apply` is **not** covered end-to-end, and the fallback build-smoke integration test wasn't built either - loading a project via `ProjectLoader.LoadProject` (needed to get a real `VisualStudioProject`) itself touches `MainGlueWindow.Self` directly in places the new seams don't cover (e.g. setting the window title), so it would need a live WinForms message loop regardless. That's a materially bigger lift than #1894 scoped. Scoping documented in a code comment above `Apply()` and in REFACTORING.md. Remaining work tracked as a comment on #1894, not a new issue.

## Verified
- `dotnet test "Glue with All.sln" --filter "Category!=BuildSmoke"` → 138 passed (119 existing + 19 new), 0 failed.
- `dotnet test "Glue with All.sln" --filter "Category=BuildSmoke"` → 1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)