### PR TITLE
Cover real WizardProjectLogic.HandleAddPlayerInstance behavior in tests (#1894 follow-up)

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -931,6 +931,44 @@ public class PluginManager : PluginManagerBase
         TabControlViewModel = tabControlViewModel;
     }
 
+    /// <summary>
+    /// Test-only seam (issue #1894 follow-up): registers an already-constructed plugin instance with
+    /// this process's global <see cref="PluginManager"/> the same way <see cref="StartupPlugin"/> does
+    /// for a real, discovered plugin - just without <see cref="LoadPlugins"/>'s reflection/directory-scan
+    /// discovery step in front of it. Once registered this way, every dispatch path plugins normally run
+    /// through - <see cref="CallMethodOnPlugin"/>, <see cref="CallMethodOnPluginAsync(Action{PluginBase}, Predicate{PluginBase}, string)"/>,
+    /// the various <c>ReactTo*</c>/event methods - finds and invokes the plugin for real, so a test can
+    /// exercise a compiled-in official plugin's real event-subscriber behavior (e.g.
+    /// <see cref="PluginBase.ReactToCreateCollisionRelationshipsBetween"/>, only ever wired by a plugin's
+    /// own <c>StartUp</c>) instead of silently no-oping because <c>PluginContainers</c> is empty.
+    /// Third-party plugin discovery via <see cref="LoadPlugins"/> is completely untouched - this is purely
+    /// an alternate, direct way to populate the same dispatch table for one plugin at a time.
+    /// </summary>
+    internal static void RegisterPluginForTesting(PluginBase plugin)
+    {
+        globalPluginsManager ??= new PluginManager(true);
+        var manager = (PluginManager)globalPluginsManager;
+
+        if (!mInstances.Contains(manager))
+        {
+            mInstances.Add(manager);
+        }
+
+        manager.StartupPlugin(plugin);
+
+        // StartupPlugin (see above) swallows any exception from plugin.StartUp() - correct for real plugin
+        // loading (one misbehaving plugin shouldn't take down Glue.exe), but a silently-disabled plugin in
+        // a test is a confusing, hard-to-diagnose false negative (the plugin just never gets dispatched to,
+        // with no obvious reason why). Surface it loudly instead.
+        var failure = manager.PluginContainers[plugin].FailureException;
+        if (failure != null)
+        {
+            throw new InvalidOperationException(
+                $"{plugin.GetType().Name}.StartUp() failed during PluginManager.RegisterPluginForTesting - the plugin is now registered but disabled, so it will never be dispatched to.",
+                failure);
+        }
+    }
+
     internal static void SetToolbarTray(ToolbarControl toolbar)
     {
         ToolBarTray = toolbar.ToolBarTray;
@@ -1950,8 +1988,12 @@ public class PluginManager : PluginManagerBase
             // Before today, PluginCommand
             // always ran on a UI thread (if
             // possible). However, some commands
-            // do not require UI thread, and they can 
-            if (mMenuStrip.IsDisposed || !doOnUiThread)
+            // do not require UI thread, and they can
+            // mMenuStrip is null outside a live MainGlueWindow (e.g. a test host that registers a plugin
+            // via PluginManager.RegisterPluginForTesting without ever calling ShareMenuStripReference) -
+            // treat that the same as "no UI thread available", same as the !doOnUiThread branch, rather
+            // than NRE-ing on a menu strip that will never exist in that host.
+            if (mMenuStrip == null || mMenuStrip.IsDisposed || !doOnUiThread)
             {
                 try
                 {

--- a/FRBDK/Glue/OfficialPlugins/CollisionPlugin/MainCollisionPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/CollisionPlugin/MainCollisionPlugin.cs
@@ -82,11 +82,22 @@ namespace OfficialPlugins.CollisionPlugin
         /// without going through PluginManager.LoadPlugins - e.g. by GlueUnitTests'
         /// GlueTestBootstrap.EnsureCollisionPluginAssetTypesRegistered, without instantiating the rest of
         /// this plugin (UI tabs, code generators, event subscriptions).
+        /// Idempotent (checks before adding): production only ever calls this once (from StartUp, which
+        /// itself only runs once per process), but a test host can legitimately reach this from two
+        /// independent paths - GlueTestBootstrap.EnsureCollisionPluginAssetTypesRegistered (asset types
+        /// only) and GlueTestBootstrap.EnsureCollisionPluginRegisteredWithPluginManager (full StartUp, so
+        /// this runs again) - and AssetTypeInfoManager.Self.CollisionRelationshipAti is a cached singleton
+        /// instance, so a same-reference containment check is a correct, cheap dedupe.
         /// </summary>
         public static void RegisterAssetTypes()
         {
-            AvailableAssetTypes.Self.AddAssetType(
-                AssetTypeInfoManager.Self.CollisionRelationshipAti);
+            var ati = AssetTypeInfoManager.Self.CollisionRelationshipAti;
+            if (AvailableAssetTypes.Self.AllAssetTypes.Contains(ati))
+            {
+                return;
+            }
+
+            AvailableAssetTypes.Self.AddAssetType(ati);
         }
 
         private void AssignEvents()

--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -313,6 +313,90 @@ Traversal** (14) groups — 24 methods. Everything else stays on `ObjectFinder`.
 
 ## Completed Refactors
 
+### 2026-07-23 — `PluginManager.TabControlViewModel`/`RegisterPluginForTesting`, real `HandleAddPlayerInstance` coverage (issue #1894, likely final piece)
+
+Part of #1894. The one item every prior PR in this effort (#1901-#1904) left open: `PluginManager`'s two
+private/UI-only statics, `TabControlViewModel` and `mMenuStrip`, first flagged in #1901's investigation as
+blocking the real `WizardProjectLogic.HandleAddPlayerInstance` path (collision-relationship creation
+between the player entity and level geometry) from being driven end-to-end.
+
+**Investigation finding: the real minimal surface was much smaller than the `IMainGlueWindow`-style
+interface extraction the issue anticipated.** Neither static needed a full interface seam:
+
+- **`TabControlViewModel`** is a plain MVVM view model (`GlueFormsCore.ViewModels.TabControlViewModel`) -
+  `ObservableCollection`-backed tab containers, no live WPF `Dispatcher`/message loop needed to construct
+  one. `PluginManager.SetTabs` (the setter, already `internal`) was already reachable from `GlueUnitTests`
+  via the existing `InternalsVisibleTo`. Fix: `GlueTestBootstrap.EnsureInitialized` now calls
+  `PluginManager.SetTabs(new TabControlViewModel())` when unset - no production code change at all. Reading
+  it when empty (e.g. `DialogCommands.FocusTab` searching for a tab that was never added, since nothing
+  here runs the real WPF tab UI) is not an error case for that code; it just finds nothing.
+- **`mMenuStrip`** turned out to be *unreachable* by every currently-tested Wizard path, for a reason
+  distinct from the `TabControlViewModel` gap: `PluginManager`'s plugin-dispatch loops
+  (`CallMethodOnPlugin`/`CallMethodOnPluginAsync`) only ever touch it when a matching plugin is actually
+  registered, and no test in this effort had ever registered a real plugin with `PluginManager` - every
+  prior PR (correctly, per their own scope) called an extracted static method directly instead
+  (`RegisterAssetTypes`, `TryFixSourceClassType`, `TmxCreationManager.Self`, `MainController.Self`). Once
+  this PR registers a real plugin for the first time (see below), `mMenuStrip` *does* become reachable -
+  `PluginCommand`'s synchronous dispatch path (used by `PluginManager.CallPluginMethod`, e.g.
+  `FixNamedObjectCollisionType`) unconditionally read `mMenuStrip.IsDisposed`, NULL outside a live
+  `MainGlueWindow`. Fixed with a one-line null-guard (`mMenuStrip == null || mMenuStrip.IsDisposed || ...`),
+  same shape as the earlier `MainGlueWindow.Self.HasErrorOccurred` null-conditional fix - mMenuStrip is
+  never null in real production, so this is a zero-behavior-change addition for a case that could only ever
+  happen in this test host.
+
+**The real remaining blocker was `PluginManager.ReactToCreateCollisionRelationshipsBetween` needing a live
+plugin subscriber** - `MainCollisionPlugin` only wires its handler for this event inside its own `StartUp`,
+and no test in this effort had ever registered a real plugin instance with `PluginManager` (every prior PR
+deliberately avoided it, calling an already-extracted static method directly instead - see #1901's
+"option (a) rejected" writeup). Extracting yet another static method wasn't an option here: the handler is
+a `+=` event subscription set up inside `StartUp`, not a callable static. Added
+**`PluginManager.RegisterPluginForTesting(PluginBase plugin)`** - registers a real, already-constructed
+plugin instance into `PluginManager`'s dispatch tables the same way `StartupPlugin` does for a real,
+discovered plugin, just without `LoadPlugins`' reflection/directory-scan discovery step in front of it.
+Third-party plugin discovery is completely untouched; this is purely an alternate, direct way to populate
+the same dispatch table for one compiled-in official plugin at a time. Surfaces any `StartUp()` failure
+loudly (rethrows `PluginContainer.FailureException` instead of leaving the plugin silently
+disabled/undispatchable) - `StartupPlugin`'s own swallow-and-log-and-continue is correct for real plugin
+loading (one bad plugin shouldn't crash Glue.exe) but is exactly the kind of silent, hard-to-diagnose
+failure mode a *test* registration helper shouldn't have.
+`GlueTestBootstrap.EnsureCollisionPluginRegisteredWithPluginManager` constructs a real `MainCollisionPlugin`
+and calls this once per process (guarded, like the sibling `EnsureCollisionPluginAssetTypesRegistered`).
+
+Registering a real plugin's full `StartUp()` (not just its already-extracted `RegisterAssetTypes()`)
+surfaced three more real, previously-unreached production gaps, all fixed the same "give the test host the
+same one-time init call `MainGlueWindow.cs` makes" way already established throughout this effort:
+`ExposedVariableManager.Initialize()` (CustomVariableCodeGenerator NREd - a plain reflection pass over
+`typeof(PositionedObject)`, only reachable once a test drives real entity code generation, which no prior
+PR in this effort did), and the legacy `Container` needing real `NamedObjectSetVariableLogic` and
+`GlueErrorManager` instances (both plain classes, registered the same way `EntitySaveSetPropertyLogic`
+already was). Also made `MainCollisionPlugin.RegisterAssetTypes` idempotent (checks
+`AvailableAssetTypes.Self.AllAssetTypes.Contains(ati)` before adding) - needed because a test can now reach
+asset-type registration via two independent paths (`EnsureCollisionPluginAssetTypesRegistered`, and this
+PR's `EnsureCollisionPluginRegisteredWithPluginManager`, whose full `StartUp()` also calls
+`RegisterAssetTypes`), and `AssetTypeInfoManager.Self.CollisionRelationshipAti` is a cached singleton
+instance, so a same-reference containment check is a correct, cheap dedupe regardless of call order.
+
+With all of that in place, `GlueUnitTests.Wizard.WizardProjectLogicAddPlayerInstanceTests` drives the real,
+full `WizardProjectLogic.Apply(vm)` with `AddPlayerEntity`/`AddPlayerListToGameScreen`/solid+cloud collision
+all enabled - the exact `HandleAddPlayerInstance` path #1901 stopped at - and asserts real production side
+effects: both `PlayerListVsSolidCollision`/`PlayerListVsCloudCollision` relationship `NamedObjectSave`s
+exist, `FirstCollisionName`/`SecondCollisionName` wired to the real player list and collision objects, and
+`SourceClassType` recomputed by the real (now-dispatched, not silently no-op'd)
+`FixNamedObjectCollisionType` - not just "`Apply()` didn't throw." `PluginManager.HandleExceptions` is
+turned off for the duration of this test so any real exception in the dispatch path surfaces as a test
+failure instead of being caught-and-logged by `PluginCommand`, which exists precisely so one misbehaving
+plugin can't crash a live Glue.exe - the right behavior for production but a false-negative risk for a test
+asserting the real path ran without incident.
+
+154/154 fast tests (run twice for stability) + 1/1 build-smoke green.
+
+**This closes the last open item #1894 was tracking.** Every plugin-routed Wizard step (Collision, Gum,
+Tiled, Entity Input Movement) has real coverage, and the `PluginManager.TabControlViewModel`/`mMenuStrip`
+UI coupling flagged in #1901 is resolved to the extent any current test needs it. `mMenuStrip`'s null-guard
+only covers "no live menu strip" (treated as "no UI thread available", same as `!doOnUiThread`) - a genuine
+third-party plugin registered via the real `LoadPlugins` path still gets a real `mMenuStrip` from
+`ShareMenuStripReference` exactly as before; nothing about real plugin loading changed.
+
 ### 2026-07-23 — Real Entity Input Movement Plugin coverage (issue #1894 follow-up)
 
 Part of #1894 (reopened) - same shape as PR #1901 (Collision Plugin), #1902 (Gum Plugin), #1903 (Tiled

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -4,9 +4,11 @@ using EditorObjects.IoC;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.IO;
 using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Plugins.ExportedInterfaces;
 using FlatRedBall.Glue.Services;
+using GlueFormsCore.ViewModels;
 using OfficialPlugins.CollisionPlugin;
 using Glue;
 
@@ -38,6 +40,14 @@ namespace GlueUnitTests.TestSupport;
 ///    ReferencedFileSave" call chain reaches. Guarding on the exact field this bootstrap needs to have set,
 ///    rather than a same-method side effect that can apparently already be true from elsewhere, is correct
 ///    regardless of that upstream cause.
+///  - <see cref="FlatRedBall.Glue.Reflection.ExposedVariableManager"/>.Initialize populates the reflected
+///    list of PositionedObject members (X/Y/Z/Velocity/etc.) that code generation uses to decide whether a
+///    CustomVariable is "exposing" an already-existing base member - a plain, UI-free reflection pass over
+///    <c>typeof(PositionedObject)</c>, the same call MainGlueWindow.cs makes. Without it,
+///    CustomVariableCodeGenerator NREs (ArgumentNullException on a null source list) the first time code
+///    generation runs for *any* entity - only reachable once something in a test drives real entity code
+///    generation (e.g. WizardProjectLogic.HandleAddPlayerEntity's AddEntityAsync), which is why this went
+///    unnoticed until the first end-to-end player-entity test.
 ///  - <see cref="MainGlueWindow"/>.Self is given a <see cref="FakeMainGlueWindow"/> (only Program.cs ever
 ///    constructs the real WinForms window, which this test host never does) so any code path reading
 ///    MainGlueWindow.Self - PropertyGrid, HasErrorOccurred, Invoke/BeginInvoke, etc. - gets a harmless
@@ -45,10 +55,29 @@ namespace GlueUnitTests.TestSupport;
 ///  - <see cref="GlueState.Find"/> is given a <see cref="FakeFindManager"/> (only ever set by
 ///    MainTreeViewPlugin.StartUp, which this test host never runs) so tree-node-resolving setters like
 ///    GlueState.CurrentNamedObjectSave don't NRE.
+///  - <see cref="PluginManager.TabControlViewModel"/> is given a real (not fake) <c>TabControlViewModel</c>
+///    - only ever set by MainPanelControl.xaml.cs's real WPF startup, which this test host never runs.
+///    It's a plain MVVM view model (ObservableCollection-backed tab containers, no live Dispatcher/message
+///    loop needed to construct), so any code path reading it - DialogCommands.FocusTab,
+///    GlueState.CurrentFocusedTabs, GlueCommands.RestoreTabs - gets a real, just permanently empty (no
+///    tabs ever added, since nothing here runs the real WPF tab UI) TabControlViewModel instead of NREing.
+///    Searching for a tab that was never added is not an error case for that code (e.g. FocusTab just
+///    finds nothing and returns).
 ///  - The legacy <see cref="Container"/> is also given a real <c>EntitySaveSetPropertyLogic</c> (only ever
 ///    set by MainGlueWindow.cs's real startup) so <c>ElementCommands.ReactToPropertyChanged</c> - the path
 ///    any "flip an Implements* flag on an EntitySave" call goes through, e.g. ImplementsICollidable - can
 ///    resolve it instead of throwing "container does not contain an entry".
+///  - The legacy <see cref="Container"/> is also given a real
+///    <see cref="FlatRedBall.Glue.SetVariable.NamedObjectSetVariableLogic"/> (only ever set by
+///    MainGlueWindow.cs's real startup) so any "a NamedObjectSave's ExposedInDerived/instance name/property
+///    changed" path - e.g. GluxCommands.AddNewNamedObjectToAsync's ExposedInDerived notification - can
+///    resolve it instead of throwing "container does not contain an entry". Its constructor only reads
+///    from the Builder DI container (already built above), no live UI needed.
+///  - The legacy <see cref="Container"/> is also given a real
+///    <see cref="FlatRedBall.Glue.Errors.GlueErrorManager"/> (only ever set by MainGlueWindow.cs's real
+///    startup) so <c>PluginBase.AddErrorReporter</c> - called from a real plugin's <c>StartUp</c>, e.g.
+///    <see cref="PluginManager.RegisterPluginForTesting"/> - can resolve it instead of throwing "container
+///    does not contain an entry". A plain in-memory list, no live UI needed.
 ///  - <see cref="TaskManager.SynchronousMode"/> is forced on, process-wide, for the lifetime of the test
 ///    run (set here, first, before anything else touches <see cref="TaskManager.Self"/>). Individual tests
 ///    still flip it in their own constructor/Dispose for documentation purposes, but if it were left at its
@@ -71,6 +100,7 @@ internal static class GlueTestBootstrap
     static readonly object _lock = new();
     static bool _initialized;
     static bool _collisionPluginAssetTypesRegistered;
+    static bool _collisionPluginRegisteredWithPluginManager;
 
     public static void EnsureInitialized()
     {
@@ -105,10 +135,22 @@ internal static class GlueTestBootstrap
                 AvailableAssetTypes.Self.Initialize(FindGlueStartupPath());
             }
 
+            if (FlatRedBall.Glue.Reflection.ExposedVariableManager.PositionedObjectMembers == null)
+            {
+                FlatRedBall.Glue.Reflection.ExposedVariableManager.Initialize();
+            }
+
             MainGlueWindow.Self ??= new FakeMainGlueWindow();
             GlueState.Self.Find ??= new FakeFindManager();
 
+            if (PluginManager.TabControlViewModel == null)
+            {
+                PluginManager.SetTabs(new TabControlViewModel());
+            }
+
             Container.Set(new FlatRedBall.Glue.SetVariable.EntitySaveSetPropertyLogic());
+            Container.Set(new FlatRedBall.Glue.SetVariable.NamedObjectSetVariableLogic());
+            Container.Set(new FlatRedBall.Glue.Errors.GlueErrorManager());
         }
     }
 
@@ -132,6 +174,34 @@ internal static class GlueTestBootstrap
             _collisionPluginAssetTypesRegistered = true;
 
             MainCollisionPlugin.RegisterAssetTypes();
+        }
+    }
+
+    /// <summary>
+    /// Opt-in, separate from <see cref="EnsureInitialized"/> and <see cref="EnsureCollisionPluginAssetTypesRegistered"/>:
+    /// constructs a real <see cref="MainCollisionPlugin"/> and registers it with
+    /// <see cref="PluginManager.RegisterPluginForTesting"/>, running its real <c>StartUp</c> (asset types,
+    /// code generators, view model, and - the piece this exists for - wiring
+    /// <see cref="FlatRedBall.Glue.Plugins.PluginBase.ReactToCreateCollisionRelationshipsBetween"/> to the
+    /// real <c>CollidableNamedObjectController.CreateCollisionRelationshipBetweenObjects</c> handler).
+    /// Call this (instead of <see cref="EnsureCollisionPluginAssetTypesRegistered"/> - StartUp already does
+    /// what that does, and MainCollisionPlugin.RegisterAssetTypes is idempotent if a test calls both) when
+    /// a test needs the Collision Plugin's real plugin-event behavior, not just its asset type registered -
+    /// e.g. driving WizardProjectLogic.HandleAddPlayerInstance end-to-end, which creates collision
+    /// relationships via PluginManager.ReactToCreateCollisionRelationshipsBetween, a static event that has
+    /// no subscriber (and silently no-ops) unless a real MainCollisionPlugin has run this.
+    /// </summary>
+    public static void EnsureCollisionPluginRegisteredWithPluginManager()
+    {
+        lock (_lock)
+        {
+            if (_collisionPluginRegisteredWithPluginManager)
+            {
+                return;
+            }
+            _collisionPluginRegisteredWithPluginManager = true;
+
+            PluginManager.RegisterPluginForTesting(new MainCollisionPlugin());
         }
     }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddPlayerInstanceTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Wizard/WizardProjectLogicAddPlayerInstanceTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Managers;
