### PR TITLE
Fix NineSlice/Sprite/Container Gum codegen bugs (Animate, RenderTargetTextureSource, SourceShaderFile)

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/ContainerCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/ContainerCodeGenerator.cs
@@ -84,21 +84,30 @@ public class ContainerCodeGenerator
 
     internal void AddTypeSpecificVariableNamesToSkipForStates(Dictionary<string, List<string>> typeSpecificVariableNamesToSkipForStates)
     {
+        // Container has no backing runtime type at all (StandardsCodeGenerator.mStandardElementToQualifiedTypes["Container"]
+        // is null - CreateContainedObjectMembers generates against a bare IRenderableIpso cast instead).
+        // "SourceShaderFile" (Gum v3) has no equivalent surface on Container - permanent, version-
+        // independent skip, unlike Alpha/Blend/IsRenderTarget below which are real InvisibleRenderable-backed
+        // properties gated on HasIsRenderTarget.
+        var variablesToSkip = new List<string> { "SourceShaderFile" };
 
         if(!HasIsRenderTarget)
         {
-            typeSpecificVariableNamesToSkipForStates["Container"] = new List<string>
-            {
-                "Alpha",
-                "Blend",
-                "IsRenderTarget"
-            };
+            variablesToSkip.Add("Alpha");
+            variablesToSkip.Add("Blend");
+            variablesToSkip.Add("IsRenderTarget");
         }
+
+        typeSpecificVariableNamesToSkipForStates["Container"] = variablesToSkip;
     }
 
     internal void AddTypeSpecificVariableNamesToSkipForProperties(Dictionary<string, List<string>> typedVariableNamesToSkipForProperties)
     {
-
+        // See AddTypeSpecificVariableNamesToSkipForStates above - Container has no backing runtime type,
+        // so "SourceShaderFile" can't back a generated property at any version. Left unskipped it's
+        // generated against ((RenderingLibrary.Graphics.IRenderableIpso)this.RenderableComponent), which
+        // has no such member (CS1061).
+        typedVariableNamesToSkipForProperties.Add("Container", new List<string> { "SourceShaderFile" });
     }
 }
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/SpriteCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/SpriteCodeGenerator.cs
@@ -74,6 +74,18 @@ public class SpriteCodeGenerator
 
     }
 
