### PR TITLE
Bootstrap AvailableAssetTypes + Collision Plugin ATI registration for tests

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/CollisionPlugin/MainCollisionPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/CollisionPlugin/MainCollisionPlugin.cs
@@ -68,13 +68,25 @@ namespace OfficialPlugins.CollisionPlugin
             RegisterCodeGenerator(new CollisionCodeGenerator());
             RegisterCodeGenerator(new StackableCodeGenerator());
 
-            AvailableAssetTypes.Self.AddAssetType(
-                AssetTypeInfoManager.Self.CollisionRelationshipAti);
-
+            RegisterAssetTypes();
 
             AssignEvents();
 
             AddErrorReporter(new CollisionErrorReporter());
+        }
+
+        /// <summary>
+        /// Registers this plugin's AssetTypeInfos (currently just
+        /// <see cref="AssetTypeInfoManager.CollisionRelationshipAti"/>) with <see cref="AvailableAssetTypes"/>.
+        /// Split out of <see cref="StartUp"/> (which still calls this, unchanged) so it's directly callable
+        /// without going through PluginManager.LoadPlugins - e.g. by GlueUnitTests'
+        /// GlueTestBootstrap.EnsureCollisionPluginAssetTypesRegistered, without instantiating the rest of
+        /// this plugin (UI tabs, code generators, event subscriptions).
+        /// </summary>
+        public static void RegisterAssetTypes()
+        {
+            AvailableAssetTypes.Self.AddAssetType(
+                AssetTypeInfoManager.Self.CollisionRelationshipAti);
         }
 
         private void AssignEvents()

--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -312,6 +312,55 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
 
 ## Completed Refactors
 
+### 2026-07-23 — AvailableAssetTypes.Self.Initialize / Collision Plugin asset-type test seam (issue #1894 follow-up)
+
+Follow-up to "Cover `WizardProjectLogic.Apply()` end-to-end" directly below: that entry left the
+`AvailableAssetTypes.CommonAtis`/plugin-loading blocker open. Rather than replicate `PluginManager`'s
+reflection/directory-scan plugin loading in tests (rejected - too big a shift, and would blur the
+third-party extensibility boundary that machinery exists for), this splits the blocker into its two real
+parts and unblocks each directly:
+
+- **`AvailableAssetTypes.CommonAtis`** (Camera/Text/Sprite/Polygon/etc.) is populated by
+  `AvailableAssetTypes.Self.Initialize(startupPath)` from `Content/ContentTypes.csv` - a plain CSV read,
+  nothing plugin-related. `GlueTestBootstrap.EnsureInitialized` now calls it (same call
+  `MainGlueWindow.cs:336` makes), with `startupPath` resolved by walking up from the test assembly's
+  `AppContext.BaseDirectory` to find `Glue/Content/ContentTypes.csv` (mirrors the existing
+  `FindTemplatesRoot` pattern in `NewProjectCreationSmokeTests`) rather than hardcoding a path that only
+  resolves from one machine/output layout.
+- **Per-plugin ATIs** (e.g. `AssetTypeInfoManager.Self.CollisionRelationshipAti`, registered today only
+  from inside `MainCollisionPlugin.StartUp`) are a separate concern: official plugins are already compiled
+  directly into `Glue with All.sln` as a real project reference (not a sideloaded DLL), so their
+  registration can be called directly without touching `PluginManager.LoadPlugins` at all. Split
+  `MainCollisionPlugin.StartUp`'s asset-type registration into `MainCollisionPlugin.RegisterAssetTypes()`
+  (`StartUp` still calls it, unchanged - zero behavior change) and added
+  `GlueTestBootstrap.EnsureCollisionPluginAssetTypesRegistered()`, a separate opt-in call (not part of the
+  always-on `EnsureInitialized`) that invokes it directly. Third-party plugin loading through
+  `PluginManager.LoadPlugins`'s reflection/directory scan is completely untouched.
+
+`GlueUnitTests/CollisionPlugin/CollisionAssetTypeRegistrationTests` pins this: without the registration,
+`NamedObjectSave.GetAssetTypeInfo()` (which resolves by `SourceClassType` string via
+`AvailableAssetTypes.Self.GetAssetTypeFromRuntimeType`, not object identity) can never find
+`CollisionRelationshipAti`, so every production consumer that compares against it - the
+`NamedObjectSaveCodeGenerator.ConstructorFunc` dispatch, `HandleAddEventsForObject`,
+`GetEventSignatureAndArgs`, `CollidableNamedObjectController`, etc. - silently treats a
+collision-relationship `NamedObjectSave` as an unrecognized type. The test adds one via the real
+`GluxCommands.AddNamedObjectToAsync` path, drives real code generation for its containing screen, and
+asserts the lookup now resolves.
+
+**Deliberately not attempted**: driving `CollidableNamedObjectController.CreateCollisionRelationshipBetweenObjects`
+(the real handler `MainCollisionPlugin` wires to `PluginManager.ReactToCreateCollisionRelationshipsBetween`)
+end-to-end. It also calls `GlueCommands.Self.DialogCommands.FocusTab`, which reads
+`PluginManager.TabControlViewModel` - only ever set by a live WinForms `MainGlueWindow` - so it NREs outside
+one. That's a separate, UI-rooted blocker, not an asset-type one.
+
+**Still open after this entry**: the Wizard's `AddSolidCollision`/`AddCloudCollision` steps
+(`MainAddScreenPlugin.AddCollision`) no longer NRE on `AvailableAssetTypes.CommonAtis` (fixed above), but
+hit a different, unrelated NRE one level down: they go through `GluxCommands.AddNewNamedObjectToAsync`,
+which always runs with `updateUi:true` (no way to opt out from that entry point), and that path calls
+`MainGlueWindow.Self.PropertyGrid.Refresh()` - a generic `AddNewNamedObjectToAsync` UI coupling, unrelated
+to collision types specifically. Not fixed here - out of scope for this entry, left for whichever future
+work needs `AddNewNamedObjectToAsync` testable.
+
 ### 2026-07-23 — Unblock WizardProjectLogic AddGameScreen testing (issue #1894 follow-up)
 
 Follow-up to the "Wizard apply-engine test seams" entry directly below: that PR left `HandleAddGameScreen`