+using Glue;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.Elements;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using OfficialPlugins.CollisionPlugin.ViewModels;
+using OfficialPlugins.Wizard.Managers;
+using OfficialPlugins.Wizard.Models;
+using Shouldly;
+
+namespace GlueUnitTests.Wizard;
+
+// Follow-up to GitHub issue #1894: after Collision (#1901) / Gum (#1902) / Tiled (#1903) / Entity Input
+// Movement (#1904) plugin coverage, the one remaining item was the PluginManager.TabControlViewModel /
+// mMenuStrip UI coupling flagged in #1901's investigation, which blocked the real
+// WizardProjectLogic.HandleAddPlayerInstance path (collision-relationship creation between the player
+// entity and level geometry) from being driven end-to-end.
+//
+// Two things were actually needed to unblock it (see PluginManager.cs and GlueTestBootstrap.cs):
+//  - PluginManager.TabControlViewModel is now given a real (not fake) TabControlViewModel by
+//    GlueTestBootstrap.EnsureInitialized. It's a plain MVVM view model - ObservableCollection-backed tab
+//    containers, no live WPF Dispatcher/message loop needed to construct one - only ever set in
+//    production by MainPanelControl.xaml.cs's real WPF startup. DialogCommands.FocusTab (called at the
+//    end of collision-relationship creation) just finds no matching tab in this always-empty instance and
+//    returns, which is not an error case for that code.
+//  - PluginManager.ReactToCreateCollisionRelationshipsBetween (what HandleAddPlayerInstance actually
+//    calls) is a static event with no subscriber unless a real MainCollisionPlugin has run StartUp - true
+//    in this test host, since PluginManager.LoadPlugins' reflection/directory-scan plugin discovery never
+//    runs here. GlueTestBootstrap.EnsureCollisionPluginRegisteredWithPluginManager constructs a real
+//    MainCollisionPlugin and registers it via the new PluginManager.RegisterPluginForTesting - the same
+//    dispatch-table registration StartupPlugin does for a discovered plugin, just without the discovery
+//    step in front of it. That, in turn, surfaced one more real gap: PluginManager's synchronous plugin
+//    dispatch (used by PluginManager.CallPluginMethod, e.g. "FixNamedObjectCollisionType") unconditionally
+//    read the private static PluginManager.mMenuStrip - null outside a live MainGlueWindow - fixed with a
+//    null-guard (same shape as the earlier MainGlueWindow.Self.HasErrorOccurred fix).
+//
+// With those in place, this drives the real, full WizardProjectLogic.Apply(vm) - the exact
+// HandleAddPlayerInstance path #1901 stopped at - and asserts real production side effects: both
+// collision-relationship NamedObjectSaves exist, wired to the real player list and collision objects, with
+// SourceClassType recomputed by the real (now actually-dispatched) FixNamedObjectCollisionType - not just
+// "Apply() didn't throw."
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class WizardProjectLogicAddPlayerInstanceTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _originalRelativeDirectory;
+    private readonly bool _originalSynchronousMode;
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly string _tempProjectDirectory;
+
+    public WizardProjectLogicAddPlayerInstanceTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        GlueTestBootstrap.EnsureCollisionPluginRegisteredWithPluginManager();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        FlatRedBall.IO.FileManager.RelativeDirectory = _tempProjectDirectory + "\\";
+
+        TaskManager.SynchronousMode = true;
+        TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+
+        // PluginManager.PluginCommand normally catches exceptions thrown by real plugin dispatch and just
+        // logs them (production correctly doesn't want one misbehaving plugin to crash Glue.exe) - but that
+        // means a real bug in the collision-relationship creation path this test drives would silently
+        // produce a wrong/incomplete NamedObjectSave instead of failing the test. Disabled here so any real
+        // exception surfaces directly as a test failure.
+        FlatRedBall.Glue.Plugins.PluginManager.HandleExceptions = false;
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+        FlatRedBall.Glue.Plugins.PluginManager.HandleExceptions = true;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public async Task Apply_ShouldCreateRealCollisionRelationships_ForPlayerVsSolidAndCloudCollision()
+    {
+        var vm = new WizardViewModel
+        {
+            AddGameScreen = true,
+            AddSolidCollision = true,
+            AddCloudCollision = true,
+            AddPlayerEntity = true,
+            PlayerCreationType = PlayerCreationType.SelectOptions,
+            PlayerControlType = GameType.TopDown,
+            PlayerCollisionType = OfficialPlugins.Wizard.Models.CollisionType.Rectangle,
+            AddPlayerListToGameScreen = true,
+            AddPlayerToList = true,
+            CollideAgainstSolidCollision = true,
+            CollideAgainstCloudCollision = true,
+            // Skip sprite/animation setup entirely - irrelevant to collision-relationship creation, and
+            // avoids embedded-resource copying that has nothing to do with what this test covers.
+            AddPlayerSprite = false,
+        };
+
+        await WizardProjectLogic.Self.Apply(vm);
+
+        var glueProject = ObjectFinder.Self.GlueProject;
+        var gameScreen = glueProject.Screens.FirstOrDefault(item => item.Name == @"Screens\GameScreen");
+        gameScreen.ShouldNotBeNull();
+
+        // Real side effect #1: HandleAddPlayerEntity's real CreatePlayerEntityFromOptions ran and produced
+        // a real Player entity, and AddEntityViewModel.IncludeListsInScreens (set from
+        // vm.AddPlayerListToGameScreen) produced a real player list NamedObjectSave in GameScreen.
+        var playerEntity = glueProject.Entities.FirstOrDefault(item => item.GetStrippedName() == "Player");
+        playerEntity.ShouldNotBeNull();
+
+        var playerList = gameScreen.NamedObjects.FirstOrDefault(
+            item => item.IsList && item.SourceClassGenericType == playerEntity.Name);
+        playerList.ShouldNotBeNull();
+
+        var solidCollisionNos = gameScreen.NamedObjects.FirstOrDefault(item => item.InstanceName == "SolidCollision");
+        solidCollisionNos.ShouldNotBeNull();
+        var cloudCollisionNos = gameScreen.NamedObjects.FirstOrDefault(item => item.InstanceName == "CloudCollision");
+        cloudCollisionNos.ShouldNotBeNull();
+
+        // Real side effect #2: PluginManager.ReactToCreateCollisionRelationshipsBetween found the real,
+        // now-registered MainCollisionPlugin subscriber and ran
+        // CollidableNamedObjectController.CreateCollisionRelationshipBetweenObjects for real - these
+        // relationship NamedObjectSaves only exist if that production logic actually executed (previously
+        // this event had no subscriber and silently produced nothing).
+        var solidRelationship = gameScreen.NamedObjects.FirstOrDefault(item =>
+            item.InstanceName == "PlayerVsSolidCollision" || item.InstanceName == "PlayerListVsSolidCollision");
+        solidRelationship.ShouldNotBeNull();
+        solidRelationship.Properties.GetValue<string>(nameof(CollisionRelationshipViewModel.FirstCollisionName))
+            .ShouldBe(playerList.InstanceName);
+        solidRelationship.Properties.GetValue<string>(nameof(CollisionRelationshipViewModel.SecondCollisionName))
+            .ShouldBe(solidCollisionNos.InstanceName);
+
+        var cloudRelationship = gameScreen.NamedObjects.FirstOrDefault(item =>
+            item.InstanceName == "PlayerVsCloudCollision" || item.InstanceName == "PlayerListVsCloudCollision");
+        cloudRelationship.ShouldNotBeNull();
+        cloudRelationship.Properties.GetValue<string>(nameof(CollisionRelationshipViewModel.FirstCollisionName))
+            .ShouldBe(playerList.InstanceName);
+        cloudRelationship.Properties.GetValue<string>(nameof(CollisionRelationshipViewModel.SecondCollisionName))
+            .ShouldBe(cloudCollisionNos.InstanceName);
+
+        // Real side effect #3: PluginManager.CallPluginMethod("Collision Plugin",
+        // "FixNamedObjectCollisionType", ...) now actually finds and dispatches to the real
+        // MainCollisionPlugin (previously silently no-op'd, since no plugin was registered) - proven by
+        // SourceClassType having been recomputed to a real collision-relationship runtime type, not left
+        // at whatever CreateCollisionRelationshipBetweenObjects's own initial computation produced.
+        solidRelationship.SourceClassType.ShouldStartWith("FlatRedBall.Math.Collision.");
+        cloudRelationship.SourceClassType.ShouldStartWith("FlatRedBall.Math.Collision.");
+
+        // Both relationships are real, distinct NamedObjectSaves wired into the screen.
+        gameScreen.NamedObjects.ShouldContain(solidRelationship);
+        gameScreen.NamedObjects.ShouldContain(cloudRelationship);
+        solidRelationship.ShouldNotBe(cloudRelationship);
+
+        // Real code generation ran for the containing screen after both relationships were added.
+        var generatedCodeFile = Path.Combine(_tempProjectDirectory, "Screens", "GameScreen.Generated.cs");
+        File.Exists(generatedCodeFile).ShouldBeTrue();
+    }
+
+    private class InlineUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public Task Invoke(Func<Task> func) => func();
+        public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+}