+    internal void AddTypeSpecificVariableNamesToSkipForProperties(Dictionary<string, List<string>> typedVariableNamesToSkipForProperties)
+    {
+        // RenderTargetTextureSource is entirely handled by GenerateIRenderTargetTextureReferencerProperties
+        // below (correctly typed as IRenderableIpso?, gated on GluxVersions.GumHasIRenderTargetTextureReferencer).
+        // The generic property-generation loop must never also generate it from the raw schema (Type
+        // "string") - left unskipped, it either mismatches the real backing type (CS0029, below the gate,
+        // where it's never generated at all) or duplicates SpriteCodeGenerator's own emission (CS0102, at/
+        // above the gate). Permanent, version-independent skip - SpriteCodeGenerator is always the sole
+        // source when this property exists.
+        typedVariableNamesToSkipForProperties.Add("Sprite", new List<string> { "RenderTargetTextureSource" });
+    }
+
     public void AddAdditionalInheritance(StandardElementSave standardElementSave, List<string> inheritanceList)
     {
         if (standardElementSave.Name != "Sprite")

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
@@ -127,6 +127,8 @@ namespace GumPlugin.CodeGeneration
 
             _nineSliceCodeGenerator.AddTypeSpecificVariableNamesToSkipForProperties(_typedVariableNamesToSkipForProperties);
 
+            _spriteCodeGenerator.AddTypeSpecificVariableNamesToSkipForProperties(_typedVariableNamesToSkipForProperties);
+
             // Gum's "Rectangle" and "Circle" standard elements (StandardElementsManager v3 standard
             // surface - see Gum issues #2929/#2931/#3009/#3617) now define a fill/stroke/gradient/
             // dropshadow/blend variable family on their default state. Glue maps both of these

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
@@ -99,6 +99,12 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         mVariableNamesToSkipForStates.Add("ContainedType");
         mVariableNamesToSkipForStates.Add("IsXamarinFormsControl");
         mVariableNamesToSkipForStates.Add("IsOverrideInCodeGen");
+
+        // Mirrors the property-pipeline exclusion in SpriteCodeGenerator.AddTypeSpecificVariableNamesToSkipForProperties -
+        // Sprite's RenderTargetTextureSource is only ever a plain get/set pass-through to ContainedSprite
+        // (SpriteCodeGenerator.GenerateIRenderTargetTextureReferencerProperties), never state-switch driven.
+        // Permanent, version-independent skip - the name is unique to Sprite so a global skip is safe.
+        mVariableNamesToSkipForStates.Add("RenderTargetTextureSource");
         //mVariableNamesToSkipForStates.Add("IsBold");
 
         // Eventually we'll support this but first Gum needs to support
@@ -183,6 +189,18 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         else
         {
             Skip("IsTilingMiddleSections");
+        }
+
+        // Mirrors the property-pipeline gate in NineSliceCodeGenerator.HasNineSliceAnimate. "Animate"
+        // only exists on NineSlice, so a global skip here is fine (same precedent as StackSpacing/
+        // IsTilingMiddleSections above) - older projects don't have a NineSlice with this variable.
+        if (version >= (int)GluxVersions.GumNineSliceHasAnimate)
+        {
+            Include("Animate");
+        }
+        else
+        {
+            Skip("Animate");
         }
 
         if (version >= (int)GluxVersions.GumTextHasIsBold)

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumStandardElementCodegenSweepTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumStandardElementCodegenSweepTests.cs
@@ -22,31 +22,33 @@ namespace GlueUnitTests.GumPluginTests;
 // canonical always-current schema - see that file's header comment for why this beats driving fresh
 // project creation (stale embedded templates never reconcile against the canonical schema).
 //
-// Sweep result: only Text and ColoredRectangle turned out clean. The other four are NOT covered here:
-//  - NineSlice: real bug. "Animate" is skipped in the property pipeline below GluxVersions.
-//    GumNineSliceHasAnimate (NineSliceCodeGenerator.HasNineSliceAnimate) but is NOT gated at all in
-//    StateCodeGenerator.RefreshVariableNamesToSkipBasedOnGlueVersion, so the state-switch still emits
-//    "Animate = value;" against a property that was never generated - CS0103 for any project below that
-//    version with a NineSlice standard element.
-//  - Sprite: real bug. "RenderTargetTextureSource" is a plain default-state variable (Type "string",
-//    never added to any skip list) so the generic property loop generates
-//    "public string RenderTargetTextureSource" backed by ContainedSprite.RenderTargetTextureSource,
-//    which is actually "IRenderableIpso?" (CS0029). At/above GluxVersions.
-//    GumHasIRenderTargetTextureReferencer, SpriteCodeGenerator additionally emits its own, correctly
-//    typed "RenderTargetTextureSource" property, so the two collide (CS0102 duplicate member).
-//  - Container: real bug. "SourceShaderFile" (Gum v3) is never added to any skip list, so it's
-//    generated against "((RenderingLibrary.Graphics.IRenderableIpso)this.RenderableComponent)"
-//    (Container's null-backing-type contained-object expression), and IRenderableIpso has no
-//    SourceShaderFile member - CS1061.
+// Sweep result: only Text and ColoredRectangle turned out clean on the first pass. Three real, live bugs
+// were found and are now fixed (and pinned below), plus one non-bug:
+//  - NineSlice: "Animate" was skipped in the property pipeline below GluxVersions.GumNineSliceHasAnimate
+//    (NineSliceCodeGenerator.HasNineSliceAnimate) but had no matching gate in StateCodeGenerator.
+//    RefreshVariableNamesToSkipBasedOnGlueVersion, so the state-switch still emitted "Animate = value;"
+//    against a property that was never generated - CS0103 for any project below that version with a
+//    NineSlice standard element. Fixed by adding the missing paired Include/Skip("Animate") block to
+//    RefreshVariableNamesToSkipBasedOnGlueVersion, gated on the same GumNineSliceHasAnimate value.
+//  - Sprite: "RenderTargetTextureSource" was a plain default-state variable (Type "string", never added
+//    to any skip list) so the generic property loop generated "public string RenderTargetTextureSource"
+//    backed by ContainedSprite.RenderTargetTextureSource, which is actually "IRenderableIpso?" (CS0029).
+//    At/above GluxVersions.GumHasIRenderTargetTextureReferencer, SpriteCodeGenerator additionally emits
+//    its own, correctly typed "RenderTargetTextureSource" property, so the two collided (CS0102 duplicate
+//    member) instead. Fixed with a permanent (version-independent) skip in both pipelines -
+//    SpriteCodeGenerator.GenerateIRenderTargetTextureReferencerProperties is the sole source whenever this
+//    property exists at all.
+//  - Container: "SourceShaderFile" (Gum v3) was never added to any skip list, so it was generated against
+//    "((RenderingLibrary.Graphics.IRenderableIpso)this.RenderableComponent)", and IRenderableIpso has no
+//    such member - CS1061. Container has no backing runtime type at all
+//    (StandardsCodeGenerator.mStandardElementToQualifiedTypes["Container"] is null), so this is a
+//    permanent skip in both pipelines, not version-gated.
 //  - SolidRectangle: not applicable, not a bug. "SolidRectangle" is not a registered standard element
 //    in Gum.Managers.StandardElementsManager at all - only "ColoredRectangle" (kept for legacy loading;
 //    Gum's v3 Rectangle absorbed its role). GetDefaultStateFor("SolidRectangle") throws
 //    InvalidOperationException, so no fixture can be built via this technique; see
 //    GenerateStandardElementSaveCodeFor_SolidRectangle_HasNoCanonicalDefaultState below, which pins that
 //    absence rather than a codegen behavior.
-//
-// Per the fix-coordination rule for this sweep, the four bugs above are reported to the orchestrator in
-// detail rather than fixed or pinned with a red test here.
 [Collection(nameof(TaskManagerSequentialCollection))]
 public class GumStandardElementCodegenSweepTests : IDisposable
 {
@@ -203,5 +205,135 @@ public class GumStandardElementCodegenSweepTests : IDisposable
         // not a bug.
         Should.Throw<Exception>(() =>
             Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("SolidRectangle"));
+    }
+
+    [Fact]
+    public void GenerateStandardElementSaveCodeFor_NineSlice_BelowAnimateGate_ShouldNotReferenceAnimateAtAll()
+    {
+        // Below GluxVersions.GumNineSliceHasAnimate, the property pipeline already skipped "Animate"
+        // (NineSliceCodeGenerator.HasNineSliceAnimate) before this fix - the bug was that the state
+        // pipeline didn't, so the state-switch alone still referenced it (CS0103). Pin the whole surface:
+        // neither pipeline should mention "Animate" at all below the gate.
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject.FileVersion = 0;
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = new StandardElementSave { Name = "NineSlice" };
+        standardElementSave.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("NineSlice"));
+
+        // Sanity check on the fixture: if this ever fails, the fixture stopped carrying the vulnerable
+        // variable and this test would silently stop pinning anything.
+        var fixtureVariableNames = standardElementSave.DefaultState.Variables.Select(v => v.GetRootName()).ToHashSet();
+        fixtureVariableNames.ShouldContain("Animate");
+
+        var codeBlock = new CodeBlockBase();
+        var generated = StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+        generated.ShouldBeTrue();
+
+        codeBlock.ToString().ShouldNotContain("Animate");
+    }
+
+    [Fact]
+    public void GenerateStandardElementSaveCodeFor_NineSlice_AtAnimateGate_ShouldGenerateAndAssignAnimate()
+    {
+        // At/above the gate, both pipelines must agree the property exists: a generated property
+        // declaration AND a state-switch assignment referencing it.
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject.FileVersion = (int)FlatRedBall.Glue.SaveClasses.GlueProjectSave.GluxVersions.GumNineSliceHasAnimate;
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = new StandardElementSave { Name = "NineSlice" };
+        standardElementSave.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("NineSlice"));
+
+        var codeBlock = new CodeBlockBase();
+        var generated = StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+        generated.ShouldBeTrue();
+
+        var generatedSource = codeBlock.ToString();
+
+        // Property declaration (generic property-generation loop, driven by the schema's own type for
+        // "Animate") and the state-switch assignment both need to be present - if either pipeline alone
+        // skipped/included it, this would be exactly one or the other, not both.
+        var animateMentions = System.Text.RegularExpressions.Regex.Matches(generatedSource, "Animate").Count;
+        animateMentions.ShouldBeGreaterThanOrEqualTo(2);
+        generatedSource.ShouldContain("Animate = ");
+    }
+
+    [Fact]
+    public void GenerateStandardElementSaveCodeFor_Sprite_BelowRenderTargetTextureSourceGate_ShouldNotGenerateIt()
+    {
+        // Below GluxVersions.GumHasIRenderTargetTextureReferencer, SpriteCodeGenerator itself generates
+        // nothing for "RenderTargetTextureSource" - before this fix, the generic property loop still
+        // generated "public string RenderTargetTextureSource" backed by ContainedSprite.
+        // RenderTargetTextureSource, which is actually IRenderableIpso? (CS0029).
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject.FileVersion = 0;
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = new StandardElementSave { Name = "Sprite" };
+        standardElementSave.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("Sprite"));
+
+        // Sanity check on the fixture: if this ever fails, the fixture stopped carrying the vulnerable
+        // variable and this test would silently stop pinning anything.
+        var fixtureVariableNames = standardElementSave.DefaultState.Variables.Select(v => v.GetRootName()).ToHashSet();
+        fixtureVariableNames.ShouldContain("RenderTargetTextureSource");
+
+        var codeBlock = new CodeBlockBase();
+        var generated = StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+        generated.ShouldBeTrue();
+
+        codeBlock.ToString().ShouldNotContain("RenderTargetTextureSource");
+    }
+
+    [Fact]
+    public void GenerateStandardElementSaveCodeFor_Sprite_AtRenderTargetTextureSourceGate_ShouldGenerateOnlyTypedVersionOnce()
+    {
+        // At/above the gate, SpriteCodeGenerator.GenerateIRenderTargetTextureReferencerProperties emits
+        // the correctly-typed IRenderableIpso? property (plus the explicit interface implementation).
+        // Before this fix, the generic property loop ALSO generated a plain-string version of the same
+        // name, producing a duplicate member (CS0102).
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject.FileVersion = (int)FlatRedBall.Glue.SaveClasses.GlueProjectSave.GluxVersions.GumHasIRenderTargetTextureReferencer;
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = new StandardElementSave { Name = "Sprite" };
+        standardElementSave.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("Sprite"));
+
+        var codeBlock = new CodeBlockBase();
+        var generated = StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+        generated.ShouldBeTrue();
+
+        var generatedSource = codeBlock.ToString();
+
+        // Only SpriteCodeGenerator's own correctly-typed property/explicit-interface-implementation pair
+        // should exist - never the generic loop's plain "string" version.
+        generatedSource.ShouldNotContain("public string RenderTargetTextureSource");
+        generatedSource.ShouldContain("public global::RenderingLibrary.Graphics.IRenderableIpso? RenderTargetTextureSource");
+        generatedSource.ShouldContain("global::RenderingLibrary.Graphics.IRenderTargetTextureReferencer.RenderTargetTextureSource");
+
+        // Never state-switch driven at any version (see the permanent skip in
+        // StateCodeGenerator.RefreshVariablesToSkipForStates) - it's a plain get/set pass-through.
+        generatedSource.ShouldNotContain("RenderTargetTextureSource = null");
+        generatedSource.ShouldNotContain("RenderTargetTextureSource = \"\"");
+    }
+
+    [Fact]
+    public void GenerateStandardElementSaveCodeFor_Container_ShouldNotGenerateSourceShaderFile()
+    {
+        // Container has no backing runtime type at all (mStandardElementToQualifiedTypes["Container"] is
+        // null) - before this fix, "SourceShaderFile" (Gum v3) was generated against a bare
+        // IRenderableIpso cast, which has no such member (CS1061). Permanent skip, not version-gated, so
+        // this uses the class's default LatestVersion fixture setup.
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = new StandardElementSave { Name = "Container" };
+        standardElementSave.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("Container"));
+
+        // Sanity check on the fixture: if this ever fails, the fixture stopped carrying the vulnerable
+        // variable and this test would silently stop pinning anything.
+        var fixtureVariableNames = standardElementSave.DefaultState.Variables.Select(v => v.GetRootName()).ToHashSet();
+        fixtureVariableNames.ShouldContain("SourceShaderFile");
+
+        var codeBlock = new CodeBlockBase();
+        var generated = StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+        generated.ShouldBeTrue();
+
+        codeBlock.ToString().ShouldNotContain("SourceShaderFile");
     }
 }


