### PR TITLE
Add ColorOperation.AddSubtract for genuine negative-channel subtraction

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Assets/Shaders/FlatRedBallShaderXNA4.fx
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Assets/Shaders/FlatRedBallShaderXNA4.fx
@@ -67,6 +67,19 @@ float4 SubtractPixelShader(a2v IN ) : COLOR
 	return color;
 }
 
+float4 AddSubtractPixelShader(a2v IN ) : COLOR
+{
+    // RGB were bias/scale-encoded into [0,1] on the CPU (VertexColorPacker) to survive the
+    // unsigned-normalized vertex color format; decode back to a signed [-1,1] value here.
+    float4 fromTexture =  tex2D(textureSampler, IN.texCoord).rgba;
+    float3 signedColor = IN.color.rgb * 2.0 - 1.0;
+    fromTexture[0] = (fromTexture[0] + signedColor[0] * fromTexture[3]) * IN.color[3];
+    fromTexture[1] = (fromTexture[1] + signedColor[1] * fromTexture[3]) * IN.color[3];
+    fromTexture[2] = (fromTexture[2] + signedColor[2] * fromTexture[3]) * IN.color[3];
+    fromTexture[3] = fromTexture[3] * IN.color[3];
+	return fromTexture;
+}
+
 float4 ModulatePixelShader(a2v IN ) : COLOR
 {
     float4 color =  tex2D(textureSampler, IN.texCoord).rgba;
@@ -160,6 +173,15 @@ technique Subtract
 	{
 		vertexshader = compile vs_1_1 vs();
 		pixelshader = compile ps_2_0 SubtractPixelShader();
+	}
+}
+
+technique AddSubtract
+{
+	pass p0
+	{
+		vertexshader = compile vs_1_1 vs();
+		pixelshader = compile ps_2_0 AddSubtractPixelShader();
 	}
 }
 

--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallShared.projitems
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallShared.projitems
@@ -138,6 +138,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\Text.PreRendered.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\TextManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\TextureCoordinateFlipper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Graphics\VertexColorPacker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\Texture\RenderTargetRenderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\Texture\RenderTargetSprite.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Gui\Controls\IButton.cs" />

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/CustomEffectManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/CustomEffectManager.cs
@@ -33,6 +33,7 @@ namespace FlatRedBall.Graphics
 
         EffectTechnique? _techniqueTexture;
         EffectTechnique? _techniqueAdd;
+        EffectTechnique? _techniqueAddSubtract;
         EffectTechnique? _techniqueSubtract;
         EffectTechnique? _techniqueModulate;
         EffectTechnique? _techniqueModulate2X;
@@ -44,6 +45,7 @@ namespace FlatRedBall.Graphics
 
         EffectTechnique? _techniqueTexture_CM;
         EffectTechnique? _techniqueAdd_CM;
+        EffectTechnique? _techniqueAddSubtract_CM;
         EffectTechnique? _techniqueSubtract_CM;
         EffectTechnique? _techniqueModulate_CM;
         EffectTechnique? _techniqueModulate2X_CM;
@@ -55,6 +57,7 @@ namespace FlatRedBall.Graphics
 
         EffectTechnique? _techniqueTexture_LN;
         EffectTechnique? _techniqueAdd_LN;
+        EffectTechnique? _techniqueAddSubtract_LN;
         EffectTechnique? _techniqueSubtract_LN;
         EffectTechnique? _techniqueModulate_LN;
         EffectTechnique? _techniqueModulate2X_LN;
@@ -66,6 +69,7 @@ namespace FlatRedBall.Graphics
 
         EffectTechnique? _techniqueTexture_LN_CM;
         EffectTechnique? _techniqueAdd_LN_CM;
+        EffectTechnique? _techniqueAddSubtract_LN_CM;
         EffectTechnique? _techniqueSubtract_LN_CM;
         EffectTechnique? _techniqueModulate_LN_CM;
         EffectTechnique? _techniqueModulate2X_LN_CM;
