### PR TITLE
Cover real FixNamedObjectCollisionType behavior in tests (Collision Plugin only)

### DIFF
--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -313,6 +313,67 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
 
 ## Completed Refactors
 
+### 2026-07-23 — Real `FixNamedObjectCollisionType` coverage, Collision Plugin only (issue #1894 reopened)
+
+Issue #1894 was reopened: closing it after the `IMainGlueWindow` PR was premature because everything routed
+through `PluginManager.CallPluginMethod`/`CallPluginMethodAsync` (Gum, Tiled, Entity Input Movement,
+Collision Plugin's `FixNamedObjectCollisionType`) is untested and silently no-ops in a test host instead of
+running the real plugin behavior - `CallPluginMethod` iterates loaded plugins by friendly name and returns
+null if none match, it does not throw. This entry covers the Collision-Plugin slice only, per the reopened
+issue's scoping (Gum/Tiled/Entity-Input-Movement are separate follow-ups).
+
+**No production code changes were needed.** `MainCollisionPlugin.FixNamedObjectCollisionType` (the method
+`WizardProjectLogic.cs`'s two call sites, ~line 996/1033, reach via
+`PluginManager.CallPluginMethod("Collision Plugin", "FixNamedObjectCollisionType", nos)`) was already a
+one-line forwarder to the public static `CollisionRelationshipViewModelController.TryFixSourceClassType` -
+the same "thin forwarder to a directly-callable static method" shape as the earlier
+`MainCollisionPlugin.RegisterAssetTypes` extraction. Of the two seam shapes the issue proposed - (a)
+register a real plugin instance with `PluginManager` so `CallPluginMethod`'s reflection lookup finds it, or
+(b) call the already-extracted static method directly, bypassing `CallPluginMethod` for tests - (b) needed
+zero extraction work, so it's what's used: `GlueUnitTests.CollisionPlugin.FixNamedObjectCollisionTypeTests`
+calls `CollisionRelationshipViewModelController.TryFixSourceClassType` directly.
+
+(a) was investigated and rejected: `PluginManager.CallMethodOnPlugin` always routes through
+`PluginCommand(doOnUiThread: true)`, which reads the private static `PluginManager.mMenuStrip` - only ever
+set by `MainGlueWindow`'s real startup (`PluginManager.ShareMenuStripReference`) - so a lightweight
+test-registered plugin would still NRE there, and reaching a workaround (e.g. a headless `MenuStrip` whose
+`Control.Invoke` executes without a live message loop) rests on unverified WinForms internals not worth the
+risk for this scope.
+
+The test drives the real `WizardProjectLogic.HandleAddGameScreen` path (`AddSolidCollision`/
+`AddCloudCollision = true`) to get real `SolidCollision`/`CloudCollision` `TileShapeCollection`
+`NamedObjectSave`s, then builds a collision-relationship `NamedObjectSave` referencing them via
+`FirstCollisionName`/`SecondCollisionName` (mirroring what
+`CollidableNamedObjectController.CreateCollisionRelationshipBetweenObjects` would produce - see the blocker
+below for why that method isn't driven directly), and calls `TryFixSourceClassType` twice: once with
+`CollisionType = BounceCollision` (asserts `SourceClassType` becomes
+`CollidableVsTileShapeCollectionRelationship<...>`), then again after changing the property to
+`PlatformerSolidCollision` (asserts it becomes `DelegateCollisionRelationship<...>` and differs from the
+first result) - proving the recomputation is driven by the real `CollisionType` property read through
+`AssetTypeInfoManager.GetCollisionRelationshipSourceClassType`, not a stub.
+
+**Still not covered, and why (the real, deeper blocker found here):** `FixNamedObjectCollisionType`'s two
+production call sites live inside `WizardProjectLogic.HandleAddPlayerInstance`, which is unreachable
+end-to-end in a test host for reasons that have nothing to do with `FixNamedObjectCollisionType` itself:
+
+1. The relationship `NamedObjectSave` (`"PlayerVsSolidCollision"`/`"PlayerVsCloudCollision"`) is created by
+   `PluginManager.ReactToCreateCollisionRelationshipsBetween(playerList, collisionNos)`, a static event with
+   no subscriber unless a real `MainCollisionPlugin` instance has run `StartUp`/`AssignEvents` - the same
+   "would need real plugin loading" problem this entry's seam choice avoided.
+2. Even with a subscriber, the handler
+   (`CollidableNamedObjectController.CreateCollisionRelationshipBetweenObjects`) ends by calling
+   `GlueCommands.Self.DialogCommands.FocusTab("Collision")`, which reads `PluginManager.TabControlViewModel`
+   - `private set`, only ever assigned by a live WinForms `MainGlueWindow`. This NREs in a test host.
+
+Point 2 is not new - it's the same blocker the "AvailableAssetTypes.Self.Initialize / Collision Plugin
+asset-type test seam" entry below already flagged as "deliberately not attempted" for
+`CreateCollisionRelationshipBetweenObjects`. It's also not Collision-Plugin-specific: `TabControlViewModel`
+is a `PluginManager`-wide static, the same shape of problem `IMainGlueWindow` solved for
+`MainGlueWindow.Self` - fixing it properly means an `ITabControlViewModel`-style seam across all of
+`PluginManager`, a materially bigger refactor than "Collision Plugin only" scope. Left open; a future pass
+extending the `IMainGlueWindow` pattern to `PluginManager.TabControlViewModel` would unblock this along with
+every other `FocusTab`/tab-selection call site, not just this one.
+
 ### 2026-07-23 — Extract `IMainGlueWindow`, unblock `AddSolidCollision`/`AddCloudCollision` end-to-end (issue #1894 follow-up)
 
 Follow-up to "AvailableAssetTypes.Self.Initialize / Collision Plugin asset-type test seam" directly below:

--- a/FRBDK/Glue/Tests/GlueUnitTests/CollisionPlugin/FixNamedObjectCollisionTypeTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CollisionPlugin/FixNamedObjectCollisionTypeTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using OfficialPlugins.CollisionPlugin.Controllers;
+using OfficialPlugins.CollisionPlugin.ViewModels;
+using OfficialPlugins.Wizard.Managers;
+using OfficialPlugins.Wizard.Models;
+using Shouldly;
+
+namespace GlueUnitTests.CollisionPlugin;
+
+// Follow-up to GitHub issue #1894 (reopened): WizardProjectLogic.HandleAddPlayerInstance's two
+// FixNamedObjectCollisionType call sites (~line 996/1033) go through
+// PluginManager.CallPluginMethod("Collision Plugin", "FixNamedObjectCollisionType", nos), which silently
+// no-ops in a test host (no plugin registered with PluginManager) - exactly the false-coverage risk the
+// issue was reopened for: a naive test could pass without the real fixup ever running.
+//
+// MainCollisionPlugin.FixNamedObjectCollisionType is already a one-line forwarder to the public static
+// CollisionRelationshipViewModelController.TryFixSourceClassType (same "thin forwarder to a directly-
+// callable static method" shape as MainCollisionPlugin.RegisterAssetTypes) - no extraction was needed,
+// it was already directly callable. This test calls that real method directly (bypassing
+// PluginManager.CallPluginMethod, per option (b) in the #1894 follow-up plan - see REFACTORING.md) on a
+// NamedObjectSave whose FirstCollisionName/SecondCollisionName point at real NamedObjectSaves produced by
+// the real WizardProjectLogic.HandleAddGameScreen path, and asserts the real recomputed SourceClassType -
+// not just that the call didn't throw.
+//
+// Registering "Collision Plugin" with PluginManager so CallPluginMethod itself resolves it for real
+// (option (a)) was investigated and rejected here: PluginManager.CallMethodOnPlugin always routes calls
+// through PluginCommand(doOnUiThread: true), which reads the private static PluginManager.mMenuStrip -
+// only ever set by MainGlueWindow's real startup (PluginManager.ShareMenuStripReference), so a registered
+// plugin would still NRE there. And even if that were faked, the real call sites' surrounding method
+// (HandleAddPlayerInstance) is blocked further upstream: PluginManager.ReactToCreateCollisionRelationshipsBetween
+// needs a live MainCollisionPlugin subscriber (only wired by a fully-instantiated, StartUp'd plugin), and
+// its handler (CollidableNamedObjectController.CreateCollisionRelationshipBetweenObjects) then calls
+// DialogCommands.FocusTab, which reads PluginManager.TabControlViewModel - only ever set by a live
+// WinForms MainGlueWindow. That's a PluginManager-wide UI coupling (not Collision-Plugin-specific),
+// already flagged as "deliberately not attempted" in REFACTORING.md's "AvailableAssetTypes.Self.Initialize
+// / Collision Plugin asset-type test seam" entry - out of scope for a Collision-Plugin-only pass. See
+// REFACTORING.md for the full writeup and the precise blocker chain.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class FixNamedObjectCollisionTypeTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _originalRelativeDirectory;
+    private readonly bool _originalSynchronousMode;
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly string _tempProjectDirectory;
+
+    public FixNamedObjectCollisionTypeTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        GlueTestBootstrap.EnsureCollisionPluginAssetTypesRegistered();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        FlatRedBall.IO.FileManager.RelativeDirectory = _tempProjectDirectory + "\\";
+
+        TaskManager.SynchronousMode = true;
+        TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public async Task TryFixSourceClassType_ShouldRecomputeSourceClassType_WhenCollisionTypePropertyChanges()
+    {
+        // Real Wizard path: produces real SolidCollision/CloudCollision TileShapeCollection NamedObjectSaves,
+        // the same objects WizardProjectLogic.HandleAddPlayerInstance passes into
+        // PluginManager.ReactToCreateCollisionRelationshipsBetween / FixNamedObjectCollisionType.
+        var vm = new WizardViewModel { AddGameScreen = true, AddSolidCollision = true, AddCloudCollision = true };
+        var (gameScreen, solidCollisionNos, cloudCollisionNos) = await WizardProjectLogic.HandleAddGameScreen(vm);
+
+        // Mirrors the shape of the real "PlayerVsSolidCollision"/"PlayerVsCloudCollision" NamedObjectSave
+        // that CollidableNamedObjectController.CreateCollisionRelationshipBetweenObjects would produce:
+        // a collision-relationship NamedObjectSave whose SourceClassType is derived from its
+        // FirstCollisionName/SecondCollisionName/CollisionType properties (see
+        // AssetTypeInfoManager.GetCollisionRelationshipSourceClassType), constructed directly here since
+        // driving the real creation path is blocked by the PluginManager.TabControlViewModel issue
+        // described above.
+        var relationshipNos = new NamedObjectSave();
+        relationshipNos.SetDefaults();
+        relationshipNos.InstanceName = "PlayerVsSolidCollision";
+        relationshipNos.SourceType = SourceType.FlatRedBallType;
+        relationshipNos.Properties.SetValue(nameof(CollisionRelationshipViewModel.FirstCollisionName), solidCollisionNos.InstanceName);
+        relationshipNos.Properties.SetValue(nameof(CollisionRelationshipViewModel.SecondCollisionName), cloudCollisionNos.InstanceName);
+        relationshipNos.Properties.SetValue(nameof(CollisionRelationshipViewModel.CollisionType), (int)OfficialPlugins.CollisionPlugin.ViewModels.CollisionType.BounceCollision);
+        // Stale placeholder value, as if this NamedObjectSave was just created - still recognized as a
+        // collision relationship by IsCollisionRelationship() (used as the entry gate by TryFixSourceClassType).
+        relationshipNos.SourceClassType = "FlatRedBall.Math.Collision.CollisionRelationship";
+        gameScreen.NamedObjects.Add(relationshipNos);
+
+        // The seam under test: this is exactly what MainCollisionPlugin.FixNamedObjectCollisionType does
+        // (a one-line forward), and exactly what
+        // PluginManager.CallPluginMethod("Collision Plugin", "FixNamedObjectCollisionType", nos) invokes
+        // via reflection in production - real production logic, not a fake.
+        var changedForBounce = CollisionRelationshipViewModelController.TryFixSourceClassType(relationshipNos);
+
+        changedForBounce.ShouldBeTrue();
+        var bounceSourceClassType = relationshipNos.SourceClassType;
+        // Non-list-vs-TileShapeCollection, non-platformer CollisionType -> CollidableVsTileShapeCollectionRelationship<T>.
+        bounceSourceClassType.ShouldStartWith("FlatRedBall.Math.Collision.CollidableVsTileShapeCollectionRelationship<");
+        bounceSourceClassType.ShouldContain("TileShapeCollection");
+
+        // Mirrors WizardProjectLogic.cs's isPlatformer branch (~line 1020): the CollisionType property is
+        // changed, then FixNamedObjectCollisionType is called again to recompute SourceClassType to match.
+        relationshipNos.Properties.SetValue(nameof(CollisionRelationshipViewModel.CollisionType), (int)OfficialPlugins.CollisionPlugin.ViewModels.CollisionType.PlatformerSolidCollision);
+        var changedForPlatformer = CollisionRelationshipViewModelController.TryFixSourceClassType(relationshipNos);
+
+        changedForPlatformer.ShouldBeTrue();
+        // Platformer CollisionType -> DelegateCollisionRelationship<T1, T2>, a different runtime type -
+        // proves the recompute is driven by the real CollisionType property, not cached/stale.
+        relationshipNos.SourceClassType.ShouldStartWith("FlatRedBall.Math.Collision.DelegateCollisionRelationship<");
+        relationshipNos.SourceClassType.ShouldNotBe(bounceSourceClassType);
+    }
+
+    private class InlineUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public Task Invoke(Func<Task> func) => func();
+        public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+}


### PR DESCRIPTION
## Summary
Part of #1894 (reopened - only 3 of the Wizard's plugin-routed steps had real coverage; `FixNamedObjectCollisionType` was one of the untested, silently-no-op'd ones). Scoped to Collision Plugin only, per the issue - Gum/Tiled/Entity-Input-Movement are separate follow-ups.

- No production code change needed: `MainCollisionPlugin.FixNamedObjectCollisionType` was already a one-line forwarder to the public static `CollisionRelationshipViewModelController.TryFixSourceClassType` (same shape as the earlier `RegisterAssetTypes` extraction). New test calls that real method directly, bypassing `PluginManager.CallPluginMethod`'s silent no-op in a test host.
- Registering a real plugin instance with `PluginManager` (the other seam option) was investigated and rejected: `CallMethodOnPlugin` always routes through the private static `PluginManager.mMenuStrip`, only ever set by a live `MainGlueWindow`.
- `GlueUnitTests.CollisionPlugin.FixNamedObjectCollisionTypeTests` drives the real `WizardProjectLogic.HandleAddGameScreen` path to get real `SolidCollision`/`CloudCollision` NamedObjectSaves, builds a relationship NOS referencing them, and calls `TryFixSourceClassType` twice (Bounce then Platformer `CollisionType`) - asserts `SourceClassType` is recomputed to the correct, *different* runtime relationship type each time. Proves the real property-driven logic ran, not just "didn't throw."
- Found and documented a deeper blocker in REFACTORING.md: the real Wizard call sites (`HandleAddPlayerInstance`) can't be driven end-to-end because relationship creation goes through `PluginManager.ReactToCreateCollisionRelationshipsBetween` (needs a live plugin subscriber) and then `DialogCommands.FocusTab` → `PluginManager.TabControlViewModel` (only set by a live `MainGlueWindow`) - a `PluginManager`-wide UI coupling, not Collision-Plugin-specific, out of scope here.

## Test plan
- [x] `dotnet build "Glue with All.sln"` - 0 errors
- [x] `dotnet test --filter "Category!=BuildSmoke"` - 144/144 passed
- [x] `dotnet test --filter "Category=BuildSmoke"` - 1/1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)