### PR TITLE
Unblock and test WizardProjectLogic's AddGameScreen step

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueCommands.cs
@@ -61,12 +61,12 @@ public class GlueCommands : IGlueCommands
     
     public void DoOnUiThread(Action action)
     {
-        MainGlueWindow.Self.Invoke(action);
+        TaskManager.UiThreadMarshaller.Invoke(action);
     }
 
-    public Task DoOnUiThread(Func<Task> func) => MainGlueWindow.Self.Invoke(func);
+    public Task DoOnUiThread(Func<Task> func) => TaskManager.UiThreadMarshaller.Invoke(func);
 
-    public T DoOnUiThread<T>(Func<T> func) => MainGlueWindow.Self.Invoke(func);
+    public T DoOnUiThread<T>(Func<T> func) => TaskManager.UiThreadMarshaller.Invoke(func);
 
     public void CloseGlueProject(bool shouldSave = true, bool isExiting = false, GlueFormsCore.Controls.InitializationWindowWpf initWindow = null)
     {

--- a/FRBDK/Glue/OfficialPlugins/Wizard/Managers/WizardProjectLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/Wizard/Managers/WizardProjectLogic.cs
@@ -33,23 +33,24 @@ namespace OfficialPlugins.Wizard.Managers
         }
         #endregion
 
-        // Not covered by an end-to-end unit test - see GitHub issue #1894 and GlueUnitTests.Wizard.WizardProjectLogicTests
-        // for what *is* covered and why.
+        // Apply() itself is still not covered by an end-to-end unit test - see GitHub issue #1894,
+        // REFACTORING.md's "Unblock WizardProjectLogic AddGameScreen testing" entry, and
+        // GlueUnitTests.Wizard.WizardProjectLogicTests / WizardProjectLogicAddGameScreenTests for what *is*
+        // covered and why.
         //
-        // #1894 added test seams for the two couplings it identified (TaskManager's background thread and
-        // MainGlueWindow's Invoke/BeginInvoke - see TaskManager.SynchronousMode/UiThreadMarshaller). Those
-        // seams are real and tested directly. But driving Apply() itself - even for the plugin-free
-        // "bare AddGameScreen" step suggested as a fallback - turns out to be blocked by a *deeper*
-        // coupling than plugins: HandleAddGameScreen -> GluxCommands.ScreenCommands.AddScreen ->
-        // ProjectCommands.CreateAndAddCodeFile, which throws NullReferenceException("Main Project") unless
-        // GlueState.CurrentMainProject is a real, MSBuild-backed VisualStudioProject (abstract, no fake-able
-        // interface). That's the same blocker already called out in REFACTORING.md's "Known Areas Needing
-        // Improvement" section for ProjectCommands - out of scope here, since fully addressing it means
-        // building an IVisualStudioProject seam, a separate and much larger refactor.
+        // #1894 added test seams for TaskManager's background thread and MainGlueWindow's
+        // Invoke/BeginInvoke (TaskManager.SynchronousMode/UiThreadMarshaller). A follow-up unblocked the
+        // "bare AddGameScreen" step specifically: HandleAddGameScreen is now internal and driven directly
+        // in GlueUnitTests.Wizard.WizardProjectLogicAddGameScreenTests, against a real (not fake)
+        // VisualStudioProject backed by a minimal non-SDK .csproj (GlueUnitTests.TestSupport) - no
+        // IVisualStudioProject seam needed after all.
         //