@@ -77,6 +81,7 @@ namespace FlatRedBall.Graphics
 
         EffectTechnique? _techniqueTexture_Linear;
         EffectTechnique? _techniqueAdd_Linear;
+        EffectTechnique? _techniqueAddSubtract_Linear;
         EffectTechnique? _techniqueSubtract_Linear;
         EffectTechnique? _techniqueModulate_Linear;
         EffectTechnique? _techniqueModulate2X_Linear;
@@ -88,6 +93,7 @@ namespace FlatRedBall.Graphics
 
         EffectTechnique? _techniqueTexture_Linear_CM;
         EffectTechnique? _techniqueAdd_Linear_CM;
+        EffectTechnique? _techniqueAddSubtract_Linear_CM;
         EffectTechnique? _techniqueSubtract_Linear_CM;
         EffectTechnique? _techniqueModulate_Linear_CM;
         EffectTechnique? _techniqueModulate2X_Linear_CM;
@@ -99,6 +105,7 @@ namespace FlatRedBall.Graphics
 
         EffectTechnique? _techniqueTexture_Linear_LN;
         EffectTechnique? _techniqueAdd_Linear_LN;
+        EffectTechnique? _techniqueAddSubtract_Linear_LN;
         EffectTechnique? _techniqueSubtract_Linear_LN;
         EffectTechnique? _techniqueModulate_Linear_LN;
         EffectTechnique? _techniqueModulate2X_Linear_LN;
@@ -110,6 +117,7 @@ namespace FlatRedBall.Graphics
 
         EffectTechnique? _techniqueTexture_Linear_LN_CM;
         EffectTechnique? _techniqueAdd_Linear_LN_CM;
+        EffectTechnique? _techniqueAddSubtract_Linear_LN_CM;
         EffectTechnique? _techniqueSubtract_Linear_LN_CM;
         EffectTechnique? _techniqueModulate_Linear_LN_CM;
         EffectTechnique? _techniqueModulate2X_Linear_LN_CM;
@@ -155,6 +163,7 @@ namespace FlatRedBall.Graphics
 
                     //_techniqueTexture = GetTechniqueSafe("Texture_Point"); // This has been already cached
                     _techniqueAdd = GetTechniqueSafe("Add_Point");
+                    _techniqueAddSubtract = GetTechniqueSafe("AddSubtract_Point");
                     _techniqueSubtract = GetTechniqueSafe("Subtract_Point");
                     _techniqueModulate = GetTechniqueSafe("Modulate_Point");
                     _techniqueModulate2X = GetTechniqueSafe("Modulate2X_Point");
@@ -166,6 +175,7 @@ namespace FlatRedBall.Graphics
 
                     _techniqueTexture_CM = GetTechniqueSafe("Texture_Point_CM");
                     _techniqueAdd_CM = GetTechniqueSafe("Add_Point_CM");
+                    _techniqueAddSubtract_CM = GetTechniqueSafe("AddSubtract_Point_CM");
                     _techniqueSubtract_CM = GetTechniqueSafe("Subtract_Point_CM");
                     _techniqueModulate_CM = GetTechniqueSafe("Modulate_Point_CM");
                     _techniqueModulate2X_CM = GetTechniqueSafe("Modulate2X_Point_CM");
@@ -177,6 +187,7 @@ namespace FlatRedBall.Graphics
 
                     _techniqueTexture_LN = GetTechniqueSafe("Texture_Point_LN");
                     _techniqueAdd_LN = GetTechniqueSafe("Add_Point_LN");
+                    _techniqueAddSubtract_LN = GetTechniqueSafe("AddSubtract_Point_LN");
                     _techniqueSubtract_LN = GetTechniqueSafe("Subtract_Point_LN");
                     _techniqueModulate_LN = GetTechniqueSafe("Modulate_Point_LN");
                     _techniqueModulate2X_LN = GetTechniqueSafe("Modulate2X_Point_LN");
