### PR TITLE
Cover WizardProjectLogic.Apply() end-to-end

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
@@ -276,7 +276,10 @@ public class GluxCommands : IGluxCommands
         if (ProjectManager.GlueProjectSave != null)
         {
 
-            if (MainGlueWindow.Self.HasErrorOccurred)
+            // MainGlueWindow.Self is null in a plain xunit test host (never a real editor window),
+            // so this and the other MainGlueWindow.Self.HasErrorOccurred reads/writes below are
+            // null-conditional. No behavior change in production - Self is always set there.
+            if (MainGlueWindow.Self?.HasErrorOccurred == true)
             {
                 var projectName = GlueState.Self.GlueProjectFileName.NoPathNoExtension;
 
@@ -385,10 +388,13 @@ public class GluxCommands : IGluxCommands
                         PluginManager.ReceiveError("Error saving glux:\n\n" + e.ToString());
                     });
 
-                    MainGlueWindow.Self.HasErrorOccurred = true;
+                    if (MainGlueWindow.Self != null)
+                    {
+                        MainGlueWindow.Self.HasErrorOccurred = true;
+                    }
                 }
 
-                if (!MainGlueWindow.Self.HasErrorOccurred)
+                if (MainGlueWindow.Self?.HasErrorOccurred != true)
                 {
                     List<FilePath> fileChangesToIgnore = GlueState.Self.CurrentGlueProject.GetAllSerializedFiles(GlueState.Self.GlueProjectFileName);
                     foreach (var fileToIgnore in fileChangesToIgnore)

--- a/FRBDK/Glue/OfficialPlugins/Wizard/Managers/WizardProjectLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/Wizard/Managers/WizardProjectLogic.cs
@@ -33,24 +33,25 @@ namespace OfficialPlugins.Wizard.Managers
         }
         #endregion
 
-        // Apply() itself is still not covered by an end-to-end unit test - see GitHub issue #1894,
-        // REFACTORING.md's "Unblock WizardProjectLogic AddGameScreen testing" entry, and
-        // GlueUnitTests.Wizard.WizardProjectLogicTests / WizardProjectLogicAddGameScreenTests for what *is*
-        // covered and why.
+        // Apply() is covered end-to-end (with a WizardViewModel that only sets AddGameScreen = true) by
+        // GlueUnitTests.Wizard.WizardProjectLogicAddGameScreenTests.Apply_ShouldAddGameScreenGenerateCodeAndSaveProject_EndToEnd
+        // - see GitHub issue #1894 and REFACTORING.md's "Cover WizardProjectLogic.Apply() end-to-end" and
+        // "Unblock WizardProjectLogic AddGameScreen testing" entries for how it got there.
         //
         // #1894 added test seams for TaskManager's background thread and MainGlueWindow's
         // Invoke/BeginInvoke (TaskManager.SynchronousMode/UiThreadMarshaller). A follow-up unblocked the
         // "bare AddGameScreen" step specifically: HandleAddGameScreen is now internal and driven directly
         // in GlueUnitTests.Wizard.WizardProjectLogicAddGameScreenTests, against a real (not fake)
         // VisualStudioProject backed by a minimal non-SDK .csproj (GlueUnitTests.TestSupport) - no
-        // IVisualStudioProject seam needed after all.
+        // IVisualStudioProject seam needed after all. A second follow-up drove Apply() itself the same way:
+        // GenerateAllCode and the hard-coded 2.5s+ "Flush Files" delay needed no changes, and the one new
+        // blocker (MainGlueWindow.Self.HasErrorOccurred NREing in SaveProjectAndElementsImmediately) was
+        // fixed with a null-conditional read/write - see REFACTORING.md.
         //
