### PR TITLE
Retry transient .sln file-lock failures during new-project creation

### DIFF
--- a/FRBDK/Glue/Glue/Utilities/RetryHelper.cs
+++ b/FRBDK/Glue/Glue/Utilities/RetryHelper.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading;
+
+namespace FlatRedBall.Glue.Utilities
+{
+    /// <summary>
+    /// Small reusable retry-with-backoff helper. Intended for transient failures such as a file
+    /// being briefly locked by another process (e.g. a just-exited subprocess whose file handle
+    /// hasn't fully released yet, an antivirus scan, or an IDE file watcher).
+    /// </summary>
+    public static class RetryHelper
+    {
+        public const int DefaultMaxAttempts = 3;
+        public static readonly TimeSpan DefaultInitialDelay = TimeSpan.FromMilliseconds(250);
+
+        /// <summary>
+        /// Invokes <paramref name="operation"/>, retrying up to <paramref name="maxAttempts"/> times
+        /// total if it throws an exception that <paramref name="isTransient"/> identifies as transient.
+        /// The delay between attempts starts at <paramref name="initialDelay"/> and doubles each retry.
+        /// A non-transient exception, or the exception from the final attempt, propagates to the caller.
+        /// </summary>
+        public static T Retry<T>(
+            Func<T> operation,
+            Func<Exception, bool> isTransient,
+            int maxAttempts = DefaultMaxAttempts,
+            TimeSpan? initialDelay = null)
+        {
+            if (maxAttempts < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxAttempts), "maxAttempts must be at least 1.");
+            }
+
+            var delay = initialDelay ?? DefaultInitialDelay;
+
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    return operation();
+                }
+                catch (Exception ex) when (attempt < maxAttempts && isTransient(ex))
+                {
+                    Thread.Sleep(delay);
+                    delay += delay;
+                }
+            }
+
+            // Unreachable: the loop above either returns on success, or - once attempt == maxAttempts -
+            // the `when` clause is false so the exception propagates out of the loop instead of being caught.
+            throw new InvalidOperationException("RetryHelper.Retry reached unreachable code.");
+        }
+
+        /// <summary>
+        /// Action overload of <see cref="Retry{T}"/>.
+        /// </summary>
+        public static void Retry(
+            Action operation,
+            Func<Exception, bool> isTransient,
+            int maxAttempts = DefaultMaxAttempts,
+            TimeSpan? initialDelay = null)
+        {
+            Retry<object>(
+                () => { operation(); return null; },
+                isTransient,
+                maxAttempts,
+                initialDelay);
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/VSHelpers/VSSolution.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/VSSolution.cs
@@ -1,4 +1,5 @@
-﻿using FlatRedBall.IO;
+﻿using FlatRedBall.Glue.Utilities;
+using FlatRedBall.IO;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -44,7 +45,9 @@ namespace FlatRedBall.Glue.VSHelpers
 
             if(solution.Exists())
             {
-                var contents = System.IO.File.ReadAllText(solution.FullPath);
+                var contents = RetryHelper.Retry(
+                    () => System.IO.File.ReadAllText(solution.FullPath),
+                    isTransient: ex => ex is IOException);
 
                 if(contents?.Contains(project) == true)
                 {
@@ -61,7 +64,9 @@ namespace FlatRedBall.Glue.VSHelpers
                         // Remove between indexOfStart and indexOfEnd
                         contents = contents.Remove(indexOfStart, endWithLenth - indexOfStart);
 
-                        System.IO.File.WriteAllText(solution.FullPath, contents);
+                        RetryHelper.Retry(
+                            () => System.IO.File.WriteAllText(solution.FullPath, contents),
+                            isTransient: ex => ex is IOException);
                         return true;
                     }
                 }
@@ -69,10 +74,63 @@ namespace FlatRedBall.Glue.VSHelpers
             return false;
         }
 