@@ -188,6 +199,7 @@ namespace FlatRedBall.Graphics
 
                     _techniqueTexture_LN_CM = GetTechniqueSafe("Texture_Point_LN_CM");
                     _techniqueAdd_LN_CM = GetTechniqueSafe("Add_Point_LN_CM");
+                    _techniqueAddSubtract_LN_CM = GetTechniqueSafe("AddSubtract_Point_LN_CM");
                     _techniqueSubtract_LN_CM = GetTechniqueSafe("Subtract_Point_LN_CM");
                     _techniqueModulate_LN_CM = GetTechniqueSafe("Modulate_Point_LN_CM");
                     _techniqueModulate2X_LN_CM = GetTechniqueSafe("Modulate2X_Point_LN_CM");
@@ -199,6 +211,7 @@ namespace FlatRedBall.Graphics
 
                     _techniqueTexture_Linear = GetTechniqueSafe("Texture_Linear");
                     _techniqueAdd_Linear = GetTechniqueSafe("Add_Linear");
+                    _techniqueAddSubtract_Linear = GetTechniqueSafe("AddSubtract_Linear");
                     _techniqueSubtract_Linear = GetTechniqueSafe("Subtract_Linear");
                     _techniqueModulate_Linear = GetTechniqueSafe("Modulate_Linear");
                     _techniqueModulate2X_Linear = GetTechniqueSafe("Modulate2X_Linear");
@@ -210,6 +223,7 @@ namespace FlatRedBall.Graphics
 
                     _techniqueTexture_Linear_CM = GetTechniqueSafe("Texture_Linear_CM");
                     _techniqueAdd_Linear_CM = GetTechniqueSafe("Add_Linear_CM");
+                    _techniqueAddSubtract_Linear_CM = GetTechniqueSafe("AddSubtract_Linear_CM");
                     _techniqueSubtract_Linear_CM = GetTechniqueSafe("Subtract_Linear_CM");
                     _techniqueModulate_Linear_CM = GetTechniqueSafe("Modulate_Linear_CM");
                     _techniqueModulate2X_Linear_CM = GetTechniqueSafe("Modulate2X_Linear_CM");
@@ -221,6 +235,7 @@ namespace FlatRedBall.Graphics
 
                     _techniqueTexture_Linear_LN = GetTechniqueSafe("Texture_Linear_LN");
                     _techniqueAdd_Linear_LN = GetTechniqueSafe("Add_Linear_LN");
+                    _techniqueAddSubtract_Linear_LN = GetTechniqueSafe("AddSubtract_Linear_LN");
                     _techniqueSubtract_Linear_LN = GetTechniqueSafe("Subtract_Linear_LN");
                     _techniqueModulate_Linear_LN = GetTechniqueSafe("Modulate_Linear_LN");
                     _techniqueModulate2X_Linear_LN = GetTechniqueSafe("Modulate2X_Linear_LN");
@@ -232,6 +247,7 @@ namespace FlatRedBall.Graphics
 
                     _techniqueTexture_Linear_LN_CM = GetTechniqueSafe("Texture_Linear_LN_CM");
                     _techniqueAdd_Linear_LN_CM = GetTechniqueSafe("Add_Linear_LN_CM");
+                    _techniqueAddSubtract_Linear_LN_CM = GetTechniqueSafe("AddSubtract_Linear_LN_CM");
                     _techniqueSubtract_Linear_LN_CM = GetTechniqueSafe("Subtract_Linear_LN_CM");
                     _techniqueModulate_Linear_LN_CM = GetTechniqueSafe("Modulate_Linear_LN_CM");
                     _techniqueModulate2X_Linear_LN_CM = GetTechniqueSafe("Modulate2X_Linear_LN_CM");
@@ -247,6 +263,7 @@ namespace FlatRedBall.Graphics
 
                     _techniqueTexture = GetTechniqueSafe("Texture");
                     _techniqueAdd = GetTechniqueSafe("Add");