### PR DESCRIPTION
## Summary
Part of #1894. Last open item after Collision (#1901) / Gum (#1902) / Tiled (#1903) / Entity Input Movement (#1904) plugin coverage: the `PluginManager.TabControlViewModel`/`mMenuStrip` UI coupling #1901 stopped at, which blocked `WizardProjectLogic.HandleAddPlayerInstance` (collision-relationship creation between the player entity and level geometry) from being driven end-to-end.

Investigation found the real minimal surface was smaller than the anticipated `IMainGlueWindow`-style interface extraction:
- `PluginManager.TabControlViewModel` is a plain MVVM view model - no live WPF message loop needed to construct one. `GlueTestBootstrap` now gives it a real instance via the already-internal `PluginManager.SetTabs` - no production seam needed.
- `mMenuStrip` was actually unreachable by every test in this effort so far (no test had ever registered a real plugin with `PluginManager`). The real blocker was `PluginManager.ReactToCreateCollisionRelationshipsBetween` needing a live plugin subscriber - `MainCollisionPlugin` only wires that handler inside its own `StartUp`. Added `PluginManager.RegisterPluginForTesting` - registers a real plugin instance into `PluginManager`'s dispatch tables the same way `StartupPlugin` does for a discovered plugin, minus `LoadPlugins`' reflection/directory-scan discovery step. Third-party plugin loading is untouched. This surfaced `mMenuStrip` for real (in `PluginManager.CallPluginMethod`'s sync dispatch, e.g. `FixNamedObjectCollisionType`) - fixed with a one-line null-guard, same shape as the earlier `MainGlueWindow.Self.HasErrorOccurred` fix.
- Registering a plugin's full `StartUp()` surfaced three more real gaps, all fixed the same "give the test host the one-time init call `MainGlueWindow.cs` already makes" way: `ExposedVariableManager.Initialize()` (CustomVariable code generation NREd), and two missing legacy `Container` registrations (`NamedObjectSetVariableLogic`, `GlueErrorManager`).
- Made `MainCollisionPlugin.RegisterAssetTypes` idempotent (a test can now reach it via two independent paths).

`GlueUnitTests.Wizard.WizardProjectLogicAddPlayerInstanceTests` drives the real, full `WizardProjectLogic.Apply(vm)` with a player entity + solid/cloud collision enabled, and asserts real side effects: both relationship `NamedObjectSave`s exist, wired to the real player list and collision objects, with `SourceClassType` recomputed by the real (now-dispatched) `FixNamedObjectCollisionType` - not just "didn't throw."

This closes the last item #1894 was tracking - every plugin-routed Wizard step now has real coverage.

## Test plan
- [x] `dotnet build "Glue with All.sln"` - 0 errors
- [x] `dotnet test --filter "Category!=BuildSmoke"` - 154/154 passed (run twice for stability)
- [x] `dotnet test --filter "Category=BuildSmoke"` - 1/1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)