### PR TITLE
Fix Gum Rectangle/Circle codegen emitting unsupported fill/stroke/gradient properties

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
@@ -127,6 +127,45 @@ namespace GumPlugin.CodeGeneration
 
             _nineSliceCodeGenerator.AddTypeSpecificVariableNamesToSkipForProperties(_typedVariableNamesToSkipForProperties);
 
+            // Gum's "Rectangle" and "Circle" standard elements (StandardElementsManager v3 standard
+            // surface - see Gum issues #2929/#2931/#3009/#3617) now define a fill/stroke/gradient/
+            // dropshadow/blend variable family on their default state. Glue maps both of these
+            // standard elements to plain outline-only RenderingLibrary.Math.Geometry types
+            // (LineRectangle/LineCircle - see mStandardElementToQualifiedTypes above), which have no
+            // fill/stroke/gradient/dropshadow support and an unsettable get-only BlendState, so none
+            // of these variables can back a generated property. Exclude them here rather than mapping
+            // to a Skia-backed runtime, since that's a much larger change than this fix warrants.
+            var fillStrokeGradientDropshadowBlendVariables = new List<string>
+            {
+                // stroke (AddFillAndStrokeVariables)
+                "StrokeWidth", "StrokeAlpha", "StrokeRed", "StrokeGreen", "StrokeBlue",
+                // fill (AddFillAndStrokeVariables)
+                "IsFilled", "FillAlpha", "FillRed", "FillGreen", "FillBlue",
+                // gradient (AddGradientVariables, includeStartColor: false for Circle/Rectangle)
+                "UseGradient", "GradientType",
+                "GradientX1", "GradientX1Units", "GradientY1", "GradientY1Units",
+                "GradientX2", "GradientX2Units", "GradientY2", "GradientY2Units",
+                "GradientInnerRadius", "GradientInnerRadiusUnits",
+                "GradientOuterRadius", "GradientOuterRadiusUnits",
+                "Alpha2", "Red2", "Green2", "Blue2",
+                // dropshadow (AddDropshadowVariables)
+                "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY", "DropshadowBlur",
+                "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
+                // blend (AddBlendVariable) - LineRectangle/LineCircle's BlendState has no setter
+                "Blend",
+            };
+
+            _typedVariableNamesToSkipForProperties.Add("Circle", new List<string>(fillStrokeGradientDropshadowBlendVariables));
+
+            var rectangleVariablesToSkip = new List<string>(fillStrokeGradientDropshadowBlendVariables)
+            {
+                // Rounded-corner surface (Rectangle only - a Circle has no corners). LineRectangle
+                // always renders hard corners.
+                "CornerRadius",
+                "CustomRadiusTopLeft", "CustomRadiusTopRight", "CustomRadiusBottomLeft", "CustomRadiusBottomRight",
+            };
+            _typedVariableNamesToSkipForProperties.Add("Rectangle", rectangleVariablesToSkip);
+
 
 
             void ExcludeIfVersionLessThan(string propertyName, GluxVersions gluxVersion)

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
@@ -109,7 +109,33 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
 
         _containerCodeGenerator.AddTypeSpecificVariableNamesToSkipForStates(typeSpecificVariableNamesToSkipForStates);
 
+        // Mirrors the property-pipeline exclusion in StandardsCodeGenerator.RefreshVariableNamesToSkipForProperties -
+        // Gum's "Rectangle"/"Circle" standard elements now define a fill/stroke/gradient/dropshadow/blend
+        // variable family that plain LineRectangle/LineCircle can't back. Both pipelines must agree or a
+        // state-switch assignment references a property that was never generated (CS0103).
+        var fillStrokeGradientDropshadowBlendVariables = new List<string>
+        {
+            "StrokeWidth", "StrokeAlpha", "StrokeRed", "StrokeGreen", "StrokeBlue",
+            "IsFilled", "FillAlpha", "FillRed", "FillGreen", "FillBlue",
+            "UseGradient", "GradientType",
+            "GradientX1", "GradientX1Units", "GradientY1", "GradientY1Units",
+            "GradientX2", "GradientX2Units", "GradientY2", "GradientY2Units",
+            "GradientInnerRadius", "GradientInnerRadiusUnits",
+            "GradientOuterRadius", "GradientOuterRadiusUnits",
+            "Alpha2", "Red2", "Green2", "Blue2",
+            "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY", "DropshadowBlur",
+            "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
+            "Blend",
+        };
 