+                    _techniqueAddSubtract = GetTechniqueSafe("AddSubtract");
                     _techniqueSubtract = GetTechniqueSafe("Subtract");
                     _techniqueModulate = GetTechniqueSafe("Modulate");
                     _techniqueModulate2X = GetTechniqueSafe("Modulate2X");
@@ -336,6 +353,10 @@ namespace FlatRedBall.Graphics
                     technique = GetTechniqueVariant(
                     useDefaultOrPointFilterInternal, _techniqueAdd, _techniqueAdd_LN, _techniqueAdd_Linear, _techniqueAdd_Linear_LN); break;
 
+                case ColorOperation.AddSubtract:
+                    technique = GetTechniqueVariant(
+                    useDefaultOrPointFilterInternal, _techniqueAddSubtract, _techniqueAddSubtract_LN, _techniqueAddSubtract_Linear, _techniqueAddSubtract_Linear_LN); break;
+
                 case ColorOperation.Subtract:
                     technique = GetTechniqueVariant(
                     useDefaultOrPointFilterInternal, _techniqueSubtract, _techniqueSubtract_LN, _techniqueSubtract_Linear, _techniqueSubtract_Linear_LN); break;
@@ -413,6 +434,10 @@ namespace FlatRedBall.Graphics
                 case ColorOperation.Add:
                     technique = GetTechniqueVariant(
                     useDefaultOrPointFilterInternal, _techniqueAdd_CM, _techniqueAdd_LN_CM, _techniqueAdd_Linear_CM, _techniqueAdd_Linear_LN_CM); break;
+
+                case ColorOperation.AddSubtract:
+                    technique = GetTechniqueVariant(
+                    useDefaultOrPointFilterInternal, _techniqueAddSubtract_CM, _techniqueAddSubtract_LN_CM, _techniqueAddSubtract_Linear_CM, _techniqueAddSubtract_Linear_LN_CM); break;
 
                 case ColorOperation.Subtract:
                     technique = GetTechniqueVariant(

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/GraphicalEmumerations.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/GraphicalEmumerations.cs
@@ -24,7 +24,13 @@ namespace FlatRedBall.Graphics
         ColorTextureAlpha,
         Modulate2X,
         Modulate4X,
-        InterpolateColor
+        InterpolateColor,
+        /// <summary>
+        /// Like <see cref="Add"/>, but negative channel values genuinely subtract instead of
+        /// clamping to 0. Signed [-1, 1] values are bias/scale-encoded into the unsigned vertex
+        /// color byte and decoded back to signed in the pixel shader.
+        /// </summary>
+        AddSubtract
     }
 
 

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/VertexColorPacker.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/VertexColorPacker.cs
@@ -1,0 +1,33 @@
+using Microsoft.Xna.Framework;
+
+namespace FlatRedBall.Graphics
+{
+    /// <summary>
+    /// Packs a Sprite's unpacked (signed float, per-channel) vertex color into the packed uint used
+    /// by the unsigned-normalized-byte4 GPU vertex color format.
+    /// </summary>
+    public static class VertexColorPacker
+    {
+        public static uint Pack(Vector4 color, ColorOperation colorOperation)
+        {
+            if (colorOperation == ColorOperation.AddSubtract)
+            {
+                // RGB store a signed [-1, 1] value in an unsigned-normalized byte, using the standard
+                // bias/scale trick (same as tangent-space normal maps): encode (v * 0.5 + 0.5) here,
+                // decode (v * 2 - 1) in the AddSubtract pixel shader technique. Alpha is not part of
+                // the signed trick, so it packs the same as every other ColorOperation.
+                return
+                    ((uint)(255 * (color.X * 0.5f + 0.5f))) +
+                    (((uint)(255 * (color.Y * 0.5f + 0.5f))) << 8) +
+                    (((uint)(255 * (color.Z * 0.5f + 0.5f))) << 16) +
+                    (((uint)(255 * color.W)) << 24);
+            }
+
+            return
+                ((uint)(255 * color.X)) +
+                (((uint)(255 * color.Y)) << 8) +
+                (((uint)(255 * color.Z)) << 16) +
+                (((uint)(255 * color.W)) << 24);
+        }
+    }
+}

