### PR TITLE
Extract IMainGlueWindow seam, unblock Wizard AddSolidCollision/AddCloudCollision

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -115,7 +115,8 @@ namespace GameCommunicationPlugin.GlueControl
             _variableSendingManager = new VariableSendingManager(_refreshManager);
             _commandReceiver = new CommandReceiver(_refreshManager, _variableSendingManager);
 
-            _modalReportingService = new ModalReportingService(MainGlueWindow.Self, GlueCommands.Self.DialogCommands, CommandSender.Self);
+            _modalReportingService = new ModalReportingService(
+                (System.ComponentModel.ISynchronizeInvoke)MainGlueWindow.Self, GlueCommands.Self.DialogCommands, CommandSender.Self);
             _modalReportingService.Initialize();
 
             CreateBuildControl();
@@ -580,7 +581,7 @@ namespace GameCommunicationPlugin.GlueControl
             var dragDropTimerFrequency = 100; // ms
             dragDropTimer = new Timer(dragDropTimerFrequency);
             dragDropTimer.Elapsed += (not, used) => _dragDropManagerGameWindow.HandleDragDropTimerElapsed(gameHostView);
-            dragDropTimer.SynchronizingObject = MainGlueWindow.Self;
+            dragDropTimer.SynchronizingObject = (System.ComponentModel.ISynchronizeInvoke)MainGlueWindow.Self;
             dragDropTimer.Start();
 
             #endregion