### PR DESCRIPTION
## Summary

Fixes three more instances of the Rectangle/Circle CS1061 bug class (#1907/#1908): a Gum standard element's default-state schema defines a variable its Glue-mapped backing runtime type can't support.

- **NineSlice `Animate`** — property pipeline already gated it below `GluxVersions.GumNineSliceHasAnimate`, but the state pipeline had no matching gate, so the state-switch still referenced it (CS0103) on older projects. Added the missing paired gate to `StateCodeGenerator.RefreshVariableNamesToSkipBasedOnGlueVersion`.
- **Sprite `RenderTargetTextureSource`** — never skipped from the generic property loop, which generated it as the schema's plain `string` type. Below `GluxVersions.GumHasIRenderTargetTextureReferencer` this mismatched the real backing type (`IRenderableIpso?`, CS0029); at/above it, it duplicated `SpriteCodeGenerator`'s own correctly-typed property (CS0102). Added a permanent skip in both pipelines — `SpriteCodeGenerator` is now the sole source.
- **Container `SourceShaderFile`** (Gum v3) — never skipped, generated against a bare `IRenderableIpso` cast with no such member (CS1061). Container has no backing runtime type at all, so this is a permanent skip in both pipelines.

Part of #1894

## Test plan

- Added regression tests to `GumStandardElementCodegenSweepTests.cs`, with below/at-gate coverage for the two version-gated bugs (NineSlice, Sprite) and a single test for Container's permanent skip.
- Verified each fix is a real tripwire (temporarily reverted, confirmed red, restored).
- `dotnet test "Glue with All.sln" --filter "Category!=BuildSmoke"` — 214/214 passing, no regressions.