+        typeSpecificVariableNamesToSkipForStates.Add("Circle", new List<string>(fillStrokeGradientDropshadowBlendVariables));
+
+        var rectangleVariablesToSkip = new List<string>(fillStrokeGradientDropshadowBlendVariables)
+        {
+            "CornerRadius",
+            "CustomRadiusTopLeft", "CustomRadiusTopRight", "CustomRadiusBottomLeft", "CustomRadiusBottomRight",
+        };
+        typeSpecificVariableNamesToSkipForStates.Add("Rectangle", rectangleVariablesToSkip);
 
     }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleCircleCodegenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleCircleCodegenTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using GumPlugin.Managers;
+using Shouldly;
+
+namespace GlueUnitTests.GumPluginTests;
+
+// GitHub issue #1907 - Gum's "Rectangle" (and "Circle") standard elements now define a
+// fill/stroke/gradient/dropshadow/blend variable family (Gum's v3 standard surface -
+// StandardElementsManager.AddFillAndStrokeVariables/AddGradientVariables/AddDropshadowVariables/
+// AddBlendVariable), but Glue maps both to plain outline-only RenderingLibrary.Math.Geometry types
+// (LineRectangle/LineCircle - see StandardsCodeGenerator.mStandardElementToQualifiedTypes), which
+// can't back any of those members. Before the fix, RectangleRuntime.Generated.cs failed to compile
+// with CS1061 for GradientY1/HasDropshadow/StrokeWidth/UseGradient/etc. (and CircleRuntime.Generated.cs
+// had the identical latent bug - LineCircle is the same kind of outline-only shape - just not yet hit by
+// any repro because no default template places a Circle).
+//
+// This drives the real, unfaked codegen pipeline (same NewGumProjectCreationLogic.
+// CreateGumProjectInternal -> CodeGeneratorManager.GenerateDerivedGueRuntimesAsync path exercised by
+// GumProjectCreationTests) and asserts on the two real generated files. A full offline recompile of
+// these files was evaluated but dropped: RectangleRuntime.Generated.cs's declared base type
+// (Gum.Wireframe.GraphicalUiElement) and StateInterpolationPlugin.TweenerManager only get their real,
+// complete member surface from a full game project's reference graph (MonoGameGum +
+// FlatRedBall.Forms.StateInterpolation's shared source + the full engine) - reproducing that in this
+// tool-side test process would mean loading a second, conflicting copy of MonoGame/the engine
+// alongside Glue's own tool-side assemblies. See this PR's description for the real `dotnet build`
+// verification against an actual generated game project instead.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class RectangleCircleCodegenTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _originalRelativeDirectory;
+    private readonly bool _originalSynchronousMode;
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly Gum.DataTypes.GumProjectSave? _originalGumProjectSave;
+    private readonly string _tempProjectDirectory;
+
+    public RectangleCircleCodegenTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+        _originalGumProjectSave = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        FlatRedBall.IO.FileManager.RelativeDirectory = _tempProjectDirectory + "\\";
+
+        TaskManager.SynchronousMode = true;
+        TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = null;
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = _originalGumProjectSave;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public async Task CreateGumProjectInternal_ShouldNotGenerateUnsupportedFillStrokeGradientPropertiesForRectangleAndCircle()
+    {
+        // Needed so standard-element runtime generation actually runs (and doesn't silently no-op):
+        // populates Gum.Managers.StandardElementsManager.Self.DefaultStates with the full variable
+        // list (including the fill/stroke/gradient/dropshadow family under test), and wires up
+        // StandardsCodeGenerator/StateCodeGenerator's per-type generators + skip lists the same way
+        // MainGumPlugin.StartUp/glux-load does - without it, GenerateStandardElementSaveCodeFor NREs
+        // internally, which CodeGeneratorManager.GenerateAllElements swallows, so no
+        // RectangleRuntime.Generated.cs/CircleRuntime.Generated.cs get written at all.
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var creationLogic = new NewGumProjectCreationLogic(new GumxPropertiesManager());
+
+        await creationLogic.CreateGumProjectInternal(shouldAlsoAddForms: false, askToOverwrite: false);
+
+        var rectangleRuntimePath = Directory
+            .GetFiles(_tempProjectDirectory, "RectangleRuntime.Generated.cs", SearchOption.AllDirectories)
+            .ShouldHaveSingleItem();
+        var circleRuntimePath = Directory
+            .GetFiles(_tempProjectDirectory, "CircleRuntime.Generated.cs", SearchOption.AllDirectories)
+            .ShouldHaveSingleItem();
+
+        var rectangleSource = File.ReadAllText(rectangleRuntimePath);
+        var circleSource = File.ReadAllText(circleRuntimePath);
+
+        // These are exactly the members LineRectangle/LineCircle can't back (no fill, no stroke, no
+        // gradient, no dropshadow, and a get-only BlendState). This is the real, unfaked pipeline
+        // output - if StandardsCodeGenerator's/StateCodeGenerator's Rectangle/Circle skip lists ever
+        // regress, one of these properties will start showing up again and CS1061/CS0200 comes right
+        // back in any real generated game project.
+        foreach (var excludedMember in new[]
+                 {
+                     "StrokeWidth", "StrokeAlpha", "StrokeRed", "StrokeGreen", "StrokeBlue",
+                     "IsFilled", "FillAlpha", "FillRed", "FillGreen", "FillBlue",
+                     "UseGradient", "GradientType",
+                     "GradientX1", "GradientX1Units", "GradientY1", "GradientY1Units",
+                     "GradientX2", "GradientX2Units", "GradientY2", "GradientY2Units",
+                     "GradientInnerRadius", "GradientInnerRadiusUnits",
+                     "GradientOuterRadius", "GradientOuterRadiusUnits",
+                     "Alpha2", "Red2", "Green2", "Blue2",
+                     "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY", "DropshadowBlur",
+                     "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
+                     "Blend",
+                 })
+        {
+            rectangleSource.ShouldNotContain(excludedMember);
+            circleSource.ShouldNotContain(excludedMember);
+        }
+
+        // Rectangle-only rounded-corner surface (v3's per-corner override of the legacy
+        // RoundedRectangle standard) must also be excluded - LineRectangle always renders hard corners.
+        rectangleSource.ShouldNotContain("CornerRadius");
+        rectangleSource.ShouldNotContain("CustomRadiusTopLeft");
+
+        // Sanity: the single-color family Rectangle/Circle DO support (handled via
+        // TryHandleCustomGetter/TryHandleCustomSetter, not the excluded *2/Stroke*/Fill* family) must
+        // still be generated - proves this is a targeted exclusion, not an accidental blanket one.
+        rectangleSource.ShouldContain("public int Red");
+        rectangleSource.ShouldContain("public int Green");
+        rectangleSource.ShouldContain("public int Blue");
+        rectangleSource.ShouldContain("public int Alpha");
+        circleSource.ShouldContain("public int Red");
+    }
+
+    private class InlineUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public Task Invoke(Func<Task> func) => func();
+        public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -102,6 +102,7 @@ internal static class GlueTestBootstrap
     static bool _collisionPluginAssetTypesRegistered;
     static bool _collisionPluginRegisteredWithPluginManager;
     static bool _gumPluginStandardElementsInitialized;