@@ -356,14 +405,13 @@ that only sets `AddGameScreen = true`, pinning: the returned `ScreenSave`'s name
 get added to the project.
 
 **Still not covered:**
-- `WizardProjectLogic.Apply()` end-to-end was covered by a follow-up - see the entry directly above this
-  one in the file (most recent first).
-- `AddSolidCollision`/`AddCloudCollision` (and by extension most of the Wizard's other add-on steps):
-  they route through `NamedObjectSaveCodeGenerator.GetDestroyForNamedObject`, which reads
-  `AvailableAssetTypes.CommonAtis` - a catalog populated by scanning every plugin's registered
-  `AssetTypeInfo`s during real `PluginManager` startup - and NREs when that catalog is empty.
-  `GlueTestBootstrap` intentionally does not attempt to replicate plugin loading; that's a materially
-  bigger, separate blocker from the `VisualStudioProject` one this entry unblocks. Still open (issue #1894).
+- `WizardProjectLogic.Apply()` end-to-end was covered by a follow-up - see the entry two above this one in
+  the file (most recent first).
+- `AddSolidCollision`/`AddCloudCollision` (and by extension most of the Wizard's other add-on steps): the
+  `AvailableAssetTypes.CommonAtis` NRE this note used to describe is fixed - see the "AvailableAssetTypes.
+  Self.Initialize / Collision Plugin asset-type test seam" entry directly above this one - but a different,
+  unrelated NRE blocks them one level down (`AddNewNamedObjectToAsync`'s `MainGlueWindow.Self.PropertyGrid`
+  UI coupling). Still open (issue #1894); see that entry for details.
 
 ### 2026-07-23 — Cover `WizardProjectLogic.Apply()` end-to-end (issue #1894 follow-up)
 
@@ -396,9 +444,11 @@ project, `GenerateAllCode` writes `GameScreen.Generated.cs` to disk, and `SavePr
 the project file to disk (`.glux`, since a fresh `GlueProjectSave()` defaults to `FileVersion` 0 - `.gluj`
 requires `GluxVersions.GlueSavedToJson` or later).
 
-This closes the `Apply()`-end-to-end gap issue #1894 was tracking. The one remaining open item under that
-issue is the `AvailableAssetTypes.CommonAtis`/plugin-loading blocker on `AddSolidCollision`/
-`AddCloudCollision` and most other Wizard add-on steps - noted above and still out of scope.
+This closes the `Apply()`-end-to-end gap issue #1894 was tracking. The `AvailableAssetTypes.CommonAtis`/
+plugin-loading blocker on `AddSolidCollision`/`AddCloudCollision` and most other Wizard add-on steps this
+note used to flag as the one remaining open item was split and partly fixed by a follow-up - see the
+"AvailableAssetTypes.Self.Initialize / Collision Plugin asset-type test seam" entry (most recent, near the
+top of this section) for the current state and what's still open.
 
 ### 2026-07-23 — Wizard apply-engine test seams (issue #1894)
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/CollisionPlugin/CollisionAssetTypeRegistrationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CollisionPlugin/CollisionAssetTypeRegistrationTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using OfficialPlugins.CollisionPlugin.Managers;
+using Shouldly;
+
+namespace GlueUnitTests.CollisionPlugin;
+
+// Follow-up to GitHub issue #1894: pins the seam that unblocks Collision-Plugin-typed NamedObjectSaves
+// outside a live Glue.exe. MainCollisionPlugin.RegisterAssetTypes (extracted from StartUp, but still
+// called from there unchanged) registers AssetTypeInfoManager.Self.CollisionRelationshipAti with
+// AvailableAssetTypes - called here directly via GlueTestBootstrap.EnsureCollisionPluginAssetTypesRegistered,
+// bypassing PluginManager.LoadPlugins' reflection/directory-scan entirely (that machinery, and real/
+// third-party plugin loading through it, is completely unchanged).
+//
+// Without that registration, NamedObjectSave.GetAssetTypeInfo() - which resolves via
+// AvailableAssetTypes.Self.GetAssetTypeFromRuntimeType keyed on SourceClassType, not object identity -
+// can never find CollisionRelationshipAti, so every production consumer that compares against it
+// (NamedObjectSaveCodeGenerator's ConstructorFunc dispatch, HandleAddEventsForObject,
+// GetEventSignatureAndArgs, CollidableNamedObjectController, ...) silently treats a collision-relationship
+// NamedObjectSave as an unrecognized FlatRedBall type instead of routing it through CollisionCodeGenerator.
+//
+// This does NOT attempt to drive the full CollidableNamedObjectController.CreateCollisionRelationshipBetweenObjects
+// (the real handler MainCollisionPlugin wires up to PluginManager.ReactToCreateCollisionRelationshipsBetween)
+// end-to-end: that method also calls GlueCommands.Self.DialogCommands.FocusTab, which reads
+// PluginManager.TabControlViewModel - only ever set by a live WinForms MainGlueWindow, so it NREs outside
+// one. That's a separate, UI-rooted blocker, out of scope here - see REFACTORING.md.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class CollisionAssetTypeRegistrationTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _originalRelativeDirectory;
+    private readonly bool _originalSynchronousMode;
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly string _tempProjectDirectory;
+
+    public CollisionAssetTypeRegistrationTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        GlueTestBootstrap.EnsureCollisionPluginAssetTypesRegistered();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        FlatRedBall.IO.FileManager.RelativeDirectory = _tempProjectDirectory + "\\";
+
+        TaskManager.SynchronousMode = true;
+        TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public async Task NamedObjectSave_WithCollisionRelationshipSourceClassType_ShouldResolveCollisionRelationshipAti()
+    {
+        var gameScreen = await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen("GameScreen");
+
+        var collisionAti = AssetTypeInfoManager.Self.CollisionRelationshipAti;
+
+        var nos = new NamedObjectSave();
+        nos.SetDefaults();
+        nos.InstanceName = "TestCollisionRelationship";
+        nos.SourceType = SourceType.FlatRedBallType;
+        nos.SourceClassType = collisionAti.QualifiedRuntimeTypeName.QualifiedType;
+
+        // AddNamedObjectToAsync (not the higher-level AddNewNamedObjectToAsync, which always runs with
+        // updateUi:true and would NRE on MainGlueWindow.Self.PropertyGrid outside a live app) is the same
+        // production add-and-generate path Glue.exe uses; performSaveAndGenerateCode:true drives real
+        // code generation for the containing screen.
+        await GlueCommands.Self.GluxCommands.AddNamedObjectToAsync(
+            nos, gameScreen, listToAddTo: null, selectNewNos: false,
+            performSaveAndGenerateCode: true, updateUi: false);
+
+        // The seam under test: before MainCollisionPlugin.RegisterAssetTypes runs, AvailableAssetTypes has
+        // no record of CollisionRelationshipAti, so this lookup (keyed on SourceClassType, not identity)
+        // returns null instead of resolving back to it.
+        nos.GetAssetTypeInfo().ShouldBe(collisionAti);
+
+        // Confirms GenerateElementCode (triggered above) actually ran to completion for the screen -
+        // exercising NamedObjectSaveCodeGenerator.GenerateInstantiationOrAssignment's `nosAti?.ConstructorFunc`
+        // dispatch for this object, not just the lookup in isolation.
+        var generatedCodeFile = Path.Combine(_tempProjectDirectory, "Screens", "GameScreen.Generated.cs");
+        File.Exists(generatedCodeFile).ShouldBeTrue();
+    }
+
+    private class InlineUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public Task Invoke(Func<Task> func) => func();
+        public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -1,8 +1,12 @@
+using System;
+using System.IO;
 using EditorObjects.IoC;
+using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.IO;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Plugins.ExportedInterfaces;
 using FlatRedBall.Glue.Services;
+using OfficialPlugins.CollisionPlugin;
 
 namespace GlueUnitTests.TestSupport;
 
@@ -19,6 +23,9 @@ namespace GlueUnitTests.TestSupport;
 ///    code-file-adding path (e.g. AddScreen).
 ///  - <see cref="FileWatchManager"/>.Initialize sets up the self-save-suppression list that
 ///    IgnoreNextChangeOnFile writes to.
+///  - <see cref="AvailableAssetTypes"/>.Initialize populates <see cref="AvailableAssetTypes.CommonAtis"/>
+///    (Camera/Text/Sprite/Polygon/etc.) from the same Content/ContentTypes.csv that MainGlueWindow reads -
+///    this is CSV-driven and needs no plugins, unlike the per-plugin ATIs below.
 ///
 /// Any test that drives production code through GlueCommands.Self/GlueState.Self (rather than calling a
 /// pure static method directly) needs this. Call <see cref="EnsureInitialized"/> once per test.
@@ -27,6 +34,7 @@ internal static class GlueTestBootstrap
 {
     static readonly object _lock = new();
     static bool _initialized;
+    static bool _collisionPluginAssetTypesRegistered;
 
     public static void EnsureInitialized()
     {
@@ -52,6 +60,54 @@ internal static class GlueTestBootstrap
             }
 
             FileWatchManager.Initialize();
+
+            if (AvailableAssetTypes.CommonAtis == null)
+            {
+                AvailableAssetTypes.Self.Initialize(FindGlueStartupPath());
+            }
         }
+    }
+
+    /// <summary>
+    /// Opt-in, separate from <see cref="EnsureInitialized"/>: registers the Collision Plugin's
+    /// <see cref="OfficialPlugins.CollisionPlugin.Managers.AssetTypeInfoManager.CollisionRelationshipAti"/>
+    /// into <see cref="AvailableAssetTypes"/>, the same single call <see cref="MainCollisionPlugin.StartUp"/>
+    /// makes - <see cref="MainCollisionPlugin.RegisterAssetTypes"/> is called directly here, bypassing
+    /// PluginManager.LoadPlugins' reflection/directory-scan entirely (that machinery is unchanged and still
+    /// the only way real/third-party plugins load). Kept separate from the base bootstrap so tests that
+    /// don't touch collision types don't pay for it. Call <see cref="EnsureInitialized"/> first.
+    /// </summary>
+    public static void EnsureCollisionPluginAssetTypesRegistered()
+    {
+        lock (_lock)
+        {
+            if (_collisionPluginAssetTypesRegistered)
+            {
+                return;
+            }
+            _collisionPluginAssetTypesRegistered = true;
+
+            MainCollisionPlugin.RegisterAssetTypes();
+        }
+    }
+
+    // Walks up from the test assembly to the repo's Glue/Content/ContentTypes.csv - the same file
+    // MainGlueWindow.cs reads via `FileManager.GetDirectory(assembly location) + "Content\ContentTypes.csv"`.
+    // Test hosts run from a different output directory, so this can't be hardcoded or copied from
+    // MainGlueWindow's own startupPath calculation.
+    static string FindGlueStartupPath()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "Glue", "Content", "ContentTypes.csv");
+            if (File.Exists(candidate))
+            {
+                return Path.Combine(dir.FullName, "Glue") + Path.DirectorySeparatorChar;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate the repo 'Glue/Content/ContentTypes.csv' above " + AppContext.BaseDirectory);
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs
@@ -131,12 +131,15 @@ public class WizardProjectLogicAddGameScreenTests : IDisposable
         File.Exists(GlueState.Self.GlueProjectFileName.FullPath).ShouldBeTrue();
     }
 
-    // AddSolidCollision/AddCloudCollision were deliberately NOT added as a follow-up test here: they
-    // route through NamedObjectSaveCodeGenerator.GetDestroyForNamedObject, which reads
-    // AvailableAssetTypes.CommonAtis (a catalog populated by scanning every plugin's registered
-    // AssetTypeInfos at real app startup - PluginManager loading, not something GlueTestBootstrap
-    // reasonably replicates) and NREs when that catalog is empty. That's a materially bigger, separate
-    // blocker from the VisualStudioProject one this test class exists to unblock - out of scope here.
+    // AddSolidCollision/AddCloudCollision were deliberately NOT added as a follow-up test here. The
+    // AvailableAssetTypes.CommonAtis NRE this comment used to describe is now fixed - see
+    // GlueTestBootstrap.EnsureInitialized and REFACTORING.md's "AvailableAssetTypes.Self.Initialize /
+    // Collision Plugin asset-type test seam" entry - but driving AddSolidCollision/AddCloudCollision hits a
+    // different, unrelated NRE one level down: MainAddScreenPlugin.AddCollision goes through
+    // GluxCommands.AddNewNamedObjectToAsync, which always runs with updateUi:true (no way to opt out), and
+    // that path calls MainGlueWindow.Self.PropertyGrid.Refresh() - MainGlueWindow.Self is only ever set by a
+    // live WinForms MainGlueWindow. That's a generic AddNewNamedObjectToAsync UI coupling unrelated to
+    // collision types specifically - out of scope here.
 
     private class InlineUiThreadMarshaller : IUiThreadMarshaller
     {


### PR DESCRIPTION
## Summary
- `GlueTestBootstrap.EnsureInitialized` now calls `AvailableAssetTypes.Self.Initialize` (same as `MainGlueWindow.cs:336`), populating `CommonAtis` from `Content/ContentTypes.csv`. Fixes the NRE that blocked most Wizard add-on steps in tests.
- Extracted `MainCollisionPlugin.RegisterAssetTypes()` from `StartUp` (unchanged, zero behavior change) so `GlueTestBootstrap.EnsureCollisionPluginAssetTypesRegistered()` can register `CollisionRelationshipAti` directly - bypassing `PluginManager.LoadPlugins`'s reflection/directory-scan entirely. Third-party plugin loading is completely untouched.
- New `CollisionAssetTypeRegistrationTests` pins the registration seam via the real `GluxCommands.AddNamedObjectToAsync` + code-gen path.
- Updated `REFACTORING.md`.

`AddSolidCollision`/`AddCloudCollision` still don't work end-to-end through the Wizard - a different, unrelated NRE (`AddNewNamedObjectToAsync`'s `MainGlueWindow.Self.PropertyGrid` UI coupling) blocks them. Documented, not fixed here.

Part of #1894.

## Test plan
- [x] `dotnet build "Glue with All.sln"` - 0 errors
- [x] `dotnet test --filter "Category!=BuildSmoke"` - 142 passed
- [x] `dotnet test --filter "Category=BuildSmoke"` - 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)