-        // Apply() as a whole remains untested: even with only AddGameScreen set, it unconditionally also
-        // runs GenerateAllCode (walks every element in the project), a "Flush Files" step with a hard-coded
-        // 2.5s+ real delay, and SaveProjectAndElements - a meaningfully bigger surface than AddScreen alone.
-        // Most of the other Wizard steps (player entity, collisions, camera, levels, ...) are also
-        // untested; collisions specifically NRE on AvailableAssetTypes.CommonAtis, which is only populated
-        // by real PluginManager plugin loading - see REFACTORING.md for details.
+        // Most of the other Wizard steps (player entity, collisions, camera, levels, ...) remain untested;
+        // collisions specifically NRE on AvailableAssetTypes.CommonAtis, which is only populated by real
+        // PluginManager plugin loading - see REFACTORING.md for details. That's the one piece of #1894
+        // still open.
         public async Task Apply(WizardViewModel vm)
         {
             ///////////////////Early Out/////////////////////

--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -356,17 +356,49 @@ that only sets `AddGameScreen = true`, pinning: the returned `ScreenSave`'s name
 get added to the project.
 
 **Still not covered:**
-- `WizardProjectLogic.Apply()` end-to-end. Even with only `AddGameScreen` set, `Apply()` unconditionally
-  also runs "Generate all code" (`GenerateAllCode`, walks every element in the project), a "Flush Files"
-  step with a hard-coded 2.5s+ real delay, and "Saving Project" - a meaningfully larger surface than
-  `AddScreen` alone, and more than issue #1894's stated fallback ("at minimum the AddGameScreen step")
-  required.
+- `WizardProjectLogic.Apply()` end-to-end was covered by a follow-up - see the entry directly above this
+  one in the file (most recent first).
 - `AddSolidCollision`/`AddCloudCollision` (and by extension most of the Wizard's other add-on steps):
   they route through `NamedObjectSaveCodeGenerator.GetDestroyForNamedObject`, which reads
   `AvailableAssetTypes.CommonAtis` - a catalog populated by scanning every plugin's registered
   `AssetTypeInfo`s during real `PluginManager` startup - and NREs when that catalog is empty.
   `GlueTestBootstrap` intentionally does not attempt to replicate plugin loading; that's a materially
-  bigger, separate blocker from the `VisualStudioProject` one this entry unblocks.
+  bigger, separate blocker from the `VisualStudioProject` one this entry unblocks. Still open (issue #1894).
+
+### 2026-07-23 — Cover `WizardProjectLogic.Apply()` end-to-end (issue #1894 follow-up)
+
+Follow-up to the "Unblock WizardProjectLogic AddGameScreen testing" entry directly below: that entry left
+`Apply()` itself untested because, beyond `HandleAddGameScreen`, it unconditionally also runs "Generate all
+code" (`GenerateAllCode`), a "Flush Files" step with a hard-coded 2.5s+ real delay, and "Saving Project"
+(`SaveProjectAndElements`).
+
+Driving `Apply()` with a `WizardViewModel { AddGameScreen = true }` (the same minimal config the
+`HandleAddGameScreen` test uses) against the existing `GlueTestBootstrap`/`TestVisualStudioProjectFactory`
+setup got through `GenerateAllCode` and the Flush Files delay with no changes needed, and hit exactly one
+new blocker: `GluxCommands.SaveProjectAndElementsImmediately` reads `MainGlueWindow.Self.HasErrorOccurred`
+directly - `MainGlueWindow.Self` is only ever set by constructing a real WinForms `MainGlueWindow`, which
+`GlueTestBootstrap` deliberately does not do, so it NREs in a plain xunit host.
+
+**Fix**: made the three `MainGlueWindow.Self.HasErrorOccurred` reads/writes in
+`SaveProjectAndElementsImmediately` null-conditional (`MainGlueWindow.Self?.HasErrorOccurred`). Zero
+behavior change in production - `MainGlueWindow.Self` is always set there; this only changes behavior when
+`Self` is null, which previously just crashed.
+
+No other blockers found: `GenerateAllCode` walking every element worked cleanly off the project state left
+by `HandleAddGameScreen`, and the Flush Files delay is exactly what it says - a real 2.5s+ `Task.Delay`,
+not a wait on a file-watcher event, so it slows the test but doesn't hang it.
+
+Added `Apply_ShouldAddGameScreenGenerateCodeAndSaveProject_EndToEnd` to
+`GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs`, reusing that class's existing
+bootstrap/teardown. It drives the real `WizardProjectLogic.Apply()` (not just `HandleAddGameScreen`) and
+pins: the GameScreen lands in the project and becomes `StartUpScreen`, both code files are part of the
+project, `GenerateAllCode` writes `GameScreen.Generated.cs` to disk, and `SaveProjectAndElements` writes
+the project file to disk (`.glux`, since a fresh `GlueProjectSave()` defaults to `FileVersion` 0 - `.gluj`
+requires `GluxVersions.GlueSavedToJson` or later).
+
+This closes the `Apply()`-end-to-end gap issue #1894 was tracking. The one remaining open item under that
+issue is the `AvailableAssetTypes.CommonAtis`/plugin-loading blocker on `AddSolidCollision`/
+`AddCloudCollision` and most other Wizard add-on steps - noted above and still out of scope.
 
 ### 2026-07-23 — Wizard apply-engine test seams (issue #1894)
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
@@ -27,11 +28,13 @@ namespace GlueUnitTests.Wizard;
 // seam PR #1895 added - see REFACTORING.md - plus a handful of one-time bootstrap calls
 // (GlueTestBootstrap) that mirror what Glue.exe's real startup does.
 //
-// WizardProjectLogic.Apply() itself is still not covered end-to-end: even with only AddGameScreen set,
-// Apply() unconditionally also runs "Generate all code" (GenerateAllCode, walks every element in the
-// project), a "Flush Files" step with a hard-coded 2.5s+ real delay, and "Saving Project" - a
-// meaningfully larger surface than AddScreen alone, and not needed to satisfy issue #1894's stated
-// fallback ("at minimum the AddGameScreen step"). HandleAddGameScreen is called directly here instead.
+// HandleAddGameScreen_ShouldAddGameScreenToProject_WithNoOptionalAddOns drives just that one sub-step
+// directly. Apply_ShouldAddGameScreenGenerateCodeAndSaveProject_EndToEnd (below) drives the real
+// WizardProjectLogic.Apply() with the same minimal WizardViewModel, covering the rest of Apply's
+// unconditional pipeline too: "Generate all code" (GenerateAllCode, walks every element in the project),
+// a "Flush Files" step with a hard-coded 2.5s+ real delay, and "Saving Project"
+// (SaveProjectAndElements) - see REFACTORING.md's "Cover WizardProjectLogic.Apply() end-to-end" entry
+// for the one new blocker that took (MainGlueWindow.Self.HasErrorOccurred NREing) and how it was fixed.
 [Collection(nameof(TaskManagerSequentialCollection))]
 public class WizardProjectLogicAddGameScreenTests : IDisposable
 {
@@ -100,6 +103,32 @@ public class WizardProjectLogicAddGameScreenTests : IDisposable
         var mainProject = GlueState.Self.CurrentMainProject;
         mainProject.CodeProject.IsFilePartOfProject(@"Screens\GameScreen.cs").ShouldBeTrue();
         mainProject.CodeProject.IsFilePartOfProject(@"Screens\GameScreen.Generated.cs").ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Apply_ShouldAddGameScreenGenerateCodeAndSaveProject_EndToEnd()
+    {
+        var vm = new WizardViewModel { AddGameScreen = true };
+
+        await WizardProjectLogic.Self.Apply(vm);
+
+        var glueProject = ObjectFinder.Self.GlueProject;
+        var gameScreen = glueProject.Screens.FirstOrDefault(item => item.Name == @"Screens\GameScreen");
+        gameScreen.ShouldNotBeNull();
+        glueProject.StartUpScreen.ShouldBe(gameScreen.Name);
+
+        var mainProject = GlueState.Self.CurrentMainProject;
+        mainProject.CodeProject.IsFilePartOfProject(@"Screens\GameScreen.cs").ShouldBeTrue();
+        mainProject.CodeProject.IsFilePartOfProject(@"Screens\GameScreen.Generated.cs").ShouldBeTrue();
+
+        // "Regenerating All Code" should have written the generated code file to disk.
+        var generatedCodeFile = Path.Combine(_tempProjectDirectory, "Screens", "GameScreen.Generated.cs");
+        File.Exists(generatedCodeFile).ShouldBeTrue();
+
+        // "Saving Project" (SaveProjectAndElements) should have written the project file to disk.
+        // A fresh GlueProjectSave() defaults to FileVersion 0, so GlueProjectFileName resolves to
+        // .glux (not .gluj - that requires GluxVersions.GlueSavedToJson or later).
+        File.Exists(GlueState.Self.GlueProjectFileName.FullPath).ShouldBeTrue();
     }
 
     // AddSolidCollision/AddCloudCollision were deliberately NOT added as a follow-up test here: they


### PR DESCRIPTION
## Summary
- Drives the real `WizardProjectLogic.Apply()` (not just `HandleAddGameScreen`) with a minimal `WizardViewModel{AddGameScreen=true}`, covering `GenerateAllCode`, the 2.5s+ "Flush Files" delay, and `SaveProjectAndElements`.
- Found and fixed one new blocker: `GluxCommands.SaveProjectAndElementsImmediately` reads `MainGlueWindow.Self.HasErrorOccurred` directly, which NREs outside a live WinForms app. Made the three read/write sites null-conditional - zero behavior change in production (`Self` is always set there).
- New test: `WizardProjectLogicAddGameScreenTests.Apply_ShouldAddGameScreenGenerateCodeAndSaveProject_EndToEnd`.
- Updated `REFACTORING.md` and the code comment above `Apply()` to reflect the new coverage.

Part of #1894 / follow-up to #1896. Remaining open scope under #1894: collision/most other Wizard add-on steps still NRE on `AvailableAssetTypes.CommonAtis`, populated only by real `PluginManager` plugin loading - out of scope here.

## Test plan
- [x] `dotnet test "Glue with All.sln" --filter "Category!=BuildSmoke"` - 141 passed
- [x] `dotnet test "Glue with All.sln" --filter "Category=BuildSmoke"` - 1 passed