+    static bool _gumPluginCodeGeneratorsInitialized;
 
     public static void EnsureInitialized()
     {
@@ -228,6 +229,51 @@ internal static class GlueTestBootstrap
             Gum.Managers.StandardElementsManager.Self.Initialize();
             GumPlugin.Managers.AssetTypeInfoManager.Self.AddCommonAtis();
         }
+    }
+
+    /// <summary>
+    /// Opt-in: wires up <see cref="GumPlugin.CodeGeneration.StandardsCodeGenerator"/> and
+    /// <see cref="GumPlugin.CodeGeneration.StateCodeGenerator"/> with their real per-type generators (the
+    /// same construction <see cref="MainGumPlugin.StartUp"/> performs), then runs the same
+    /// Refresh*SkipFor* calls <c>MainGumPlugin</c> runs on glux load. Without this,
+    /// <c>StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor</c> NREs inside
+    /// <c>AddAdditionalInheritance</c> (its per-type generator fields are never assigned), which
+    /// <c>CodeGeneratorManager.GenerateAllElements</c> swallows into its own error list - so standard-element
+    /// runtimes (e.g. RectangleRuntime.Generated.cs) silently never get written instead of throwing. Needed
+    /// by any test that drives real standard-element (not just Forms-component) code generation, e.g. via
+    /// <c>CodeGeneratorManager.GenerateDerivedGueRuntimesAsync</c>.
+    /// </summary>
+    public static void EnsureGumPluginCodeGeneratorsInitialized()
+    {
+        EnsureGumPluginStandardElementsInitialized();
+
+        lock (_lock)
+        {
+            if (!_gumPluginCodeGeneratorsInitialized)
+            {
+                _gumPluginCodeGeneratorsInitialized = true;
+
+                var textCodeGenerator = new GumPlugin.CodeGeneration.TextCodeGenerator();
+                var containerCodeGenerator = new GumPlugin.CodeGeneration.ContainerCodeGenerator(GlueState.Self);
+                var nineSliceCodeGenerator = new GumPlugin.CodeGeneration.NineSliceCodeGenerator(GlueState.Self);
+                var spriteCodeGenerator = new GumPlugin.CodeGeneration.SpriteCodeGenerator(GlueState.Self);
+                var polygonCodeGenerator = new GumPlugin.CodeGeneration.PolygonCodeGenerator(GlueState.Self);
+
+                GumPlugin.CodeGeneration.StandardsCodeGenerator.Self.Initialize(
+                    spriteCodeGenerator,
+                    textCodeGenerator,
+                    containerCodeGenerator,
+                    nineSliceCodeGenerator,
+                    polygonCodeGenerator);
+                GumPlugin.CodeGeneration.StateCodeGenerator.Self.Initialize(textCodeGenerator, containerCodeGenerator);
+            }
+        }
+
+        // Version-dependent (reads GlueState.Self.CurrentGlueProject.FileVersion), and cheap - re-run every
+        // call rather than caching, since callers may set up a different CurrentGlueProject per test.
+        GumPlugin.CodeGeneration.StateCodeGenerator.Self.RefreshVariablesToSkipForStates();
+        GumPlugin.CodeGeneration.StateCodeGenerator.Self.RefreshVariableNamesToSkipBasedOnGlueVersion();
+        GumPlugin.CodeGeneration.StandardsCodeGenerator.Self.RefreshVariableNamesToSkipForProperties();
     }
 
     // Walks up from the test assembly to the repo's Glue/Content/ContentTypes.csv - the same file


