### PR TITLE
Cover real Gum project-creation behavior in tests (Gum Plugin only)

### DIFF
--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -313,6 +313,89 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
 
 ## Completed Refactors
 
+### 2026-07-23 — Real Gum project-creation coverage, Gum Plugin only (issue #1894 follow-up)
+
+Part of #1894 (reopened) - same shape as PR #1901's Collision Plugin fix, applied to the Gum Plugin's
+project-creation step. `WizardProjectLogic.HandleAddGum` (~line 279/283) routes through
+`PluginManager.CallPluginMethodAsync("Gum Plugin", "CreateGumProjectWithForms"/"CreateGumProjectNoForms",
+false)`, which silently no-ops in a test host. Tiled and Entity Input Movement remain separate, still-open
+follow-ups - not touched here.
+
+**No production seam extraction needed for the "no forms" path.** `MainGumPlugin.CreateGumProjectWithForms`/
+`CreateGumProjectNoForms` are thin forwarders to the already-public
+`NewGumProjectCreationLogic.CreateGumProjectInternal(shouldAlsoAddForms, askToOverwrite)`, and
+`NewGumProjectCreationLogic` only depends on a `GumxPropertiesManager` (plain class, parameterless
+constructor, no UI dependency) - it does not need a live, `StartUp`'d `MainGumPlugin` instance at all.
+`GlueUnitTests.GumPluginTests.GumProjectCreationTests` constructs `NewGumProjectCreationLogic` directly and
+calls `CreateGumProjectInternal(shouldAlsoAddForms: false, askToOverwrite: false)` - the exact arguments
+`HandleAddGum`'s "no forms" branch passes - bypassing `MainGumPlugin`/`CallPluginMethodAsync` entirely.
+
+The test pins four real side effects, not just "didn't throw": the `.gumx` and its standard-element/
+font-cache siblings are written to disk (`EmbeddedResourceManager.SaveEmptyProject`); the `.gumx` is added
+to the Glue project as a real `ReferencedFileSave` with `AutoCreateGumScreens` set
+(`GumProjectManager.AddNewGumProject` / `SetGumxReferencedFileSaveDefaults`); the newly-saved `.gumx` is
+loaded back off disk into Gum's own `ObjectFinder.GumProjectSave`
+(`FileReferenceTracker.LoadGumxIfNecessaryFromDirectory`), proving the written file is well-formed and
+loadable, not just copied bytes; and `CodeGeneratorManager.GenerateDerivedGueRuntimesAsync(forceReload:
+true)` ran for real, writing `GumIdb.Generated.cs` to disk - proving Glue's actual Gum code-generation
+pipeline ran, not a stub.
+
+Getting this far needed:
+- **`GlueUnitTests.csproj` now references `GumPlugin.csproj`** (a `ProjectReference`, same as the
+  `OfficialPlugins.csproj` reference already there) - the Gum Plugin is an *external* plugin
+  (`GumPlugin/GumPlugin/`, not under `OfficialPlugins/`), so it wasn't reachable from the test project at
+  all before this.
+- **Namespace landmine**: the real Gum Plugin's root namespace is the bare `GumPlugin` (not nested under
+  `OfficialPlugins.*` like every other plugin this effort has touched). Naming the new test namespace
+  `GlueUnitTests.GumPlugin` shadowed that global namespace for every file under `GlueUnitTests.*` - C#
+  resolves an unqualified name against enclosing namespaces before usings, so any bare `GumPlugin.X`
+  reference elsewhere in the test project would have silently bound to the empty test namespace instead and
+  failed to compile with a confusing "does not exist" error pointing at the wrong namespace. Fixed by naming
+  the test namespace `GlueUnitTests.GumPluginTests` instead. Worth knowing before adding more Gum-Plugin test
+  files under this folder.
+- **Path assumption fixed by testing, not guessing**: `GumProjectManager.DefaultGumProjectDirectory` is
+  `GlueState.Self.ContentDirectory + "GumProject/"`, and `ContentDirectory` is empty for `ClassLibraryProject`
+  (no `ContentDirectory` override), so the `.gumx` lands directly under the project directory
+  (`<projectDir>/GumProject/GumProject.gumx`), not under a `Content/` subfolder as first assumed.
+
+**A live-dialog incident during this work, and the fix**: an early draft of the test called
+`CreateGumProjectInternal` a second time (to assert the "already exists" branch is a no-op). That branch's
+guard (`GumProjectManager.GetIsGumProjectAlreadyInGlueProject()`) routes to a real, unfaked
+`System.Windows.Forms.MessageBox.Show("A Gum project already exists")` - unlike `MainGlueWindow`/
+`PluginManager`, this dialog was never put behind an interface, so nothing in `GlueTestBootstrap` fakes it.
+Running that version of the test (twice, concurrently, from an accidental duplicate `dotnet test` invocation)
+popped real blocking WinForms dialogs on the developer's desktop. Fixed by removing the second call instead
+of chasing a dialog seam: the single-call coverage above already proves `CreateGumProjectNoForms`'s real
+behavior, and the guard itself is a one-line bool check not worth a live-dialog risk to cover. Flagging for
+future work: **any test driving Gum/FRB project-creation code should audit for unfaked `MessageBox.Show`
+calls before adding a second/repeated call to the same method**, the same way `IMainGlueWindow.Invoke` calls
+are audited today - this codebase has at least one more such call
+(`FormsControlAdder.AskToSaveIfOverwriting`, gated behind `askToOverwrite: true`, which the Wizard's own call
+sites always pass `false` for and this test never exercises).
+
+**Not covered, and why (real, out-of-scope blockers, not forced):**
+1. `CreateGumProjectInternal(shouldAlsoAddForms: true, ...)` - the `CreateGumProjectWithForms` call site -
+   unconditionally calls `MainGumPlugin.HandleBuildMissingFonts`, which spawns an external process at the
+   hardcoded relative path `"Plugins/GumPlugin/Tools/GumProjectFontGenerator/GumProjectFontGenerator.exe"`.
+   That path is only ever populated by `GumPlugin.csproj`'s `PostBuild` xcopy target into `Glue.exe`'s own
+   bin folder, not into `GlueUnitTests`'s output directory - `Process.Start` throws
+   `Win32Exception ("The system cannot find the file specified")` in a test host. Unlike every other blocker
+   found in this effort, this isn't a `PluginManager`/`MainGlueWindow` UI coupling - it's a real external-
+   tool/file-layout dependency. Fixing it would mean either copying the font generator into the test output
+   (a real build-layout change, not a test seam) or extracting a seam around the `Process.Start` call itself;
+   neither was attempted here as out of scope for a Gum-Plugin-project-creation-only pass.
+2. Getting there also needed one small production-adjacent addition that was reverted: adding a Forms
+   Component (`GumPluginCommands.AddComponent`) requires `Gum.Managers.StandardElementsManager.Self
+   .Initialize()` (called by `MainGumPlugin.StartUp`, same "plain no-UI-dependency init call, bypass
+   `StartUp` for tests" shape as `AvailableAssetTypes.Self.Initialize`) - this alone worked cleanly, but with
+   nothing left to assert once the font-generator blocker above was hit, the bootstrap seam for it was
+   removed rather than left as unexercised dead code. Re-add
+   `Gum.Managers.StandardElementsManager.Self.Initialize()` (plus
+   `GumPlugin.Managers.AssetTypeInfoManager.Self.AddCommonAtis()`) to `GlueTestBootstrap` if/when the
+   font-generator blocker above is solved and Forms-path coverage is picked back up.
+
+145/145 fast tests + 1/1 build-smoke green.
+
 ### 2026-07-23 — Real `FixNamedObjectCollisionType` coverage, Collision Plugin only (issue #1894 reopened)
 
 Issue #1894 was reopened: closing it after the `IMainGlueWindow` PR was premature because everything routed

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Glue\Glue.csproj" />
     <ProjectReference Include="..\..\OfficialPlugins\OfficialPlugins.csproj" />
+    <ProjectReference Include="..\..\GumPlugin\GumPlugin\GumPlugin.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumProjectCreationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumProjectCreationTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using GumPlugin.Managers;
+using Shouldly;
+
+// Namespace is "GumPluginTests", not "GumPlugin": the real Gum plugin project's root namespace is the bare
+// (non-nested) "GumPlugin", so nesting a same-named namespace under GlueUnitTests would shadow it for every
+// file under GlueUnitTests.* (C# resolves unqualified names against enclosing namespaces before usings),
+// silently breaking unrelated "GumPlugin.X" references elsewhere in this test project.
+namespace GlueUnitTests.GumPluginTests;
+
+// Follow-up to GitHub issue #1894 (reopened): WizardProjectLogic.HandleAddGum's two call sites
+// (~line 279/283) go through PluginManager.CallPluginMethodAsync("Gum Plugin",
+// "CreateGumProjectWithForms"/"CreateGumProjectNoForms", false), which silently no-ops in a test host
+// (no plugin registered with PluginManager) - the same false-coverage risk PR #1901 fixed for the
+// Collision Plugin's FixNamedObjectCollisionType.
+//
+// MainGumPlugin.CreateGumProjectWithForms/CreateGumProjectNoForms are already thin forwarders to the
+// public NewGumProjectCreationLogic.CreateGumProjectInternal(shouldAlsoAddForms, askToOverwrite) - same
+// "thin forwarder to directly-callable logic" shape as MainCollisionPlugin.FixNamedObjectCollisionType.
+// NewGumProjectCreationLogic itself only depends on a GumxPropertiesManager (a plain class with a
+// parameterless constructor, no UI dependency) - it does not need a live, StartUp'd MainGumPlugin
+// instance at all. This test constructs NewGumProjectCreationLogic directly and calls
+// CreateGumProjectInternal, bypassing both MainGumPlugin and PluginManager.CallPluginMethodAsync
+// entirely - real production logic, not a fake.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class GumProjectCreationTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _originalRelativeDirectory;
+    private readonly bool _originalSynchronousMode;
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly Gum.DataTypes.GumProjectSave? _originalGumProjectSave;
+    private readonly string _tempProjectDirectory;
+
+    public GumProjectCreationTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+        _originalGumProjectSave = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        FlatRedBall.IO.FileManager.RelativeDirectory = _tempProjectDirectory + "\\";
+
+        TaskManager.SynchronousMode = true;
+        TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = null;
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = _originalGumProjectSave;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public async Task CreateGumProjectInternal_ShouldWriteGumxToDiskAndAddItToTheGlueProject_WhenNoFormsRequested()
+    {
+        // Mirrors WizardProjectLogic.HandleAddGum's "no forms" branch: askToOverwrite is always false at
+        // that call site (there is nothing to overwrite for a brand-new project), and shouldAlsoAddForms
+        // is false for CreateGumProjectNoForms.
+        var creationLogic = new NewGumProjectCreationLogic(new GumxPropertiesManager());
+
+        await creationLogic.CreateGumProjectInternal(shouldAlsoAddForms: false, askToOverwrite: false);
+
+        // Real side effect #1: the .gumx (and its standard-element/font-cache siblings) were actually
+        // written to disk by EmbeddedResourceManager.SaveEmptyProject - not just an in-memory object.
+        // (Lands directly under the project's content folder + "GumProject/", not "Content/GumProject/" -
+        // GlueState.ContentDirectory is empty for this minimal test .csproj, same as any real project with
+        // no explicit content-folder override.)
+        var expectedGumxPath = Path.Combine(_tempProjectDirectory, "GumProject", "GumProject.gumx");
+        File.Exists(expectedGumxPath).ShouldBeTrue();
+
+        // Real side effect #2: the .gumx was added to the Glue project as a real ReferencedFileSave -
+        // exactly what GumProjectManager.GetIsGumProjectAlreadyInGlueProject checks for.
+        var gumRfs = GumProjectManager.Self.GetRfsForGumProject();
+        gumRfs.ShouldNotBeNull();
+        gumRfs.Name.ShouldEndWith("GumProject.gumx");
+        gumRfs.Properties.GetValue<bool>(nameof(global::GumPlugin.ViewModels.GumViewModel.AutoCreateGumScreens)).ShouldBeTrue();
+
+        // Real side effect #3: the newly-saved .gumx was actually loaded back off disk into Gum's own
+        // ObjectFinder (FileReferenceTracker.LoadGumxIfNecessaryFromDirectory), proving the file GumPlugin
+        // wrote is a well-formed, loadable Gum project - not just bytes copied from an embedded resource.
+        Gum.Managers.ObjectFinder.Self.GumProjectSave.ShouldNotBeNull();
+        Gum.Managers.ObjectFinder.Self.GumProjectSave.FullFileName.ShouldBe(FlatRedBall.IO.FileManager.Standardize(expectedGumxPath));
+
+        // Real side effect #4: CodeGeneratorManager.GenerateDerivedGueRuntimesAsync(forceReload: true) ran
+        // for real at the end of CreateGumProjectInternal and generated actual Gum runtime code to disk -
+        // proves this isn't just a file-copy step but drives Glue's real Gum code generation pipeline.
+        Directory.GetFiles(_tempProjectDirectory, "GumIdb.Generated.cs", SearchOption.AllDirectories)
+            .ShouldNotBeEmpty();
+
+        // Deliberately NOT calling CreateGumProjectInternal a second time here to check the "already
+        // exists" no-op branch: GumProjectManager.GetIsGumProjectAlreadyInGlueProject()==true routes to a
+        // real, unfaked System.Windows.Forms.MessageBox.Show("A Gum project already exists") with no
+        // GlueTestBootstrap seam (unlike MainGlueWindow/PluginManager, this dialog isn't behind any
+        // interface) - calling it again would pop a real blocking dialog in a headless test host instead of
+        // asserting anything. Single-call coverage above is sufficient to prove CreateGumProjectNoForms's
+        // real behavior; the guard branch is simple enough (one bool check) not to need its own test at the
+        // cost of a live MessageBox.
+    }
+
+    // CreateGumProjectInternal(shouldAlsoAddForms: true, ...) - the CreateGumProjectWithForms call site -
+    // is NOT covered here. Driving it hits a genuine, out-of-scope blocker: it unconditionally calls
+    // MainGumPlugin.HandleBuildMissingFonts, which spawns an external process at the hardcoded relative
+    // path "Plugins/GumPlugin/Tools/GumProjectFontGenerator/GumProjectFontGenerator.exe" - only ever
+    // deployed there by GumPlugin.csproj's PostBuild xcopy target into Glue.exe's own bin folder, not into
+    // this test project's output directory. This isn't a PluginManager/MainGlueWindow coupling (the seam
+    // shape every other blocker in this effort has been) - it's a real external-tool/file-layout dependency
+    // with nothing to fake without either shipping a copy of the font generator into the test output or
+    // extracting a seam around Process.Start itself. See REFACTORING.md for the full writeup; left
+    // undone rather than forced.
+
+    private class InlineUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public Task Invoke(Func<Task> func) => func();
+        public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+}