-        // What's genuinely unit tested instead: the pure, side-effect-free decision logic inside each step
-        // that doesn't touch GlueState/TaskManager/plugins - e.g. GetDisplaySettingsFor (the
-        // CameraResolution -> width/height/aspect-ratio mapping used by ApplyMainCameraSettings).
+        // Apply() as a whole remains untested: even with only AddGameScreen set, it unconditionally also
+        // runs GenerateAllCode (walks every element in the project), a "Flush Files" step with a hard-coded
+        // 2.5s+ real delay, and SaveProjectAndElements - a meaningfully bigger surface than AddScreen alone.
+        // Most of the other Wizard steps (player entity, collisions, camera, levels, ...) are also
+        // untested; collisions specifically NRE on AvailableAssetTypes.CommonAtis, which is only populated
+        // by real PluginManager plugin loading - see REFACTORING.md for details.
         public async Task Apply(WizardViewModel vm)
         {
             ///////////////////Early Out/////////////////////
@@ -289,7 +290,10 @@ namespace OfficialPlugins.Wizard.Managers
 
         #region Add GameScreen
 
-        private static async Task<(ScreenSave gameScreen, NamedObjectSave solidCollision, NamedObjectSave cloudCollisionNos)> HandleAddGameScreen(WizardViewModel vm)
+        // internal (not private) so GlueUnitTests can drive the bare AddGameScreen step directly - see
+        // WizardProjectLogicAddGameScreenTests and the comment above Apply() for why Apply() itself isn't
+        // covered end-to-end.
+        internal static async Task<(ScreenSave gameScreen, NamedObjectSave solidCollision, NamedObjectSave cloudCollisionNos)> HandleAddGameScreen(WizardViewModel vm)
         {
             ScreenSave gameScreen = await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen("GameScreen");
             NamedObjectSave solidCollisionNos = null;

--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -286,12 +286,17 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
 ## Known Areas Needing Improvement
 
 - **`ProjectCommands.UpdateFileMembershipInProject`** is a ~170-line method with no seams — it touches
-  a concrete `VisualStudioProject` (abstract, but its constructor requires a live MSBuild `Project`, so
-  it can't be constructed in a unit test), `FileReferenceManager`, and `PluginManager` all inline. The
-  `GlueState.Self` dependency was removed (see below), but `VisualStudioProject` remains the blocker.
-  Fully unit-testing this method would require extracting an `IVisualStudioProject`-style seam around
-  the MSBuild-backed project type — out of scope until a feature actually needs to touch this method
-  again.
+  a concrete `VisualStudioProject`, `FileReferenceManager`, and `PluginManager` all inline. The
+  `GlueState.Self` dependency was removed (see below), but `VisualStudioProject` remains the blocker to
+  fully unit-testing this specific method (it's ~170 lines with several branches, more than the one call
+  site `GlueUnitTests/TestSupport/TestVisualStudioProjectFactory` was built to unblock — see the
+  "Unblock WizardProjectLogic AddGameScreen testing" entry below). Note that `VisualStudioProject`'s
+  constructor requiring a live MSBuild `Project` is no longer an unconditional blocker: a real (not
+  fake) `VisualStudioProject` can now be constructed in a unit test via a minimal, non-SDK-style `.csproj`
+  written to a temp directory — see `TestVisualStudioProjectFactory`. Widening that factory's coverage to
+  `UpdateFileMembershipInProject`'s branches (content vs. code items, synced projects, etc.) — rather than
+  extracting an `IVisualStudioProject` seam — is the path forward when a feature next needs to touch this
+  method.
 
 - **`UpdateReactor.ReloadGlux`'s apply step** (swap the replaced Screen/Entity/GlobalFile into
   `ProjectManager.GlueProjectSave`, then call `GlueCommands.Self.RefreshCommands`/`UpdateCommands`/
@@ -306,6 +311,62 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
   what gets computed.
 
 ## Completed Refactors
+
+### 2026-07-23 — Unblock WizardProjectLogic AddGameScreen testing (issue #1894 follow-up)
+
+Follow-up to the "Wizard apply-engine test seams" entry directly below: that PR left `HandleAddGameScreen`
+untested because `ProjectCommands.CreateAndAddCodeFile` throws `NullReferenceException("Main Project")`
+unless `GlueState.CurrentMainProject` is a real, MSBuild-backed `VisualStudioProject`, and building a
+fakeable `IVisualStudioProject` seam looked like a separate, much larger refactor (that type's constructor
+takes a live `Microsoft.Build.Evaluation.Project` and dereferences it immediately, and `CurrentMainProject`
+is read as the concrete type in dozens of places, e.g. `is MonoGameDesktopGlBaseProject` checks - widening
+the property to an interface would ripple everywhere).
+
+Turns out no interface extraction was needed. `VisualStudioProject`'s constructor only needs *a* real
+`Project` - it doesn't need one loaded through Glue's SDK-style-project machinery (which requires
+`MSBuildLocator.RegisterDefaults()`, only ever called from `MainGlueWindow`). A bare, non-SDK-style
+`.csproj` (no `Sdk="..."` attribute, no imports) evaluates with zero SDK/toolset resolution, so
+`new Project(path)` and wrapping it in the existing concrete `ClassLibraryProject` works cleanly in a
+plain xunit host. `GlueUnitTests/TestSupport/TestVisualStudioProjectFactory` does exactly this, writing a
+minimal `.csproj` to a fresh temp directory per test.
+
+Getting `GluxCommands.ScreenCommands.AddScreen` to run cleanly from there needed:
+- **One real production fix**: `GlueCommands.DoOnUiThread` (all three overloads) called
+  `MainGlueWindow.Self.Invoke`/`Invoke<T>` directly - a coupling the previous entry's
+  `TaskManager.UiThreadMarshaller` seam didn't reach because it's not on `TaskManager`. Routed through
+  `TaskManager.UiThreadMarshaller` instead, same as the other four call sites. Zero behavior change in
+  production (still resolves to `WinFormsUiThreadMarshaller` by default).
+- **Test-only bootstrap**, in `GlueUnitTests/TestSupport/GlueTestBootstrap`: a handful of one-time calls
+  that mirror what `Glue.exe`'s own startup (`Program.cs`, `MainGlueWindow.cs`) does before
+  `GlueCommands.Self`/`GlueState.Self` are usable - building the app's lightweight DI container
+  (`Services.Builder`), registering `IGlueCommands`/`IGlueState` on the legacy `EditorObjects.IoC.Container`
+  service locator (a second, older locator several command classes still read from directly, e.g.
+  `GenerateCodeCommands.GlueCommands`), and `ProjectManager.Initialize()`/`FileWatchManager.Initialize()`.
+  None of this is faked - it's real production initialization, just never previously run outside a live
+  WinForms app.
+- Per-test setup of `GlueState.CurrentMainProject`, `ObjectFinder.Self.GlueProject`, and
+  `FileManager.RelativeDirectory` (the last one because `ElementCommands.AddScreen` builds its code-file
+  path from that static rather than from the project's own directory - both need to agree for
+  `IsFilePartOfProject` to correctly recognize a freshly-added file).
+
+`HandleAddGameScreen` was changed from `private static` to `internal static` (zero behavior change) so
+`GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs` can call it directly with a `WizardViewModel`
+that only sets `AddGameScreen = true`, pinning: the returned `ScreenSave`'s name/tags, that it lands in
+`GlueProjectSave.Screens` and becomes `StartUpScreen`, and that both the custom and generated code files
+get added to the project.
+
+**Still not covered:**
+- `WizardProjectLogic.Apply()` end-to-end. Even with only `AddGameScreen` set, `Apply()` unconditionally
+  also runs "Generate all code" (`GenerateAllCode`, walks every element in the project), a "Flush Files"
+  step with a hard-coded 2.5s+ real delay, and "Saving Project" - a meaningfully larger surface than
+  `AddScreen` alone, and more than issue #1894's stated fallback ("at minimum the AddGameScreen step")
+  required.
+- `AddSolidCollision`/`AddCloudCollision` (and by extension most of the Wizard's other add-on steps):
+  they route through `NamedObjectSaveCodeGenerator.GetDestroyForNamedObject`, which reads
+  `AvailableAssetTypes.CommonAtis` - a catalog populated by scanning every plugin's registered
+  `AssetTypeInfo`s during real `PluginManager` startup - and NREs when that catalog is empty.
+  `GlueTestBootstrap` intentionally does not attempt to replicate plugin loading; that's a materially
+  bigger, separate blocker from the `VisualStudioProject` one this entry unblocks.
 
 ### 2026-07-23 — Wizard apply-engine test seams (issue #1894)
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -1,0 +1,57 @@
+using EditorObjects.IoC;
+using FlatRedBall.Glue.IO;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces;
+using FlatRedBall.Glue.Services;
+
+namespace GlueUnitTests.TestSupport;
+
+/// <summary>
+/// One-time, process-wide bootstrap that mirrors the handful of static/DI registrations Glue.exe's real
+/// startup (Program.cs / MainGlueWindow.cs) performs before GlueCommands.Self/GlueState.Self are usable.
+/// None of this is a fake or a mock - it is the same calls production makes, just run in-process for a
+/// test host instead of a live WinForms app:
+///  - <see cref="Builder"/> wires up the app's lightweight DI container (GluxCommands, ElementCommands,
+///    etc. all resolve through it).
+///  - The legacy <see cref="Container"/> (EditorObjects.IoC) is a second, older service locator that
+///    several command classes (GenerateCodeCommands, VisualStudioProject, ...) still read from directly.
+///  - <see cref="FlatRedBall.Glue.ProjectManager"/>.Initialize sets up CodeProjectHelper, used by any
+///    code-file-adding path (e.g. AddScreen).
+///  - <see cref="FileWatchManager"/>.Initialize sets up the self-save-suppression list that
+///    IgnoreNextChangeOnFile writes to.
+///
+/// Any test that drives production code through GlueCommands.Self/GlueState.Self (rather than calling a
+/// pure static method directly) needs this. Call <see cref="EnsureInitialized"/> once per test.
+/// </summary>
+internal static class GlueTestBootstrap
+{
+    static readonly object _lock = new();
+    static bool _initialized;
+
+    public static void EnsureInitialized()
+    {
+        lock (_lock)
+        {
+            if (_initialized)
+            {
+                return;
+            }
+            _initialized = true;
+
+            if (Builder.App == null)
+            {
+                new Builder().Build();
+            }
+
+            Container.Set<IGlueCommands>(GlueCommands.Self);
+            Container.Set<IGlueState>(GlueState.Self);
+
+            if (FlatRedBall.Glue.ProjectManager.CodeProjectHelper == null)
+            {
+                FlatRedBall.Glue.ProjectManager.Initialize();
+            }
+
+            FileWatchManager.Initialize();
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using Microsoft.Build.Evaluation;
+using FlatRedBall.Glue.VSHelpers.Projects;
+
+namespace GlueUnitTests.TestSupport;
+
+/// <summary>
+/// Builds a real, MSBuild-backed <see cref="VisualStudioProject"/> for tests, working around the
+/// blocker documented in REFACTORING.md's "Known Areas Needing Improvement": VisualStudioProject's
+/// constructor requires a live Microsoft.Build.Evaluation.Project and dereferences it immediately
+/// (TargetFrameworkVersion, RootNamespace), so it can't be mocked/faked - only a real Project will do.
+///
+/// Loading a real *SDK-style* .csproj (the kind Glue actually ships) needs MSBuildLocator/SDK
+/// resolution that only Glue.exe's own startup registers. But a bare, non-SDK-style project file (no
+/// `Sdk="..."` attribute, no imports) evaluates with zero SDK/toolset resolution, so it constructs
+/// cleanly in a plain xunit test host. This is a real VisualStudioProject with a real backing MSBuild
+/// project - not a mock - just a minimal one.
+/// </summary>
+internal static class TestVisualStudioProjectFactory
+{
+    /// <summary>
+    /// Creates a real ClassLibraryProject (the lightest concrete VisualStudioProject subclass) backed by
+    /// a freshly-written, minimal .csproj in a new temp directory. Callers own cleanup of the returned
+    /// directory.
+    /// </summary>
+    public static ClassLibraryProject CreateInNewTempDirectory(out string directory, string projectName = "TestProject")
+    {
+        directory = Path.Combine(Path.GetTempPath(), "GlueUnitTests_" + Guid.NewGuid());
+        Directory.CreateDirectory(directory);
+
+        var csprojPath = Path.Combine(directory, projectName + ".csproj");
+        File.WriteAllText(csprojPath, $@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <RootNamespace>{projectName}</RootNamespace>
+  </PropertyGroup>
+</Project>");
+
+        var project = new Project(csprojPath, null, null, new ProjectCollection());
+        return new ClassLibraryProject(project);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactoryTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactoryTests.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using Shouldly;
+
+namespace GlueUnitTests.TestSupport;
+
+public class TestVisualStudioProjectFactoryTests
+{
+    [Fact]
+    public void CreateInNewTempDirectory_ShouldReturnARealMsBuildBackedProject()
+    {
+        string? directory = null;
+        try
+        {
+            var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out directory, "ProbeProject");
+
+            project.ShouldNotBeNull();
+            project.RootNamespace.ShouldBe("ProbeProject");
+            project.FullFileName.FullPath.ShouldContain("ProbeProject.csproj");
+            project.CodeProject.ShouldBe(project);
+        }
+        finally
+        {
+            if (directory != null)
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.Elements;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using OfficialPlugins.Wizard.Managers;
+using OfficialPlugins.Wizard.Models;
+using Shouldly;
+
+namespace GlueUnitTests.Wizard;
+
+// Follow-up to GitHub issue #1894 / WizardProjectLogicTests: that first pass left
+// WizardProjectLogic.Apply's "bare AddGameScreen" fallback step untested because
+// GlueState.CurrentMainProject needs a real, MSBuild-backed VisualStudioProject and there was no
+// fakeable interface (see REFACTORING.md's "Known Areas Needing Improvement" and the comment above
+// WizardProjectLogic.Apply). Rather than build an IVisualStudioProject seam - a separate, much larger
+// refactor whose need turned out to be avoidable - this drives a real VisualStudioProject backed by a
+// minimal, non-SDK-style .csproj (TestVisualStudioProjectFactory), which doesn't require the
+// SDK/MSBuildLocator resolution that only Glue.exe's own startup registers.
+//
+// Getting from there to a passing AddScreen call also required routing a previously-missed
+// MainGlueWindow.Self.Invoke call (GlueCommands.DoOnUiThread) through the TaskManager.UiThreadMarshaller
+// seam PR #1895 added - see REFACTORING.md - plus a handful of one-time bootstrap calls
+// (GlueTestBootstrap) that mirror what Glue.exe's real startup does.
+//
+// WizardProjectLogic.Apply() itself is still not covered end-to-end: even with only AddGameScreen set,
+// Apply() unconditionally also runs "Generate all code" (GenerateAllCode, walks every element in the
+// project), a "Flush Files" step with a hard-coded 2.5s+ real delay, and "Saving Project" - a
+// meaningfully larger surface than AddScreen alone, and not needed to satisfy issue #1894's stated
+// fallback ("at minimum the AddGameScreen step"). HandleAddGameScreen is called directly here instead.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class WizardProjectLogicAddGameScreenTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _originalRelativeDirectory;
+    private readonly bool _originalSynchronousMode;
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly string _tempProjectDirectory;
+
+    public WizardProjectLogicAddGameScreenTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        FlatRedBall.IO.FileManager.RelativeDirectory = _tempProjectDirectory + "\\";
+
+        TaskManager.SynchronousMode = true;
+        TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public async Task HandleAddGameScreen_ShouldAddGameScreenToProject_WithNoOptionalAddOns()
+    {
+        var vm = new WizardViewModel { AddGameScreen = true };
+
+        var (gameScreen, solidCollisionNos, cloudCollisionNos) = await WizardProjectLogic.HandleAddGameScreen(vm);
+
+        gameScreen.ShouldNotBeNull();
+        gameScreen.Name.ShouldBe(@"Screens\GameScreen");
+        gameScreen.Tags.ShouldContain("GLUE");
+        solidCollisionNos.ShouldBeNull();
+        cloudCollisionNos.ShouldBeNull();
+
+        ObjectFinder.Self.GlueProject.Screens.ShouldContain(gameScreen);
+        // First screen added becomes the startup screen - see ElementCommands.AddScreen.
+        ObjectFinder.Self.GlueProject.StartUpScreen.ShouldBe(gameScreen.Name);
+
+        var mainProject = GlueState.Self.CurrentMainProject;
+        mainProject.CodeProject.IsFilePartOfProject(@"Screens\GameScreen.cs").ShouldBeTrue();
+        mainProject.CodeProject.IsFilePartOfProject(@"Screens\GameScreen.Generated.cs").ShouldBeTrue();
+    }
+
+    // AddSolidCollision/AddCloudCollision were deliberately NOT added as a follow-up test here: they
+    // route through NamedObjectSaveCodeGenerator.GetDestroyForNamedObject, which reads
+    // AvailableAssetTypes.CommonAtis (a catalog populated by scanning every plugin's registered
+    // AssetTypeInfos at real app startup - PluginManager loading, not something GlueTestBootstrap
+    // reasonably replicates) and NREs when that catalog is empty. That's a materially bigger, separate
+    // blocker from the VisualStudioProject one this test class exists to unblock - out of scope here.
+
+    private class InlineUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public Task Invoke(Func<Task> func) => func();
+        public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicTests.cs
@@ -8,16 +8,15 @@ namespace GlueUnitTests.Wizard;
 // synchronous-mode / UI-thread-marshaller seams added in this same change (see
 // GlueUnitTests.Tasks.TaskManagerSynchronousModeTests). Those seams are real and directly tested.
 //
-// But driving Apply() itself - even for the plugin-free "bare AddGameScreen" step suggested as a
-// fallback - turns out to be blocked by a deeper coupling than plugins: HandleAddGameScreen ends up in
-// ProjectCommands.CreateAndAddCodeFile, which throws NullReferenceException("Main Project") unless
-// GlueState.CurrentMainProject is a real, MSBuild-backed VisualStudioProject (abstract, no fakeable
-// interface) - the same blocker already called out in REFACTORING.md's "Known Areas Needing Improvement"
-// section. Building an IVisualStudioProject seam to unblock that is a separate, larger refactor, out of
-// scope here.
+// This file covers the pure, side-effect-free decision logic inside an Apply step that doesn't touch
+// GlueState/TaskManager/plugins - GetDisplaySettingsFor, extracted from ApplyMainCameraSettings.
 //
-// What's covered instead: the pure, side-effect-free decision logic inside an Apply step that doesn't
-// touch GlueState/TaskManager/plugins - GetDisplaySettingsFor, extracted from ApplyMainCameraSettings.
+// The "bare AddGameScreen" step is covered separately, in
+// GlueUnitTests.Wizard.WizardProjectLogicAddGameScreenTests - see that file and REFACTORING.md's "Unblock
+// WizardProjectLogic AddGameScreen testing" entry for how the VisualStudioProject construction blocker
+// mentioned in earlier versions of this comment was actually unblocked (no IVisualStudioProject seam
+// needed). Apply() as a whole is still not covered end-to-end - see the comment above
+// WizardProjectLogic.Apply for what's left and why.
 public class WizardProjectLogicTests
 {
     [Theory]


### PR DESCRIPTION
Part of #1894. Follow-up to #1892/#1893/#1895.

## Findings
- `VisualStudioProject`'s constructor only needs *a* real MSBuild `Project` - not one loaded through Glue's SDK-style-project machinery (`MSBuildLocator.RegisterDefaults()`, only ever called from `MainGlueWindow`). A bare, non-SDK-style `.csproj` evaluates with zero SDK/toolset resolution, so a real `VisualStudioProject` can be constructed in a plain xunit host. No `IVisualStudioProject` seam needed after all - see `TestVisualStudioProjectFactory`.
- `GlueCommands.DoOnUiThread` (all 3 overloads) called `MainGlueWindow.Self.Invoke` directly - a coupling PR #1895's `TaskManager.UiThreadMarshaller` seam didn't reach because it's not on `TaskManager`.
- Getting `AddScreen` to run cleanly also needed a handful of one-time bootstrap calls that mirror what `Glue.exe`'s own startup does (DI container, legacy service locator registrations, `ProjectManager`/`FileWatchManager` init) - none of it faked, just never run outside a live WinForms app before. See `GlueTestBootstrap`.

## What's done
- `GlueCommands.DoOnUiThread` now routes through `TaskManager.UiThreadMarshaller`. Zero behavior change in production.
- `GlueUnitTests/TestSupport/TestVisualStudioProjectFactory` + `GlueTestBootstrap` (test-only).
- `WizardProjectLogic.HandleAddGameScreen` changed from `private` to `internal` (zero behavior change) so it's directly testable.
- `GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs` drives the real `HandleAddGameScreen` → `AddScreen` path end-to-end: screen name/tags, `GlueProjectSave.Screens`/`StartUpScreen`, both code files added to the project.

## Still not covered (documented in REFACTORING.md)
- `WizardProjectLogic.Apply()` end-to-end - even with only `AddGameScreen` set, it unconditionally runs `GenerateAllCode`, a "Flush Files" step with a hard-coded 2.5s+ real delay, and `SaveProjectAndElements`. Bigger surface than issue #1894's stated fallback required.
- Collision add-on steps (`AddSolidCollision`/`AddCloudCollision`) and most other Wizard steps - they NRE on `AvailableAssetTypes.CommonAtis`, populated only by real `PluginManager` plugin loading. Separate, bigger blocker from the one this PR unblocks.

#1894 is **not** fully resolved after this PR - see above.

## Verified
- `dotnet test "Glue with All.sln" --filter "Category!=BuildSmoke"` → 140 passed (138 existing + 2 new), 0 failed.
- `dotnet test "Glue with All.sln" --filter "Category=BuildSmoke"` → 1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)