### PR DESCRIPTION
## Summary
Gum's v3 standard surface added a fill/stroke/gradient/dropshadow/blend variable family (plus `CornerRadius` on Rectangle) to the "Rectangle" and "Circle" standard elements. Glue maps both to plain outline-only `RenderingLibrary.Math.Geometry` types (`LineRectangle`/`LineCircle`) with no such support, so any project with a Gum project failed to build with CS1061 in `RectangleRuntime.Generated.cs` (`GradientY1`, `HasDropshadow`, `StrokeWidth`, `UseGradient`, etc.). `CircleRuntime.Generated.cs` had the identical latent bug - not yet hit by any repro since no default template places a Circle.

- `StandardsCodeGenerator.RefreshVariableNamesToSkipForProperties`: added `"Rectangle"`/`"Circle"` entries to `_typedVariableNamesToSkipForProperties` excluding the full unsupported family.
- `StateCodeGenerator.RefreshVariablesToSkipForStates`: mirrored exclusion so the state-switch pipeline agrees (otherwise a different compile error - undefined variable in a state assignment).
- `Circle`/`RoundedRectangle`/`ColoredCircle`/`Arc` (Skia-backed, DO support gradients) are untouched - only the two `Line*`-backed standards lose these properties.
- Legit single-color family (`Red`/`Green`/`Blue`/`Alpha`, no `2` suffix) is untouched.

