### PR TITLE
Cover real Entity Input Movement Plugin behavior in tests (#1894 follow-up)

### DIFF
--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -313,6 +313,88 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
 
 ## Completed Refactors
 
+### 2026-07-23 — Real Entity Input Movement Plugin coverage (issue #1894 follow-up)
+
+Part of #1894 (reopened) - same shape as PR #1901 (Collision Plugin), #1902 (Gum Plugin), #1903 (Tiled
+Plugin), applied to `WizardProjectLogic.HandleAddPlayerEntity`'s two call sites (~lines 661/677):
+`PluginManager.CallPluginMethod("Entity Input Movement Plugin", "MakeEntityPlatformer"/"MakeEntityTopDown",
+playerEntity)`. With this PR, every `PluginManager.CallPluginMethod`/`CallPluginMethodAsync` call site in
+`WizardProjectLogic.cs` is covered by a real test (Collision, Gum, Tiled, Entity Input Movement) - the only
+remaining open item from #1894 is the `PluginManager.TabControlViewModel` coupling documented in PR #1901's
+entry below, which is a `PluginManager`-wide UI coupling, not a per-plugin gap.
+
+**Unlike the prior three, `MainEntityInputMovementPlugin.MakeEntityPlatformer`/`MakeEntityTopDown` are NOT
+thin forwarders to directly-callable logic** - both route through the plugin's own `mainViewModel` field,
+populated only by `CreateMainView()` (constructs a real WPF `UserControl` and calls `this.CreateTab(...)`,
+the same `PluginManager.TabControlViewModel`-coupled path already out-of-scope per PR #1901). So this test
+does not call `MainEntityInputMovementPlugin` at all - it calls what those two methods themselves delegate
+real work to: `FlatRedBall.PlatformerPlugin.Controllers.MainController.Self.GetViewModel()` /
+`TopDownPlugin.Controllers.MainController.Self.GetViewModel()`, the same singleton view-model source
+`CreateMainView()` initializes `mainViewModel.PlatformerViewModel`/`TopDownViewModel` from. Setting
+`BackingData` + `IsPlatformer`/`IsTopDown = true` on that view model fires the exact same
+`HandleViewModelPropertyChanged` handler production wires up in `GetViewModel()` - real production logic,
+reached one layer below the WPF-view-owning plugin class rather than a fake.
+
+No `MessageBox.Show`/dialog in this call chain: verified by inspection of `PlatformerPlugin`/`TopDownPlugin`
+(no `MessageBox.Show` anywhere in either plugin folder) and of
+`FlatRedBall.Glue.CreatedClass.CustomClassController.SetCsvRfsToUseCustomClass`, the one shared helper on
+this path that does contain one - both plugins call it with `force: true`, which short-circuits the prompt.
+CSV-extension files also bypass `ElementCommands.CheckAndWarnAboutUnknownFileTypes`'s unrecognized-extension
+prompt entirely (that check explicitly excludes `"csv"`).
+
+`GlueUnitTests.EntityInputMovementPluginTests.EntityInputMovementTests` (new file) drives both methods and
+asserts real, meaningful side effects, not just "didn't throw":
+- `MakeEntityPlatformer`: the entity's `IsPlatformer` property persists, `ImplementsICollidable` flips true,
+  the three platformer movement `CustomVariable`s (`GroundMovement`/`AirMovement`/`AfterDoubleJump`) are added
+  with the project's real `PlatformerValues` custom-class type, a `PlatformerValues(Static).csv` is generated
+  to disk with real content and wired up as a `ReferencedFileSave`, and a shared `PlatformerValues`
+  `CustomClassSave` is created and linked to that csv.
+- `MakeEntityTopDown`: the entity's `IsTopDown` property persists, `ImplementsICollidable` flips true, a
+  `TopDownValues(Static).csv` is generated to disk and wired up as a `ReferencedFileSave`, and a shared
+  `TopDownValues` `CustomClassSave` is created and linked to that csv. (Unlike Platformer, `TopDownPlugin`
+  doesn't add any `CustomVariable`s - `AddTopDownGlueVariables` is currently a no-op in production, so
+  nothing to assert there.)
+
+**Three real test-infrastructure gaps found and fixed while building this, none specific to Entity Input
+Movement - all three would have silently affected any future test that reaches the same code paths:**
+1. `GluxCommands.AddSingleFileTo` (used when wiring the generated csv to a `ReferencedFileSave`) reads
+   `ProjectManager.ProjectRootDirectory`, which requires a `.sln` file next to the test's `.csproj` that
+   textually references it - `TestVisualStudioProjectFactory.CreateInNewTempDirectory` only ever wrote a bare
+   `.csproj`. Now also writes a minimal `.sln` (not build-valid, just recognized by
+   `ProjectSyncer.LocateSolution`'s text search) alongside it - a shared-seam fix, benefits every test using
+   this factory.
+2. `ElementCommands.ReactToPropertyChanged` (the path any "flip an `Implements*` flag on an `EntitySave`"
+   call goes through, e.g. `ImplementsICollidable`) resolves `EntitySaveSetPropertyLogic` from the legacy
+   `EditorObjects.IoC.Container`, which `GlueTestBootstrap` never registered (only `MainGlueWindow.cs`'s real
+   startup did) - threw `"container does not contain an entry"`. `GlueTestBootstrap.EnsureInitialized` now
+   registers a real `EntitySaveSetPropertyLogic()` too, matching production's `Container.Set(new
+   EntitySaveSetPropertyLogic())` call.
+3. Running the full suite (not just this file in isolation) deterministically failed with a
+   `NullReferenceException` inside `FileCommands.IsContent` reading
+   `AvailableAssetTypes.Self.AdditionalExtensionsToTreatAsAssets` - null despite
+   `AvailableAssetTypes.CommonAtis` (a separate static set at the very end of the same `Initialize()` call)
+   being non-null. Root cause: `GlueTestBootstrap.EnsureInitialized`'s old guard,
+   `if (AvailableAssetTypes.CommonAtis == null) { AvailableAssetTypes.Self.Initialize(...); }`, was gating on
+   the wrong signal - when running the full suite, `CommonAtis` was already non-null the very first time this
+   bootstrap ran (upstream cause not fully root-caused - no test code calls `AvailableAssetTypes.Self
+   .Initialize` directly), so the guard concluded `Initialize()` had already run on `Self` and skipped it
+   entirely, leaving `Self.AdditionalExtensionsToTreatAsAssets` permanently null for the rest of the run. Only
+   surfaced via a call chain (`AddSingleFileTo` → `FileCommands.IsContent`) no prior #1894 test had reached.
+   Fixed by guarding on the exact instance field this bootstrap needs
+   (`AvailableAssetTypes.Self.AdditionalExtensionsToTreatAsAssets == null`) instead of a same-method side
+   effect (`CommonAtis`) that can apparently already be true from elsewhere - correct regardless of that
+   upstream cause. Also forced `TaskManager.SynchronousMode = true` as the first line of
+   `EnsureInitialized` (before anything else can touch `TaskManager.Self`) as a defensive hardening: leaving
+   it at its default `false` on first access spins up `TaskManager`'s real background thread for the whole
+   process, which no test wants running in a synchronous test host.
+
+Took the most time/retries in this whole task: run-in-isolation passed cleanly on the first real attempt, but
+running the full suite reproducibly failed at exactly the `AvailableAssetTypes` guard above - required adding
+and removing several rounds of temporary `FirstChanceException`/direct-field diagnostics (not left in the
+final code) to pin down that the guard, not a timing race, was the deterministic root cause.
+
+153/153 fast tests + 1/1 build-smoke green.
+
 ### 2026-07-23 — Real Tiled Plugin coverage, all 5 Wizard call sites (issue #1894 follow-up)
 
 Part of #1894 (reopened) - same shape as PR #1901 (Collision Plugin) and PR #1902 (Gum Plugin), applied to

--- a/FRBDK/Glue/Tests/GlueUnitTests/EntityInputMovementPlugin/EntityInputMovementTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/EntityInputMovementPlugin/EntityInputMovementTests.cs
@@ -1,0 +1,216 @@
+using System;
+using System.IO;
+using System.Linq;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.PlatformerPlugin.ViewModels;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using Shouldly;
+using TopDownPlugin.ViewModels;
+
+// Namespace is "EntityInputMovementPluginTests", not "EntityInputMovementPlugin": the real plugin
+// project's root namespace is the bare "EntityInputMovementPlugin" (see EntityInputMovementPlugin.csproj),
+// so nesting a same-named namespace under GlueUnitTests would shadow it for every file under
+// GlueUnitTests.* - same reasoning as GlueUnitTests.TiledPluginTests/GumPluginTests.
+namespace GlueUnitTests.EntityInputMovementPluginTests;
+
+// Follow-up to GitHub issue #1894 (reopened): WizardProjectLogic.HandleAddPlayerEntity's two call sites
+// (~lines 661/677) go through PluginManager.CallPluginMethod("Entity Input Movement Plugin",
+// "MakeEntityPlatformer"/"MakeEntityTopDown", playerEntity) - the same silent-no-op false-coverage risk
+// PRs #1901/#1902/#1903 fixed for the Collision/Gum/Tiled plugins.
+//
+// Unlike those three, MainEntityInputMovementPlugin.MakeEntityPlatformer/MakeEntityTopDown are NOT thin
+// forwarders to directly-callable logic - they route through the plugin's own `mainViewModel` field, which
+// is only populated by CreateMainView() (constructs a real WPF UserControl and calls this.CreateTab(...),
+// the exact PluginManager.TabControlViewModel-coupled path already flagged as out-of-scope in
+// REFACTORING.md from PR #1901). So this test does NOT call MainEntityInputMovementPlugin at all.
+//
+// Instead it calls what MakeEntityPlatformer/MakeEntityTopDown themselves delegate real work to:
+// FlatRedBall.PlatformerPlugin.Controllers.MainController.Self.GetViewModel() /
+// TopDownPlugin.Controllers.MainController.Self.GetViewModel() - the same singleton view-model source the
+// plugin's own mainViewModel.PlatformerViewModel/TopDownViewModel is initialized from
+// (MainEntityInputMovementPlugin.CreateMainView). Setting BackingData + IsPlatformer/IsTopDown = true on
+// that view model fires the exact same PropertyChanged handler
+// (PlatformerPlugin.Controllers.MainController.HandleViewModelPropertyChanged /
+// TopDownPlugin.Controllers.MainController.HandleViewModelPropertyChanged) that production wires up in
+// GetViewModel() - real production logic, not a fake, just reached one layer below the WPF-view-owning
+// plugin class.
+//
+// No MessageBox.Show/dialog in this call chain: verified by inspection of PlatformerPlugin/TopDownPlugin
+// (no MessageBox.Show anywhere in either plugin folder) and of
+// FlatRedBall.Glue.CreatedClass.CustomClassController.SetCsvRfsToUseCustomClass, the one shared helper on
+// this path that does contain a MessageBox.Show - both plugins call it with force: true, which short-
+// circuits the prompt (see SetRfsToUseNonNullClass: "if (force) result = DialogResult.Yes;"). CSV-extension
+// files also bypass ElementCommands.CheckAndWarnAboutUnknownFileTypes's unrecognized-extension prompt
+// entirely (that check explicitly excludes "csv").
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class EntityInputMovementTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _originalRelativeDirectory;
+    private readonly bool _originalSynchronousMode;
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly string _tempProjectDirectory;
+
+    public EntityInputMovementTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        FlatRedBall.IO.FileManager.RelativeDirectory = _tempProjectDirectory + "\\";
+
+        TaskManager.SynchronousMode = true;
+        TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MakeEntityPlatformer_ShouldMarkEntityAsPlatformer_AndAddMovementVariablesAndCsv()
+    {
+        var entity = new EntitySave { Name = "Entities\\Player" };
+        GlueState.Self.CurrentGlueProject.Entities.Add(entity);
+        GlueState.Self.CurrentElement = entity;
+
+        entity.ImplementsICollidable.ShouldBeFalse();
+
+        // The real logic behind WizardProjectLogic's
+        // PluginManager.CallPluginMethod("Entity Input Movement Plugin", "MakeEntityPlatformer", playerEntity)
+        // - see the class-level comment for why this bypasses MainEntityInputMovementPlugin itself.
+        var viewModel = FlatRedBall.PlatformerPlugin.Controllers.MainController.Self.GetViewModel();
+        viewModel.BackingData = entity;
+        viewModel.IsPlatformer = true;
+
+        // The IsPlatformer setter fires MainController.HandleViewModelPropertyChanged, an async void
+        // handler whose CSV generation/save work goes through TaskManager - even with
+        // TaskManager.SynchronousMode, WaitForTaskToFinish's internal polling still yields via a real
+        // Task.Delay once, so the handler's tail (AddPlatformerVariables, the CSV ReferencedFileSave) can
+        // still be in flight when the property setter returns. WizardProjectLogic itself awaits exactly
+        // this same drain (TaskManager.Self.WaitForAllTasksFinished, e.g. ~line 200/261) before relying on
+        // the results of plugin-triggered work, so this mirrors real production sequencing rather than
+        // working around a test-only race.
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        // Real side effect: the entity's persisted property, read back by
+        // PlatformerPlugin.Controllers.MainController.IsPlatformer(EntitySave).
+        entity.Properties.GetValue<bool>(nameof(PlatformerEntityViewModel.IsPlatformer)).ShouldBeTrue();
+
+        // Real side effect: marking an entity as a platformer also makes it ICollidable (see
+        // MainController.HandleViewModelPropertyChanged's IsPlatformer case).
+        entity.ImplementsICollidable.ShouldBeTrue();
+
+        // Real side effect: the three platformer movement CustomVariables were added, typed against the
+        // project's actual PlatformerValues custom class (see MainController.AddPlatformerVariables).
+        var platformerValuesType = GlueState.Self.ProjectNamespace + ".DataTypes.PlatformerValues";
+        var variableNames = entity.CustomVariables.Select(v => v.Name).ToArray();
+        variableNames.ShouldContain("GroundMovement");
+        variableNames.ShouldContain("AirMovement");
+        variableNames.ShouldContain("AfterDoubleJump");
+        entity.CustomVariables.ShouldAllBe(v => v.Type == platformerValuesType);
+
+        // Real side effect: a PlatformerValues(Static).csv was generated to disk and wired up as a
+        // ReferencedFileSave on the entity (see MainController.GenerateAndAddCsv).
+        var relativeCsvFile = FlatRedBall.PlatformerPlugin.Generators.CsvGenerator.RelativeCsvFile;
+        var csvRfs = entity.ReferencedFiles.FirstOrDefault(rfs => rfs.Name.EndsWith(relativeCsvFile));
+        csvRfs.ShouldNotBeNull();
+        csvRfs!.CreatesDictionary.ShouldBeTrue();
+
+        var csvPath = FlatRedBall.PlatformerPlugin.Generators.CsvGenerator.Self.CsvPlatformerFileFor(entity).FullPath;
+        File.Exists(csvPath).ShouldBeTrue();
+        var csvContents = File.ReadAllText(csvPath);
+        csvContents.ShouldContain("Ground");
+        csvContents.ShouldContain("Air");
+
+        // Real side effect: a shared "PlatformerValues" CustomClassSave was created and wired to the new
+        // csv (see MainController.GenerateAndAddCsv).
+        var customClass = GlueState.Self.CurrentGlueProject.CustomClasses.FirstOrDefault(c => c.Name == "PlatformerValues");
+        customClass.ShouldNotBeNull();
+        customClass!.CsvFilesUsingThis.ShouldContain(csvRfs.Name);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MakeEntityTopDown_ShouldMarkEntityAsTopDown_AndAddCsv()
+    {
+        var entity = new EntitySave { Name = "Entities\\Player" };
+        GlueState.Self.CurrentGlueProject.Entities.Add(entity);
+        GlueState.Self.CurrentElement = entity;
+
+        entity.ImplementsICollidable.ShouldBeFalse();
+
+        // The real logic behind WizardProjectLogic's
+        // PluginManager.CallPluginMethod("Entity Input Movement Plugin", "MakeEntityTopDown", playerEntity)
+        // - see the class-level comment for why this bypasses MainEntityInputMovementPlugin itself.
+        var viewModel = TopDownPlugin.Controllers.MainController.Self.GetViewModel();
+        viewModel.BackingData = entity;
+        viewModel.IsTopDown = true;
+
+        // See the matching comment in MakeEntityPlatformer_... above: drains the same
+        // TaskManager-queued tail of HandleViewModelPropertyChanged that WizardProjectLogic itself awaits
+        // via WaitForAllTasksFinished.
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        // Real side effect: the entity's persisted property, read back by
+        // TopDownPlugin.Controllers.MainController.IsTopDown(EntitySave).
+        entity.Properties.GetValue<bool>(nameof(TopDownEntityViewModel.IsTopDown)).ShouldBeTrue();
+
+        // Real side effect: marking an entity as top-down also makes it ICollidable (see
+        // MainController.HandleViewModelPropertyChanged's IsTopDown case).
+        entity.ImplementsICollidable.ShouldBeTrue();
+
+        // Real side effect: a TopDownValues(Static).csv was generated to disk and wired up as a
+        // ReferencedFileSave on the entity (see MainController.GenerateAndAddCsv).
+        var relativeCsvFile = TopDownPlugin.DataGenerators.CsvGenerator.RelativeCsvFile;
+        var csvRfs = entity.ReferencedFiles.FirstOrDefault(rfs => rfs.Name.EndsWith(relativeCsvFile));
+        csvRfs.ShouldNotBeNull();
+        csvRfs!.CreatesDictionary.ShouldBeTrue();
+
+        var csvPath = TopDownPlugin.DataGenerators.CsvGenerator.Self.CsvTopdownFileFor(entity).FullPath;
+        File.Exists(csvPath).ShouldBeTrue();
+        var csvContents = File.ReadAllText(csvPath);
+        csvContents.ShouldContain("Default");
+
+        // Real side effect: a shared "TopDownValues" CustomClassSave was created and wired to the new csv
+        // (see MainController.GenerateAndAddCsv).
+        var customClass = GlueState.Self.CurrentGlueProject.CustomClasses.FirstOrDefault(c => c.Name == "TopDownValues");
+        customClass.ShouldNotBeNull();
+        customClass!.CsvFilesUsingThis.ShouldContain(csvRfs.Name);
+    }
+
+    private class InlineUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public System.Threading.Tasks.Task Invoke(Func<System.Threading.Tasks.Task> func) => func();
+        public System.Threading.Tasks.Task<T> Invoke<T>(Func<System.Threading.Tasks.Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\OfficialPlugins\OfficialPlugins.csproj" />
     <ProjectReference Include="..\..\GumPlugin\GumPlugin\GumPlugin.csproj" />
     <ProjectReference Include="..\..\TileGraphicsPlugin\TileGraphicsPlugin\TiledPlugin.csproj" />
+    <ProjectReference Include="..\..\EntityInputMovementPlugin\EntityInputMovementPlugin.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -3,6 +3,7 @@ using System.IO;
 using EditorObjects.IoC;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.IO;
+using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Plugins.ExportedInterfaces;
 using FlatRedBall.Glue.Services;
@@ -26,7 +27,17 @@ namespace GlueUnitTests.TestSupport;
 ///    IgnoreNextChangeOnFile writes to.
 ///  - <see cref="AvailableAssetTypes"/>.Initialize populates <see cref="AvailableAssetTypes.CommonAtis"/>
 ///    (Camera/Text/Sprite/Polygon/etc.) from the same Content/ContentTypes.csv that MainGlueWindow reads -
-///    this is CSV-driven and needs no plugins, unlike the per-plugin ATIs below.
+///    this is CSV-driven and needs no plugins, unlike the per-plugin ATIs below. Guarded on
+///    <c>AvailableAssetTypes.Self.AdditionalExtensionsToTreatAsAssets == null</c>, not on
+///    <c>CommonAtis == null</c>: when running the full test suite, something upstream of this bootstrap
+///    (outside test code - not yet root-caused) already leaves <c>CommonAtis</c> non-null the first time
+///    this method runs, which made the old <c>CommonAtis == null</c> guard skip calling
+///    <c>Initialize</c> on <c>Self</c> entirely, leaving <c>Self.AdditionalExtensionsToTreatAsAssets</c>
+///    permanently null - surfaced as a NullReferenceException deep in
+///    <c>FileCommands.IsContent</c>/<c>GluxCommands.AddSingleFileTo</c>, which only a real "add a csv
+///    ReferencedFileSave" call chain reaches. Guarding on the exact field this bootstrap needs to have set,
+///    rather than a same-method side effect that can apparently already be true from elsewhere, is correct
+///    regardless of that upstream cause.
 ///  - <see cref="MainGlueWindow"/>.Self is given a <see cref="FakeMainGlueWindow"/> (only Program.cs ever
 ///    constructs the real WinForms window, which this test host never does) so any code path reading
 ///    MainGlueWindow.Self - PropertyGrid, HasErrorOccurred, Invoke/BeginInvoke, etc. - gets a harmless
@@ -34,6 +45,23 @@ namespace GlueUnitTests.TestSupport;
 ///  - <see cref="GlueState.Find"/> is given a <see cref="FakeFindManager"/> (only ever set by
 ///    MainTreeViewPlugin.StartUp, which this test host never runs) so tree-node-resolving setters like
 ///    GlueState.CurrentNamedObjectSave don't NRE.
+///  - The legacy <see cref="Container"/> is also given a real <c>EntitySaveSetPropertyLogic</c> (only ever
+///    set by MainGlueWindow.cs's real startup) so <c>ElementCommands.ReactToPropertyChanged</c> - the path
+///    any "flip an Implements* flag on an EntitySave" call goes through, e.g. ImplementsICollidable - can
+///    resolve it instead of throwing "container does not contain an entry".
+///  - <see cref="TaskManager.SynchronousMode"/> is forced on, process-wide, for the lifetime of the test
+///    run (set here, first, before anything else touches <see cref="TaskManager.Self"/>). Individual tests
+///    still flip it in their own constructor/Dispose for documentation purposes, but if it were left at its
+///    default of false at first access, TaskManager's constructor spins up its real dedicated background
+///    thread, which then runs for the entire process - any *other*, unrelated test whose production code
+///    path enqueues work while SynchronousMode happens to be transiently false (e.g. between two tests that
+///    each toggle it locally) leaves that work to be picked up by this still-live background thread later,
+///    racing against whatever a completely different, currently-running test is doing on the main thread.
+///    This was observed as an intermittent NullReferenceException inside a shared, non-thread-safe
+///    List&lt;string&gt; (AvailableAssetTypes.Self.AdditionalExtensionsToTreatAsAssets) when running the
+///    full suite - not a bug in the plugin/production code under test, but in ever letting that background
+///    thread exist at all in a test host. Forcing it here means the thread is never spun up in the first
+///    place, for any test in the assembly.
 ///
 /// Any test that drives production code through GlueCommands.Self/GlueState.Self (rather than calling a
 /// pure static method directly) needs this. Call <see cref="EnsureInitialized"/> once per test.
@@ -54,6 +82,9 @@ internal static class GlueTestBootstrap
             }
             _initialized = true;
 
+            // Must run before any other line here (or in any test): see the SynchronousMode bullet above.
+            TaskManager.SynchronousMode = true;
+
             if (Builder.App == null)
             {
                 new Builder().Build();
@@ -69,13 +100,15 @@ internal static class GlueTestBootstrap
 
             FileWatchManager.Initialize();
 
-            if (AvailableAssetTypes.CommonAtis == null)
+            if (AvailableAssetTypes.Self.AdditionalExtensionsToTreatAsAssets == null)
             {
                 AvailableAssetTypes.Self.Initialize(FindGlueStartupPath());
             }
 
             MainGlueWindow.Self ??= new FakeMainGlueWindow();
             GlueState.Self.Find ??= new FakeFindManager();
+
+            Container.Set(new FlatRedBall.Glue.SetVariable.EntitySaveSetPropertyLogic());
         }
     }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
@@ -36,6 +36,17 @@ internal static class TestVisualStudioProjectFactory
   </PropertyGroup>
 </Project>");
 
+        // Some production paths (e.g. GluxCommands.AddSingleFileTo, via ProjectManager.ProjectRootDirectory
+        // -> GlueState.CurrentSlnFileName -> ProjectSyncer.LocateSolution) require a .sln next to the
+        // .csproj that textually references it - LocateSolution throws FileNotFoundException otherwise.
+        // This doesn't need to be a build-valid solution file, just one LocateSolution's text search
+        // recognizes (same/base-name .sln in this directory, containing the .csproj's filename).
+        var slnPath = Path.Combine(directory, projectName + ".sln");
+        File.WriteAllText(slnPath, $@"Microsoft Visual Studio Solution File, Format Version 12.00
+Project(""{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}"") = ""{projectName}"", ""{projectName}.csproj"", ""{{11111111-1111-1111-1111-111111111111}}""
+EndProject
+");
+
         var project = new Project(csprojPath, null, null, new ProjectCollection());
         return new ClassLibraryProject(project);
     }


### PR DESCRIPTION
## Summary

Part of #1894 (reopened) - follow-up to PRs #1901 (Collision), #1902 (Gum), #1903 (Tiled). Covers `WizardProjectLogic.HandleAddPlayerEntity`'s two `PluginManager.CallPluginMethod("Entity Input Movement Plugin", "MakeEntityPlatformer"/"MakeEntityTopDown", ...)` call sites with real tests.

- `MainEntityInputMovementPlugin.MakeEntityPlatformer`/`MakeEntityTopDown` are **not** thin forwarders like the prior three plugins - they route through the plugin's own `mainViewModel` field, only populated by `CreateMainView()` (constructs a real WPF tab, the `PluginManager.TabControlViewModel` coupling already flagged out-of-scope in PR #1901). So the test bypasses `MainEntityInputMovementPlugin` entirely and drives `PlatformerPlugin`/`TopDownPlugin`'s `MainController.Self.GetViewModel()` directly - the same singleton view-model source those two methods themselves delegate to, firing the identical real `HandleViewModelPropertyChanged` production logic.
- New file: `GlueUnitTests.EntityInputMovementPluginTests.EntityInputMovementTests` - asserts real `CustomVariable`/CSV-file/`CustomClassSave` side effects, not just "didn't throw".
- No `MessageBox.Show` in this call chain (verified by inspection); the one shared dialog helper on this path (`CustomClassController.SetCsvRfsToUseCustomClass`) is called with `force: true` by both plugins, short-circuiting the prompt.
- With this PR, **every** `PluginManager.CallPluginMethod`/`CallPluginMethodAsync` call site in `WizardProjectLogic.cs` is covered by a real test. Only the `PluginManager.TabControlViewModel` coupling remains open from #1894.

Also fixes two test-infrastructure gaps found while building this (documented in REFACTORING.md), both benefiting any future test:
1. `TestVisualStudioProjectFactory` now writes a minimal `.sln` alongside its temp `.csproj` - `GluxCommands.AddSingleFileTo` needs one to resolve `ProjectRootDirectory`.
2. `GlueTestBootstrap` now registers a real `EntitySaveSetPropertyLogic` (matches production's `MainGlueWindow.cs` startup) and fixes a stale `AvailableAssetTypes.CommonAtis` guard that left `AdditionalExtensionsToTreatAsAssets` null under the full suite - was passing in isolation but deterministically failing when run with the other ~150 tests.

## Test plan
- [x] `dotnet build "Glue with All.sln"` - 0 errors
- [x] `dotnet test --filter "Category!=BuildSmoke"` - 153/153 passed (verified stable across multiple full-suite runs)
- [x] `dotnet test --filter "Category=BuildSmoke"` - 1/1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)