### PR TITLE
Retry transient same-file locks in NPC rename/GUID pipeline

### DIFF
--- a/FRBDK/Glue/NpcWpfLib/Managers/GuidLogic.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/GuidLogic.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,6 +8,12 @@ using ToolsUtilities;
 
 namespace Npc.Managers
 {
+    // GuidLogic runs immediately after ProjectCreationHelper has already renamed and rewritten
+    // these same .csproj/.sln/AssemblyInfo.cs files (RenameFiles' move, UpdateSolutionContents,
+    // UpdateNamespaces), so every read/write here is a second-or-later touch of a file Glue's own
+    // prior step just released. A transient lock (AV scan, indexer) on that handoff would surface
+    // as a raw IOException, same shape as the .sln file-lock bug fixed in VSSolution.cs - retry
+    // with the same policy here.
     public static class GuidLogic
     {
         public static void ReplaceGuids(string unpackDirectory)
@@ -64,13 +71,17 @@ namespace Npc.Managers
         {
             var fileName = GetSingleFileByExtension(unpackDirectory, extension);
 
-            var contents = FileManager.FromFileText(fileName);
+            var contents = RetryHelper.Retry(
+                () => FileManager.FromFileText(fileName),
+                isTransient: ex => ex is IOException);
 
             // Just in case cases are mixed/inconsistent:
             contents = contents.Replace(oldGuid.ToLowerInvariant(), newGuid.ToLowerInvariant());
             contents = contents.Replace(oldGuid.ToUpperInvariant(), newGuid.ToUpperInvariant());
 
-            FileManager.SaveText(contents, fileName);
+            RetryHelper.Retry(
+                () => FileManager.SaveText(contents, fileName),
+                isTransient: ex => ex is IOException);
         }
 
         private static void ReplaceSlnGuids(string newGuid)
@@ -87,7 +98,9 @@ namespace Npc.Managers
             {
                 if (s.Contains("assemblyinfo.cs", StringComparison.OrdinalIgnoreCase))
                 {
-                    string contents = FileManager.FromFileText(s);
+                    string contents = RetryHelper.Retry(
+                        () => FileManager.FromFileText(s),
+                        isTransient: ex => ex is IOException);
 
 
                     string newLine = "[assembly: Guid(\"" + newGuid + "\")]";
@@ -95,7 +108,9 @@ namespace Npc.Managers
                     StringFunctions.ReplaceLine(
                         ref contents, "[assembly: Guid(", newLine);
 
-                    FileManager.SaveText(contents, s);
+                    RetryHelper.Retry(
+                        () => FileManager.SaveText(contents, s),
+                        isTransient: ex => ex is IOException);
                 }
 
             }
@@ -103,7 +118,9 @@ namespace Npc.Managers
 
         private static string GetGUID(string projectLocation)
         {
-            string projectContents = FileManager.FromFileText(projectLocation);
+            string projectContents = RetryHelper.Retry(
+                () => FileManager.FromFileText(projectLocation),
+                isTransient: ex => ex is IOException);
             int startIndex = projectContents.IndexOf("<ProjectGuid>{") + "<ProjectGuid>{".Length;
             int endIndex = projectContents.IndexOf("}</ProjectGuid>");
             if(startIndex == -1 || endIndex == -1)

--- a/FRBDK/Glue/NpcWpfLib/Managers/ProjectCreationHelper.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/ProjectCreationHelper.cs
@@ -445,6 +445,12 @@ public static class ProjectCreationHelper
         }
 
     }
+    // Renaming/GUID-replacing a new project touches the same .sln several times back-to-back
+    // (rename move, this content rewrite, EncodeSLNFiles' re-encode, then GuidLogic's GUID
+    // rewrite) with no external process in between - just Glue's own successive read/writes.
+    // A transient lock (AV scan, indexer, previous handle not yet released) on one of these
+    // touches would otherwise surface as a raw IOException popup, same shape as the .sln
+    // file-lock bug fixed in VSSolution.cs. Retry with the same policy here.
     private static void UpdateSolutionContents(string unpackDirectory, string stringToReplace, string stringToReplaceWith)
     {
         List<string> filesToFix = FileManager.GetAllFilesInDirectory(
@@ -453,11 +459,15 @@ public static class ProjectCreationHelper
 
         foreach (string fileName in filesToFix)
         {
-            string contents = FileManager.FromFileText(fileName);
+            string contents = RetryHelper.Retry(
+                () => FileManager.FromFileText(fileName),
+                isTransient: ex => ex is IOException);
 
             contents = contents.Replace(stringToReplace, stringToReplaceWith);
 
-            FileManager.SaveText(contents, fileName);
+            RetryHelper.Retry(
+                () => FileManager.SaveText(contents, fileName),
+                isTransient: ex => ex is IOException);
         }
         foreach (string fileName in filesToFix)
         {
@@ -495,13 +505,21 @@ public static class ProjectCreationHelper
     */
     static void EncodeSLNFiles(string FileName)
     {
-        string fileContents;
-        StreamReader streamRead = new StreamReader(FileName);
-        fileContents = streamRead.ReadToEnd();
-        streamRead.Close();
-        StreamWriter streamWrite = new StreamWriter(FileName, false, Encoding.UTF8);
-        streamWrite.Write(fileContents);
-        streamWrite.Close();
+        string fileContents = RetryHelper.Retry(
+            () =>
+            {
+                using StreamReader streamRead = new StreamReader(FileName);
+                return streamRead.ReadToEnd();
+            },
+            isTransient: ex => ex is IOException);
+
+        RetryHelper.Retry(
+            () =>
+            {
+                using StreamWriter streamWrite = new StreamWriter(FileName, false, Encoding.UTF8);
+                streamWrite.Write(fileContents);
+            },
+            isTransient: ex => ex is IOException);
     }
     private static void UpdateNamespaces(string unpackDirectory, string stringToReplace, string projectNamespace, string projectName)
     {

--- a/FRBDK/Glue/NpcWpfLib/Managers/RetryHelper.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/RetryHelper.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading;
+
+namespace Npc.Managers
+{
+    /// <summary>
+    /// Small reusable retry-with-backoff helper. Intended for transient failures such as a file
+    /// being briefly locked by another process (e.g. a just-exited subprocess whose file handle
+    /// hasn't fully released yet, an antivirus scan, or an IDE file watcher).
+    /// </summary>
+    /// <remarks>
+    /// This is a deliberate duplicate of FlatRedBall.Glue.Utilities.RetryHelper (in the Glue project's
+    /// Utilities folder). NpcWpfLib cannot reference that copy: Glue.csproj depends on NpcWpfLib.csproj,
+    /// so a reference the other way would be circular. Keep the two in sync if the retry policy changes.
+    /// </remarks>
+    public static class RetryHelper
+    {
+        public const int DefaultMaxAttempts = 3;
+        public static readonly TimeSpan DefaultInitialDelay = TimeSpan.FromMilliseconds(250);
+
+        /// <summary>
+        /// Invokes <paramref name="operation"/>, retrying up to <paramref name="maxAttempts"/> times
+        /// total if it throws an exception that <paramref name="isTransient"/> identifies as transient.
+        /// The delay between attempts starts at <paramref name="initialDelay"/> and doubles each retry.
+        /// A non-transient exception, or the exception from the final attempt, propagates to the caller.
+        /// </summary>
+        public static T Retry<T>(
+            Func<T> operation,
+            Func<Exception, bool> isTransient,
+            int maxAttempts = DefaultMaxAttempts,
+            TimeSpan? initialDelay = null)
+        {
+            if (maxAttempts < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxAttempts), "maxAttempts must be at least 1.");
+            }
+
+            var delay = initialDelay ?? DefaultInitialDelay;
+
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    return operation();
+                }
+                catch (Exception ex) when (attempt < maxAttempts && isTransient(ex))
+                {
+                    Thread.Sleep(delay);
+                    delay += delay;
+                }
+            }
+
+            // Unreachable: the loop above either returns on success, or - once attempt == maxAttempts -
+            // the `when` clause is false so the exception propagates out of the loop instead of being caught.
+            throw new InvalidOperationException("RetryHelper.Retry reached unreachable code.");
+        }
+
+        /// <summary>
+        /// Action overload of <see cref="Retry{T}"/>.
+        /// </summary>
+        public static void Retry(
+            Action operation,
+            Func<Exception, bool> isTransient,
+            int maxAttempts = DefaultMaxAttempts,
+            TimeSpan? initialDelay = null)
+        {
+            Retry<object>(
+                () => { operation(); return null; },
+                isTransient,
+                maxAttempts,
+                initialDelay);
+        }
+    }
+}

--- a/FRBDK/Glue/REFACTORING.md
+++ b/FRBDK/Glue/REFACTORING.md
@@ -1318,3 +1318,44 @@ exception; does not retry a non-transient exception). `Tests/GlueUnitTests/VSHel
 drives a real OS-level file lock — a background thread holds an exclusive `FileStream` on a temp `.sln`
 for 300ms — and confirms `VSSolution.AddExistingProject` retries past it and succeeds instead of throwing;
 ran clean over multiple repeats (no flakiness observed).
+
+### 2026-07-23 — Retry transient same-file locks in the rest of the NPC rename/GUID pipeline (issue #1894 follow-up)
+
+Audited the new-project-creation (NPC) pipeline (`ProjectCreationHelper.MakeNewProject` in `NpcWpfLib`
+and everything it calls) for the same bug shape as the `VSSolution.cs` `.sln` fix above: repeated raw
+file I/O against the *same* file with zero retry. Found it twice more, both in the rename/GUID pass that
+every new project goes through (`ProjectCreationHelper.RenameProject` → `GuidLogic.ReplaceGuids`):
+
+- `ProjectCreationHelper.UpdateSolutionContents` reads and rewrites every `.sln` (`FileManager.FromFileText`/
+  `SaveText`), then immediately re-reads and re-writes the same file again via `EncodeSLNFiles`
+  (`StreamReader`/`StreamWriter`) — two back-to-back raw-I/O touches on the same file, no external
+  process needed to race it.
+- `GuidLogic.ReplaceGuids` runs right after `RenameEverything` and re-reads/re-writes the very same
+  `.csproj`, `.sln`, and `AssemblyInfo.cs` files that `RenameFiles`/`UpdateSolutionContents`/
+  `UpdateNamespaces` just touched moments earlier in the same synchronous call chain — every
+  `FileManager.FromFileText`/`SaveText` call in `GetGUID`, `ReplaceGuidInFile`, and
+  `ReplaceAssemblyInfoGuids` is a second-or-later touch of a file Glue's own prior step just released.
+
+Wrapped all of the above with the same retry policy (`isTransient: ex => ex is IOException`, 3 attempts,
+250ms/500ms backoff). `NpcWpfLib` can't reference `FlatRedBall.Glue.Utilities.RetryHelper` directly —
+`Glue.csproj` depends on `NpcWpfLib.csproj`, so a reference the other way would be circular — so
+`Npc.Managers.RetryHelper` (`NpcWpfLib/Managers/RetryHelper.cs`) is a deliberate duplicate of the same
+class; keep the two in sync if the retry policy ever changes.
+
+Ruled out the rest of `UpdateNamespaces` (cs/xaml/csv/contentproj/glux/gluj/glej/glsj/razor/
+launchSettings.json regions): each of those file sets is touched exactly once across the whole pipeline
+with no preceding/following operation on the same file, so it's a one-shot write, not this bug shape —
+left alone per the task's own scope guidance rather than wrapping defensively.
+
+Tests: `Tests/GlueUnitTests/Projects/ProjectCreationHelperRetryTests.cs`, same technique as
+`VSSolutionRetryTests` — a background thread holds an exclusive lock on a temp `.sln`/`.csproj` for
+300ms while `ProjectCreationHelper.RenameProject`/`GuidLogic.ReplaceGuids` runs on the main thread —
+confirms both retry past the lock and succeed instead of throwing. Full fast suite (165 tests) green
+afterward.
+
+Most time went to figuring out *where* to put the retry helper once NpcWpfLib turned out unable to
+reference Glue's copy (the dependency runs the opposite direction) — traced the project-reference graph
+before settling on a same-policy duplicate rather than restructuring project layering for one class. The
+first version of the `GuidLogic` retry test also failed for an unrelated reason (forgot the `.sln` file
+`ReplaceGuids` also expects to find alongside the `.csproj`), fixed by mirroring the existing
+`ReplaceGuids_ShouldReplaceLegacyProjectGuid` test's fixture shape.

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/ProjectCreationHelperRetryTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/ProjectCreationHelperRetryTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Npc;
+using Npc.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+// Pins retry-on-transient-lock behavior for the new-project-creation (NPC) rename/GUID pipeline.
+// RenameProject/GuidLogic.ReplaceGuids touch the same .sln/.csproj file several times back-to-back
+// (a rename move, a content rewrite, a GUID rewrite) with no external process in between - just
+// Glue's own successive reads/writes. Same bug shape as the VSSolution.cs .sln file-lock fix: a
+// transient lock (AV scan, indexer, previous handle not yet released) on one of these touches used
+// to surface as a raw IOException instead of being retried.
+public class ProjectCreationHelperRetryTests
+{
+    [Fact]
+    public void RenameProject_ShouldRetryAndSucceed_WhenSolutionFileIsTransientlyLockedByAnotherProcess()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"NpcRetryTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        // Named as the *target* project name already, so RenameFiles' File.Move never touches it -
+        // only its text content ("GameTemplate") needs rewriting, which is what exercises
+        // UpdateSolutionContents/EncodeSLNFiles.
+        var slnPath = Path.Combine(tempDir, "MyGame.sln");
+        File.WriteAllText(slnPath,
+            "Microsoft Visual Studio Solution File, Format Version 12.00\r\n" +
+            "Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"GameTemplate\", \"GameTemplate.csproj\", \"{11111111-1111-1111-1111-111111111111}\"\r\n" +
+            "EndProject\r\n" +
+            "Global\r\nEndGlobal");
+
+        try
+        {
+            using var lockAcquired = new ManualResetEventSlim(false);
+
+            // Simulate another process (AV scan, indexer, a handle from Glue's own prior touch not
+            // yet released) holding an exclusive lock on the .sln for a short time.
+            var lockTask = Task.Run(() =>
+            {
+                using var lockStream = new FileStream(
+                    slnPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                lockAcquired.Set();
+                Thread.Sleep(300);
+            });
+
+            lockAcquired.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue("background thread should have locked the file");
+
+            Should.NotThrow(() =>
+                ProjectCreationHelper.RenameProject("MyGame", "GameTemplate", newNamespace: null, tempDir));
+
+            lockTask.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
+            var resultContents = File.ReadAllText(slnPath);
+            resultContents.ShouldContain("MyGame");
+            resultContents.ShouldNotContain("GameTemplate");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReplaceGuids_ShouldRetryAndSucceed_WhenCsprojFileIsTransientlyLockedByAnotherProcess()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"NpcRetryTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        const string oldGuid = "ABCDEF00-AAAA-BBBB-CCCC-DDDDEEEEFFFF";
+        var csprojPath = Path.Combine(tempDir, "MyGame.csproj");
+        File.WriteAllText(csprojPath,
+            $"<Project><PropertyGroup><ProjectGuid>{{{oldGuid}}}</ProjectGuid></PropertyGroup></Project>");
+        // ReplaceGuids also rewrites the guid in the .sln (a legacy/non-SDK project always ships one).
+        File.WriteAllText(Path.Combine(tempDir, "MyGame.sln"),
+            $"Project(\"{{{oldGuid}}}\") = \"MyGame\"");
+
+        try
+        {
+            using var lockAcquired = new ManualResetEventSlim(false);
+
+            var lockTask = Task.Run(() =>
+            {
+                using var lockStream = new FileStream(
+                    csprojPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                lockAcquired.Set();
+                Thread.Sleep(300);
+            });
+
+            lockAcquired.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue("background thread should have locked the file");
+
+            Should.NotThrow(() => GuidLogic.ReplaceGuids(tempDir));
+
+            lockTask.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
+            File.ReadAllText(csprojPath).ShouldNotContain(oldGuid);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Audited the new-project-creation (NPC) pipeline for the same bug shape as the `.sln` transient-lock fix in `VSSolution.cs` (issue #1894): sequential raw file I/O against the *same* file with zero retry. Found two more instances, both in the rename/GUID pass every new project goes through:

- `ProjectCreationHelper.UpdateSolutionContents` reads/rewrites every `.sln`, then immediately re-reads/re-writes the same file again via `EncodeSLNFiles` - two back-to-back raw-I/O touches, no external process needed to race it.
- `GuidLogic.ReplaceGuids` runs right after `RenameEverything` and re-reads/re-writes the very same `.csproj`/`.sln`/`AssemblyInfo.cs` files that `RenameFiles`/`UpdateSolutionContents`/`UpdateNamespaces` just touched moments earlier in the same call chain.

Wrapped both with the same retry policy (`isTransient: ex => ex is IOException`, 3 attempts, 250ms/500ms backoff). `NpcWpfLib` can't reference `FlatRedBall.Glue.Utilities.RetryHelper` directly (`Glue.csproj` depends on `NpcWpfLib.csproj`, so referencing the other way would be circular), so `NpcWpfLib/Managers/RetryHelper.cs` is a deliberate duplicate - kept in sync in a doc comment.

Ruled out the rest of `UpdateNamespaces` (cs/xaml/csv/contentproj/glux/gluj/glej/glsj/razor/launchSettings.json): each file set is touched exactly once across the pipeline with nothing else racing it - not this bug shape, left alone.

Part of #1894

## Test plan
- [x] `Tests/GlueUnitTests/Projects/ProjectCreationHelperRetryTests.cs` - two new tests, each holding a real OS-level exclusive file lock on a temp `.sln`/`.csproj` for 300ms on a background thread while `RenameProject`/`GuidLogic.ReplaceGuids` runs, confirming both retry past it and succeed
- [x] Full fast suite green: `dotnet test "Glue with All.sln" --filter "Category!=BuildSmoke"` - 165/165 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)