## Excluded variables
Stroke: `StrokeWidth`, `StrokeAlpha`, `StrokeRed`, `StrokeGreen`, `StrokeBlue`
Fill: `IsFilled`, `FillAlpha`, `FillRed`, `FillGreen`, `FillBlue`
Gradient: `UseGradient`, `GradientType`, `GradientX1(Units)`, `GradientY1(Units)`, `GradientX2(Units)`, `GradientY2(Units)`, `GradientInnerRadius(Units)`, `GradientOuterRadius(Units)`, `Alpha2`, `Red2`, `Green2`, `Blue2`
Dropshadow: `HasDropshadow`, `DropshadowOffsetX/Y`, `DropshadowBlur`, `DropshadowAlpha/Red/Green/Blue`
Blend: `Blend` (LineRectangle/LineCircle's `BlendState` is get-only)
Rectangle-only: `CornerRadius`, `CustomRadiusTopLeft/TopRight/BottomLeft/BottomRight`

Cross-checked against Gum's `StandardElementsManager.cs` (`AddFillAndStrokeVariables`/`AddGradientVariables`/`AddDropshadowVariables`/`AddBlendVariable`) rather than the truncated error-message list, so nothing partial is excluded.

## Verification
- `dotnet build "FRBDK/Glue/Glue with All.sln"` - 0 errors.
- `dotnet test ... --filter "Category!=BuildSmoke"` - 156/156 passed (155 pre-existing + 1 new).
- `dotnet test ... --filter "Category=BuildSmoke"` - passed.
- New `RectangleCircleCodegenTests` drives the real, unfaked codegen pipeline (`NewGumProjectCreationLogic.CreateGumProjectInternal` -> `CodeGeneratorManager.GenerateDerivedGueRuntimesAsync`) and asserts none of the excluded members appear in the real generated `RectangleRuntime.Generated.cs`/`CircleRuntime.Generated.cs`, while the legit color family still does.
- Real repro: dropped the freshly generated `RectangleRuntime.Generated.cs`/`CircleRuntime.Generated.cs` into the existing `TestProjectDesktopNet6` sample project (which has the full real MonoGame/FlatRedBall/Gum reference graph) and ran `dotnet build` on it. The two target files produced **zero compiler diagnostics** - the CS1061 from #1907 is gone. (Full build still errors due to hundreds of gitignored `.Generated.cs` files this fresh worktree checkout doesn't have - pre-existing, unrelated to this fix.)

Also added `GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized()` - a reusable test seam wiring up `StandardsCodeGenerator`/`StateCodeGenerator`'s real per-type generators (same construction `MainGumPlugin.StartUp` does), needed because no prior test drove real standard-element runtime generation.

Closes #1907

🤖 Generated with [Claude Code](https://claude.com/claude-code)