+        // Thrown internally by AddExistingProjectWithDotNet to route a transient-lock-shaped subprocess
+        // error through RetryHelper.Retry, which retries based on exceptions. Never escapes this class.
+        private class TransientFileLockException : Exception
+        {
+            public TransientFileLockException(string message) : base(message) { }
+        }
+
+        // "dotnet sln add" reports failures (including a locked .sln) via stderr text rather than throwing,
+        // so we check the message shape rather than an exception type here.
+        private static bool IsTransientFileLockMessage(string message) =>
+            !string.IsNullOrEmpty(message) &&
+            (message.IndexOf("being used by another process", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             message.IndexOf("cannot access the file", StringComparison.OrdinalIgnoreCase) >= 0);
+
         public static bool AddExistingProjectWithDotNet(FilePath solution, FilePath project, out string output, out string error)
         {
-            output = null;
-            error = null;
+            string capturedOutput = null;
+            string capturedError = null;
+            bool success;
+
+            try
+            {
+                success = RetryHelper.Retry(
+                    operation: () =>
+                    {
+                        var result = RunDotnetSlnAddOnce(solution, project);
+                        capturedOutput = result.output;
+                        capturedError = result.error;
+
+                        if (!result.success && IsTransientFileLockMessage(result.error))
+                        {
+                            // Only escalate transient-looking failures to an exception so RetryHelper
+                            // retries them. A genuinely malformed project reference (or any other
+                            // non-lock failure) returns false immediately, same as before retries existed.
+                            throw new TransientFileLockException(result.error);
+                        }
+
+                        return result.success;
+                    },
+                    isTransient: ex => ex is TransientFileLockException);
+            }
+            catch (TransientFileLockException)
+            {
+                // All retries exhausted on a transient lock - surface the last real attempt's error,
+                // exactly as the caller would have seen before retries existed.
+                success = false;
+            }
+
+            output = capturedOutput;
+            error = capturedError;
+            return success;
+        }
+
+        private static (bool success, string output, string error) RunDotnetSlnAddOnce(FilePath solution, FilePath project)
+        {
+            string output = null;
+            string error = null;
             try
             {
                 var process = new Process();
@@ -92,24 +150,22 @@ namespace FlatRedBall.Glue.VSHelpers
 
                 process.WaitForExit(10000);
 
-                if (string.IsNullOrEmpty(error))
-                    return true;
-                else
-                    return false;
-
+                return (string.IsNullOrEmpty(error), output, error);
             }
             catch (Exception ex)
             {
                 error = (error ?? "") + ex.ToString();
 
-                return false;
+                return (false, output, error);
             }
         }
 
         public static bool AddExistingProject(FilePath solution, Guid projectTypeId, Guid projectId, string projectName, FilePath projectPath, List<SharedProject> sharedProjects, List<string> projectConfigurations, List<string> solutionConfigurations, out string error)
         {
             //Read file
-            var allLines = File.ReadAllLines(solution.FullPath).ToList();
+            var allLines = RetryHelper.Retry(
+                () => File.ReadAllLines(solution.FullPath),
+                isTransient: ex => ex is IOException).ToList();
 
             //Find Global Section
             int? addLineHere = null;
@@ -221,7 +277,9 @@ namespace FlatRedBall.Glue.VSHelpers
             }
 
             //Save File
-            File.WriteAllLines(solution.FullPath, allLines.ToArray());
+            RetryHelper.Retry(
+                () => File.WriteAllLines(solution.FullPath, allLines.ToArray()),
+                isTransient: ex => ex is IOException);
 
             error = null;
             return true;

--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -1286,3 +1286,35 @@ These methods have no static singleton dependencies — all they touch is `_glue
 **`SelectionLogic`**: `GlueState.Self.CurrentTreeNodes = ...` (the one singleton call remaining) replaced with an `Action<IReadOnlyList<ITreeNode>> reportSelection` callback injected via constructor. `MainTreeViewPlugin` passes `nodes => GlueState.Self.CurrentTreeNodes = nodes`. Tests pass a no-op spy lambda — `SelectionLogicTests` no longer needs any reference to `GlueState`.
 
 **Still static** (left for future steps): `ProjectManager.*`, `ObjectFinder.Self`, `FileManager.*` — these have no direct `IGlueState`/`IGlueCommands` equivalent and require more effort to wrap.
+
+### 2026-07-23 — Retry transient `.sln` file-lock failures during new-project creation
+
+Bug (found via manual testing, not filed as an issue): creating a new project intermittently failed
+with a real popup: "Failed to add project ...FlatRedBall.Forms.DesktopGlNet6.csproj. Errors: Unhandled
+exception: The process cannot access the file '...Platformer2.sln' because it is being used by another
+process." Root cause: `AddSourceManager.AddProject`/`AddSharedProject` loop over every FRB/Gum project
+reference, calling `VSSolution.AddExistingProjectWithDotNet` (shells out `dotnet.exe sln add`) or
+`VSSolution.AddExistingProject` (raw `File.ReadAllLines`/`WriteAllLines`) against the *same* `.sln`
+back-to-back with zero retry — a classic transient-lock race (previous subprocess's file handle not yet
+released, AV scan, IDE file watcher).
+
+Added `FlatRedBall.Glue.Utilities.RetryHelper.Retry<T>(Func<T> operation, Func<Exception, bool>
+isTransient, int maxAttempts = 3, TimeSpan? initialDelay = null)` — a small, pure, reusable
+retry-with-backoff helper (250ms initial delay, doubling each retry: 250ms, 500ms). Non-transient
+exceptions, and the final attempt's exception, propagate unchanged.
+
+Wired into `VSSolution.cs`:
+- `AddExistingProject` and `RemoveProjectReference` wrap their `File.ReadAllLines`/`ReadAllText`/
+  `WriteAllLines`/`WriteAllText` calls with `isTransient: ex => ex is IOException`.
+- `AddExistingProjectWithDotNet` reports failure via an `out string error` from a subprocess rather than
+  throwing, so a private `TransientFileLockException` is thrown internally when the stderr text looks
+  lock-shaped (`IsTransientFileLockMessage`: contains "being used by another process" or "cannot access
+  the file"), letting it reuse the same `RetryHelper.Retry`. A genuinely malformed project reference
+  (any other error text) still fails on the first attempt, unchanged from before.
+
+Tests: `Tests/GlueUnitTests/Utilities/RetryHelperTests.cs` pins the helper itself against a fake
+operation (succeeds first try; fails transiently then succeeds; exhausts retries and surfaces the real
+exception; does not retry a non-transient exception). `Tests/GlueUnitTests/VSHelpers/VSSolutionRetryTests.cs`
+drives a real OS-level file lock — a background thread holds an exclusive `FileStream` on a temp `.sln`
+for 300ms — and confirms `VSSolution.AddExistingProject` retries past it and succeeds instead of throwing;
+ran clean over multiple repeats (no flakiness observed).

--- a/FRBDK/Glue/Tests/GlueUnitTests/Utilities/RetryHelperTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Utilities/RetryHelperTests.cs
@@ -1,0 +1,112 @@
+using System;
+using Shouldly;
+using FlatRedBall.Glue.Utilities;
+using Xunit;
+
+namespace GlueUnitTests.Utilities;
+
+// Pins the retry-with-backoff helper added to fix intermittent "file being used by another process"
+// failures when adding projects to a .sln (VSSolution.cs mutates the same .sln file back-to-back in a
+// loop, racing a just-exited dotnet.exe subprocess's file handle / AV scan / IDE file watcher).
+public class RetryHelperTests
+{
+    [Fact]
+    public void Retry_ShouldReturnResult_WhenOperationSucceedsOnFirstAttempt()
+    {
+        var callCount = 0;
+
+        var result = RetryHelper.Retry<int>(
+            operation: () => { callCount++; return 42; },
+            isTransient: ex => true);
+
+        result.ShouldBe(42);
+        callCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Retry_ShouldRetryAndSucceed_WhenOperationFailsTransientlyThenSucceeds()
+    {
+        var callCount = 0;
+
+        var result = RetryHelper.Retry<int>(
+            operation: () =>
+            {
+                callCount++;
+                if (callCount < 3)
+                {
+                    throw new InvalidOperationException("transient failure");
+                }
+                return 99;
+            },
+            isTransient: ex => true,
+            maxAttempts: 5,
+            initialDelay: TimeSpan.Zero);
+
+        result.ShouldBe(99);
+        callCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Retry_ShouldGiveUpAndThrowRealException_WhenAttemptsExhausted()
+    {
+        var callCount = 0;
+
+        var thrown = Should.Throw<InvalidOperationException>(() =>
+        {
+            RetryHelper.Retry<int>(
+                operation: () =>
+                {
+                    callCount++;
+                    throw new InvalidOperationException($"failure #{callCount}");
+                },
+                isTransient: ex => true,
+                maxAttempts: 3,
+                initialDelay: TimeSpan.Zero);
+        });
+
+        callCount.ShouldBe(3);
+        thrown.Message.ShouldBe("failure #3");
+    }
+
+    [Fact]
+    public void Retry_ShouldNotRetry_WhenExceptionIsNotTransient()
+    {
+        var callCount = 0;
+
+        Should.Throw<InvalidOperationException>(() =>
+        {
+            RetryHelper.Retry<int>(
+                operation: () =>
+                {
+                    callCount++;
+                    throw new InvalidOperationException("not transient");
+                },
+                isTransient: ex => false,
+                maxAttempts: 5,
+                initialDelay: TimeSpan.Zero);
+        });
+
+        callCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Retry_Action_ShouldRetryAndSucceed_WhenOperationFailsTransientlyThenSucceeds()
+    {
+        var callCount = 0;
+
+        RetryHelper.Retry(
+            operation: () =>
+            {
+                callCount++;
+                if (callCount < 2)
+                {
+                    throw new InvalidOperationException("transient failure");
+                }
+            },
+            isTransient: ex => true,
+            maxAttempts: 3,
+            initialDelay: TimeSpan.Zero);
+
+        callCount.ShouldBe(2);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/VSSolutionRetryTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/VSSolutionRetryTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.VSHelpers;
+using FlatRedBall.IO;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.VSHelpers;
+
+// Pins the fix for an intermittent popup when creating a new project:
+// "Failed to add project ...csproj. Errors: Unhandled exception: The process cannot access the file
+// '...sln' because it is being used by another process." AddSourceManager mutates the same .sln file
+// back-to-back in a loop (once per FRB/Gum project reference), racing a just-exited dotnet.exe
+// subprocess's file handle, an antivirus scan, or an IDE file watcher. VSSolution.AddExistingProject
+// now retries transient IOException file locks instead of failing on the first hit.
+public class VSSolutionRetryTests
+{
+    [Fact]
+    public void AddExistingProject_ShouldRetryAndSucceed_WhenSolutionFileIsTransientlyLockedByAnotherProcess()
+    {
+        var tempSolutionPath = Path.Combine(Path.GetTempPath(), $"RetryTest_{Guid.NewGuid():N}.sln");
+        File.WriteAllLines(tempSolutionPath, new[]
+        {
+            "Microsoft Visual Studio Solution File, Format Version 12.00",
+            "Global",
+            "EndGlobal"
+        });
+
+        try
+        {
+            using var lockAcquired = new ManualResetEventSlim(false);
+
+            // Simulate another process (a just-exited dotnet.exe, an AV scan, a file watcher) holding
+            // an exclusive lock on the .sln for a short time.
+            var lockTask = Task.Run(() =>
+            {
+                using var lockStream = new FileStream(
+                    tempSolutionPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                lockAcquired.Set();
+                Thread.Sleep(300);
+            });
+
+            lockAcquired.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue("background thread should have locked the file");
+
+            FilePath solution = tempSolutionPath;
+            FilePath project = Path.Combine(Path.GetTempPath(), "SomeProject.csproj");
+
+            var succeeded = VSSolution.AddExistingProject(
+                solution,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                "SomeProject",
+                project,
+                sharedProjects: null,
+                projectConfigurations: null,
+                solutionConfigurations: null,
+                out var error);
+
+            lockTask.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
+            succeeded.ShouldBeTrue(error);
+
+            var resultContents = File.ReadAllText(tempSolutionPath);
+            resultContents.ShouldContain("SomeProject");
+        }
+        finally
+        {
+            File.Delete(tempSolutionPath);
+        }
+    }
+}


### PR DESCRIPTION
## Bug (found via manual testing, no issue filed)
Creating a new project intermittently fails with a real popup:
> Failed to add project ...FlatRedBall.Forms.DesktopGlNet6.csproj. Errors: Unhandled exception: The process cannot access the file '...Platformer2.sln' because it is being used by another process.

## Root cause
`AddSourceManager` loops over every FRB/Gum project reference, calling `VSSolution.AddExistingProjectWithDotNet` (shells out `dotnet.exe sln add`) or `VSSolution.AddExistingProject`/`RemoveProjectReference` (raw file I/O) against the *same* `.sln` back-to-back with zero retry — a transient-lock race (previous subprocess's file handle not yet released, AV scan, IDE file watcher).

## Fix
Added `FlatRedBall.Glue.Utilities.RetryHelper.Retry<T>(Func<T> operation, Func<Exception,bool> isTransient, maxAttempts=3, initialDelay=250ms doubling each retry)` — a small, pure, reusable retry-with-backoff helper.

Wired into `VSSolution.cs`:
- `AddExistingProject` / `RemoveProjectReference`: wrap `File.ReadAllLines`/`ReadAllText`/`WriteAllLines`/`WriteAllText` calls, retrying on `IOException`.
- `AddExistingProjectWithDotNet`: reports failure via an `out string error` from a subprocess rather than throwing, so a private `TransientFileLockException` is thrown internally only when the stderr text looks lock-shaped ("being used by another process" / "cannot access the file"), reusing the same helper. Any other failure (e.g. a genuinely malformed project reference) still fails immediately, unchanged.

Zero behavior change on the happy path; only the failure/retry path changes. If retries are exhausted, the same error message surfaces as before.

## Tests
- `RetryHelperTests.cs` pins the helper against a fake operation: succeeds first try, retries-then-succeeds, exhausts retries and surfaces the real exception, and does not retry non-transient exceptions.
- `VSSolutionRetryTests.cs` drives a real OS-level file lock (background thread holds an exclusive `FileStream` on a temp `.sln` for 300ms) and confirms `AddExistingProject` retries past it and succeeds. Ran clean over multiple repeats.

Documented in `REFACTORING.md`.

## Verification
- `dotnet build "Glue with All.sln"` — green
- `dotnet test ... --filter "Category!=BuildSmoke"` — 163/163 passed
- `dotnet test ... --filter "Category=BuildSmoke"` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)