### PR TITLE
Fix cross-thread WPF crash in duplicate project entry dialog

### DIFF
--- a/FRBDK/Glue/Glue/Tasks/TaskManager.cs
+++ b/FRBDK/Glue/Glue/Tasks/TaskManager.cs
@@ -876,6 +876,18 @@ namespace FlatRedBall.Glue.Managers
             }
         }
 
+        public T OnUiThread<T>(Func<T> action)
+        {
+            if (IsOnUiThread)
+            {
+                return action();
+            }
+            else
+            {
+                return UiThreadMarshaller.Invoke(action);
+            }
+        }
+
         public void BeginOnUiThread(Action action)
         {
             if (IsOnUiThread)

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/DuplicateProjectEntryDialog.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/DuplicateProjectEntryDialog.cs
@@ -1,0 +1,49 @@
+using System;
+using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Managers;
+
+namespace FlatRedBall.Glue.VSHelpers.Projects
+{
+    public enum DuplicateProjectEntryResolution
+    {
+        RemoveDuplicate,
+        RemoveDuplicateAndShowList,
+        CancelLoad
+    }
+
+    /// <summary>
+    /// Asks the user how to resolve a duplicate project entry found while loading a .csproj. Shown behind a
+    /// swappable <see cref="Show"/> delegate (same seam shape as <see cref="TaskManager.UiThreadMarshaller"/>)
+    /// so <see cref="VisualStudioProject.ResolveDuplicateProjectEntry"/>'s branch logic can be unit tested
+    /// without a live WPF window, and so the WPF construction always happens on the UI thread even when the
+    /// caller (e.g. a project reload queued via TaskManager) is running on a background thread.
+    /// </summary>
+    public static class DuplicateProjectEntryDialog
+    {
+        public static Func<string, DuplicateProjectEntryResolution> Show { get; set; } = ShowWpfDialog;
+
+        private static DuplicateProjectEntryResolution ShowWpfDialog(string itemInclude)
+        {
+            return TaskManager.Self.OnUiThread(() =>
+            {
+                var mbmb = new MultiButtonMessageBoxWpf();
+
+                mbmb.MessageText = "The item " + itemInclude + " is part of " +
+                    "the project twice.  Glue does not support double-entries in a project.  What would you like to do?";
+
+                mbmb.AddButton("Remove the duplicate entry and continue", DuplicateProjectEntryResolution.RemoveDuplicate);
+                mbmb.AddButton("Remove the duplicate, but show me a list of all contained objects before removal", DuplicateProjectEntryResolution.RemoveDuplicateAndShowList);
+                mbmb.AddButton("Cancel loading the project - this will throw an exception", DuplicateProjectEntryResolution.CancelLoad);
+
+                if (mbmb.ShowDialog() == true)
+                {
+                    return (DuplicateProjectEntryResolution)mbmb.ClickedResult;
+                }
+
+                // Window closed without a button click (e.g. Escape) - preserve the original behavior of
+                // silently removing the duplicate.
+                return DuplicateProjectEntryResolution.RemoveDuplicate;
+            });
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -844,52 +844,31 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             }
         }
 
-        private void ResolveDuplicateProjectEntry(ProjectItem buildItem)
+        internal void ResolveDuplicateProjectEntry(ProjectItem buildItem)
         {
-            var mbmb = new MultiButtonMessageBoxWpf();
+            var resolution = DuplicateProjectEntryDialog.Show(buildItem.UnevaluatedInclude);
 
-            mbmb.MessageText = "The item " + buildItem.UnevaluatedInclude + " is part of " +
-                "the project twice.  Glue does not support double-entries in a project.  What would you like to do?";
-
-            mbmb.AddButton("Remove the duplicate entry and continue", System.Windows.Forms.DialogResult.OK);
-            mbmb.AddButton("Remove the duplicate, but show me a list of all contained objects before removal", System.Windows.Forms.DialogResult.No);
-            mbmb.AddButton("Cancel loading the project - this will throw an exception", System.Windows.Forms.DialogResult.Cancel);
-
-            DialogResult result = DialogResult.Cancel;
-
-            if (mbmb.ShowDialog() == true)
+            switch (resolution)
             {
-                result = (DialogResult)mbmb.ClickedResult;
-                switch (result)
-                {
-                    case DialogResult.OK:
-                        mProject.RemoveItem(buildItem);
-                        mProject.ReevaluateIfNecessary();
-                        break;
-                    case DialogResult.No:
-                        StringBuilder stringBuilder = new StringBuilder();
-                        foreach (var item in mProject.AllEvaluatedItems)
-                        {
-                            stringBuilder.AppendLine(item.ItemType + " " + item.UnevaluatedInclude);
-                        }
-                        string whereToSave = FileManager.UserApplicationDataForThisApplication + "ProjectFileOutput.txt";
-                        FileManager.SaveText(stringBuilder.ToString(), whereToSave);
-                        Process.Start(new ProcessStartInfo(whereToSave) { UseShellExecute = true });
+                case DuplicateProjectEntryResolution.RemoveDuplicate:
+                    mProject.RemoveItem(buildItem);
+                    mProject.ReevaluateIfNecessary();
+                    break;
+                case DuplicateProjectEntryResolution.RemoveDuplicateAndShowList:
+                    StringBuilder stringBuilder = new StringBuilder();
+                    foreach (var item in mProject.AllEvaluatedItems)
+                    {
+                        stringBuilder.AppendLine(item.ItemType + " " + item.UnevaluatedInclude);
+                    }
+                    string whereToSave = FileManager.UserApplicationDataForThisApplication + "ProjectFileOutput.txt";
+                    FileManager.SaveText(stringBuilder.ToString(), whereToSave);
+                    Process.Start(new ProcessStartInfo(whereToSave) { UseShellExecute = true });
 
-
-                        mProject.RemoveItem(buildItem);
-                        mProject.ReevaluateIfNecessary();
-                        break;
-                    case DialogResult.Cancel:
-                        throw new Exception("Duplicate entries found: " + buildItem.ItemType + " " + buildItem.UnevaluatedInclude);
-                }
-
-            }
-            else
-            {
-                //mProject.EvaluatedItems.RemoveItemAt(i);
-                mProject.RemoveItem(buildItem);
-                mProject.ReevaluateIfNecessary();
+                    mProject.RemoveItem(buildItem);
+                    mProject.ReevaluateIfNecessary();
+                    break;
+                case DuplicateProjectEntryResolution.CancelLoad:
+                    throw new Exception("Duplicate entries found: " + buildItem.ItemType + " " + buildItem.UnevaluatedInclude);
             }
         }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs
@@ -139,11 +139,26 @@ public class TaskManagerUiThreadMarshallerTests : System.IDisposable
 
         // The xunit test thread is never MainGlueWindow's UI thread, so IsOnUiThread is false here,
         // exercising the marshaller branch.
+        // Block-bodied lambda: see the identical note on GlueTask_WithDoOnUiThread below - an
+        // expression-bodied `() => ran = true` is ambiguous between the Action and Func<T> overloads
+        // now that OnUiThread<T> exists, and would otherwise resolve to OnUiThread<T> instead.
         TaskManager.Self.IsOnUiThread.ShouldBeFalse();
-        TaskManager.Self.OnUiThread(() => ran = true);
+        TaskManager.Self.OnUiThread(() => { ran = true; });
 
         ran.ShouldBeTrue();
         marshaller.InvokeActionCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void OnUiThread_Func_ShouldRouteThroughMarshallerAndReturnResult_WhenNotOnUiThread()
+    {
+        var marshaller = new RecordingInlineMarshaller();
+        TaskManager.UiThreadMarshaller = marshaller;
+
+        TaskManager.Self.IsOnUiThread.ShouldBeFalse();
+        var result = TaskManager.Self.OnUiThread(() => 42);
+
+        result.ShouldBe(42);
     }
 
     [Fact]

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/VisualStudioProjectDuplicateEntryTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/VisualStudioProjectDuplicateEntryTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using System.Linq;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+
+namespace GlueUnitTests.VSHelpers;
+
+// VisualStudioProject.ResolveDuplicateProjectEntry used to construct/show a WPF window
+// (MultiButtonMessageBoxWpf) directly. That's fine on Glue's UI thread, but a project reload triggered by
+// an external file change is queued via TaskManager.Self.Add(..., doOnUiThread: false) (see
+// UpdateReactor.TryHandleSpecificProjectFileChange), so this method can run on TaskManager's background
+// thread - crashing WPF with "Cannot access Freezable ... across threads because it cannot be frozen."
+// The dialog is now shown through DuplicateProjectEntryDialog.Show, a swappable seam (same shape as
+// TaskManager.UiThreadMarshaller) whose default implementation wraps the WPF construction in
+// TaskManager.Self.OnUiThread. These tests fake that seam so ResolveDuplicateProjectEntry's branch logic -
+// previously untestable, since it was entangled with a real WPF window - is pinned without popping a
+// dialog.
+public class VisualStudioProjectDuplicateEntryTests : IDisposable
+{
+    private readonly Func<string, DuplicateProjectEntryResolution> _originalShow = DuplicateProjectEntryDialog.Show;
+
+    public void Dispose()
+    {
+        DuplicateProjectEntryDialog.Show = _originalShow;
+    }
+
+    [Fact]
+    public void ResolveDuplicateProjectEntry_ShouldRemoveTheDuplicateItem_WhenResolutionIsRemoveDuplicate()
+    {
+        string? directory = null;
+        try
+        {
+            var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out directory);
+            project.Project.AddItem("Compile", "Foo.cs");
+            var duplicate = project.Project.AddItem("Compile", "Foo.cs").First();
+
+            DuplicateProjectEntryDialog.Show = _ => DuplicateProjectEntryResolution.RemoveDuplicate;
+
+            project.ResolveDuplicateProjectEntry(duplicate);
+
+            project.Project.GetItems("Compile").ShouldNotContain(duplicate);
+        }
+        finally
+        {
+            if (directory != null) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveDuplicateProjectEntry_ShouldThrow_WhenResolutionIsCancelLoad()
+    {
+        string? directory = null;
+        try
+        {
+            var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out directory);
+            project.Project.AddItem("Compile", "Foo.cs");
+            var duplicate = project.Project.AddItem("Compile", "Foo.cs").First();
+
+            DuplicateProjectEntryDialog.Show = _ => DuplicateProjectEntryResolution.CancelLoad;
+
+            Should.Throw<Exception>(() => project.ResolveDuplicateProjectEntry(duplicate))
+                .Message.ShouldContain("Foo.cs");
+        }
+        finally
+        {
+            if (directory != null) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveDuplicateProjectEntry_ShouldPassTheDuplicateItemsInclude_ToTheDialog()
+    {
+        string? directory = null;
+        try
+        {
+            var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out directory);
+            project.Project.AddItem("Compile", "Foo.cs");
+            var duplicate = project.Project.AddItem("Compile", "Foo.cs").First();
+
+            string? passedInclude = null;
+            DuplicateProjectEntryDialog.Show = include =>
+            {
+                passedInclude = include;
+                return DuplicateProjectEntryResolution.RemoveDuplicate;
+            };
+
+            project.ResolveDuplicateProjectEntry(duplicate);
+
+            passedInclude.ShouldBe("Foo.cs");
+        }
+        finally
+        {
+            if (directory != null) Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `VisualStudioProject.ResolveDuplicateProjectEntry` constructed/showed a WPF window directly. Project reloads triggered by an external file change are queued onto TaskManager's background thread (`doOnUiThread: false` in `UpdateReactor`), so a duplicate `.csproj` entry crashed WPF with `Cannot access Freezable ... across threads`.
- Extracted the dialog behind a swappable `DuplicateProjectEntryDialog.Show` delegate (same seam shape as `TaskManager.UiThreadMarshaller`); its WPF implementation now marshals via a new `TaskManager.OnUiThread<T>`.
- `ResolveDuplicateProjectEntry` now switches on a plain enum, decoupled from WPF — makes it unit-testable for the first time.

## Test plan
- [x] New unit tests pin `ResolveDuplicateProjectEntry`'s branch logic (remove / cancel / dialog input) via a fake `DuplicateProjectEntryDialog.Show`, no real WPF window involved.
- [x] New unit test pins `TaskManager.OnUiThread<T>` routing through the marshaller.
- [x] Full suite green: `dotnet test "Glue with All.sln" --filter "Category!=BuildSmoke"` — 218/218 passed.