### PR DESCRIPTION
## Summary
Part of #1894 (reopened - only 3 of the Wizard's plugin-routed steps had real coverage; Gum project creation was one of the untested, silently-no-op'd ones). Scoped to the Gum Plugin only, per the issue - Tiled/Entity-Input-Movement are separate follow-ups.

- No production code change needed: `MainGumPlugin.CreateGumProjectWithForms`/`CreateGumProjectNoForms` are thin forwarders to the already-public `NewGumProjectCreationLogic.CreateGumProjectInternal`, which has no UI dependency. New test calls it directly, bypassing `PluginManager.CallPluginMethodAsync`'s silent no-op in a test host.
- `GlueUnitTests.GumPluginTests.GumProjectCreationTests` drives the real "no forms" path (`CreateGumProjectInternal(shouldAlsoAddForms: false, askToOverwrite: false)` - the exact args `WizardProjectLogic.HandleAddGum`'s "no forms" branch passes) and asserts four real side effects, not just "didn't throw": the `.gumx` (+ standard-element/font-cache siblings) written to disk, the `.gumx` added to the Glue project as a real `ReferencedFileSave`, the file loaded back off disk into Gum's own `ObjectFinder`, and real Gum code generation (`GumIdb.Generated.cs`) written to disk.
- `GlueUnitTests.csproj` now references `GumPlugin.csproj` (an external plugin, not previously reachable from the test project).
- Found and documented two real, out-of-scope blockers in REFACTORING.md:
  - The "with forms" path (`CreateGumProjectWithForms`) spawns an external `GumProjectFontGenerator.exe` at a path only ever populated by `Glue.exe`'s own build output, not the test project's - a real external-tool/file-layout dependency, not a UI coupling.
  - An early draft of this test triggered a real, unfaked `MessageBox.Show("A Gum project already exists")` dialog by calling `CreateGumProjectInternal` twice to check the no-op branch - popped real dialogs on the developer's desktop. Fixed by removing the second call rather than chasing a dialog seam.

## Test plan
- [x] `dotnet build "Glue with All.sln"` - 0 errors
- [x] `dotnet test --filter "Category!=BuildSmoke"` - 145/145 passed
- [x] `dotnet test --filter "Category=BuildSmoke"` - 1/1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)