--- a/Engines/FlatRedBallXNA/FlatRedBall/Sprite.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Sprite.cs
@@ -411,7 +411,7 @@ namespace FlatRedBall
                     Debugging.CrossPlatform.ShouldApplyRestrictionsFor(Debugging.Platform.Android) ||
                     Debugging.CrossPlatform.ShouldApplyRestrictionsFor(Debugging.Platform.WindowsRt))
                 {
-                    if(value == Graphics.ColorOperation.Add || value == Graphics.ColorOperation.Subtract ||
+                    if(value == Graphics.ColorOperation.Add || value == Graphics.ColorOperation.AddSubtract || value == Graphics.ColorOperation.Subtract ||
                         value == Graphics.ColorOperation.InterpolateColor || value == Graphics.ColorOperation.InverseTexture ||
                         value == Graphics.ColorOperation.Modulate2X || value == Graphics.ColorOperation.Modulate4X)
                     {

--- a/Engines/FlatRedBallXNA/FlatRedBall/SpriteManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/SpriteManager.cs
@@ -2143,29 +2143,11 @@ namespace FlatRedBall
             else
     #endif
             {
-                verticesForDrawing[0].Color.PackedValue =
-                    ((uint)(255 * vertices[0].Color.X)) +
-                    (((uint)(255 * vertices[0].Color.Y)) << 8) +
-                    (((uint)(255 * vertices[0].Color.Z)) << 16) +
-                    (((uint)(255 * vertices[0].Color.W)) << 24);
-
-                verticesForDrawing[1].Color.PackedValue =
-                    ((uint)(255 * vertices[1].Color.X)) +
-                    (((uint)(255 * vertices[1].Color.Y)) << 8) +
-                    (((uint)(255 * vertices[1].Color.Z)) << 16) +
-                    (((uint)(255 * vertices[1].Color.W)) << 24);
-
-                verticesForDrawing[2].Color.PackedValue =
-                    ((uint)(255 * vertices[2].Color.X)) +
-                    (((uint)(255 * vertices[2].Color.Y)) << 8) +
-                    (((uint)(255 * vertices[2].Color.Z)) << 16) +
-                    (((uint)(255 * vertices[2].Color.W)) << 24);
-
-                verticesForDrawing[3].Color.PackedValue =
-                    ((uint)(255 * vertices[3].Color.X)) +
-                    (((uint)(255 * vertices[3].Color.Y)) << 8) +
-                    (((uint)(255 * vertices[3].Color.Z)) << 16) +
-                    (((uint)(255 * vertices[3].Color.W)) << 24);
+                var colorOperation = spriteToUpdate.ColorOperation;
+                verticesForDrawing[0].Color.PackedValue = FlatRedBall.Graphics.VertexColorPacker.Pack(vertices[0].Color, colorOperation);
+                verticesForDrawing[1].Color.PackedValue = FlatRedBall.Graphics.VertexColorPacker.Pack(vertices[1].Color, colorOperation);
+                verticesForDrawing[2].Color.PackedValue = FlatRedBall.Graphics.VertexColorPacker.Pack(vertices[2].Color, colorOperation);
+                verticesForDrawing[3].Color.PackedValue = FlatRedBall.Graphics.VertexColorPacker.Pack(vertices[3].Color, colorOperation);
             }
 
             if (!spriteToUpdate.FlipHorizontal && !spriteToUpdate.FlipVertical)

--- a/Tests/EngineUnitTests/Graphics/VertexColorPackerTests.cs
+++ b/Tests/EngineUnitTests/Graphics/VertexColorPackerTests.cs
@@ -1,0 +1,54 @@
+using FlatRedBall.Graphics;
+using Microsoft.Xna.Framework;
+using Shouldly;
+
+namespace EngineUnitTests.Graphics;
+
+public class VertexColorPackerTests
+{
+    [Fact]
+    public void Pack_AddSubtract_RedMinusOne_EncodesToByteZero()
+    {
+        var packed = VertexColorPacker.Pack(new Vector4(-1, 0, 0, 1), ColorOperation.AddSubtract);
+
+        (packed & 0xFF).ShouldBe(0u);
+    }
+
+    [Fact]
+    public void Pack_AddSubtract_RedZero_EncodesToNeutralByte127()
+    {
+        // (0 * 0.5 + 0.5) * 255 = 127.5, truncated to 127 - consistent with the existing
+        // (uint)(255 * value) truncating cast used everywhere else in this packing step.
+        var packed = VertexColorPacker.Pack(new Vector4(0, 0, 0, 1), ColorOperation.AddSubtract);
+
+        (packed & 0xFF).ShouldBe(127u);
+    }
+
+    [Fact]
+    public void Pack_AddSubtract_RedOne_EncodesToByte255()
+    {
+        var packed = VertexColorPacker.Pack(new Vector4(1, 0, 0, 1), ColorOperation.AddSubtract);
+
+        (packed & 0xFF).ShouldBe(255u);
+    }
+
+    [Fact]
+    public void Pack_AddSubtract_AlphaChannel_PacksUnbiased()
+    {
+        var packed = VertexColorPacker.Pack(new Vector4(0, 0, 0, 1), ColorOperation.AddSubtract);
+
+        ((packed >> 24) & 0xFF).ShouldBe(255u);
+    }
+
+    [Fact]
+    public void Pack_Add_NegativeRed_KeepsExistingUnbiasedPacking_RegressionGuard()
+    {
+        // ColorOperation.Add must keep its existing packing math untouched: (uint)(255 * -0.5f)
+        // truncates to -127 and is reinterpreted as a uint32, so the low byte wraps to 129 on this
+        // (.NET 8 / x64) target - it does not cleanly clamp to 0 and it does not subtract. Either
+        // way, it does not produce a genuine subtraction; AddSubtract is the new op for that.
+        var packed = VertexColorPacker.Pack(new Vector4(-0.5f, 0, 0, 1), ColorOperation.Add);
+
+        (packed & 0xFF).ShouldBe(129u);
+    }
+}


### PR DESCRIPTION
## Summary
`Sprite.Red/Green/Blue` accept `[-1, 1]`, but `ColorOperation.Add` loses negative values in the UNORM vertex-color packing step - a negative float doesn't survive the cast, so it can't be used as a poor-man's Subtract. New `ColorOperation.AddSubtract` bias/scale-encodes signed RGB `(v*0.5+0.5)` into the packed byte and decodes it `(v*2-1)` in a new pixel shader technique, so negative values genuinely subtract. `Add`'s existing packing is untouched.

- `GraphicalEmumerations.cs`: new enum value
- `VertexColorPacker.cs` (new): extracted, testable packing logic; wired into `SpriteManager.ManualUpdate`
- `FlatRedBallShaderXNA4.fx`: `AddSubtractPixelShader` + `technique AddSubtract`
- `CustomEffectManager.cs`: full technique-field/lookup/switch-case plumbing mirroring `Add` (8 filter variants x 2 methods)
- `Sprite.cs`: added to the DEBUG platform-restriction list (same as `Add`)

## Test plan
- [x] `Tests/EngineUnitTests/Graphics/VertexColorPackerTests.cs` - new unit tests pin Red=-1/0/1 packed bytes (0/127/255) and alpha unbiased; regression test locks in `Add`'s unchanged negative-value packing
- [x] `dotnet test` in `Tests/EngineUnitTests` - 26/26 passing
- [x] `dotnet build` - clean

Part of #1924