--- a/FRBDK/Glue/Glue/IO/UpdateReactor.cs
+++ b/FRBDK/Glue/Glue/IO/UpdateReactor.cs
@@ -133,7 +133,10 @@ namespace FlatRedBall.Glue.IO
 
             if (changedFile.Extension == "")
             {
-                MainGlueWindow.Self.Invoke((MethodInvoker)delegate
+                // Was (MethodInvoker) - changed to (Action) because IMainGlueWindow.Invoke only declares an
+                // Action overload (MainGlueWindow's own, not the untyped Control.Invoke(Delegate) this used
+                // to resolve to incidentally through the concrete type). Same delegate, zero behavior change.
+                MainGlueWindow.Self.Invoke((Action)delegate
                 {
                     try
                     {

--- a/FRBDK/Glue/Glue/MainGlueWindow.cs
+++ b/FRBDK/Glue/Glue/MainGlueWindow.cs
@@ -40,21 +40,21 @@ using Wpf = System.Windows;
 
 namespace Glue;
 
-public partial class MainGlueWindow : Form
+public partial class MainGlueWindow : Form, IMainGlueWindow
 {
     #region Fields/Properties
 
-    public bool HasErrorOccurred = false;
+    public bool HasErrorOccurred { get; set; } = false;
 
     public static MainPanelControl MainWpfControl { get; private set; }
-    public static MainGlueWindow Self { get; private set; }
+    public static IMainGlueWindow Self { get; internal set; }
     public static int UiThreadId { get; private set; }
 
     private MenuStrip mMenu;
 
     public IContainer Components => components;
 
-    public PropertyGrid PropertyGrid;
+    public PropertyGrid PropertyGrid { get; set; }
 
     public int NumberOfStoredRecentFiles
     {
@@ -235,8 +235,8 @@ public partial class MainGlueWindow : Form
 
             FrbMenuStripRenderer renderer = new FrbMenuStripRenderer(bg, fg, primary);
 
-            Self.MainMenuStrip.Renderer = renderer;
-            Self.MainMenuStrip.Invalidate();
+            this.MainMenuStrip.Renderer = renderer;
+            this.MainMenuStrip.Invalidate();
         }
     }
 

--- a/FRBDK/Glue/Glue/Managers/IMainGlueWindow.cs
+++ b/FRBDK/Glue/Glue/Managers/IMainGlueWindow.cs
@@ -1,0 +1,51 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace FlatRedBall.Glue.Managers
+{
+    /// <summary>
+    /// Abstraction over Glue's main WinForms window (<c>global::Glue.MainGlueWindow</c>), reached from all
+    /// over the codebase through the static <c>MainGlueWindow.Self</c>. The default value is the real
+    /// WinForms window (unchanged - still only set once <c>Program.cs</c> constructs it), so production
+    /// behavior is identical; test hosts can swap in a fake that doesn't require a live message loop.
+    ///
+    /// Covers every member any call site outside <c>MainGlueWindow.cs</c> itself touches through
+    /// <c>MainGlueWindow.Self</c>, found by grepping for both <c>MainGlueWindow.Self.&lt;member&gt;</c> and
+    /// bare <c>MainGlueWindow.Self</c> passed by value (the latter is how the <see cref="IWin32Window"/>,
+    /// <see cref="Width"/>, and <see cref="Height"/> members were found - a member-only grep misses a value
+    /// assigned to a local and used later, e.g. <c>var window = MainGlueWindow.Self; window.Width</c>).
+    /// <see cref="IWin32Window"/> covers every <c>ShowDialog</c>/<c>Show</c>/<c>MessageBox.Show</c> call site
+    /// that passes <c>MainGlueWindow.Self</c> as an owner window. A couple of call sites need the concrete
+    /// <c>Form</c> or <c>System.ComponentModel.ISynchronizeInvoke</c> (a WinForms <c>Timer</c>'s
+    /// <c>SynchronizingObject</c>, and <c>Form.Owner</c>) - those stayed as narrow casts at the call site
+    /// rather than widening the interface further for one or two consumers each.
+    /// </summary>
+    public interface IMainGlueWindow : IWin32Window
+    {
+        void Invoke(Action action);
+        T Invoke<T>(Func<T> func);
+        Task Invoke(Func<Task> func);
+        Task<T> Invoke<T>(Func<Task<T>> func);
+        IAsyncResult BeginInvoke(Delegate method);
+
+        // Fully qualified: unqualified "PropertyGrid" here would bind to the FlatRedBall.PropertyGrid
+        // namespace (FlatRedBall.PropertyGrid/LateBinder.cs), which shadows the System.Windows.Forms type
+        // because enclosing-namespace lookup (FlatRedBall -> FlatRedBall.PropertyGrid) wins over the
+        // "using System.Windows.Forms;" directive above.
+        System.Windows.Forms.PropertyGrid PropertyGrid { get; set; }
+        bool HasErrorOccurred { get; set; }
+        bool IsDisposed { get; }
+        string Text { get; set; }
+        IContainer Components { get; }
+        int NumberOfStoredRecentFiles { get; set; }
+        int Width { get; set; }
+        int Height { get; set; }
+
+        void Close();
+        void SyncMenuStripWithTheme(System.Windows.Controls.UserControl control);
+        void TryGenerateImplicitWindowStylesFor(Assembly assembly);
+    }
+}

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
@@ -1527,7 +1527,7 @@ class DialogCommands : IDialogCommands
 
     public void SetFormOwner(Form form)
     {
-        if (MainGlueWindow.Self != null)
-            form.Owner = MainGlueWindow.Self;
+        if (MainGlueWindow.Self is Form owner)
+            form.Owner = owner;
     }
 }

--- a/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
@@ -790,7 +790,9 @@ public class MainGumPlugin : PluginBase
 
     public override bool ShutDown(FlatRedBall.Glue.Plugins.Interfaces.PluginShutDownReason shutDownReason)
     {
-        Glue.MainGlueWindow.Self.Invoke((MethodInvoker)RemoveAllMenuItems);
+        // Was (MethodInvoker) - changed to (Action) because IMainGlueWindow.Invoke only declares an Action
+        // overload. Same method, zero behavior change.
+        Glue.MainGlueWindow.Self.Invoke((Action)RemoveAllMenuItems);
 
         CodeGeneratorManager.Self.RemoveCodeGenerators();
 

--- a/FRBDK/Glue/OfficialPlugins/SpritePlugin/Views/MapTextureButtonContainer.xaml.cs
+++ b/FRBDK/Glue/OfficialPlugins/SpritePlugin/Views/MapTextureButtonContainer.xaml.cs
@@ -81,7 +81,7 @@ public partial class MapTextureButtonContainer : UserControl, IDataUi
             }
             else
             {
-                window.MoveToMainWindowCenterAndSize(Glue.MainGlueWindow.Self, .7f, .85f);
+                window.MoveToMainWindowCenterAndSize((System.Windows.Forms.Form)Glue.MainGlueWindow.Self, .7f, .85f);
                 window.Width = 100 + window.Height; //How to get width of wpf element before window shown?  100 is just some random amount
                 GlueCommands.Self.DialogCommands.MoveToCursor(window);
 

--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -312,6 +312,93 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
 
 ## Completed Refactors
 
+### 2026-07-23 — Extract `IMainGlueWindow`, unblock `AddSolidCollision`/`AddCloudCollision` end-to-end (issue #1894 follow-up)
+
+Follow-up to "AvailableAssetTypes.Self.Initialize / Collision Plugin asset-type test seam" directly below:
+that entry's remaining blocker was `MainAddScreenPlugin.AddCollision` → `GluxCommands.AddNewNamedObjectToAsync`
+always running with `updateUi: true` (no way to opt out) and unconditionally calling
+`MainGlueWindow.Self.PropertyGrid.Refresh()` - `MainGlueWindow.Self` is only ever set by a live WinForms
+window. This was the third time a `MainGlueWindow.Self.X` call site NRE'd in a test host and got patched
+one member at a time (`DoOnUiThread`→`Invoke` in #1896, `SaveProjectAndElementsImmediately`→`HasErrorOccurred`
+in #1898) - systemic fix this time: put `MainGlueWindow.Self` itself behind an interface, so every current
+and future call site resolves through one seam.
+
+- **`IMainGlueWindow`** (`Glue/Managers/IMainGlueWindow.cs`) covers every member any call site outside
+  `MainGlueWindow.cs` touches through `MainGlueWindow.Self` - `Invoke`/`BeginInvoke`, `PropertyGrid`,
+  `HasErrorOccurred`, `Close`, `IsDisposed`, `Text`, `Components`, `NumberOfStoredRecentFiles`,
+  `SyncMenuStripWithTheme`, `TryGenerateImplicitWindowStylesFor`, plus `Width`/`Height` and
+  `IWin32Window.Handle` (found only by also grepping for bare `MainGlueWindow.Self` passed *by value* -
+  e.g. `var window = MainGlueWindow.Self; window.Width`, or `ShowDialog(MainGlueWindow.Self)` - a
+  member-only grep for `MainGlueWindow.Self.<name>` misses these). `IMainGlueWindow : IWin32Window` alone
+  fixed every `ShowDialog`/`Show`/`MessageBox.Show(MainGlueWindow.Self, ...)` call site (about a dozen)
+  since `Control` already implements `IWin32Window` via `Handle`.
+- **`MainGlueWindow : Form, IMainGlueWindow`** - two members were plain fields, which can't satisfy an
+  interface property, so `PropertyGrid` and `HasErrorOccurred` became auto-properties (zero behavior
+  change - same get/set semantics, just compiler-backed instead of directly declared).
+- **`MainGlueWindow.Self`** changed from `public static MainGlueWindow Self { get; private set; }` to
+  `public static IMainGlueWindow Self { get; internal set; }` - `internal` (not `public`) so only
+  `GlueTestBootstrap` can swap it, and deliberately still starts `null` and is only ever assigned inside
+  `MainGlueWindow`'s own constructor (`Self = this;`), unlike `GlueCommands.Self`/
+  `TaskManager.UiThreadMarshaller`, which eagerly construct their default in the field initializer.
+  `MainGlueWindow`'s constructor has real WinForms/WPF side effects (spins up a `System.Windows.Application`,
+  calls `SetMsBuildEnvironmentVariable`), so eagerly constructing one at static-field-init time would be a
+  real production behavior change, not the zero-behavior-change this pattern is supposed to guarantee -
+  `Self` staying lazily-null until `Program.cs` constructs the real window preserves exactly today's
+  lifecycle.
+- **Two call sites broke from the interface-vs-concrete-class overload resolution difference, not scope
+  gaps**: `UpdateReactor.cs` and `MainGumPlugin.cs` each called `MainGlueWindow.Self.Invoke((MethodInvoker)x)`.
+  This compiled against the concrete `MainGlueWindow` type only because C# overload resolution for
+  differently-*signed* methods sharing a name merges the derived type's overloads with the base type's
+  (unlike same-signature hiding, which fully replaces) - so `(MethodInvoker)x` was silently resolving to
+  the *inherited, untyped* `Control.Invoke(Delegate)`, not any of `MainGlueWindow`'s own four `Invoke`
+  overloads. `IMainGlueWindow` isn't a `Control` and declares no `Invoke(Delegate)` overload, so that
+  fallback path doesn't exist through the interface. Fixed by changing the cast from `(MethodInvoker)` to
+  `(Action)` at both call sites - same delegate, now resolves to `IMainGlueWindow.Invoke(Action)`, the
+  overload this was always meant to hit.
+- **Three call sites needed the concrete `Form`/`ISynchronizeInvoke`, not `IMainGlueWindow`**: a WinForms
+  `Timer.SynchronizingObject` (`ISynchronizeInvoke`) in `MainCompilerPlugin.cs` (×2, one live, one
+  already-commented-out) and `ModalReportingService`'s constructor param, plus `Form.Owner` in
+  `DialogCommands.SetFormOwner` and a `Form`-typed extension-method parameter in
+  `MapTextureButtonContainer.xaml.cs`. Widening `IMainGlueWindow` to cover `ISynchronizeInvoke` (4 more
+  members, colliding in name with the `Invoke`/`BeginInvoke` already declared) for two framework-interop
+  call sites wasn't worth it - left as explicit casts (`(ISynchronizeInvoke)MainGlueWindow.Self`,
+  `MainGlueWindow.Self is Form owner`) at the call site instead. In production `Self` is always the real
+  `MainGlueWindow`, so these casts never fail; they're a narrower exception than the `IWin32Window`
+  widening above because each has exactly one or two consumers instead of a dozen.
+- **`FakeMainGlueWindow`** (`GlueUnitTests/TestSupport/`) - no-op/harmless implementation, wired into
+  `GlueTestBootstrap.EnsureInitialized` (`MainGlueWindow.Self ??= new FakeMainGlueWindow()`).
+  `Invoke`/`BeginInvoke` run the delegate synchronously (tests are single-threaded). `PropertyGrid` is a
+  real (not mocked) `System.Windows.Forms.PropertyGrid` instance - constructing one needs no running
+  message loop, and a real control means `.Refresh()`/`.SelectedObject` behave exactly like production.
+
+Unblocking `PropertyGrid.Refresh()` immediately surfaced one more, unrelated NRE one level further in:
+`GluxCommands.AddNamedObjectToAsync`'s `updateUi:true` path also sets `GlueState.Self.CurrentNamedObjectSave`,
+whose setter calls `GlueState.Self.Find.TreeNodeByTag(...)` - `GlueState.Self.Find` (`IFindManager`) is only
+ever set by `MainTreeViewPlugin.StartUp` (which also constructs a WPF `MainTreeViewControl`), never run in a
+test host. Same fix shape: added **`FakeFindManager`** (`GlueUnitTests/TestSupport/`, all five `IFindManager`
+members return null/empty/false) and wired it into `GlueTestBootstrap` (`GlueState.Self.Find ??= new
+FakeFindManager()`). `GlueState.CurrentTreeNode`'s setter already tolerates a null tree node (just clears
+the selection), so this needed no other production change.
+
+`GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.HandleAddGameScreen_ShouldAddSolidAndCloudCollision_WhenRequested`
+drives `WizardProjectLogic.HandleAddGameScreen` with `AddSolidCollision`/`AddCloudCollision` both true (the
+one Wizard add-on path #1894 was tracking as still-blocked) and pins: both `NamedObjectSave`s land in the
+screen with the right `InstanceName`/`SourceClassType`, the fake `PropertyGrid` ran instead of NRE-ing, and
+code generation completed (`GameScreen.Generated.cs` written to disk).
+
+**`IUiThreadMarshaller` (added in #1895) is now overlapping, not redundant, with `IMainGlueWindow.Invoke`/
+`BeginInvoke`** - deliberately left both rather than folding one into the other. `IUiThreadMarshaller` is
+reached through `TaskManager.UiThreadMarshaller`/`TaskManager.OnUiThread`/`GlueTask.DoOnUiThread`, a
+narrower, purpose-built seam for "marshal onto the UI thread" that has nothing WinForms-specific in its
+signature (`Action`/`Func<T>`/`Task` only). `IMainGlueWindow` is the *window*, and `Invoke`/`BeginInvoke`
+are two of eleven-plus members alongside `PropertyGrid`/`Text`/`Close`/etc. that have nothing to do with UI
+marshalling. Production's `WinFormsUiThreadMarshaller` already forwards to `MainGlueWindow.Self.Invoke`/
+`BeginInvoke` - that forwarding is the correct relationship between the two seams and doesn't change here.
+Collapsing them would mean either giving `IMainGlueWindow` to every `TaskManager` caller (dragging in
+`PropertyGrid`/`Close`/`Text` for callers that only want "run this on the UI thread") or giving
+`IUiThreadMarshaller` to every window-property caller (which doesn't have `PropertyGrid` etc. to give) -
+neither direction simplifies anything, so both stay, each doing its one job.
+
 ### 2026-07-23 — AvailableAssetTypes.Self.Initialize / Collision Plugin asset-type test seam (issue #1894 follow-up)
 
 Follow-up to "Cover `WizardProjectLogic.Apply()` end-to-end" directly below: that entry left the

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/FakeFindManager.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/FakeFindManager.cs
@@ -1,0 +1,25 @@
+using FlatRedBall.Glue.FormHelpers;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.SaveClasses;
+
+namespace GlueUnitTests.TestSupport;
+
+/// <summary>
+/// Test-only <see cref="IFindManager"/>. <c>GlueState.Self.Find</c> is only ever set by
+/// <c>MainTreeViewPlugin.StartUp</c> (which also constructs a WPF <c>MainTreeViewControl</c>) - never run
+/// in a plain xunit host - so it's null by default there, and any production code path that resolves a
+/// tree node from a model object (e.g. <c>GlueState.CurrentNamedObjectSave</c>'s setter calling
+/// <c>Find.TreeNodeByTag</c>) NREs. Wired in by <see cref="GlueTestBootstrap"/>.
+///
+/// All lookups return null/empty/false: tests here don't assert on tree-node identity, they just need the
+/// production selection-plumbing that reads through <c>GlueState.Self.Find</c> to not crash. A test that
+/// needs real tree-node resolution should build a real <c>FindManager</c> instead of relying on this fake.
+/// </summary>
+internal class FakeFindManager : IFindManager
+{
+    public ITreeNode NamedObjectTreeNode(NamedObjectSave namedObjectSave) => null!;
+    public ITreeNode TreeNodeByTag(object tag) => null!;
+    public ITreeNode GlobalContentTreeNode => null!;
+    public string GlobalContentFilesPath => "";
+    public bool IfReferencedFileSaveIsReferenced(ReferencedFileSave referencedFileSave) => false;
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/FakeMainGlueWindow.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/FakeMainGlueWindow.cs
@@ -1,0 +1,44 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Managers;
+
+namespace GlueUnitTests.TestSupport;
+
+/// <summary>
+/// Test-only <see cref="IMainGlueWindow"/> that doesn't require a live WinForms message loop. Wired in by
+/// <see cref="GlueTestBootstrap"/> so any production code path that reads <c>MainGlueWindow.Self</c> - e.g.
+/// <c>PropertyGrid.Refresh()</c>, <c>HasErrorOccurred</c>, <c>Invoke</c>/<c>BeginInvoke</c> - gets a harmless
+/// object instead of NRE-ing (Self is null in a plain xunit host, since only Program.cs ever constructs the
+/// real WinForms window).
+///
+/// <c>Invoke</c>/<c>BeginInvoke</c> just run the delegate synchronously on the calling thread - fine for
+/// tests, which are always single-threaded here. <see cref="PropertyGrid"/> is a real (not mocked)
+/// <see cref="System.Windows.Forms.PropertyGrid"/> instance: constructing one doesn't require a running
+/// message loop, and a real control means <c>PropertyGrid.Refresh()</c>/<c>SelectedObject</c> writes behave
+/// exactly like production instead of needing a special test-only no-op path.
+/// </summary>
+internal class FakeMainGlueWindow : IMainGlueWindow
+{
+    public System.Windows.Forms.PropertyGrid PropertyGrid { get; set; } = new();
+    public bool HasErrorOccurred { get; set; }
+    public bool IsDisposed { get; private set; }
+    public string Text { get; set; } = "";
+    public IContainer Components { get; } = new Container();
+    public int NumberOfStoredRecentFiles { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public IntPtr Handle { get; } = IntPtr.Zero;
+
+    public void Invoke(Action action) => action();
+    public T Invoke<T>(Func<T> func) => func();
+    public Task Invoke(Func<Task> func) => func();
+    public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+    // No call site inspects the returned IAsyncResult - null is fine after running synchronously.
+    public IAsyncResult BeginInvoke(Delegate method) { method.DynamicInvoke(); return null!; }
+
+    public void Close() => IsDisposed = true;
+    public void SyncMenuStripWithTheme(System.Windows.Controls.UserControl control) { }
+    public void TryGenerateImplicitWindowStylesFor(Assembly assembly) { }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -7,6 +7,7 @@ using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Plugins.ExportedInterfaces;
 using FlatRedBall.Glue.Services;
 using OfficialPlugins.CollisionPlugin;
+using Glue;
 
 namespace GlueUnitTests.TestSupport;
 
@@ -26,6 +27,13 @@ namespace GlueUnitTests.TestSupport;
 ///  - <see cref="AvailableAssetTypes"/>.Initialize populates <see cref="AvailableAssetTypes.CommonAtis"/>
 ///    (Camera/Text/Sprite/Polygon/etc.) from the same Content/ContentTypes.csv that MainGlueWindow reads -
 ///    this is CSV-driven and needs no plugins, unlike the per-plugin ATIs below.
+///  - <see cref="MainGlueWindow"/>.Self is given a <see cref="FakeMainGlueWindow"/> (only Program.cs ever
+///    constructs the real WinForms window, which this test host never does) so any code path reading
+///    MainGlueWindow.Self - PropertyGrid, HasErrorOccurred, Invoke/BeginInvoke, etc. - gets a harmless
+///    object instead of NRE-ing.
+///  - <see cref="GlueState.Find"/> is given a <see cref="FakeFindManager"/> (only ever set by
+///    MainTreeViewPlugin.StartUp, which this test host never runs) so tree-node-resolving setters like
+///    GlueState.CurrentNamedObjectSave don't NRE.
 ///
 /// Any test that drives production code through GlueCommands.Self/GlueState.Self (rather than calling a
 /// pure static method directly) needs this. Call <see cref="EnsureInitialized"/> once per test.
@@ -65,6 +73,9 @@ internal static class GlueTestBootstrap
             {
                 AvailableAssetTypes.Self.Initialize(FindGlueStartupPath());
             }
+
+            MainGlueWindow.Self ??= new FakeMainGlueWindow();
+            GlueState.Self.Find ??= new FakeFindManager();
         }
     }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddGameScreenTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FlatRedBall.Glue.Managers;
+using Glue;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.Glue.Elements;
@@ -131,15 +132,35 @@ public class WizardProjectLogicAddGameScreenTests : IDisposable
         File.Exists(GlueState.Self.GlueProjectFileName.FullPath).ShouldBeTrue();
     }
 
-    // AddSolidCollision/AddCloudCollision were deliberately NOT added as a follow-up test here. The
-    // AvailableAssetTypes.CommonAtis NRE this comment used to describe is now fixed - see
-    // GlueTestBootstrap.EnsureInitialized and REFACTORING.md's "AvailableAssetTypes.Self.Initialize /
-    // Collision Plugin asset-type test seam" entry - but driving AddSolidCollision/AddCloudCollision hits a
-    // different, unrelated NRE one level down: MainAddScreenPlugin.AddCollision goes through
-    // GluxCommands.AddNewNamedObjectToAsync, which always runs with updateUi:true (no way to opt out), and
-    // that path calls MainGlueWindow.Self.PropertyGrid.Refresh() - MainGlueWindow.Self is only ever set by a
-    // live WinForms MainGlueWindow. That's a generic AddNewNamedObjectToAsync UI coupling unrelated to
-    // collision types specifically - out of scope here.
+    // AddSolidCollision/AddCloudCollision were blocked by two separate NREs, both now fixed:
+    // AvailableAssetTypes.CommonAtis (see GlueTestBootstrap.EnsureInitialized) and
+    // MainGlueWindow.Self.PropertyGrid.Refresh() (AddNewNamedObjectToAsync always runs with updateUi:true -
+    // see IMainGlueWindow/FakeMainGlueWindow and REFACTORING.md). Covered end-to-end below.
+    [Fact]
+    public async Task HandleAddGameScreen_ShouldAddSolidAndCloudCollision_WhenRequested()
+    {
+        var vm = new WizardViewModel { AddGameScreen = true, AddSolidCollision = true, AddCloudCollision = true };
+
+        var (gameScreen, solidCollisionNos, cloudCollisionNos) = await WizardProjectLogic.HandleAddGameScreen(vm);
+
+        gameScreen.ShouldNotBeNull();
+        solidCollisionNos.ShouldNotBeNull();
+        solidCollisionNos.InstanceName.ShouldBe("SolidCollision");
+        solidCollisionNos.SourceClassType.ShouldBe("FlatRedBall.TileCollisions.TileShapeCollection");
+        gameScreen.NamedObjects.ShouldContain(solidCollisionNos);
+
+        cloudCollisionNos.ShouldNotBeNull();
+        cloudCollisionNos.InstanceName.ShouldBe("CloudCollision");
+        gameScreen.NamedObjects.ShouldContain(cloudCollisionNos);
+
+        // AddNamedObjectToAsync's updateUi:true path (MainGlueWindow.Self.PropertyGrid.Refresh()) ran
+        // against the fake window instead of NRE-ing - this is the assertion that matters for #1894.
+        ((FakeMainGlueWindow)MainGlueWindow.Self).PropertyGrid.ShouldNotBeNull();
+
+        // Confirms code generation for the screen actually completed for both new objects.
+        var generatedCodeFile = Path.Combine(_tempProjectDirectory, "Screens", "GameScreen.Generated.cs");
+        File.Exists(generatedCodeFile).ShouldBeTrue();
+    }
 
     private class InlineUiThreadMarshaller : IUiThreadMarshaller
     {


### PR DESCRIPTION
## Summary
- `MainGlueWindow.Self.X` call sites kept NRE-ing in tests one member at a time (`Invoke`, `HasErrorOccurred`, now `PropertyGrid`). Systemic fix: `MainGlueWindow.Self` is now typed `IMainGlueWindow` (transitional-injection pattern, same shape as `GlueCommands.Self`/`TaskManager.UiThreadMarshaller`), defaulting to the real WinForms window in production, swapped for `FakeMainGlueWindow` in tests via `GlueTestBootstrap`.
- `IMainGlueWindow` covers `Invoke`/`BeginInvoke`, `PropertyGrid`, `HasErrorOccurred`, `Close`, `IsDisposed`, `Text`, `Components`, `NumberOfStoredRecentFiles`, `Width`, `Height`, `SyncMenuStripWithTheme`, `TryGenerateImplicitWindowStylesFor`, and `IWin32Window` (fixes every `ShowDialog`/`Show`/`MessageBox.Show(MainGlueWindow.Self, ...)` call site in one move - about a dozen).
- `PropertyGrid`/`HasErrorOccurred` converted from fields to auto-properties (fields can't satisfy interface properties) - zero behavior change.
- `Self` deliberately stays lazily-null until `Program.cs` constructs the real window, unlike its eager-init siblings - `MainGlueWindow`'s constructor has real WinForms/WPF side effects, so eager construction would be an actual behavior change.
- A few call sites needed narrow `ISynchronizeInvoke`/`Form` casts instead of interface widening (one or two consumers each).
- Unblocking `PropertyGrid.Refresh()` immediately surfaced a second, unrelated NRE: `GlueState.Self.Find` (`IFindManager`, only ever set by the TreeView plugin's UI startup). Added `FakeFindManager`, wired into `GlueTestBootstrap` the same way.
- Closes the last item #1894 was tracking: `HandleAddGameScreen_ShouldAddSolidAndCloudCollision_WhenRequested` drives `AddSolidCollision`/`AddCloudCollision` end-to-end.
- This branch was missing PR #1899 (origin/NetStandard was 1 commit ahead) - merged that in first, resolved one conflict in `GlueTestBootstrap.cs`.
- `IUiThreadMarshaller` (from #1895) is kept separate, not folded in - reasoning in REFACTORING.md.

Part of #1894.

## Test plan
- [x] `dotnet build "Glue with All.sln"` - 0 errors
- [x] `dotnet test --filter "Category!=BuildSmoke"` - 143/143 passed
- [x] `dotnet test --filter "Category=BuildSmoke"` - 1/1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)