### PR TITLE
Add DialogService seam; migrate all direct MessageBox/MultiButtonMessageBoxWpf call sites

### DIFF
--- a/FRBDK/Glue/Glue/AutomatedGlue/GlueGui.cs
+++ b/FRBDK/Glue/Glue/AutomatedGlue/GlueGui.cs
@@ -1,4 +1,5 @@
-﻿using FlatRedBall.Glue.Plugins.ExportedImplementations;
+﻿using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using Glue;
 using System;
 using System.Windows.Forms;
@@ -55,10 +56,8 @@ namespace FlatRedBall.Glue.AutomatedGlue
         {
             if (ShowGui)
             {
-                GlueCommands.Self.DoOnUiThread(() =>
-                {
-                    MessageBox.Show(MainGlueWindow.Self, text, caption);
-                });
+                // DialogService.ShowMessage has no caption parameter, so the caption is dropped here.
+                DialogService.ShowMessage(text);
             }
         }
 
@@ -66,10 +65,7 @@ namespace FlatRedBall.Glue.AutomatedGlue
         {
             if (ShowGui)
             {
-                GlueCommands.Self.DoOnUiThread(() =>
-                {
-                    MessageBox.Show(MainGlueWindow.Self, text);
-                });
+                DialogService.ShowMessage(text);
             }
         }
 
@@ -77,11 +73,8 @@ namespace FlatRedBall.Glue.AutomatedGlue
         {
             if (ShowGui)
             {
-                GlueCommands.Self.DoOnUiThread(() =>
-                {
-                    // We want to show the exception here so we can diagnose it better.
-                    MessageBox.Show(MainGlueWindow.Self, text + "\n\n\nDetails:\n\n" + ex, caption);
-                });
+                // We want to show the exception here so we can diagnose it better.
+                DialogService.ShowMessage(text + "\n\n\nDetails:\n\n" + ex);
             }
             else
             {

--- a/FRBDK/Glue/Glue/Build/BuildToolAssociation.cs
+++ b/FRBDK/Glue/Glue/Build/BuildToolAssociation.cs
@@ -5,10 +5,10 @@ using FlatRedBall.IO;
 using System.Diagnostics;
 using EditorObjects.Parsing;
 using System.IO;
-using System.Windows.Forms;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
+using FlatRedBall.Glue.Controls;
 
 namespace EditorObjects.SaveClasses;
 
@@ -289,10 +289,10 @@ public class BuildToolAssociation
 
             if (numberOfWaitTimes > numberOfTimesToWait && doesUserWantToWait == false)
             {
-                DialogResult dialogResult = MessageBox.Show("The tool\n\n" + executable + "\n\nis taking a long time to build the file\n\n" +
-                    sourceFile + "\n\nWould you like to end this build process?", "End process?", MessageBoxButtons.YesNo);
+                var dialogResult = DialogService.ShowConfirm("The tool\n\n" + executable + "\n\nis taking a long time to build the file\n\n" +
+                    sourceFile + "\n\nWould you like to end this build process?");
 
-                if (dialogResult == DialogResult.Yes)
+                if (dialogResult == DialogButton.Yes)
                 {
 
                     if (!process.HasExited)

--- a/FRBDK/Glue/Glue/Build/BuildToolAssociationList.cs
+++ b/FRBDK/Glue/Glue/Build/BuildToolAssociationList.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using EditorObjects.SaveClasses;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.IO;
@@ -95,8 +96,8 @@ namespace EditorObjects.SaveClasses
             if (string.IsNullOrEmpty(buildToolErrors) == false)
             {
                 buildToolErrors = "The following build tools could not be located:\n" + buildToolErrors + "\nYou will not be able to build the associated assets until this issue is resolved.";
-                System.Windows.Forms.MessageBox.Show(buildToolErrors);
-            
+                DialogService.ShowMessage(buildToolErrors);
+
             }
         }
 

--- a/FRBDK/Glue/Glue/CodeGeneration/EventCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/EventCodeGenerator.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
-using System.Windows.Forms;
 using FlatRedBall.Glue.AutomatedGlue;
 using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
 using FlatRedBall.Glue.Events;
@@ -16,6 +15,7 @@ using FlatRedBall.Utilities;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.IO;
 using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Instructions.Pause;
 
 namespace FlatRedBall.Glue.CodeGeneration
@@ -454,7 +454,7 @@ namespace FlatRedBall.Glue.CodeGeneration
                         }
                         catch(Exception e)
                         {
-                            MessageBox.Show("Failed to generate custom code stubs for event " + ers.EventName + "\n\n" + e);
+                            DialogService.ShowMessage("Failed to generate custom code stubs for event " + ers.EventName + "\n\n" + e);
 
                         }
                     }

--- a/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
@@ -1362,7 +1362,7 @@ namespace FlatRedBall.Glue.CodeGeneration
 
                 if (keyType == null)
                 {
-                    System.Windows.Forms.MessageBox.Show("Could not find the key type for:\n\n" + referencedFile.Name + "\n\nYou need to mark one of the headers as required or not load this file as a dictionary.");
+                    DialogService.ShowMessage("Could not find the key type for:\n\n" + referencedFile.Name + "\n\nYou need to mark one of the headers as required or not load this file as a dictionary.");
                     keyType = "UNKNOWN_TYPE";
 
                 }

--- a/FRBDK/Glue/Glue/ContentPipeline/ContentPipelineHelper.cs
+++ b/FRBDK/Glue/Glue/ContentPipeline/ContentPipelineHelper.cs
@@ -9,13 +9,13 @@ using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.VSHelpers.Projects;
 using FlatRedBall.IO;
 using System.IO;
-using System.Windows.Forms;
 using Glue;
 using FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using Microsoft.Build.Evaluation;
 using FlatRedBall.Glue.Services;
+using FlatRedBall.Glue.Controls;
 
 namespace FlatRedBall.Glue.ContentPipeline
 {
@@ -171,7 +171,7 @@ namespace FlatRedBall.Glue.ContentPipeline
             if (rfs.GetAssetTypeInfo() != null && rfs.GetAssetTypeInfo().MustBeAddedToContentPipeline && rfs.UseContentPipeline == false)
             {
                 rfs.UseContentPipeline = true;
-                MessageBox.Show("The file " + rfs.Name + " must use the content pipeline");
+                DialogService.ShowMessage("The file " + rfs.Name + " must use the content pipeline");
 
             }
             else

--- a/FRBDK/Glue/Glue/Controls/AddExistingFileWindow.xaml.cs
+++ b/FRBDK/Glue/Glue/Controls/AddExistingFileWindow.xaml.cs
@@ -96,13 +96,10 @@ namespace FlatRedBall.Glue.Controls
             var shouldDownload = true;
             if(destination.Exists())
             {
-                DialogResult result =
-                    System.Windows.Forms.MessageBox.Show("Do you want to download this file? It will overwrite:" + "\n" +
-                    destination.FullPath,
-                    L.Texts.DownloadAndOverwrite,
-                    MessageBoxButtons.YesNo);
+                var result = DialogService.ShowConfirm("Do you want to download this file? It will overwrite:" + "\n" +
+                    destination.FullPath);
 
-                shouldDownload = result == System.Windows.Forms.DialogResult.Yes;
+                shouldDownload = result == DialogButton.Yes;
             }
 
             var innerVm = new IndividualFileAddDownloadViewModel();

--- a/FRBDK/Glue/Glue/Controls/CreatePluginWindow.xaml.cs
+++ b/FRBDK/Glue/Glue/Controls/CreatePluginWindow.xaml.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Forms;
 using L = Localization;
-using MessageBox = System.Windows.Forms.MessageBox;
 using GlueFormsCore.Extensions;
 
 namespace FlatRedBall.Glue.Controls;
@@ -90,7 +89,7 @@ public partial class CreatePluginWindow
         //Validate plugin folder
         if (!Directory.Exists(PluginFolder))
         {
-            MessageBox.Show(L.Texts.PluginNeedsValidFolder);
+            DialogService.ShowMessage(L.Texts.PluginNeedsValidFolder);
             return;
         }
 

--- a/FRBDK/Glue/Glue/Controls/DialogService.cs
+++ b/FRBDK/Glue/Glue/Controls/DialogService.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Linq;
+using FlatRedBall.Glue.Managers;
+
+namespace FlatRedBall.Glue.Controls
+{
+    /// <summary>
+    /// The result of a simple confirm/choice dialog. Used both as the return type of <see cref="DialogService.ShowConfirm"/>
+    /// and as the button-identity vocabulary for the default WPF implementations.
+    /// </summary>
+    public enum DialogButton
+    {
+        Ok,
+        Yes,
+        No,
+        Cancel,
+        Retry
+    }
+
+    /// <summary>
+    /// Central seam for all simple message/confirm/choice dialogs in Glue. Every public method here routes
+    /// through <see cref="TaskManager.OnUiThread{T}"/>, so callers never need to think about which thread
+    /// they're on - it's always safe to call these from a background task (e.g. code reached via the
+    /// file-watcher / glux-reload path), not just from a WPF event handler.
+    /// </summary>
+    /// <remarks>
+    /// This is the generalization of the swappable-delegate pattern first introduced for
+    /// <c>DuplicateProjectEntryDialog.Show</c> (see #1921) - each of the three <c>*Impl</c> properties can be
+    /// replaced in unit tests so calling code can be tested without a live WPF window. WPF-specific code
+    /// (<c>MultiButtonMessageBoxWpf</c>, <c>System.Windows.MessageBox</c>) is isolated to the three
+    /// <c>Default*</c> methods below - nothing else in the codebase should reference those types directly.
+    /// </remarks>
+    public static class DialogService
+    {
+        public static Action<string> ShowMessageImpl { get; set; } = DefaultShowMessage;
+        public static Func<string, DialogButton, DialogButton, DialogButton?> ShowConfirmImpl { get; set; } = DefaultShowConfirm;
+        public static Func<string, (string label, object value)[], object> ShowChoiceImpl { get; set; } = DefaultShowChoice;
+
+        /// <summary>
+        /// Shows a simple single-button ("OK") informational message.
+        /// </summary>
+        public static void ShowMessage(string text)
+        {
+            TaskManager.Self.OnUiThread(() => ShowMessageImpl(text));
+        }
+
+        /// <summary>
+        /// Shows a two-button confirm dialog and returns which button was clicked, or null if the dialog was
+        /// closed without clicking a button (e.g. Escape).
+        /// </summary>
+        public static DialogButton? ShowConfirm(string text, DialogButton primary = DialogButton.Yes, DialogButton secondary = DialogButton.No)
+        {
+            return TaskManager.Self.OnUiThread(() => ShowConfirmImpl(text, primary, secondary));
+        }
+
+        /// <summary>
+        /// Shows an N-button choice dialog, one button per entry in <paramref name="options"/>, and returns the
+        /// <typeparamref name="TResult"/> value associated with whichever button was clicked. If the dialog is
+        /// closed without clicking a button (e.g. Escape), returns <c>default(TResult)</c> - callers that need
+        /// different escape behavior should order their options so the intended fallback is the default value
+        /// (e.g. an enum whose 0 value means "do nothing"/"cancel").
+        /// </summary>
+        public static TResult ShowChoice<TResult>(string text, params (string label, TResult value)[] options)
+        {
+            var boxedOptions = options
+                .Select(o => (o.label, (object)o.value))
+                .ToArray();
+
+            var result = TaskManager.Self.OnUiThread(() => ShowChoiceImpl(text, boxedOptions));
+
+            return result is TResult typed ? typed : default;
+        }
+
+        private static void DefaultShowMessage(string text)
+        {
+            System.Windows.MessageBox.Show(text);
+        }
+
+        private static DialogButton? DefaultShowConfirm(string text, DialogButton primary, DialogButton secondary)
+        {
+            var mbmb = new MultiButtonMessageBoxWpf
+            {
+                MessageText = text
+            };
+
+            mbmb.AddButton(primary.ToString(), primary);
+            mbmb.AddButton(secondary.ToString(), secondary);
+
+            if (mbmb.ShowDialog() == true)
+            {
+                return (DialogButton)mbmb.ClickedResult;
+            }
+
+            return null;
+        }
+
+        private static object DefaultShowChoice(string text, (string label, object value)[] options)
+        {
+            var mbmb = new MultiButtonMessageBoxWpf
+            {
+                MessageText = text
+            };
+
+            foreach (var option in options)
+            {
+                mbmb.AddButton(option.label, option.value);
+            }
+
+            if (mbmb.ShowDialog() == true)
+            {
+                return mbmb.ClickedResult;
+            }
+
+            return null;
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/Controls/FileBuildToolAssociationWindow.cs
+++ b/FRBDK/Glue/Glue/Controls/FileBuildToolAssociationWindow.cs
@@ -187,7 +187,7 @@ namespace FlatRedBall.Glue.Controls
                 }
                 else
                 {
-                    MessageBox.Show("The directory for externally built content does not exist:\n" + absoluteDirectory);
+                    DialogService.ShowMessage("The directory for externally built content does not exist:\n" + absoluteDirectory);
                 }
             }
         }

--- a/FRBDK/Glue/Glue/Controls/PluginsWindow.cs
+++ b/FRBDK/Glue/Glue/Controls/PluginsWindow.cs
@@ -169,17 +169,16 @@ namespace FlatRedBall.Glue.Controls
 
                 if (shouldBeEnabled && !container.IsEnabled)
                 {
-                    DialogResult result = System.Windows.Forms.DialogResult.Yes;
+                    DialogButton? result = DialogButton.Yes;
 
                     if (!string.IsNullOrEmpty(container.FailureDetails))
                     {
-                        result = MessageBox.Show("The plugin " + container.Name + " has crashed so " +
+                        result = DialogService.ShowConfirm("The plugin " + container.Name + " has crashed so " +
                             " it was disabled.  Are you sure you want to re-enable it?",
-                            "Re-enable crashed plugin?",
-                            MessageBoxButtons.YesNo);
+                            DialogButton.Yes, DialogButton.No);
                     }
 
-                    if (result == System.Windows.Forms.DialogResult.Yes)
+                    if (result == DialogButton.Yes)
                     {
                         container.IsEnabled = true;
                         try
@@ -487,7 +486,7 @@ namespace FlatRedBall.Glue.Controls
                 }
                 catch (Exception exc)
                 {
-                    MessageBox.Show($"{L.Texts.PluginDownloadFailed}: {exc.Message}");
+                    DialogService.ShowMessage($"{L.Texts.PluginDownloadFailed}: {exc.Message}");
                 }
             }
         }

--- a/FRBDK/Glue/Glue/Controls/ProjectSpecificFileCollectionEditorForm.cs
+++ b/FRBDK/Glue/Glue/Controls/ProjectSpecificFileCollectionEditorForm.cs
@@ -185,7 +185,7 @@ namespace FlatRedBall.Glue.Controls
         {
             if (!ProjectManager.SyncedProjects.Any(syncedProject => cboProjectType.Text == syncedProject.Name))
             {
-                MessageBox.Show(@"Must select a valid project type and not already have an entry.", @"Error");
+                DialogService.ShowMessage(@"Must select a valid project type and not already have an entry.");
                 return false;
             }
 

--- a/FRBDK/Glue/Glue/Controls/UninstallPluginWindow.cs
+++ b/FRBDK/Glue/Glue/Controls/UninstallPluginWindow.cs
@@ -69,7 +69,7 @@ namespace FlatRedBall.Glue.Controls
         {
             if (dgvPlugins.CurrentRow == null)
             {
-                MessageBox.Show(@"Please select a plugin to install.");
+                DialogService.ShowMessage(@"Please select a plugin to install.");
                 return;
             }
 
@@ -80,7 +80,7 @@ namespace FlatRedBall.Glue.Controls
             databoundList.Remove(plugin);
             dgvPlugins.DataSource = null;
             dgvPlugins.DataSource = databoundList;
-            MessageBox.Show(@"Plugin " + plugin.Name + @" successfully uninstalled.");
+            DialogService.ShowMessage(@"Plugin " + plugin.Name + @" successfully uninstalled.");
         }
 
         private bool Uninstall(string plugin)
@@ -97,7 +97,7 @@ namespace FlatRedBall.Glue.Controls
                     w.WriteLine(plugin);
                 }
 
-                MessageBox.Show(@"Failed to uninstall plugin.  Plugin will be uninstalled on next Glue start.");
+                DialogService.ShowMessage(@"Failed to uninstall plugin.  Plugin will be uninstalled on next Glue start.");
 
                 return false;
             }

--- a/FRBDK/Glue/Glue/CreatedClass/CustomClassController.cs
+++ b/FRBDK/Glue/Glue/CreatedClass/CustomClassController.cs
@@ -1,4 +1,5 @@
-﻿using FlatRedBall.Glue.Elements;
+﻿using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.IO;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins;
@@ -50,18 +51,18 @@ namespace FlatRedBall.Glue.CreatedClass
                     oldCustomClass = GetCustomClassSaveIncludingThis(currentReferencedFile.Name);
 
                     result =
-                        System.Windows.Forms.MessageBox.Show("Make the " + currentReferencedFile.Name + " file no longer use the " +
+                        DialogService.ShowChoice("Make the " + currentReferencedFile.Name + " file no longer use the " +
                         oldCustomClass.Name + " class?",
-                        "Remove Custom Class Association",
-                        MessageBoxButtons.YesNo);
+                        ("Yes", DialogResult.Yes),
+                        ("No", DialogResult.No));
 
                 }
 
-                if (result == System.Windows.Forms.DialogResult.Yes)
+                if (result == DialogResult.Yes)
                 {
                     if (currentReferencedFile == null)
                     {
-                        MessageBox.Show("You've just encountered a Glue error that someone needs to fix.  Error details: " +
+                        DialogService.ShowMessage("You've just encountered a Glue error that someone needs to fix.  Error details: " +
                             "Attempting to remove a ReferencedFileSave from a CustomClass, but the RFS doesn't actually exist");
                     }
                     else
@@ -119,10 +120,12 @@ namespace FlatRedBall.Glue.CreatedClass
                     }
                     else
                     {
-                        result = MessageBox.Show("The CSV\n\n" + currentReferencedFile.Name + "\n\nwas using the file\n\n" +
-                            file + "\n\nThis file is no associated with this CSV file.  Would you like to remove this file?", "Remove unused file?", MessageBoxButtons.YesNo);
+                        result = DialogService.ShowChoice("The CSV\n\n" + currentReferencedFile.Name + "\n\nwas using the file\n\n" +
+                            file + "\n\nThis file is no associated with this CSV file.  Would you like to remove this file?",
+                            ("Yes", DialogResult.Yes),
+                            ("No", DialogResult.No));
                     }
-                    if (result == System.Windows.Forms.DialogResult.Yes)
+                    if (result == DialogResult.Yes)
                     {
                         GlueState.Self.CurrentMainProject.RemoveItem(file);
                         try

--- a/FRBDK/Glue/Glue/CreatedClass/CustomClassWindow.cs
+++ b/FRBDK/Glue/Glue/CreatedClass/CustomClassWindow.cs
@@ -88,7 +88,7 @@ namespace FlatRedBall.Glue.Controls
 
                 if(response.OperationResult == Plugins.ExportedInterfaces.CommandInterfaces.OperationResult.Failure)
                 {
-                    MessageBox.Show(response.Message);
+                    DialogService.ShowMessage(response.Message);
                 }
                 else
                 {
@@ -173,12 +173,11 @@ namespace FlatRedBall.Glue.Controls
                     if (node.Parent == null)
                     {
                         // This thing is a class
-                        DialogResult result = 
-                            System.Windows.Forms.MessageBox.Show("Are you sure you want to remove the " + node.Text + " class?  All CSV types will return to their default types.",
-                            "Remove Class?",
-                            MessageBoxButtons.YesNo);
+                        var result = DialogService.ShowConfirm(
+                            "Are you sure you want to remove the " + node.Text + " class?  All CSV types will return to their default types.",
+                            DialogButton.Yes, DialogButton.No);
 
-                        if (result == System.Windows.Forms.DialogResult.Yes)
+                        if (result == DialogButton.Yes)
                         {
                             ProjectManager.GlueProjectSave.CustomClasses.Remove(CurrentCustomClassSave);
                             GluxCommands.Self.SaveProjectAndElements();

--- a/FRBDK/Glue/Glue/Elements/AvailableAssetTypes.cs
+++ b/FRBDK/Glue/Glue/Elements/AvailableAssetTypes.cs
@@ -7,8 +7,8 @@ using FlatRedBall.IO.Csv;
 using FlatRedBall.IO;
 
 
-using System.Windows.Forms;
 using System.IO;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Plugins;
 using FlatRedBall.Math.Geometry;
 using FlatRedBall.Graphics;
@@ -188,7 +188,7 @@ namespace FlatRedBall.Glue.Elements
                     }
                     catch(Exception e)
                     {
-                        MessageBox.Show("Failed to add additional asset types from file " + file + "\n\nError info:\n" + e);
+                        DialogService.ShowMessage("Failed to add additional asset types from file " + file + "\n\nError info:\n" + e);
                     }
                 }
             }
@@ -515,7 +515,7 @@ namespace FlatRedBall.Glue.Elements
             }
             if (File.Exists(desiredFullPath))
             {
-                MessageBox.Show("The CSV " + desiredFullPath + " already exists.");
+                DialogService.ShowMessage("The CSV " + desiredFullPath + " already exists.");
             }
             else
             {
@@ -525,11 +525,11 @@ namespace FlatRedBall.Glue.Elements
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    MessageBox.Show("Unable to save the CSV file.  You need to run Glue as an administrator");
+                    DialogService.ShowMessage("Unable to save the CSV file.  You need to run Glue as an administrator");
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show("Unknown error attempting to create the CSV:\n\n" + e.ToString());
+                    DialogService.ShowMessage("Unknown error attempting to create the CSV:\n\n" + e.ToString());
                 }
             }
                 

--- a/FRBDK/Glue/Glue/Errors/FileErrorReporter.cs
+++ b/FRBDK/Glue/Glue/Errors/FileErrorReporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using FlatRedBall.Glue.Controls;
 
 namespace FlatRedBall.Glue.Errors
 {
@@ -35,8 +36,8 @@ namespace FlatRedBall.Glue.Errors
                 {
                     string first = mErrorMessageAndFiles[0].Item1;
                     string second = mErrorMessageAndFiles[0].Item2;
-                    mErrorMessageAndFiles.RemoveAt(0); 
-                    MessageBox.Show(first, second);
+                    mErrorMessageAndFiles.RemoveAt(0);
+                    DialogService.ShowMessage(first);
                     Plugins.PluginManager.ReceiveError(first);
 
                 }

--- a/FRBDK/Glue/Glue/Events/EventManager.cs
+++ b/FRBDK/Glue/Glue/Events/EventManager.cs
@@ -6,7 +6,7 @@ using FlatRedBall.IO.Csv;
 using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.IO;
 using FlatRedBall.Glue.Parsing;
-using System.Windows.Forms;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.IO;
 
@@ -40,7 +40,7 @@ namespace FlatRedBall.Glue.Events
             
             if(fileToLoad.Exists() == false)
             {
-                System.Windows.Forms.MessageBox.Show("Could not find the file: " + fileToLoad);
+                DialogService.ShowMessage("Could not find the file: " + fileToLoad);
             }
             else
             {
@@ -50,7 +50,7 @@ namespace FlatRedBall.Glue.Events
                 }
                 catch (Exception e)
                 {
-                    System.Windows.Forms.MessageBox.Show("Could not initialize event manager.  Check to make sure " +
+                    DialogService.ShowMessage("Could not initialize event manager.  Check to make sure " +
                         "the following file exists and is not corrupt: " + fileToLoad + "\n\n" + e.ToString());
                 }
             }

--- a/FRBDK/Glue/Glue/Events/EventManagerExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/Events/EventManagerExtensionMethods.cs
@@ -5,7 +5,7 @@ using System.Text;
 using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.IO;
 using FlatRedBall.Glue.Parsing;
-using System.Windows.Forms;
+using FlatRedBall.Glue.Controls;
 
 namespace FlatRedBall.Glue.Events
 {
@@ -66,11 +66,11 @@ namespace FlatRedBall.Glue.Events
                 // See if there is already a method here
                 if (parsedClassToUse.GetMethod(methodName) == null)
                 {
-                    DialogResult result =
-                        MessageBox.Show("The method\n\n" + methodName + "\n\ndoes not exist.  Create this " +
-                            "method in your .Event.cs code file?", "Create method?", MessageBoxButtons.YesNo);
+                    var result =
+                        DialogService.ShowConfirm("The method\n\n" + methodName + "\n\ndoes not exist.  Create this " +
+                            "method in your .Event.cs code file?");
 
-                    if (result == DialogResult.Yes)
+                    if (result == DialogButton.Yes)
                     {
                         int indexToInsertAt = EventManager.GetLastLocationInClass(fullFileContents, startOfLine:true, out bool hasBracketNamespace);
 

--- a/FRBDK/Glue/Glue/Factories/FactoryManager.cs
+++ b/FRBDK/Glue/Glue/Factories/FactoryManager.cs
@@ -7,7 +7,7 @@ using FlatRedBall.Glue.Parsing;
 using FlatRedBall.Content;
 using FlatRedBall.Content.Scene;
 using FlatRedBall.Content.SpriteFrame;
-using System.Windows.Forms;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.FormHelpers;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Utilities;
@@ -81,7 +81,7 @@ namespace FlatRedBall.Glue.Factories
                     message += "\n " + skipped.InstanceName;
                 }
 
-                MessageBox.Show(message);
+                DialogService.ShowMessage(message);
             }
             #endregion
 
@@ -115,12 +115,12 @@ namespace FlatRedBall.Glue.Factories
 
             if (areAnyVariablesBeingAdded)
             {
-                DialogResult result = MessageBox.Show("Glue will add some best-guess variables to be reset " +
+                var result = DialogService.ShowConfirm("Glue will add some best-guess variables to be reset " +
                     "to the objects in your Entity.  Existing variables will be preserved.  You may " +
                     "need to manually add additional variables depending on the logic contained in your Entity." +
-                    "\n\nAdd variables?", "Add Variables for " + entitySave.Name + "?", MessageBoxButtons.YesNo);
+                    "\n\nAdd variables?");
 
-                if (result == DialogResult.Yes)
+                if (result == DialogButton.Yes)
                 {
                     foreach (KeyValuePair<NamedObjectSave, List<string>> kvp in mResetVariablesToAdd)
                     {
@@ -152,11 +152,11 @@ namespace FlatRedBall.Glue.Factories
 
             if (hasNamedObjectEntities)
             {
-                DialogResult result = MessageBox.Show(
+                var result = DialogService.ShowConfirm(
                     "Would you like to set reset variables for all contained objects which reference Entities inside " + entitySave.Name + "?  This " +
-                    "action is recommended.", "Reset objects referencing Entities?", MessageBoxButtons.YesNo);
+                    "action is recommended.");
 
-                if (result == DialogResult.Yes)
+                if (result == DialogButton.Yes)
                 {
                     foreach (NamedObjectSave nos in entitySave.NamedObjects)
                     {
@@ -193,10 +193,9 @@ namespace FlatRedBall.Glue.Factories
                 message += "\nThis " +
                     "action is recommended.";
 
-                DialogResult result = MessageBox.Show(message,
-                    "Reset Entities inheriting from this?", MessageBoxButtons.YesNo);
+                var result = DialogService.ShowConfirm(message);
 
-                if (result == DialogResult.Yes)
+                if (result == DialogButton.Yes)
                 {
                     foreach (EntitySave inheritingEntity in inheritingEntities)
                     {

--- a/FRBDK/Glue/Glue/FormHelpers/PropertyGrids/NamedObjectPropertyGridDisplayer.cs
+++ b/FRBDK/Glue/Glue/FormHelpers/PropertyGrids/NamedObjectPropertyGridDisplayer.cs
@@ -15,6 +15,7 @@ using FlatRedBall.Glue.Parsing;
 using System.Reflection;
 using FlatRedBall.Glue.Plugins.ExportedInterfaces;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.Controls;
 
 //using FlatRedBall.Glue.FormHelpers.StringConverters;
 //using FlatRedBall.Glue.FormHelpers;
@@ -157,7 +158,7 @@ namespace FlatRedBall.Glue.GuiDisplay
             if (textureScale != 0)
             {
                 string memberChanged = e.Member;
-                MessageBox.Show("Setting " + memberChanged + " when TextureScale is not 0 may result in the " + 
+                DialogService.ShowMessage("Setting " + memberChanged + " when TextureScale is not 0 may result in the " +
                     memberChanged + " value not applying");
             }
         }

--- a/FRBDK/Glue/Glue/GlueView/GlueViewToolbar.xaml.cs
+++ b/FRBDK/Glue/Glue/GlueView/GlueViewToolbar.xaml.cs
@@ -1,4 +1,5 @@
-﻿using FlatRedBall.Glue.Plugins.ExportedImplementations;
+﻿using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.IO;
 using OfficialPlugins.GlueView;
 using System;
@@ -98,7 +99,7 @@ namespace FlatRedBall.Glue.GlueView
             }
             else
             {
-                MessageBox.Show("Could not find GlueView at the following location:\n\n" + glueViewLocation);
+                DialogService.ShowMessage("Could not find GlueView at the following location:\n\n" + glueViewLocation);
             }
         }
 

--- a/FRBDK/Glue/Glue/IO/BuiltFileCopier.cs
+++ b/FRBDK/Glue/Glue/IO/BuiltFileCopier.cs
@@ -7,7 +7,7 @@ using FlatRedBall.IO;
 using FlatRedBall.Glue.Plugins.EmbeddedPlugins;
 using FlatRedBall.Glue.VSHelpers.Projects;
 using FlatRedBall.Glue.SaveClasses;
-using System.Windows.Forms;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.Plugins;
@@ -83,7 +83,7 @@ namespace FlatRedBall.Glue.IO
 
                 if (!System.IO.File.Exists(outputFile))
                 {
-                    MessageBox.Show("The XNB doesn't exist.  Did you build the file?");
+                    DialogService.ShowMessage("The XNB doesn't exist.  Did you build the file?");
                 }
                 else
                 {
@@ -180,7 +180,7 @@ namespace FlatRedBall.Glue.IO
                     {
                         if (errorReportingStyle == ErrorReportingStyle.MessageBox)
                         {
-                            System.Windows.Forms.MessageBox.Show("Error copying built file:\n\n" + e.ToString());
+                            DialogService.ShowMessage("Error copying built file:\n\n" + e.ToString());
                         }
                         else
                         {

--- a/FRBDK/Glue/Glue/IO/ElementExporter.cs
+++ b/FRBDK/Glue/Glue/IO/ElementExporter.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using FlatRedBall.Utilities;
 using System.IO;
 using FlatRedBall.Glue.AutomatedGlue;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Parsing;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
@@ -156,9 +157,9 @@ namespace FlatRedBall.Glue.IO
                 string message = string.Format(L.Texts.QuestionFilesOutsideContent, screenOrEntity);
 
 
-                var result = MessageBox.Show(message, L.Texts.QuestionExport, MessageBoxButtons.YesNo);
+                var result = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-                shouldContinue = result == DialogResult.Yes;
+                shouldContinue = result == DialogButton.Yes;
 
                 copyExternalFiles = true;
             }
@@ -206,13 +207,13 @@ namespace FlatRedBall.Glue.IO
 
             string absoluteXml = directory + FileManager.RemovePath(element.Name) + "." + extension;
             string absoluteZip = directory + FileManager.RemovePath(element.Name) + "." + zipExtension;
-            DialogResult dialogResult = DialogResult.Yes;
+            DialogButton? dialogResult = DialogButton.Yes;
 
             if (automaticOverwrite == false && FileManager.FileExists(absoluteZip))
             {
-                dialogResult = MessageBox.Show(
+                dialogResult = DialogService.ShowConfirm(
                     String.Format(L.Texts.FileXExistsOverwrite, absoluteXml),
-                    L.Texts.QuestionOverwrite, MessageBoxButtons.YesNo);
+                    DialogButton.Yes, DialogButton.No);
 
             }
 
@@ -221,9 +222,9 @@ namespace FlatRedBall.Glue.IO
 
             if (!string.IsNullOrEmpty(reasonWhyElementCantBeExported))
             {
-                MessageBox.Show($"{L.Texts.ExportCant}\n\n{reasonWhyElementCantBeExported}");
+                DialogService.ShowMessage($"{L.Texts.ExportCant}\n\n{reasonWhyElementCantBeExported}");
             }
-            else if (dialogResult == DialogResult.Yes)
+            else if (dialogResult == DialogButton.Yes)
             {
                 PerformExport(element, glueProjectSave, openDirectory, absoluteXml, absoluteZip, copyExternalFiles);
                 exportedFile = absoluteZip;

--- a/FRBDK/Glue/Glue/IO/ElementImporter.cs
+++ b/FRBDK/Glue/Glue/IO/ElementImporter.cs
@@ -382,9 +382,11 @@ public class ElementImporter
 
             if (File.Exists(destinationFolder + fileToCopy))
             {
-                dialogResult = MessageBox.Show("The following file already exists:\n\n" +
-                                               destinationFolder + fileToCopy + "\n\nOverwrite this file?", "Overwrite file?",
-                    MessageBoxButtons.YesNo);
+                // If closed without a click (e.g. Escape), ShowConfirm returns null, which - same as the
+                // original code - doesn't match DialogResult.Yes, so the file is skipped (not overwritten).
+                var confirmResult = DialogService.ShowConfirm("The following file already exists:\n\n" +
+                                               destinationFolder + fileToCopy + "\n\nOverwrite this file?");
+                dialogResult = confirmResult == DialogButton.Yes ? DialogResult.Yes : DialogResult.No;
             }
 
             if (dialogResult == DialogResult.Yes)
@@ -515,23 +517,21 @@ public class ElementImporter
 
                     if (candidates.Count == 0)
                     {
-                        MessageBox.Show(newElement.ToString() + " has an object named " + nos.InstanceName + " which references an Entity " + nos.SourceClassType + "\n\n" +
+                        DialogService.ShowMessage(newElement.ToString() + " has an object named " + nos.InstanceName + " which references an Entity " + nos.SourceClassType + "\n\n" +
                                         "Could not find a matching Entity.  Your project may not run properly until this issue is resolved.");
                     }
                     else
                     {
-                        var mbmb = new MultiButtonMessageBoxWpf();
-                        mbmb.MessageText = "FRB found possible matches for the object " + nos.InstanceName + " which expects the type " + nos.SourceClassType;
+                        var message = "FRB found possible matches for the object " + nos.InstanceName + " which expects the type " + nos.SourceClassType;
 
-                        foreach(var candidate in candidates)
-                        {
-                            mbmb.AddButton("Use " + candidate.ToString(), candidate);
-                        }
-                        mbmb.AddButton("Don't do anything", DialogResult.Cancel);
+                        var options = candidates
+                            .Select(candidate => ($"Use {candidate}", (object)candidate))
+                            .Append(("Don't do anything", (object)DialogResult.Cancel))
+                            .ToArray();
 
-                        var result = mbmb.ShowDialog();
-
-                        var clickedResult = mbmb.ClickedResult;
+                        // If closed without a click (e.g. Escape), ShowChoice returns default(object) (null),
+                        // which - same as the original code - isn't a GlueElement, so nothing happens.
+                        var clickedResult = DialogService.ShowChoice(message, options);
 
                         if (clickedResult is GlueElement referenceToSet)
                         {
@@ -590,11 +590,12 @@ public class ElementImporter
 
                     if (unqualifiedName == newElementUnqualifiedName)
                     {
-                        // This new element may fulfill the requirements.  Let's ask the user if we should do that
-                        DialogResult change = MessageBox.Show(nos.ToString() + " has a missing reference.  Use the new Entity " + newElement.ToString() + "?",
-                            "Update reference?", MessageBoxButtons.YesNo);
+                        // This new element may fulfill the requirements.  Let's ask the user if we should do that.
+                        // If closed without a click (e.g. Escape), ShowConfirm returns null, which - same as the
+                        // original code - doesn't match Yes, so no change is made.
+                        var change = DialogService.ShowConfirm(nos.ToString() + " has a missing reference.  Use the new Entity " + newElement.ToString() + "?");
 
-                        if (change == DialogResult.Yes)
+                        if (change == DialogButton.Yes)
                         {
                             nos.SourceClassType = newElement.Name;
                             nos.UpdateCustomProperties();
@@ -604,7 +605,7 @@ public class ElementImporter
                 }
                 else if (fulfillingIElement == newElement)
                 {
-                    MessageBox.Show("The new element will now fulfill the previously-broken reference for " + nos.ToString());
+                    DialogService.ShowMessage("The new element will now fulfill the previously-broken reference for " + nos.ToString());
 
                     // Setting the value to itself will cause the properties to be refreshed
                     nos.SourceClassType = newElement.Name;

--- a/FRBDK/Glue/Glue/IO/ProjectLoader.cs
+++ b/FRBDK/Glue/Glue/IO/ProjectLoader.cs
@@ -512,25 +512,24 @@ namespace FlatRedBall.Glue.IO
             }
             catch (Exception e)
             {
-                var mbmb = new MultiButtonMessageBoxWpf();
-                mbmb.MessageText = "There was an error loading the .glux file.  What would you like to do?";
+                // DialogService.ShowChoice returns default(DialogResult) (None) if the dialog is closed
+                // without a button click (e.g. Escape), which matches the explicit None case below.
+                var choice = DialogService.ShowChoice("There was an error loading the .glux file.  What would you like to do?",
+                    ("Nothing - Glue will abort loading the project.", DialogResult.None),
+                    ("See the Exception", DialogResult.OK),
+                    ("Try loading again", DialogResult.Retry),
+                    ("Test for conflicts", DialogResult.Yes));
 
-                mbmb.AddButton("Nothing - Glue will abort loading the project.", DialogResult.None);
-                mbmb.AddButton("See the Exception", DialogResult.OK);
-                mbmb.AddButton("Try loading again", DialogResult.Retry);
-                mbmb.AddButton("Test for conflicts", DialogResult.Yes);
-
-                var result = mbmb.ShowDialog();
                 initializationWindow.Close();
 
-                switch (mbmb.ClickedResult)
+                switch (choice)
                 {
                     case DialogResult.None:
                         // Do nothing;
 
                         break;
                     case DialogResult.OK:
-                        MessageBox.Show(e.ToString());
+                        DialogService.ShowMessage(e.ToString());
                         break;
                     case DialogResult.Retry:
                         _=LoadProject(projectFileName);
@@ -540,12 +539,12 @@ namespace FlatRedBall.Glue.IO
 
                         if (text.Contains("<<<"))
                         {
-                            MessageBox.Show("There are conflicts in your GLUX file.  You will need to use a merging " +
+                            DialogService.ShowMessage("There are conflicts in your GLUX file.  You will need to use a merging " +
                                 "tool or text editor to resolve these conflicts.");
                         }
                         else
                         {
-                            MessageBox.Show("No Subversion conflicts found in your GLUX.");
+                            DialogService.ShowMessage("No Subversion conflicts found in your GLUX.");
                         }
                         break;
                 }
@@ -712,17 +711,16 @@ namespace FlatRedBall.Glue.IO
 
             if (!System.IO.File.Exists(fileToSearchFor))
             {
-                var mbmb = new MultiButtonMessageBoxWpf();
-                mbmb.MessageText = "The following file is missing\n\n" + fileToSearchFor + 
+                var message = "The following file is missing\n\n" + fileToSearchFor +
                     "\n\nwhich is used by\n\n" + element.ToString() + "\n\nWhat would you like to do?";
-                mbmb.AddButton("Re-create an empty custom code file", DialogResult.OK);
-                mbmb.AddButton("Ignore this problem", DialogResult.Cancel);
 
-                var result = mbmb.ShowDialog();
+                // Escape (no button click) returns default(DialogResult) (None), which isn't OK, so this
+                // falls through to "do nothing" - same as the original "Ignore this problem" behavior.
+                var choice = DialogService.ShowChoice(message,
+                    ("Re-create an empty custom code file", DialogResult.OK),
+                    ("Ignore this problem", DialogResult.Cancel));
 
-                var dialogResult = mbmb.ClickedResult;
-
-                if(dialogResult?.Equals(DialogResult.OK) == true)
+                if (choice == DialogResult.OK)
                 {
                     GlueCommands.Self.GenerateCodeCommands.GenerateElementCustomCode(element);
                 }
@@ -769,7 +767,7 @@ namespace FlatRedBall.Glue.IO
                         }
                         catch (Exception e)
                         {
-                            MessageBox.Show("Error syncing project:\n\n" + syncedProject.Name +
+                            DialogService.ShowMessage("Error syncing project:\n\n" + syncedProject.Name +
                                 "\n\nThe main project will still function properly - Glue just won't be able " +
                                 "to maintain the synced project.  Error details:\n\n" + e.ToString());
                         }
@@ -786,7 +784,7 @@ namespace FlatRedBall.Glue.IO
 
             if(!File.Exists(absoluteFileName))
             {
-                MessageBox.Show("Could not find the project" + absoluteFileName + ", removing project from synched project list.");
+                DialogService.ShowMessage("Could not find the project" + absoluteFileName + ", removing project from synched project list.");
             }
             else if (absoluteFileName == GlueState.Self.CurrentMainProject.FullFileName)
             {
@@ -798,7 +796,7 @@ namespace FlatRedBall.Glue.IO
                 // up Glue pretty badly.  We need
                 // to check for this and not allow
                 // it.
-                MessageBox.Show("A synced project is using the same file as the main project.  This is not allowed.  Glue will remove this synced project the synced project list.");
+                DialogService.ShowMessage("A synced project is using the same file as the main project.  This is not allowed.  Glue will remove this synced project the synced project list.");
             }
             else
             {

--- a/FRBDK/Glue/Glue/IO/UpdateReactor.cs
+++ b/FRBDK/Glue/Glue/IO/UpdateReactor.cs
@@ -624,7 +624,7 @@ namespace FlatRedBall.Glue.IO
                             // FINISH THIS!!!!
                             if (!namedObjects.Contains(objectToFind))
                             {
-                                System.Windows.Forms.MessageBox.Show(
+                                FlatRedBall.Glue.Controls.DialogService.ShowMessage(
                                     string.Format(
                                     "The object {0} references an object {1} in the file {2}.  This object no longer exists, so the object {0} will have its reference set to NONE.",
                                     namedObjectSave.FieldName, objectToFind, namedObjectSave.SourceFile));

--- a/FRBDK/Glue/Glue/MainGlueWindow.cs
+++ b/FRBDK/Glue/Glue/MainGlueWindow.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Forms;
 using FlatRedBall.Glue.AutomatedGlue;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.IO;
 using FlatRedBall.Glue.IO;
 using FlatRedBall.Glue.FormHelpers;
@@ -100,7 +101,7 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
             // Any further checks on .NET usage are not required.
             if (!System.IO.File.Exists(@"C:\Program Files\dotnet\dotnet.exe"))
             {
-                MessageBox.Show(Localization.Texts.ErrorDotNetIsNotInstalledOrEnvironmentVariables);
+                DialogService.ShowMessage(Localization.Texts.ErrorDotNetIsNotInstalledOrEnvironmentVariables);
                 return;
             }
 
@@ -139,7 +140,7 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
 
             GlueCommands.Self.PrintOutput(message);
 
-            MessageBox.Show(message);
+            DialogService.ShowMessage(message);
             return;
         }
 
@@ -179,7 +180,7 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
 
                 var message = String.Format(Localization.Texts.ErrorCouldNotFindNetSix, output);
                 GlueCommands.Self.PrintOutput(message);
-                MessageBox.Show(message);
+                DialogService.ShowMessage(message);
             }
             else
             {
@@ -191,7 +192,7 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
         {
             var message = String.Format(Localization.Texts.ErrorCouldNotFindNetSix, output);
             GlueCommands.Self.PrintOutput(message);
-            MessageBox.Show(message);
+            DialogService.ShowMessage(message);
         }
     }
 
@@ -379,7 +380,7 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
         {
             if (GlueGui.ShowGui)
             {
-                MessageBox.Show(exc.ToString());
+                DialogService.ShowMessage(exc.ToString());
 
                 FileManager.SaveText(exc.ToString(),
                     FileManager.UserApplicationDataForThisApplication + "InitError.txt");

--- a/FRBDK/Glue/Glue/Managers/DragDropManager.cs
+++ b/FRBDK/Glue/Glue/Managers/DragDropManager.cs
@@ -77,7 +77,7 @@ public class DragDropManager : Singleton<DragDropManager>
             }
             else
             {
-                MessageBox.Show("Invalid movement");
+                DialogService.ShowMessage("Invalid movement");
             }
 
 
@@ -122,7 +122,7 @@ public class DragDropManager : Singleton<DragDropManager>
 
         if (string.IsNullOrEmpty(targetClassType) && targetNos.SourceType != SourceType.Entity)
         {
-            MessageBox.Show("The target Object does not have a defined type.  This operation is not valid");
+            DialogService.ShowMessage("The target Object does not have a defined type.  This operation is not valid");
         }
 
         #endregion
@@ -164,7 +164,7 @@ public class DragDropManager : Singleton<DragDropManager>
 
             if (!response.Succeeded)
             {
-                MessageBox.Show($"Could not drop {movingNos} on {targetNos}");
+                DialogService.ShowMessage($"Could not drop {movingNos} on {targetNos}");
 
             }
 
@@ -240,29 +240,24 @@ public class DragDropManager : Singleton<DragDropManager>
         {
             string message = "Move to list or create collision relationship?";
 
-            var mbmb = new MultiButtonMessageBoxWpf();
-            mbmb.MessageText = message;
-            mbmb.AddButton("Move to List", DialogResult.Yes);
-            mbmb.AddButton("Create Collision Relationship", DialogResult.No);
+            var result = DialogService.ShowChoice<DialogResult>(message,
+                ("Move to List", DialogResult.Yes),
+                ("Create Collision Relationship", DialogResult.No));
 
-            var dialogResult = mbmb.ShowDialog();
-
-            if(dialogResult == true)
+            if (result == DialogResult.Yes)
             {
-                var result = (DialogResult)mbmb.ClickedResult;
-                if ( result == DialogResult.Yes)
-                {
-                    canBeMovedInList = true;
-                    canBeCollidable = false;
-                }
-                else if (result == DialogResult.No)
-                {
-                    canBeCollidable = true;
-                    canBeMovedInList = false;
-                }
+                canBeMovedInList = true;
+                canBeCollidable = false;
+            }
+            else if (result == DialogResult.No)
+            {
+                canBeCollidable = true;
+                canBeMovedInList = false;
             }
             else
             {
+                // Closed without a choice (e.g. Escape) returns default(DialogResult) == None here,
+                // which matches neither branch above - same as the original cancel behavior.
                 canBeCollidable = false;
                 canBeMovedInList = false;
             }
@@ -273,7 +268,7 @@ public class DragDropManager : Singleton<DragDropManager>
             var response = HandleDropOnList(treeNodeMoving, targetNode, targetNos, movingNos);
             if (!response.Succeeded)
             {
-                MessageBox.Show(response.Message);
+                DialogService.ShowMessage(response.Message);
             }
             succeeded = response.Succeeded;
         }
@@ -283,7 +278,7 @@ public class DragDropManager : Singleton<DragDropManager>
 
             if (!response.Succeeded && !string.IsNullOrEmpty(response.Message))
             {
-                MessageBox.Show(response.Message);
+                DialogService.ShowMessage(response.Message);
             }
 
             succeeded = response.Succeeded;
@@ -794,7 +789,7 @@ public class DragDropManager : Singleton<DragDropManager>
 
         if (!targetNamedObjectSave.IsList && !targetNamedObjectSave.IsLayer)
         {
-            MessageBox.Show("The target is not a List or Layer so we can't add an Object to it.", "Target not valid");
+            DialogService.ShowMessage("The target is not a List or Layer so we can't add an Object to it.");
         }
         else if (targetNamedObjectSave.IsLayer)
         {
@@ -815,11 +810,11 @@ public class DragDropManager : Singleton<DragDropManager>
 
             if (isOfTypeOrInherits == false)
             {
-                MessageBox.Show("The target list type is of type\n\n" +
+                DialogService.ShowMessage("The target list type is of type\n\n" +
                     listType +
                     "\n\nBut the Entity is of type\n\n" +
                     entity.Name +
-                    "\n\nCould not add an instance to the list", "Could not add instance");
+                    "\n\nCould not add an instance to the list");
             }
             else
             {
@@ -952,22 +947,14 @@ public class DragDropManager : Singleton<DragDropManager>
 
         if (elementToCreateIn is EntitySave entityToCreateIn && entityToCreateIn.ImplementsIVisible && !blueprintEntity.ImplementsIVisible)
         {
-            var mbmb = new MultiButtonMessageBoxWpf();
-            mbmb.MessageText = "The Entity\n\n" + blueprintEntity +
+            // Closed without a choice (e.g. Escape) returns default(DialogResult) == None here, which is
+            // treated the same as Cancel below (only DialogResult.OK is special-cased) - matches original behavior.
+            var result = DialogService.ShowChoice<DialogResult>(
+                "The Entity\n\n" + blueprintEntity +
                 "\n\nDoes not Implement IVisible, but the Entity it is being dropped in does.  " +
-                "What would you like to do?";
-
-            mbmb.AddButton("Make " + blueprintEntity.Name + " implement IVisible", DialogResult.OK);
-            mbmb.AddButton("Nothing (your code will not compile until this problem is resolved manually)", DialogResult.Cancel);
-
-            var dialogResult = mbmb.ShowDialog();
-
-            DialogResult result = DialogResult.Cancel;
-
-            if (mbmb.ClickedResult != null && dialogResult == true)
-            {
-                result = (DialogResult)mbmb.ClickedResult;
-            }
+                "What would you like to do?",
+                ("Make " + blueprintEntity.Name + " implement IVisible", DialogResult.OK),
+                ("Nothing (your code will not compile until this problem is resolved manually)", DialogResult.Cancel));
 
             if (result == DialogResult.OK)
             {
@@ -1037,9 +1024,9 @@ public class DragDropManager : Singleton<DragDropManager>
     {
         string message = "Add all contained files in " + element + " to Global Content Files?  Files will still be referenced by " + element;
 
-        DialogResult dialogResult = MessageBox.Show(message, "Add to Global Content?", MessageBoxButtons.YesNo);
+        var dialogResult = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-        if (dialogResult == DialogResult.Yes)
+        if (dialogResult == DialogButton.Yes)
         {
 
             if (!element.UseGlobalContent)
@@ -1051,11 +1038,11 @@ public class DragDropManager : Singleton<DragDropManager>
                     screenOrEntity = "Entity";
                 }
 
-                DialogResult result = MessageBox.Show("The " + screenOrEntity + " " + element +
+                var result = DialogService.ShowConfirm("The " + screenOrEntity + " " + element +
                     "does not UseGlobalContent.  Would you like " +
-                    " to set UseGlobalContent to true?", "Set UseGlobalContent to true?", MessageBoxButtons.YesNo);
+                    " to set UseGlobalContent to true?", DialogButton.Yes, DialogButton.No);
 
-                if (result == DialogResult.Yes)
+                if (result == DialogButton.Yes)
                 {
                     element.UseGlobalContent = true;
                 }
@@ -1271,7 +1258,7 @@ public class DragDropManager : Singleton<DragDropManager>
 
                         if (!String.IsNullOrEmpty(errorMessage))
                         {
-                            MessageBox.Show(errorMessage);
+                            DialogService.ShowMessage(errorMessage);
                         }
                         else if (newlyCreatedFile != null)
                         {
@@ -1311,7 +1298,7 @@ public class DragDropManager : Singleton<DragDropManager>
 
         if (!string.IsNullOrEmpty(response.Message))
         {
-            MessageBox.Show(response.Message);
+            DialogService.ShowMessage(response.Message);
         }
     }
 
@@ -1340,7 +1327,7 @@ public class DragDropManager : Singleton<DragDropManager>
             if (isAlreadyPartOfReferencedFiles)
             {
 
-                MessageBox.Show("The file\n\n" + referencedFileSave.Name + "\n\nis already a Global Content File");
+                DialogService.ShowMessage("The file\n\n" + referencedFileSave.Name + "\n\nis already a Global Content File");
             }
             else
             {
@@ -1363,11 +1350,11 @@ public class DragDropManager : Singleton<DragDropManager>
                         screenOrEntity = "Entity";
                     }
 
-                    DialogResult result = MessageBox.Show("The " + screenOrEntity + " " + container.ToString() +
+                    var result = DialogService.ShowConfirm("The " + screenOrEntity + " " + container.ToString() +
                         "does not UseGlobalContent.  Would you like " +
-                        " to set UseGlobalContent to true?", "Set UseGlobalContent to true?", MessageBoxButtons.YesNo);
+                        " to set UseGlobalContent to true?", DialogButton.Yes, DialogButton.No);
 
-                    if (result == DialogResult.Yes)
+                    if (result == DialogButton.Yes)
                     {
                         container.UseGlobalContent = true;
                     }
@@ -1615,12 +1602,11 @@ public class DragDropManager : Singleton<DragDropManager>
         }
         //////////////End Early Out///////////////////////
 
-        var dialogResult = MessageBox.Show(
+        var dialogResult = DialogService.ShowConfirm(
                             $"Would you like to set the object {namedObject.InstanceName} to be created from the file {referencedFileSave.Name}?",
-                            $"Set {namedObject.InstanceName} to be from file?",
-                            MessageBoxButtons.YesNo);
+                            DialogButton.Yes, DialogButton.No);
 
-        if (dialogResult == DialogResult.Yes)
+        if (dialogResult == DialogButton.Yes)
         {
             namedObject.SourceType = SourceType.File;
             namedObject.SourceFile = referencedFileSave.Name;
@@ -1635,11 +1621,9 @@ public class DragDropManager : Singleton<DragDropManager>
                 string message = $"The object {namedObject.InstanceName} has its 'Instantiate' variable set to 'false'. " +
                     $"This needs to be set to 'true' for the object to be created from the file. Set it to true?";
 
-                var setToTrueResponse = MessageBox.Show(message,
-                    "Set Instantiate to true?",
-                    MessageBoxButtons.YesNo);
+                var setToTrueResponse = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-                if (setToTrueResponse == DialogResult.Yes)
+                if (setToTrueResponse == DialogButton.Yes)
                 {
                     namedObject.Instantiate = true;
                 }
@@ -1809,7 +1793,7 @@ public class DragDropManager : Singleton<DragDropManager>
 #if !DEBUG
         catch (Exception exception)
         {
-            System.Windows.Forms.MessageBox.Show("Error moving object: " + exception.ToString());
+            DialogService.ShowMessage("Error moving object: " + exception.ToString());
         }
 #endif
     }

--- a/FRBDK/Glue/Glue/Managers/ErrorManager.cs
+++ b/FRBDK/Glue/Glue/Managers/ErrorManager.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Windows.Forms;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Reflection;
@@ -43,7 +43,7 @@ namespace FlatRedBall.Glue.Managers
 
                         if (layerNos == null || layerNos.IsLayer == false)
                         {
-                            MessageBox.Show("The object " + nos + " references the layer " + nos.LayerOn + ", but this Layer doesn't exist.");
+                            DialogService.ShowMessage("The object " + nos + " references the layer " + nos.LayerOn + ", but this Layer doesn't exist.");
                             errorFound = true;
                         }
                     }
@@ -60,7 +60,7 @@ namespace FlatRedBall.Glue.Managers
 
                         if (layerNos == null || layerNos.IsLayer == false)
                         {
-                            MessageBox.Show("The object " + nos + " references the layer " + nos.LayerOn + ", but this Layer doesn't exist.");
+                            DialogService.ShowMessage("The object " + nos + " references the layer " + nos.LayerOn + ", but this Layer doesn't exist.");
                             errorFound = true;
                         }
                     }
@@ -89,7 +89,7 @@ namespace FlatRedBall.Glue.Managers
 
             if (!errorFound)
             {
-                MessageBox.Show("No errors found.");
+                DialogService.ShowMessage("No errors found.");
             }
         }
 
@@ -166,7 +166,7 @@ namespace FlatRedBall.Glue.Managers
 
                     errorFound = true;
                     // If we got here, then that means that the .Generated.cs file really isn't referenced, so let's show a error
-                    System.Windows.Forms.MessageBox.Show(error);
+                    DialogService.ShowMessage(error);
                 }
             }
             #endregion
@@ -187,7 +187,7 @@ namespace FlatRedBall.Glue.Managers
                     {
                         errorFound = true;
 
-                        MessageBox.Show("The variable " + variable.Name + " references " + variable.SourceObject + " but " +
+                        DialogService.ShowMessage("The variable " + variable.Name + " references " + variable.SourceObject + " but " +
                             "this object doesn't exist.");
                     }
                     else
@@ -197,7 +197,7 @@ namespace FlatRedBall.Glue.Managers
                         if (!availableMembers.Contains(variable.SourceObjectProperty))
                         {
                             errorFound = true;
-                            MessageBox.Show("The variable " + variable.Name + " references the property " + variable.SourceObjectProperty +
+                            DialogService.ShowMessage("The variable " + variable.Name + " references the property " + variable.SourceObjectProperty +
                                 "in " + asIElement.ToString() + " which does not exist.");
                         }
                     }

--- a/FRBDK/Glue/Glue/Managers/InheritanceManager.cs
+++ b/FRBDK/Glue/Glue/Managers/InheritanceManager.cs
@@ -9,8 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Windows;
-using System.Windows.Forms;
 using CheckResult = FlatRedBall.Glue.ProjectManager.CheckResult;
 
 namespace GlueFormsCore.Managers;
@@ -235,14 +233,14 @@ public class InheritanceManager
             {
                 if (baseNamedObjects.Contains(derivedNamedObjects[i]))
                 {
-                    System.Windows.MessageBox.Show("There is a duplicate named object:\n\n" + derivedNamedObjects[i] + "\n\nThe base class cannot be set");
+                    DialogService.ShowMessage("There is a duplicate named object:\n\n" + derivedNamedObjects[i] + "\n\nThe base class cannot be set");
                     isValidBase = false;
                     break;
                 }
 
                 if (baseReferencedFiles.Contains(derivedNamedObjects[i]))
                 {
-                    System.Windows.MessageBox.Show("There is a file and object both named:\n\n" + derivedNamedObjects[i] + "\n\nThe base class cannot be set");
+                    DialogService.ShowMessage("There is a file and object both named:\n\n" + derivedNamedObjects[i] + "\n\nThe base class cannot be set");
                     isValidBase = false;
                     break;
                 }
@@ -252,14 +250,14 @@ public class InheritanceManager
             {
                 if (baseNamedObjectsIncludingSetByDerived.Contains(derivedReferencedFiles[i]))
                 {
-                    System.Windows.MessageBox.Show("There is a file and object both named:\n\n" + derivedReferencedFiles[i] + "\n\nThe base class cannot be set");
+                    DialogService.ShowMessage("There is a file and object both named:\n\n" + derivedReferencedFiles[i] + "\n\nThe base class cannot be set");
                     isValidBase = false;
                     break;
                 }
 
                 if (baseReferencedFiles.Contains(derivedReferencedFiles[i]))
                 {
-                    System.Windows.MessageBox.Show("There are two files named:\n\n" + derivedReferencedFiles[i] + "\n\nThe base class cannot be set");
+                    DialogService.ShowMessage("There are two files named:\n\n" + derivedReferencedFiles[i] + "\n\nThe base class cannot be set");
                     isValidBase = false;
                     break;
                 }
@@ -281,19 +279,14 @@ public class InheritanceManager
         {
             if (entitySave.GetCustomVariableRecursively(oldVariable.Name) == null)
             {
-                var mbmb = new MultiButtonMessageBoxWpf();
                 string message = "The variable\n\n" + oldVariable.ToString() + "\n\nIs no longer part of the Entity.  What do you want to do?";
 
-                mbmb.MessageText = message;
+                // If closed without a click (e.g. Escape), ShowConfirm returns null, which - same as the
+                // original code (which didn't check ShowDialog()'s return value either) - falls through to
+                // "do nothing, the variable will go away".
+                var selectedOption = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-                mbmb.AddButton("Add a new variable with the same name and type to " + entitySave.Name, DialogResult.Yes);
-                mbmb.AddButton("Nothing - the variable will go away", DialogResult.No);
-
-                var result = mbmb.ShowDialog();
-
-                var selectedOption = mbmb.ClickedResult;
-
-                if (selectedOption is DialogResult.Yes)
+                if (selectedOption == DialogButton.Yes)
                 {
                     var newVariable = new CustomVariable();
                     newVariable.Type = oldVariable.Type;
@@ -346,7 +339,7 @@ public class InheritanceManager
 
             if (InheritanceVerificationHelper(ref node, ref resultString) == CheckResult.Failed)
             {
-                System.Windows.Forms.MessageBox.Show("This assignment has created an inheritence cycle containing the following classes:\n\n" +
+                DialogService.ShowMessage("This assignment has created an inheritence cycle containing the following classes:\n\n" +
                                 resultString +
                                 "\nThe assignment will be undone.");
                 node.BaseObject = null;
@@ -533,16 +526,12 @@ public class InheritanceManager
 
             message += "\nWhat would you like to do?";
 
-            var mbmb = new MultiButtonMessageBoxWpf();
+            // If closed without a click (e.g. Escape), ShowConfirm returns null, which matches neither the
+            // "remove" nor "keep, set defined-by-base false" branches below - same as the original code's
+            // (dialogResult == true && ...) guard on the first branch.
+            var confirmResult = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-            mbmb.MessageText = message;
-
-            mbmb.AddButton($"Remove {thisOrTheseObjects}", DialogResult.Yes);
-            mbmb.AddButton($"Keep {thisOrTheseObjects}, set \"defined by base\" to false", DialogResult.No);
-
-            var dialogResult = mbmb.ShowDialog();
-
-            if (dialogResult == true && (DialogResult)mbmb.ClickedResult == DialogResult.Yes)
+            if (confirmResult == DialogButton.Yes)
             {
                 foreach (var nos in derivedNosesToAskAbout)
                 {
@@ -560,7 +549,7 @@ public class InheritanceManager
                     referencedObjectsBeforeUpdate.Remove(nos);
                 }
             }
-            else if (mbmb.ClickedResult is DialogResult clickedDialogResult && clickedDialogResult == DialogResult.No)
+            else if (confirmResult == DialogButton.No)
             {
                 foreach (var nos in derivedNosesToAskAbout)
                 {

--- a/FRBDK/Glue/Glue/Parsing/CodeParser.cs
+++ b/FRBDK/Glue/Glue/Parsing/CodeParser.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using L = Localization;
+using FlatRedBall.Glue.Controls;
 
 namespace FlatRedBall.Glue.Parsing
 {
@@ -101,7 +102,7 @@ namespace FlatRedBall.Glue.Parsing
             }
             else
             {
-                System.Windows.Forms.MessageBox.Show("Looking for the Game class.  The file  " + fileName + " is part of the project but couldn't find it on disk.");
+                DialogService.ShowMessage("Looking for the Game class.  The file  " + fileName + " is part of the project but couldn't find it on disk.");
                 return false;
             }
         }

--- a/FRBDK/Glue/Glue/Parsing/CsvCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/Parsing/CsvCodeGenerator.cs
@@ -10,7 +10,6 @@ using FlatRedBall.Glue.Parsing;
 using FlatRedBall.Utilities;
 using FlatRedBall.Glue.FormHelpers;
 using FlatRedBall.Glue.SaveClasses;
-using System.Windows.Forms;
 using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.AutomatedGlue;
 using FlatRedBall.Glue.Elements;
@@ -57,7 +56,7 @@ namespace FlatRedBall.Glue
                     }
                     catch(Exception e)
                     {
-                        MessageBox.Show("Error generating the file\n\n" + rfs.Name + "\n\nError details:\n\n" +
+                        DialogService.ShowMessage("Error generating the file\n\n" + rfs.Name + "\n\nError details:\n\n" +
                             e.ToString());
                     }
                 }
@@ -439,7 +438,7 @@ namespace FlatRedBall.Glue
                         }
                         catch (Exception e)
                         {
-                            MessageBox.Show("Error trying to parse CSV:\n" + e.ToString());
+                            DialogService.ShowMessage("Error trying to parse CSV:\n" + e.ToString());
                         }
 
                         if (runtimeToAdd != null)

--- a/FRBDK/Glue/Glue/Parsing/TypeManager.cs
+++ b/FRBDK/Glue/Glue/Parsing/TypeManager.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.IO;
 using System.Collections.ObjectModel;
 using FlatRedBall.Math;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Graphics;
 using System.Security.Policy;
@@ -128,7 +129,7 @@ namespace FlatRedBall.Glue.Parsing
                     }
                     catch(Exception exception)
                     {
-                        System.Windows.Forms.MessageBox.Show("Error making a generic type out of " + baseType.Name + "<" + genericType.Name + ">" +
+                        DialogService.ShowMessage("Error making a generic type out of " + baseType.Name + "<" + genericType.Name + ">" +
                             "\n This is probably because your game hasn't been rebuilt since you've made a critical change");
                         return null;
                     }
@@ -465,7 +466,7 @@ namespace FlatRedBall.Glue.Parsing
             }
             catch (ReflectionTypeLoadException)
             {
-                System.Windows.Forms.MessageBox.Show("Encountered exception while trying to load " + assembly.FullName +
+                DialogService.ShowMessage("Encountered exception while trying to load " + assembly.FullName +
                     "\nThis is likely because the assembly is using a different version of the .NET framework.");
             }
             catch (TypeLoadException)

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutViewModel.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutViewModel.cs
@@ -1,4 +1,5 @@
-﻿using FlatRedBall.Glue.Managers;
+﻿using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.MVVM;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using System;
@@ -116,8 +117,8 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
 
         internal async void DoInstallUpdate()
         {
-            var result = MessageBox.Show("This will download the latest version of FlatRedBall and install it.  This will overwrite any existing FRBDK.  Are you sure you want to do this?", "Install FRBDK", MessageBoxButton.YesNo);
-            if(result == MessageBoxResult.Yes)
+            var result = DialogService.ShowConfirm("This will download the latest version of FlatRedBall and install it.  This will overwrite any existing FRBDK.  Are you sure you want to do this?");
+            if(result == DialogButton.Yes)
             {
                 IsDownloading = true;
                 var location = "https://files.flatredball.com/content/FrbXnaTemplates/DailyBuild/FRBDK.zip";

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/CameraPlugin/CameraSettingsWindow.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/CameraPlugin/CameraSettingsWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -105,7 +105,7 @@ namespace FlatRedBall.Glue.Controls
 			{
 				tbResWidth.Text = ProjectManager.GlueProjectSave.ResolutionWidth.ToString();
 				desiredWidth = ProjectManager.GlueProjectSave.ResolutionWidth;
-				System.Windows.Forms.MessageBox.Show("Invalid width");
+				DialogService.ShowMessage("Invalid width");
 			}
 
 			try
@@ -116,7 +116,7 @@ namespace FlatRedBall.Glue.Controls
 			{
 				tbResHeight.Text = ProjectManager.GlueProjectSave.ResolutionHeight.ToString();
 				desiredHeight = ProjectManager.GlueProjectSave.ResolutionHeight;
-				System.Windows.Forms.MessageBox.Show("Invalid height");
+				DialogService.ShowMessage("Invalid height");
 			}
 
 			ProjectManager.GlueProjectSave.ResolutionWidth = desiredWidth;
@@ -137,7 +137,7 @@ namespace FlatRedBall.Glue.Controls
                 {
                     tbOrthWidth.Text = ProjectManager.GlueProjectSave.OrthogonalWidth.ToString();
                     desiredOrthWidth = ProjectManager.GlueProjectSave.OrthogonalWidth;
-                    System.Windows.Forms.MessageBox.Show("Invalid Orthogonal width");
+                    DialogService.ShowMessage("Invalid Orthogonal width");
                 }
 
                 try
@@ -148,7 +148,7 @@ namespace FlatRedBall.Glue.Controls
                 {
                     tbOrthHeight.Text = ProjectManager.GlueProjectSave.OrthogonalHeight.ToString();
                     desiredOrthHeight = ProjectManager.GlueProjectSave.OrthogonalHeight;
-                    System.Windows.Forms.MessageBox.Show("Invalid Orthogonal height");
+                    DialogService.ShowMessage("Invalid Orthogonal height");
                 }
 
                 ProjectManager.GlueProjectSave.OrthogonalWidth = desiredOrthWidth;
@@ -199,7 +199,7 @@ namespace FlatRedBall.Glue.Controls
 
                 if (!string.IsNullOrEmpty(whyIsntValid))
                 {
-                    MessageBox.Show(whyIsntValid);
+                    DialogService.ShowMessage(whyIsntValid);
                 }
                 else
                 {
@@ -338,7 +338,7 @@ namespace FlatRedBall.Glue.Controls
 
             if(project == null)
             {
-                MessageBox.Show("No project loaded");
+                DialogService.ShowMessage("No project loaded");
             }
             else
             {

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/FactoryPlugin/FactoryElementCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/FactoryPlugin/FactoryElementCodeGenerator.cs
@@ -13,6 +13,7 @@ using FlatRedBall.Glue.IO;
 using FlatRedBall.IO;
 using FlatRedBall.Glue.Elements;
 using System.Windows.Shapes;
+using FlatRedBall.Glue.Controls;
 
 namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.FactoryPlugin
 {
@@ -368,7 +369,7 @@ namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.FactoryPlugin
             }
             catch
             {
-                System.Windows.Forms.MessageBox.Show("Error trying to remove the Factory " + mEntireClassGenerator.ClassName);
+                DialogService.ShowMessage("Error trying to remove the Factory " + mEntireClassGenerator.ClassName);
 
             }
         }

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/MenuStripPlugin/MainMenuStripPlugin.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/MenuStripPlugin/MainMenuStripPlugin.cs
@@ -203,7 +203,7 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.MenuStripPlugin
 
                 if (matchingReferencedFileSaves.Count == 0 && matchingRegularFiles.Count == 0)
                 {
-                    MessageBox.Show(String.Format(Localization.Texts.NoFilesReferencing, tiw.Result), Localization.Texts.NoFilesFound);
+                    DialogService.ShowMessage(String.Format(Localization.Texts.NoFilesReferencing, tiw.Result));
                 }
                 else
                 {
@@ -218,7 +218,7 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.MenuStripPlugin
                     {
                         message += rfs + "\n";
                     }
-                    MessageBox.Show(message, Localization.Texts.FoundFiles);
+                    DialogService.ShowMessage(message);
                 }
             }
         }
@@ -338,7 +338,7 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.MenuStripPlugin
             }
             else
             {
-                MessageBox.Show(String.Format(Localization.Texts.ErrorCouldNotOpen, whatToView));
+                DialogService.ShowMessage(String.Format(Localization.Texts.ErrorCouldNotOpen, whatToView));
             }
         }
 
@@ -346,7 +346,7 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.MenuStripPlugin
         {
             if (ProjectManager.GlueProjectSave == null)
             {
-                MessageBox.Show(Localization.Texts.NoLoadedGlueProject);
+                DialogService.ShowMessage(Localization.Texts.NoLoadedGlueProject);
             }
             else
             {
@@ -366,11 +366,11 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.MenuStripPlugin
 
                     if (string.IsNullOrEmpty(ProjectManager.GameClassFileName))
                     {
-                        MessageBox.Show(Localization.Texts.ErrorCouldntFindGameClass);
+                        DialogService.ShowMessage(Localization.Texts.ErrorCouldntFindGameClass);
                     }
                     else
                     {
-                        MessageBox.Show(String.Format(Localization.Texts.GameClassFound, ProjectManager.GameClassFileName));
+                        DialogService.ShowMessage(String.Format(Localization.Texts.GameClassFound, ProjectManager.GameClassFileName));
                     }
                 }
             }

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/SyncedProjects/Controls/ToolbarControl.xaml.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/SyncedProjects/Controls/ToolbarControl.xaml.cs
@@ -1,4 +1,5 @@
-﻿using FlatRedBall.Glue.Plugins.ExportedImplementations;
+﻿using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using System.Windows;
 using System.Windows.Controls;
 using L = Localization;
@@ -24,7 +25,7 @@ namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.SyncedProjects.Controls
             }
             else
             {
-                MessageBox.Show("There is no loaded Glue project");
+                DialogService.ShowMessage("There is no loaded Glue project");
             }
         }
 

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/SyncedProjects/ProjectListEntry.xaml.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/SyncedProjects/ProjectListEntry.xaml.cs
@@ -1,4 +1,5 @@
-﻿using FlatRedBall.Glue.Controls.ProjectSync;
+﻿using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Controls.ProjectSync;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.VSHelpers;
 using FlatRedBall.Glue.VSHelpers.Projects;
@@ -41,7 +42,7 @@ namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.SyncedProjects
             }
             catch(FileNotFoundException fnfe)
             {
-                MessageBox.Show(fnfe.Message);
+                DialogService.ShowMessage(fnfe.Message);
             }
 
             string fileToOpen = null;
@@ -77,7 +78,7 @@ namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.SyncedProjects
 
                     if(openedWithGlue)
                     {
-                        MessageBox.Show(String.Format(L.Texts.GlueFileAssociation, fileToOpen));
+                        DialogService.ShowMessage(String.Format(L.Texts.GlueFileAssociation, fileToOpen));
                     }
                 }
                 catch(InvalidOperationException)

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/UnreferencedFiles/UnreferencedFilesManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/UnreferencedFiles/UnreferencedFilesManager.cs
@@ -8,6 +8,7 @@ using FlatRedBall.Glue.SaveClasses;
 using System.IO;
 using FlatRedBall.Glue.FormHelpers;
 using System.Windows.Forms;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.IO;
 using FlatRedBall.Glue.AutomatedGlue;
@@ -276,13 +277,12 @@ namespace FlatRedBall.Glue.Managers
             {
                 if (!projectSpecificFile.File.Exists()) continue;
 
-                DialogResult result =
-                    System.Windows.Forms.MessageBox.Show(
-                        "The following file is no longer referenced by the project\n\n" +
-                        projectSpecificFile +
-                        "\n\nRemove and delete this file?", "Remove unreferenced file?", MessageBoxButtons.YesNo);
+                var result = DialogService.ShowConfirm(
+                    "The following file is no longer referenced by the project\n\n" +
+                    projectSpecificFile +
+                    "\n\nRemove and delete this file?");
 
-                if (result != DialogResult.Yes) continue;
+                if (result != DialogButton.Yes) continue;
 
                 ProjectManager.GetProjectByName(projectSpecificFile.ProjectName).ContentProject.RemoveItem(
                     projectSpecificFile.File.FullPath);

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/UnreferencedFiles/UnreferencedFilesViewModel.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/UnreferencedFiles/UnreferencedFilesViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Windows;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.MVVM;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.VSHelpers.Projects;
@@ -169,9 +170,9 @@ namespace FlatRedBall.Glue.UnreferencedFiles
             }
             else
             {
-                var result = MessageBox.Show($"Would like to move {SelectedFileName} to the recycle bin?", "Delete file?", MessageBoxButton.YesNo);
-                
-                if(result == MessageBoxResult.Yes)
+                var result = DialogService.ShowConfirm($"Would like to move {SelectedFileName} to the recycle bin?", DialogButton.Yes, DialogButton.No);
+
+                if(result == DialogButton.Yes)
                 {
                     FileHelper.MoveToRecycleBin(SelectedAbsoluteFile);
 
@@ -222,9 +223,9 @@ namespace FlatRedBall.Glue.UnreferencedFiles
             }
             else
             {
-                var result = MessageBox.Show($"Would like to move all selected files to the recycle bin?", "Delete file?", MessageBoxButton.YesNo);
+                var result = DialogService.ShowConfirm($"Would like to move all selected files to the recycle bin?", DialogButton.Yes, DialogButton.No);
 
-                if (result == MessageBoxResult.Yes)
+                if (result == DialogButton.Yes)
                 {
                     var contentFolder = GlueState.Self.ContentDirectory;
 

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
@@ -614,7 +614,7 @@ class DialogCommands : IDialogCommands
         //////////////Early Out////////////
         if (ProjectManager.GlueProjectSave == null)
         {
-            System.Windows.Forms.MessageBox.Show(L.Texts.ErrorNewProjectFirst);
+            DialogService.ShowMessage(L.Texts.ErrorNewProjectFirst);
             return;
         }
         if (ProjectManager.StatusCheck() != ProjectManager.CheckResult.Passed)
@@ -622,7 +622,7 @@ class DialogCommands : IDialogCommands
             return;
         }
         ////////////End Early Out
-        
+
         viewModel = viewModel ?? CreateAddNewEntityViewModel();
 
         AddEntityWindow window = new();
@@ -643,7 +643,7 @@ class DialogCommands : IDialogCommands
 
             if (!_nameVerifier.IsEntityNameValid(entityName, null, out whyIsntValid))
             {
-                MessageBox.Show(whyIsntValid);
+                DialogService.ShowMessage(whyIsntValid);
             }
             else
             {
@@ -798,7 +798,7 @@ class DialogCommands : IDialogCommands
 
         if (didFailureOccur)
         {
-            MessageBox.Show(failureMessage);
+            DialogService.ShowMessage(failureMessage);
         }
         else
         {
@@ -818,7 +818,7 @@ class DialogCommands : IDialogCommands
                     }
                     else
                     {
-                        MessageBox.Show(String.Format(L.Texts.VariableInBaseAlreadyExists, resultName));
+                        DialogService.ShowMessage(String.Format(L.Texts.VariableInBaseAlreadyExists, resultName));
                         canCreate = false;
                     }
                 }
@@ -954,7 +954,7 @@ class DialogCommands : IDialogCommands
         //////////////Early Out////////////
         if (ProjectManager.GlueProjectSave == null)
         {
-            System.Windows.Forms.MessageBox.Show(L.Texts.ErrorNewProjectFirst);
+            DialogService.ShowMessage(L.Texts.ErrorNewProjectFirst);
             return;
         }
         if (ProjectManager.StatusCheck() != ProjectManager.CheckResult.Passed)
@@ -986,7 +986,7 @@ class DialogCommands : IDialogCommands
 
             if (!_nameVerifier.IsScreenNameValid(addScreenWindow.Result, null, out whyItIsntValid))
             {
-                MessageBox.Show(whyItIsntValid);
+                DialogService.ShowMessage(whyItIsntValid);
             }
             else
             {
@@ -1155,19 +1155,25 @@ class DialogCommands : IDialogCommands
 
         if (GlueGui.ShowGui)
         {
+            // DialogService.ShowConfirm already marshals to the UI thread, but this stays wrapped in
+            // DoOnUiThread since `result` is captured by the caller synchronously below via DoOnUiThread's
+            // blocking behavior.
             GlueCommands.Self.DoOnUiThread(() =>
            {
-               //var result = MessageBox.Show(message, caption, MessageBoxButtons.YesNo);
-               result = System.Windows.MessageBox.Show(message, caption, System.Windows.MessageBoxButton.YesNo);
+               var confirmResult = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-               if (result == System.Windows.MessageBoxResult.Yes)
+               if (confirmResult == DialogButton.Yes)
                {
+                   result = System.Windows.MessageBoxResult.Yes;
                    yesAction?.Invoke();
                }
-               else if (result == System.Windows.MessageBoxResult.No)
+               else if (confirmResult == DialogButton.No)
                {
+                   result = System.Windows.MessageBoxResult.No;
                    noAction?.Invoke();
                }
+               // Escape/close without a button click: confirmResult is null, result stays MessageBoxResult.None,
+               // matching the original WPF MessageBox.Show(...) escape behavior.
            });
 
         }

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ElementCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ElementCommands.cs
@@ -390,10 +390,9 @@ public class ElementCommands : IScreenCommands, IEntityCommands,IElementCommands
             }
             
             message += "\n\nOverwrite?";
-            var result = MessageBox.Show(message, "Overwrite",
-                MessageBoxButtons.YesNo);
+            var result = DialogService.ShowConfirm(message);
 
-            response.Succeeded = result == DialogResult.Yes;
+            response.Succeeded = result == DialogButton.Yes;
         }
 
 
@@ -523,7 +522,7 @@ public class ElementCommands : IScreenCommands, IEntityCommands,IElementCommands
             {
                 if (!suppressAlreadyExistingFileMessage)
                 {
-                    MessageBox.Show("There is already a file named\n\n" + fullNonGeneratedFileName + "\n\nThis file will be used instead of creating a new one just in case you have code that you want to keep there.");
+                    DialogService.ShowMessage("There is already a file named\n\n" + fullNonGeneratedFileName + "\n\nThis file will be used instead of creating a new one just in case you have code that you want to keep there.");
                 }
             }
             
@@ -1072,7 +1071,7 @@ public class ElementCommands : IScreenCommands, IEntityCommands,IElementCommands
         {
             if (!suppressAlreadyExistingFileMessage)
             {
-                MessageBox.Show("There is already a file named\n\n" + customCodeFilePath + "\n\nThis file will be used instead of creating a new one just in case you have code that you want to keep there.");
+                DialogService.ShowMessage("There is already a file named\n\n" + customCodeFilePath + "\n\nThis file will be used instead of creating a new one just in case you have code that you want to keep there.");
             }
         }
 
@@ -1514,9 +1513,13 @@ public class ElementCommands : IScreenCommands, IEntityCommands,IElementCommands
                 switch (unknownTypeHandle)
                 {
                     case PromptHandleEnum.Prompt:
-                        dialogResult = MessageBox.Show("The extension " + extension + " is not recognized by Glue.  " +
+                        // If closed without a click (Escape), ShowChoice returns default(DialogResult) (None),
+                        // matching the original behavior where None != No, so the file is still added.
+                        dialogResult = DialogService.ShowChoice("The extension " + extension + " is not recognized by Glue.  " +
                                                        "Glue will not be able to generate code for this file, but will add it to your game project.\n\nDo you " +
-                                                       "want to add this file?", "Add unknown type?", MessageBoxButtons.YesNo);
+                                                       "want to add this file?",
+                                                       ("Yes", DialogResult.Yes),
+                                                       ("No", DialogResult.No));
                         break;
                     case PromptHandleEnum.DoYes:
                         dialogResult = DialogResult.Yes;

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
@@ -19,7 +19,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Services;
 using GeneralResponse = ToolsUtilities.GeneralResponse;
 
@@ -427,15 +427,15 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
 
             if (oldFilePath.GetDirectoryContainingThis() != newFilePath.GetDirectoryContainingThis())
             {
-                MessageBox.Show("The old file was located in \n" + oldFilePath.GetDirectoryContainingThis() + "\n" +
+                DialogService.ShowMessage("The old file was located in \n" + oldFilePath.GetDirectoryContainingThis() + "\n" +
                     "The new file is located in \n" + newFilePath.GetDirectoryContainingThis() + "\n" +
-                    "Currently Glue does not support changing directories.", "Warning");
+                    "Currently Glue does not support changing directories.");
 
                 //rfs.SetNameNoCall(oldName);
             }
             else if (_nameVerifier.IsReferencedFileNameValid(instanceName, rfs.GetAssetTypeInfo(), rfs, container, out whyIsntValid) == false)
             {
-                MessageBox.Show(whyIsntValid);
+                DialogService.ShowMessage(whyIsntValid);
                 //rfs.SetNameNoCall(oldName);
             }
             else
@@ -606,7 +606,7 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
                 {
                     var message = "Error opening " + fileName + $"\nTry navigating to this file and opening it through explorer. More info: \n\n{exception}";
                     GlueCommands.Self.PrintError(message);
-                    System.Windows.Forms.MessageBox.Show(message);
+                    DialogService.ShowMessage(message);
 
 
                 }
@@ -627,7 +627,7 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
                 {
                     string error = "Could not find the application\n\n" + applicationSetInGlue;
 
-                    System.Windows.Forms.MessageBox.Show(error);
+                    DialogService.ShowMessage(error);
                 }
                 else
                 {

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
@@ -344,37 +344,33 @@ public class GluxCommands : IGluxCommands
                         {
                             message += "\n\nAn error log has been saved here:\n" + errorLogLocation;
 
-                            var mbmb = new MultiButtonMessageBoxWpf();
-                            mbmb.MessageText = message;
-                            mbmb.AddButton("Open Error File", true);
-                            mbmb.AddButton("Do nothing (Glue probably needs to be restarted)", false);
+                            // Escape (no button click) returns default(bool) (false), which matches the
+                            // original "do nothing" fallback when ShowDialog() didn't return true.
+                            var clickedResult = DialogService.ShowChoice(message,
+                                ("Open Error File", true),
+                                ("Do nothing (Glue probably needs to be restarted)", false));
 
-                            if (mbmb.ShowDialog() == true)
+                            if (clickedResult)
                             {
-                                var clickedResult = (bool)mbmb.ClickedResult;
-
-                                if (clickedResult)
+                                try
+                                {
+                                    //System.Diagnostics.Process.Start(errorLogLocation);
+                                    var p = new System.Diagnostics.Process();
+                                    p.StartInfo = new System.Diagnostics.ProcessStartInfo(errorLogLocation)
+                                    {
+                                        UseShellExecute = true
+                                    };
+                                    p.Start();
+                                }
+                                catch
                                 {
                                     try
                                     {
-                                        //System.Diagnostics.Process.Start(errorLogLocation);
-                                        var p = new System.Diagnostics.Process();
-                                        p.StartInfo = new System.Diagnostics.ProcessStartInfo(errorLogLocation)
-                                        {
-                                            UseShellExecute = true
-                                        };
-                                        p.Start();
+                                        System.Diagnostics.Process.Start(FileManager.GetDirectory(errorLogLocation));
                                     }
                                     catch
                                     {
-                                        try
-                                        {
-                                            System.Diagnostics.Process.Start(FileManager.GetDirectory(errorLogLocation));
-                                        }
-                                        catch
-                                        {
-                                            // do nothing
-                                        }
+                                        // do nothing
                                     }
                                 }
                             }
@@ -1148,15 +1144,15 @@ public class GluxCommands : IGluxCommands
                             else
                             {
                                 // Ask the user what to do here - remove it?  Keep it and not compile?
-                                var mbmb = new MultiButtonMessageBoxWpf();
-                                mbmb.MessageText = "The object\n" + nos.ToString() + "\nreferences the file\n" + referencedFileToRemove.Name +
-                                    "\nWhat would you like to do?";
-                                mbmb.AddButton("Remove this object", DialogResult.Yes);
-                                mbmb.AddButton("Keep it (object will not be valid until changed)", DialogResult.No);
+                                // Escape (no button click) returns default(DialogResult) (None), which isn't
+                                // Yes, so this falls through to "keep it" - same as the original behavior.
+                                var dialogResult = DialogService.ShowChoice(
+                                    "The object\n" + nos.ToString() + "\nreferences the file\n" + referencedFileToRemove.Name +
+                                    "\nWhat would you like to do?",
+                                    ("Remove this object", DialogResult.Yes),
+                                    ("Keep it (object will not be valid until changed)", DialogResult.No));
 
-                                var result = mbmb.ShowDialog();
-
-                                if (result == true && mbmb.ClickedResult is DialogResult dialogResult && dialogResult == DialogResult.Yes)
+                                if (dialogResult == DialogResult.Yes)
                                 {
                                     container.NamedObjects.RemoveAt(i);
                                 }
@@ -4111,15 +4107,16 @@ public class GluxCommands : IGluxCommands
 
             if (CustomVariableHelper.IsStateMissingFor(variable, element))
             {
-                var mbmb = new MultiButtonMessageBoxWpf();
-                mbmb.MessageText = String.Format(
-                    "The variable {0} no longer has any states associated with it.  What would you like to do?",
-                    variable);
+                // Escape (no button click) returns default(DialogResult) (None), which isn't OK, so this
+                // falls through to "do nothing" - same as the original behavior.
+                var asDialogResult = DialogService.ShowChoice(
+                    String.Format(
+                        "The variable {0} no longer has any states associated with it.  What would you like to do?",
+                        variable),
+                    ("Remove the variable", DialogResult.OK),
+                    ("Nothing (project may not run until this is fixed)", DialogResult.Cancel));
 
-                mbmb.AddButton("Remove the variable", DialogResult.OK);
-                mbmb.AddButton("Nothing (project may not run until this is fixed)", DialogResult.Cancel);
-
-                if (mbmb.ShowDialog() == true && mbmb.ClickedResult is DialogResult asDialogResult && asDialogResult == DialogResult.OK)
+                if (asDialogResult == DialogResult.OK)
                 {
                     element.CustomVariables.RemoveAt(i);
                     i--;

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
@@ -3,7 +3,7 @@ using FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces;
 using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.IO;
 using System;
-using System.Windows.Forms;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.FormHelpers;
 using System.IO;
 using FlatRedBall.Glue.VSHelpers.Projects;
@@ -80,7 +80,7 @@ class ProjectCommands : IProjectCommands
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    MessageBox.Show("Could not save the file because the file is in use");
+                    DialogService.ShowMessage("Could not save the file because the file is in use");
                     succeeded = false;
                 }
 
@@ -430,7 +430,7 @@ class ProjectCommands : IProjectCommands
                         "in a FRBDK tool and didn't select the \"Copy to relative\" option.\n\nYou should probably shut " +
                         "down Glue, fix this problem, then re-open your project.";
 
-                    System.Windows.Forms.MessageBox.Show(message);
+                    DialogService.ShowMessage(message);
                 }
                 else
                 {

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueCommands.cs
@@ -405,7 +405,7 @@ public class GlueCommands : IGlueCommands
             {
                 var errorLoadingSettings = global::Localization.Texts.ErrorLoadingSettings;
                 var errorDetails = global::Localization.Texts.ErrorDetails;
-                System.Windows.MessageBox.Show($"{errorLoadingSettings}\n\n{settingsFileLocation}\n\n{errorDetails}\n\n{e}");
+                FlatRedBall.Glue.Controls.DialogService.ShowMessage($"{errorLoadingSettings}\n\n{settingsFileLocation}\n\n{errorDetails}\n\n{e}");
                 didErrorOccur = true;
             }
 

--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -361,7 +361,7 @@ public class PluginManager : PluginManagerBase
         bool succeeded = true;
         if (!File.Exists(localPlugFile))
         {
-            MessageBox.Show(@"Please select a valid *.plug file to install.");
+            DialogService.ShowMessage(@"Please select a valid *.plug file to install.");
             succeeded = false;
         }
         
@@ -387,7 +387,7 @@ public class PluginManager : PluginManagerBase
                 case InstallationType.ForCurrentProject:
                     if (glueState.CurrentGlueProject == null)
                     {
-                        MessageBox.Show(@"Can not select For Current Project because no project is currently open.");
+                        DialogService.ShowMessage(@"Can not select For Current Project because no project is currently open.");
                         succeeded = false;
                     }
 
@@ -399,7 +399,7 @@ public class PluginManager : PluginManagerBase
                     }
                     break;
                 default:
-                    MessageBox.Show(@"Unknown install type.  Please select a valid install type.");
+                    DialogService.ShowMessage(@"Unknown install type.  Please select a valid install type.");
                     succeeded = false;
                     break;
             }
@@ -421,7 +421,7 @@ public class PluginManager : PluginManagerBase
                 //Only allow one folder in zip
                 if (String.IsNullOrEmpty(rootDirectory))
                 {
-                    MessageBox.Show(@"Unexpected *.plug format (No root directory found in plugin archive)");
+                    DialogService.ShowMessage(@"Unexpected *.plug format (No root directory found in plugin archive)");
                     succeeded = false;
                 }
 
@@ -432,9 +432,11 @@ public class PluginManager : PluginManagerBase
                     if (Directory.Exists(installPath + rootDirectory))
                     {
                         Plugins.PluginManager.ReceiveOutput("Plugin file already exists: " + installPath + @"\" + rootDirectory);
-                        DialogResult result = MessageBox.Show(@"Existing plugin already exists!  Do you want to replace it?", @"Confirm delete", MessageBoxButtons.YesNo);
+                        // Escape/close without a button click falls into the else branch below, same as clicking "No" -
+                        // matches the original MessageBoxButtons.YesNo behavior where Escape acts as "No".
+                        var confirmResult = DialogService.ShowConfirm(@"Existing plugin already exists!  Do you want to replace it?", DialogButton.Yes, DialogButton.No);
 
-                        if (result == DialogResult.Yes)
+                        if (confirmResult == DialogButton.Yes)
                         {
                             try
                             {
@@ -442,7 +444,7 @@ public class PluginManager : PluginManagerBase
                             }
                             catch (Exception exc)
                             {
-                                MessageBox.Show("Error trying to delete " + installPath + @"\" + rootDirectory + "\n\n" + exc.ToString());
+                                DialogService.ShowMessage("Error trying to delete " + installPath + @"\" + rootDirectory + "\n\n" + exc.ToString());
                                 succeeded = false;
                             }
                         }
@@ -503,11 +505,11 @@ public class PluginManager : PluginManagerBase
                         {
                             message += $"\n\nNote that Glue also has a plugin installed at \n{firstMatching.FullPath}";
                         }
-                        MessageBox.Show(message);
+                        DialogService.ShowMessage(message);
                     }
                     else
                     {
-                        MessageBox.Show("Failed to install plugin.");
+                        DialogService.ShowMessage("Failed to install plugin.");
 
                     }
                 }
@@ -1706,7 +1708,7 @@ public class PluginManager : PluginManagerBase
                         }
                         catch
                         {
-                            MessageBox.Show("Plugin " + kvp.Key.FriendlyName + " failed to shut down properly");
+                            DialogService.ShowMessage("Plugin " + kvp.Key.FriendlyName + " failed to shut down properly");
                             // Doesn't matter, we're shutting down
                         }
                     }else
@@ -2296,7 +2298,7 @@ public class PluginManager : PluginManagerBase
                 if (WasExceptionCausedByPlugin(exception, plugin))
                 {
                     // We're going to blame this plugin for the error
-                    MessageBox.Show($"A plugin has had an error.\n" +
+                    DialogService.ShowMessage($"A plugin has had an error.\n" +
                         $"Shutting down the plugin {plugin.Name} version {plugin.Plugin.Version} at file location\n{plugin.AssemblyLocation}\n\n" +
                         $"Additional information:\n\n" + 
                         exception.ToString());

--- a/FRBDK/Glue/Glue/Program.cs
+++ b/FRBDK/Glue/Glue/Program.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using FlatRedBall.Glue.Plugins;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using GlueFormsCore.Controls;
+using FlatRedBall.Glue.Controls;
 
 namespace Glue;
 
@@ -43,7 +44,7 @@ static class Program
         {
             if (!MainPanelControl.IsExiting)
             {
-                MessageBox.Show(e.ToString());
+                DialogService.ShowMessage(e.ToString());
             }
         }
 

--- a/FRBDK/Glue/Glue/SaveClasses/NamedObjectSaveHelper.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/NamedObjectSaveHelper.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Windows.Forms;
 
 using FlatRedBall.IO;
 
@@ -80,7 +79,7 @@ namespace FlatRedBall.Glue.SaveClasses
 
                         if (!inheritsFromFrbType)
                         {
-                            System.Windows.Forms.MessageBox.Show("The Element\n\n" + namedObjectContainer.ToString() + "\n\nhas a base type\n\n" + namedObjectContainer.BaseObject +
+                            DialogService.ShowMessage("The Element\n\n" + namedObjectContainer.ToString() + "\n\nhas a base type\n\n" + namedObjectContainer.BaseObject +
                                 "\n\nbut this base type can't be found.  " +
                                 "It was probably removed from the project.  You will need to set the base object to NONE.");
                         }
@@ -156,7 +155,7 @@ namespace FlatRedBall.Glue.SaveClasses
                         {
 
 
-                            System.Windows.Forms.MessageBox.Show("The Element\n\n" + namedObjectContainer.ToString() + "\n\nhas a base type\n\n" + namedObjectContainer.BaseObject +
+                            DialogService.ShowMessage("The Element\n\n" + namedObjectContainer.ToString() + "\n\nhas a base type\n\n" + namedObjectContainer.BaseObject +
                                 "\n\nbut this base type can't be found.  " +
                                 "It was probably removed from the project.  You will need to set the base object to NONE.");
                         }

--- a/FRBDK/Glue/Glue/SaveClasses/ReferencedFileSaveExtensionMethodsGlue.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/ReferencedFileSaveExtensionMethodsGlue.cs
@@ -6,8 +6,8 @@ using FlatRedBall.Glue.Elements;
 using FlatRedBall.IO;
 using System.IO;
 using EditorObjects.SaveClasses;
-using System.Windows.Forms;
 using EditorObjects.Parsing;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Errors;
 using FlatRedBall.Content;
 using FlatRedBall.Glue.Plugins;
@@ -146,7 +146,7 @@ namespace FlatRedBall.Glue.SaveClasses
 
             if (!doesFileExist)
             {
-                MessageBox.Show("Could not find the following source file:\n\n" +
+                DialogService.ShowMessage("Could not find the following source file:\n\n" +
                     absoluteSourceName);
 
             }
@@ -173,7 +173,7 @@ namespace FlatRedBall.Glue.SaveClasses
                         error += "\n\"" + bta.SourceFileType + "\" -> " +  bta.BuildToolProcessed + " -> \"" + bta.DestinationFileType + "\"";
                     }
 
-                    System.Windows.Forms.MessageBox.Show(error);
+                    DialogService.ShowMessage(error);
                 }
 
                 #endregion
@@ -195,11 +195,11 @@ namespace FlatRedBall.Glue.SaveClasses
                     }
                     catch (FileNotFoundException fnfe)
                     {
-                        System.Windows.Forms.MessageBox.Show("Can't find the file:\n" + fnfe.FileName);
+                        DialogService.ShowMessage("Can't find the file:\n" + fnfe.FileName);
                     }
                     catch (Exception e)
                     {
-                        System.Windows.Forms.MessageBox.Show("There was an error building the file\n" + absoluteSourceName + "\n\n" +
+                        DialogService.ShowMessage("There was an error building the file\n" + absoluteSourceName + "\n\n" +
                             e.Message);
                     }
                     #endregion

--- a/FRBDK/Glue/Glue/SaveClasses/StateSaveExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/StateSaveExtensionMethods.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Windows.Forms;
 using FlatRedBall.Content.Instructions;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.Parsing;
 
@@ -32,10 +32,10 @@ namespace FlatRedBall.Glue.SaveClasses
             {
                 string withoutSpace = variableName.Substring(0, variableName.IndexOf(' '));
 
-                DialogResult result = 
-                    MessageBox.Show("The variable " + withoutSpace + " is set in other categories that do not share states.  Are you sure you want to set it?", "Set variable?", MessageBoxButtons.YesNo);
+                var result =
+                    DialogService.ShowConfirm("The variable " + withoutSpace + " is set in other categories that do not share states.  Are you sure you want to set it?");
 
-                if (result == DialogResult.Yes)
+                if (result == DialogButton.Yes)
                 {
                     variableName = withoutSpace;
                 }

--- a/FRBDK/Glue/Glue/SetProperty/CustomVariableSaveSetPropertyLogic.cs
+++ b/FRBDK/Glue/Glue/SetProperty/CustomVariableSaveSetPropertyLogic.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Windows.Forms;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.FormHelpers;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Content.Instructions;
@@ -85,7 +85,7 @@ public class CustomVariableSaveSetPropertyLogic
                         !string.IsNullOrEmpty(variableInLoop.SourceObject) && currentVariable.SourceObject == variableInLoop.SourceObject &&
                         !string.IsNullOrEmpty(variableInLoop.SourceObjectProperty) && currentVariable.SourceObjectProperty == variableInLoop.SourceObjectProperty)
                     {
-                        MessageBox.Show("There is already a variable that is modifying " + currentVariable.SourceObjectProperty + " on " + currentVariable.SourceObject);
+                        DialogService.ShowMessage("There is already a variable that is modifying " + currentVariable.SourceObjectProperty + " on " + currentVariable.SourceObject);
 
                         currentVariable.SourceObjectProperty = (string)oldValue;
                     }
@@ -514,7 +514,7 @@ public class CustomVariableSaveSetPropertyLogic
 
             if (customVariable.IsShared && customVariable.GetIsCsv())
             {
-                MessageBox.Show("Shared CSV variables are not assigned until either an instance of this object is created, or until LoadStaticContent is called.  Until then, the variable will equal null");
+                DialogService.ShowMessage("Shared CSV variables are not assigned until either an instance of this object is created, or until LoadStaticContent is called.  Until then, the variable will equal null");
 
             }
         }
@@ -653,14 +653,14 @@ public class CustomVariableSaveSetPropertyLogic
 
                 if (characteristic == InterpolationCharacteristic.CantInterpolate)
                 {
-                    MessageBox.Show("The variable " + customVariable.SourceObjectProperty + " cannot be interpolated.");
+                    DialogService.ShowMessage("The variable " + customVariable.SourceObjectProperty + " cannot be interpolated.");
                     customVariable.HasAccompanyingVelocityProperty = false;
                 }
                 else if (characteristic == InterpolationCharacteristic.CanInterpolate)
                 {
                     string velocityMember =
                         FlatRedBall.Instructions.InstructionManager.GetVelocityForState(customVariable.SourceObjectProperty);
-                    MessageBox.Show("The variable " + customVariable.SourceObjectProperty + " already has a built-in " +
+                    DialogService.ShowMessage("The variable " + customVariable.SourceObjectProperty + " already has a built-in " +
                         "velocity member named " + velocityMember + "\n\nThere is no need to set an accompanying velocity property. " +
                         "Glue will undo this change now.");
 

--- a/FRBDK/Glue/Glue/SetProperty/ReferencedFileSaveSetPropertyManager.cs
+++ b/FRBDK/Glue/Glue/SetProperty/ReferencedFileSaveSetPropertyManager.cs
@@ -139,12 +139,12 @@ namespace FlatRedBall.Glue.SetVariable
                 {
                     if (namedObject.SourceType == SourceType.File && namedObject.SourceFile == rfs.Name && namedObject.AddToManagers == false)
                     {
-                        DialogResult result = MessageBox.Show("The object " + namedObject.InstanceName + " references this file.  " +
+                        var confirmResult = DialogService.ShowConfirm("The object " + namedObject.InstanceName + " references this file.  " +
                             "Shared files are not added to the engine, but since the object has its AddToManagers also set to false " +
                             "the content in this file will not be added to managers.  Would you like to set the object's AddToManagers to " +
-                            "true?", "Add to managers?", MessageBoxButtons.YesNo);
+                            "true?", DialogButton.Yes, DialogButton.No);
 
-                        if (result == DialogResult.Yes)
+                        if (confirmResult == DialogButton.Yes)
                         {
                             namedObject.AddToManagers = true;
                         }
@@ -187,8 +187,8 @@ namespace FlatRedBall.Glue.SetVariable
 
                 if (oldProjectLocalization != newProjectLocalization)
                 {
-                    MessageBox.Show("Because of the change to the \"Is Database For Localizing\" the generated code for the entire project is likely out of date." +
-                        "We recommend closing and re-opening the project in Glue to cause a full regeneration.", "Generated code is out of date");
+                    DialogService.ShowMessage("Because of the change to the \"Is Database For Localizing\" the generated code for the entire project is likely out of date." +
+                        "We recommend closing and re-opening the project in Glue to cause a full regeneration.");
                 }
             }
 
@@ -380,15 +380,15 @@ namespace FlatRedBall.Glue.SetVariable
             string whyIsntValid;
             if (oldDirectory != newDirectory)
             {
-                MessageBox.Show("The old file was located in \n" + oldDirectory + "\n" +
+                DialogService.ShowMessage("The old file was located in \n" + oldDirectory + "\n" +
                     "The new file is located in \n" + newDirectory + "\n" +
-                    "Currently Glue does not support changing directories.", "Warning");
+                    "Currently Glue does not support changing directories.");
 
                 rfs.SetNameNoCall(oldName);
             }
             else if (_nameVerifier.IsReferencedFileNameValid(instanceName, rfs.GetAssetTypeInfo(), rfs, container, out whyIsntValid) == false)
             {
-                MessageBox.Show(whyIsntValid);
+                DialogService.ShowMessage(whyIsntValid);
                 rfs.SetNameNoCall(oldName);
 
             }
@@ -680,15 +680,14 @@ namespace FlatRedBall.Glue.SetVariable
             {
                 string message = "The new file name already exists.  What would you like to do?";
 
-                var mbmb = new MultiButtonMessageBoxWpf();
-
-                mbmb.MessageText = message;
-
-                mbmb.AddButton("Use existing file", DialogResult.Yes);
-                mbmb.AddButton("Cancel the rename", DialogResult.Cancel);
-
-                mbmb.ShowDialog();
-                var result = (DialogResult)mbmb.ClickedResult;
+                // Escape/close without a button click returns default(DialogResult) == None here, which is
+                // neither Cancel nor Yes, so it falls through and the rename proceeds with a move (same as
+                // clicking neither button would have fallen through to below in the pre-migration code, minus
+                // the NullReferenceException that direct (DialogResult)mbmb.ClickedResult casting used to throw
+                // on Escape).
+                var result = DialogService.ShowChoice<DialogResult>(message,
+                    ("Use existing file", DialogResult.Yes),
+                    ("Cancel the rename", DialogResult.Cancel));
 
                 if (result == DialogResult.Cancel)
                 {

--- a/FRBDK/Glue/Glue/SetVariable/EntitySaves/EntitySaveSetPropertyLogic.cs
+++ b/FRBDK/Glue/Glue/SetVariable/EntitySaves/EntitySaveSetPropertyLogic.cs
@@ -57,9 +57,9 @@ class EntitySaveSetPropertyLogic
                 // variables for all contained objects
                 string message = "Would you like to add reset variables for all contained objects (recommended)";
 
-                DialogResult result = MessageBox.Show(message, "Add reset variables?", MessageBoxButtons.YesNo);
+                var confirmResult = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-                if (result == DialogResult.Yes)
+                if (confirmResult == DialogButton.Yes)
                 {
                     await FactoryManager.Self.SetResetVariablesForEntitySave(entitySave);
                 }
@@ -71,9 +71,9 @@ class EntitySaveSetPropertyLogic
                 {
                     string message = "Would you like to remove reset variables for all contained objects? Select 'Yes' if you added reset variables earlier for pooling";
 
-                    var dialogResult = MessageBox.Show(message, "Remove reset variables?", MessageBoxButtons.YesNo);
+                    var confirmResult = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-                    if(dialogResult == DialogResult.Yes)
+                    if(confirmResult == DialogButton.Yes)
                     {
                         FactoryManager.Self.RemoveResetVariablesForEntitySave(entitySave);
                     }
@@ -98,10 +98,10 @@ class EntitySaveSetPropertyLogic
                 string message = "The Click Broadcast message will not be broadcasted unless this " +
                     "Entity is made IClickable.  Would you like to make it IClickable?";
 
-                DialogResult result =
-                    MessageBox.Show(message, "Make IClickable?", MessageBoxButtons.YesNo);
+                var confirmResult =
+                    DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-                if (result == DialogResult.Yes)
+                if (confirmResult == DialogButton.Yes)
                 {
                     entitySave.ImplementsIClickable = true;
 
@@ -116,7 +116,7 @@ class EntitySaveSetPropertyLogic
         {
             if (entitySave.ImplementsIWindow && !entitySave.ImplementsIVisible)
             {
-                MessageBox.Show("IWindows must also be IVisible.  Automatically setting Implements IVisible to true");
+                DialogService.ShowMessage("IWindows must also be IVisible.  Automatically setting Implements IVisible to true");
 
                 entitySave.ImplementsIVisible = true;
             }
@@ -154,7 +154,7 @@ class EntitySaveSetPropertyLogic
             {
                 if (!itemTypeEntity.CreatedByOtherEntities)
                 {
-                    MessageBox.Show("The Entity " + entitySave.ItemType + " must be \"Created By Other Entities\" to be used as an Item Type");
+                    DialogService.ShowMessage("The Entity " + entitySave.ItemType + " must be \"Created By Other Entities\" to be used as an Item Type");
                     entitySave.ItemType = null;
                 }
             }
@@ -202,14 +202,14 @@ class EntitySaveSetPropertyLogic
             {
                 List<string> throwawayList = new List<string>();
 
-                var mbmb = new MultiButtonMessageBoxWpf();
-                mbmb.MessageText = "This entity has a \"Visible\" variable exposed.  This variable is no longer valid.  What would you like to do?";
-                mbmb.AddButton("Remove this variable", DialogResult.Yes);
-                mbmb.AddButton("Keep this as a non-functional Variable (it will no longer control the object's visibility)", DialogResult.No);
+                // Escape/close without a button click returns default(DialogResult) == None here, which
+                // is neither Yes nor matched below, so it falls into "do nothing" - same as the original.
+                var dialogResult = DialogService.ShowChoice<DialogResult>(
+                    "This entity has a \"Visible\" variable exposed.  This variable is no longer valid.  What would you like to do?",
+                    ("Remove this variable", DialogResult.Yes),
+                    ("Keep this as a non-functional Variable (it will no longer control the object's visibility)", DialogResult.No));
 
-                var result = mbmb.ShowDialog();
-
-                if (mbmb.ClickedResult is DialogResult.Yes)
+                if (dialogResult == DialogResult.Yes)
                 {
                     GlueCommands.Self.GluxCommands.RemoveCustomVariable(variableToRemove, throwawayList);
                 }
@@ -243,25 +243,20 @@ class EntitySaveSetPropertyLogic
 
                     if (nosEntitySave != null && nosEntitySave.ImplementsIVisible == false)
                     {
-                        var mbmb = new MultiButtonMessageBoxWpf();
-                        mbmb.MessageText = entitySave + " implements IVisible, but its object " + nos + " does not.  Would would you like to do?";
+                        // Escape/close without a button click returns default(DialogResult) == None here,
+                        // which isn't Yes, so nothing happens below - same as the original.
+                        var dialogResult = DialogService.ShowChoice<DialogResult>(
+                            entitySave + " implements IVisible, but its object " + nos + " does not.  Would would you like to do?",
+                            ("Make " + nosEntitySave + " implement IVisible", DialogResult.Yes),
+                            ("Ignore " + nos + " when setting Visible on " + entitySave, DialogResult.No),
+                            ("Do nothing - this will likely cause compile errors so this must be fixed manually", DialogResult.Cancel));
 
-                        mbmb.AddButton("Make " + nosEntitySave + " implement IVisible", DialogResult.Yes);
-                        mbmb.AddButton("Ignore " + nos + " when setting Visible on " + entitySave, DialogResult.No);
-                        mbmb.AddButton("Do nothing - this will likely cause compile errors so this must be fixed manually", DialogResult.Cancel);
-
-                        var result = mbmb.ShowDialog();
-
-                        if(result != null && mbmb.ClickedResult != null)
+                        if (dialogResult == DialogResult.Yes)
                         {
-                            var dialogResult = (DialogResult)mbmb.ClickedResult;
-                            if (dialogResult == DialogResult.Yes)
-                            {
-                                nosEntitySave.ImplementsIVisible = true;
+                            nosEntitySave.ImplementsIVisible = true;
 
-                                GlueCommands.Self.GenerateCodeCommands
-                                    .GenerateElementAndReferencedObjectCode(nosEntitySave);
-                            }
+                            GlueCommands.Self.GenerateCodeCommands
+                                .GenerateElementAndReferencedObjectCode(nosEntitySave);
                         }
                     }
                 }
@@ -277,7 +272,7 @@ class EntitySaveSetPropertyLogic
 
             if (itemTypeAsEntity != null && itemTypeAsEntity.ImplementsIVisible == false)
             {
-                MessageBox.Show("The item type " + itemTypeAsEntity.ToString() + " must also implement IVisible.  Glue will do this now");
+                DialogService.ShowMessage("The item type " + itemTypeAsEntity.ToString() + " must also implement IVisible.  Glue will do this now");
 
                 itemTypeAsEntity.ImplementsIVisible = true;
 

--- a/FRBDK/Glue/Glue/SetVariable/EventResponseSaveSetVariableLogic.cs
+++ b/FRBDK/Glue/Glue/SetVariable/EventResponseSaveSetVariableLogic.cs
@@ -8,7 +8,6 @@ using FlatRedBall.Glue.CodeGeneration;
 using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Plugins;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
-using System.Windows.Forms;
 using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.Glue.Parsing;
 using FlatRedBall.Utilities;
@@ -70,8 +69,8 @@ namespace FlatRedBall.Glue.SetVariable
                     PluginManager.ReceiveOutput("Saved " + ers);
                     GlueCommands.Self.GenerateCodeCommands.GenerateCurrentElementCode();
 
-                    DialogResult result = MessageBox.Show("Would you like to delete the old method On" + oldName + "?", "Delete old function?", MessageBoxButtons.YesNo);
-                    if (result == DialogResult.Yes)
+                    var result = DialogService.ShowConfirm("Would you like to delete the old method On" + oldName + "?");
+                    if (result == DialogButton.Yes)
                     {
                         int startIndex;
                         int endIndex;

--- a/FRBDK/Glue/Glue/SetVariable/NamedObjectSaves/NamedObjectSetVariableLogic.cs
+++ b/FRBDK/Glue/Glue/SetVariable/NamedObjectSaves/NamedObjectSetVariableLogic.cs
@@ -162,7 +162,7 @@ namespace FlatRedBall.Glue.SetVariable
                 if (namedObjectSave.SetByDerived && namedObjectSave.ExposedInDerived)
                 {
                     // See comment in ExposedByDerived block on why this occurs
-                    MessageBox.Show("You have set ExposedInDerived to true, but SetByDerived is also true.  Both cannot be true at the same time " +
+                    DialogService.ShowMessage("You have set ExposedInDerived to true, but SetByDerived is also true.  Both cannot be true at the same time " +
                         "so Glue will set SetByDerived to false.");
                     namedObjectSave.SetByDerived = false;
                 }
@@ -246,7 +246,7 @@ namespace FlatRedBall.Glue.SetVariable
                     if (rfs != null && !rfs.IsSharedStatic)
                     {
 
-                        System.Windows.Forms.MessageBox.Show("This object comes from a file.  Files which are part of Screens " +
+                        DialogService.ShowMessage("This object comes from a file.  Files which are part of Screens " +
                             "are automatically added to the engine managers.  " +
                             "Adding this object would result in double-membership in the engine which may cause unexpected results.  " +
                             "\n\nGlue will now set this value back to false.");
@@ -264,23 +264,19 @@ namespace FlatRedBall.Glue.SetVariable
             {
                 if (namedObjectSave.IsList)
                 {
-                    DialogResult result = DialogResult.No;
+                    DialogButton? result;
                     if (string.IsNullOrEmpty(namedObjectSave.LayerOn))
                     {
-                        result = MessageBox.Show("Do you want to remove every object in the List " + namedObjectSave.InstanceName +
-                            " from its Layer?",
-                            "Remove all from Layer?",
-                            MessageBoxButtons.YesNo);
+                        result = DialogService.ShowConfirm("Do you want to remove every object in the List " + namedObjectSave.InstanceName +
+                            " from its Layer?", DialogButton.Yes, DialogButton.No);
                     }
                     else
                     {
-                        result = MessageBox.Show("Do you want to add every object contained in the List " + namedObjectSave.InstanceName +
-                            " to the Layer " + namedObjectSave.LayerOn + "?",
-                            "Add all to Layer?",
-                            MessageBoxButtons.YesNo);
+                        result = DialogService.ShowConfirm("Do you want to add every object contained in the List " + namedObjectSave.InstanceName +
+                            " to the Layer " + namedObjectSave.LayerOn + "?", DialogButton.Yes, DialogButton.No);
                     }
 
-                    if (result == DialogResult.Yes)
+                    if (result == DialogButton.Yes)
                     {
                         namedObjectSave.SetLayerRecursively(namedObjectSave.LayerOn);
                     }
@@ -306,22 +302,20 @@ namespace FlatRedBall.Glue.SetVariable
             {
                 if (namedObjectSave.IsList)
                 {
-                    DialogResult result = DialogResult.No;
+                    DialogButton? result;
 
                     if (namedObjectSave.AttachToCamera)
                     {
-                        result = MessageBox.Show("Do you want to attach every object contained in the list " + namedObjectSave.InstanceName +
-                            " to the Camera?", "Attach all to Camera?",
-                            MessageBoxButtons.YesNo);
+                        result = DialogService.ShowConfirm("Do you want to attach every object contained in the list " + namedObjectSave.InstanceName +
+                            " to the Camera?", DialogButton.Yes, DialogButton.No);
                     }
                     else
                     {
-                        result = MessageBox.Show("Do you want to detach every object contained in the list " + namedObjectSave.InstanceName +
-                            " from the Camera?", "Detach all from the Camera?",
-                            MessageBoxButtons.YesNo);
+                        result = DialogService.ShowConfirm("Do you want to detach every object contained in the list " + namedObjectSave.InstanceName +
+                            " from the Camera?", DialogButton.Yes, DialogButton.No);
                     }
 
-                    if (result == DialogResult.Yes)
+                    if (result == DialogButton.Yes)
                     {
                         namedObjectSave.SetAttachToCameraRecursively(namedObjectSave.AttachToCamera);
                     }
@@ -339,7 +333,7 @@ namespace FlatRedBall.Glue.SetVariable
                 // or else text will draw incorrectly
                 if (namedObjectSave.DestinationRectangle.HasValue && namedObjectSave.DestinationRectangle.Value.Y % 2 == 1)
                 {
-                    MessageBox.Show("Setting an odd value to the DestinationRectangle's Y may cause text to render improperly.  An " +
+                    DialogService.ShowMessage("Setting an odd value to the DestinationRectangle's Y may cause text to render improperly.  An " +
                         "even value is recommended");
 
                 }
@@ -362,7 +356,7 @@ namespace FlatRedBall.Glue.SetVariable
                         // Is this CreatedByOtherEntities?
                         if (!entitySave.CreatedByOtherEntities)
                         {
-                            MessageBox.Show("The Entity " + entitySave + " should have its CreatedByOtherEntities set to true to enable " +
+                            DialogService.ShowMessage("The Entity " + entitySave + " should have its CreatedByOtherEntities set to true to enable " +
                                 "visibility-based removal to work properly");
                         }
                     }
@@ -490,7 +484,7 @@ namespace FlatRedBall.Glue.SetVariable
                 {
                     succeeded = false;
 
-                    MessageBox.Show("The object " + existingContainer + " is already marked as IsContainer. " +
+                    DialogService.ShowMessage("The object " + existingContainer + " is already marked as IsContainer. " +
                         "Two objects in the same element cannot be marked as Iscontainer");
 
                 }
@@ -509,30 +503,26 @@ namespace FlatRedBall.Glue.SetVariable
 
                     if (!doesBaseMatch)
                     {
-                        var mbmb = new MultiButtonMessageBoxWpf();
-
                         string containerType = element.BaseElement;
                         if (string.IsNullOrEmpty(containerType))
                         {
                             containerType = "<NONE>";
                         }
 
+                        // Closed without a choice (e.g. Escape) returns default(DialogResult) == None, which
+                        // matches neither branch below - same as the original cancel behavior (do nothing).
+                        var selectedOption = DialogService.ShowChoice<DialogResult>(
+                            "The object is of type " + nosType + " but the container is of type " + containerType + "\n\n" +
+                            "What would you like to do?",
+                            ("Set the container's type to " + nosType, DialogResult.Yes),
+                            ("Nothing - game may not compile until this has been fixed", DialogResult.No),
+                            ("Set 'IsContainer' back to false", DialogResult.Cancel));
 
-                        mbmb.MessageText = "The object is of type " + nosType + " but the container is of type " + containerType + "\n\n" +
-                            "What would you like to do?";
-
-                        mbmb.AddButton("Set the container's type to " + nosType, DialogResult.Yes);
-                        mbmb.AddButton("Nothing - game may not compile until this has been fixed", DialogResult.No);
-                        mbmb.AddButton("Set 'IsContainer' back to false", DialogResult.Cancel);
-
-                        var dialogResult = mbmb.ShowDialog();
-                        var selectedOption = mbmb.ClickedResult;
-
-                        if (selectedOption is DialogResult.Yes)
+                        if (selectedOption == DialogResult.Yes)
                         {
                             element.BaseObject = nosType;
                         }
-                        else if (selectedOption is DialogResult.Cancel)
+                        else if (selectedOption == DialogResult.Cancel)
                         {
                             succeeded = false;
                         }
@@ -578,19 +568,12 @@ namespace FlatRedBall.Glue.SetVariable
                             string message = "This object has type of " + namedObjectSave.InstanceType +
                                 " but the base object in " + baseElement.ToString() + " is untyped.  What would you like to do?";
 
-                            var mbmb = new MultiButtonMessageBoxWpf();
-                            mbmb.MessageText = message;
+                            var selectedOption = DialogService.ShowChoice<DialogResult>(message,
+                                ("Change " + namedObjectInBase.InstanceName + " to " +
+                                    namedObjectSave.InstanceType + " in " + baseElement.ToString(), DialogResult.Yes),
+                                ("Do nothing (your project will likely not compile so you will need to fix this manually)", DialogResult.No));
 
-                            mbmb.AddButton("Change " + namedObjectInBase.InstanceName + " to " +
-                                namedObjectSave.InstanceType + " in " + baseElement.ToString(), DialogResult.Yes);
-
-                            mbmb.AddButton("Do nothing (your project will likely not compile so you will need to fix this manually)", DialogResult.No);
-
-                            var result = mbmb.ShowDialog();
-
-                            var selectedOption = mbmb.ClickedResult;
-
-                            if (selectedOption is DialogResult.Yes)
+                            if (selectedOption == DialogResult.Yes)
                             {
                                 switch (namedObjectInBase.SourceType)
                                 {
@@ -620,7 +603,7 @@ namespace FlatRedBall.Glue.SetVariable
                             string message = "This object is of type " + namedObjectSave.InstanceType + " but the base " +
                                 "object is of type " + namedObjectInBase.InstanceType + "";
 
-                            MessageBox.Show(message);
+                            DialogService.ShowMessage(message);
 
                             namedObjectSave.SourceName = oldValue;
 
@@ -863,9 +846,9 @@ namespace FlatRedBall.Glue.SetVariable
                 {
                     message += "\nDo you want to change to " + namedObjectSave.SourceClassType + " anyway?";
 
-                    DialogResult result = MessageBox.Show(message, "Change anyway?", MessageBoxButtons.YesNo);
+                    var result = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-                    if (result == DialogResult.No)
+                    if (result == DialogButton.No)
                     {
                         namedObjectSave.SourceClassType = (string)oldValue;
                         namedObjectSave.UpdateCustomProperties();
@@ -946,14 +929,13 @@ namespace FlatRedBall.Glue.SetVariable
                             {
                                 whatIsWrong += "\nWhat would you like to do?";
 
-                                var mbmb = new MultiButtonMessageBoxWpf();
-                                mbmb.MessageText = whatIsWrong;
-                                mbmb.AddButton("Undo the change", DialogResult.Cancel);
-                                mbmb.AddButton("Keep the change (May cause runtime crashes)", DialogResult.Yes);
+                                // Closed without a choice (e.g. Escape) returns default(DialogResult) == None, which is not
+                                // Cancel, so the change is kept - same as the original behavior.
+                                var result = DialogService.ShowChoice<DialogResult>(whatIsWrong,
+                                    ("Undo the change", DialogResult.Cancel),
+                                    ("Keep the change (May cause runtime crashes)", DialogResult.Yes));
 
-                                var result = mbmb.ShowDialog();
-
-                                if(mbmb.ClickedResult is DialogResult.Cancel)
+                                if (result == DialogResult.Cancel)
                                 {
                                     addressModeVariable.Value = oldValue;
                                 }

--- a/FRBDK/Glue/Glue/SetVariable/NamedObjectSaves/SetByDerivedSetLogic.cs
+++ b/FRBDK/Glue/Glue/SetVariable/NamedObjectSaves/SetByDerivedSetLogic.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
 
 namespace GlueFormsCore.SetVariable.NamedObjectSaves
 {
@@ -85,34 +84,28 @@ namespace GlueFormsCore.SetVariable.NamedObjectSaves
 
                         message += "\nWhat would you like to do?";
 
-                        var mbmb = new MultiButtonMessageBoxWpf();
-
-                        mbmb.MessageText = message;
-
                         const string remove = "remove";
                         const string keep = "keep";
                         const string cancel = "cancel";
 
-                        mbmb.AddButton($"Remove {thisOrTheseObjects}", remove);
-                        mbmb.AddButton($"Keep {thisOrTheseObjects}, set \"defined by base\" to false", keep);
-                        mbmb.AddButton($"Cancel", cancel);
+                        var choice = DialogService.ShowChoice(message,
+                            ($"Remove {thisOrTheseObjects}", remove),
+                            ($"Keep {thisOrTheseObjects}, set \"defined by base\" to false", keep),
+                            ($"Cancel", cancel));
 
-                        var dialogResult = mbmb.ShowDialog();
-
-                        
-                        if(dialogResult == null || mbmb.ClickedResult as string == cancel)
+                        if(choice == null || choice == cancel)
                         {
                             didSet = false;
                             namedObjectSave.SetByDerived = true;
                         }
-                        else if(mbmb.ClickedResult as string == remove)
+                        else if(choice == remove)
                         {
                             foreach (var nos in orphanedNoses)
                             {
                                 GlueCommands.Self.GluxCommands.RemoveNamedObject(nos);
                             }
                         }
-                        else if(mbmb.ClickedResult as string == keep)
+                        else if(choice == keep)
                         {
                             foreach(var nos in orphanedNoses)
                             {

--- a/FRBDK/Glue/Glue/VSHelpers/CodeBuildItemAdder.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/CodeBuildItemAdder.cs
@@ -7,8 +7,8 @@ using System.IO;
 using FlatRedBall.Glue;
 using FlatRedBall.IO;
 using FlatRedBall.Glue.Plugins;
-using System.Windows.Forms;
 using System.ComponentModel.Composition;
+using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.SaveClasses;
@@ -272,7 +272,7 @@ namespace FlatRedBall.Glue.VSHelpers
             {
                 succeeded = false;
 
-                MessageBox.Show("Could not copy the file " + resourceName + "\n\n" + e.ToString());
+                DialogService.ShowMessage("Could not copy the file " + resourceName + "\n\n" + e.ToString());
             }
             return succeeded;
         }

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/DuplicateProjectEntryDialog.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/DuplicateProjectEntryDialog.cs
@@ -13,9 +13,9 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
     /// <summary>
     /// Asks the user how to resolve a duplicate project entry found while loading a .csproj. Shown behind a
-    /// swappable <see cref="Show"/> delegate (same seam shape as <see cref="TaskManager.UiThreadMarshaller"/>)
-    /// so <see cref="VisualStudioProject.ResolveDuplicateProjectEntry"/>'s branch logic can be unit tested
-    /// without a live WPF window, and so the WPF construction always happens on the UI thread even when the
+    /// swappable <see cref="Show"/> delegate so <see cref="VisualStudioProject.ResolveDuplicateProjectEntry"/>'s
+    /// branch logic can be unit tested without a live WPF window. The default implementation goes through
+    /// <see cref="DialogService.ShowChoice{TResult}"/>, which already marshals to the UI thread even when the
     /// caller (e.g. a project reload queued via TaskManager) is running on a background thread.
     /// </summary>
     public static class DuplicateProjectEntryDialog
@@ -24,26 +24,16 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
         private static DuplicateProjectEntryResolution ShowWpfDialog(string itemInclude)
         {
-            return TaskManager.Self.OnUiThread(() =>
-            {
-                var mbmb = new MultiButtonMessageBoxWpf();
+            var message = "The item " + itemInclude + " is part of " +
+                "the project twice.  Glue does not support double-entries in a project.  What would you like to do?";
 
-                mbmb.MessageText = "The item " + itemInclude + " is part of " +
-                    "the project twice.  Glue does not support double-entries in a project.  What would you like to do?";
-
-                mbmb.AddButton("Remove the duplicate entry and continue", DuplicateProjectEntryResolution.RemoveDuplicate);
-                mbmb.AddButton("Remove the duplicate, but show me a list of all contained objects before removal", DuplicateProjectEntryResolution.RemoveDuplicateAndShowList);
-                mbmb.AddButton("Cancel loading the project - this will throw an exception", DuplicateProjectEntryResolution.CancelLoad);
-
-                if (mbmb.ShowDialog() == true)
-                {
-                    return (DuplicateProjectEntryResolution)mbmb.ClickedResult;
-                }
-
-                // Window closed without a button click (e.g. Escape) - preserve the original behavior of
-                // silently removing the duplicate.
-                return DuplicateProjectEntryResolution.RemoveDuplicate;
-            });
+            // If the window is closed without a button click (e.g. Escape), ShowChoice returns
+            // default(DuplicateProjectEntryResolution), which is RemoveDuplicate (value 0) - this preserves
+            // the original behavior of silently removing the duplicate.
+            return DialogService.ShowChoice(message,
+                ("Remove the duplicate entry and continue", DuplicateProjectEntryResolution.RemoveDuplicate),
+                ("Remove the duplicate, but show me a list of all contained objects before removal", DuplicateProjectEntryResolution.RemoveDuplicateAndShowList),
+                ("Cancel loading the project - this will throw an exception", DuplicateProjectEntryResolution.CancelLoad));
         }
     }
 }

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/ProjectCreator.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/ProjectCreator.cs
@@ -375,22 +375,19 @@ Additional Info:
 
                 if(toReturn == null)
                 {
-                    var mbmb = new MultiButtonMessageBoxWpf();
+                    var options = loadCalls
+                        .Select(loadCall => (loadCall.Preprocessor, loadCall.Func))
+                        .ToList();
 
-                    mbmb.MessageText = "FlatRedBall could not determine the project type. Would you like to manually set the project type?";
+                    options.Add(("No, do not manually set the type", (Func<ProjectBase>)null));
 
-                    foreach(var loadCall in loadCalls)
+                    var chosenFunc = DialogService.ShowChoice(
+                        "FlatRedBall could not determine the project type. Would you like to manually set the project type?",
+                        options.ToArray());
+
+                    if(chosenFunc != null)
                     {
-                        mbmb.AddButton(loadCall.Preprocessor, loadCall.Func);
-                    }
-
-                    mbmb.AddButton("No, do not manually set the type", null);
-
-                    var showResult = mbmb.ShowDialog();
-
-                    if(mbmb.ClickedResult is Func<ProjectBase> asFunc)
-                    {
-                        toReturn = asFunc();
+                        toReturn = chosenFunc();
                     }
                 }
             }

--- a/FRBDK/Glue/Tests/GlueUnitTests/Controls/DialogServiceTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Controls/DialogServiceTests.cs
@@ -1,0 +1,186 @@
+using System;
+using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Managers;
+using GlueUnitTests.Tasks;
+using Shouldly;
+
+namespace GlueUnitTests.Controls;
+
+// DialogService is the shared seam for all simple message/confirm/choice dialogs in Glue (added to fix a
+// cross-thread WPF crash class - see ProjectLoader.CheckForMissingCustomFile and #1921's
+// DuplicateProjectEntryDialog). Every public method routes through TaskManager.Self.OnUiThread, so these
+// tests share TaskManagerSequentialCollection with the other TaskManager-state tests (see
+// TaskManagerSynchronousModeTests.cs) since both mutate TaskManager's process-wide UiThreadMarshaller state.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class DialogServiceTests : IDisposable
+{
+    private readonly Action<string> _originalShowMessageImpl = DialogService.ShowMessageImpl;
+    private readonly Func<string, DialogButton, DialogButton, DialogButton?> _originalShowConfirmImpl = DialogService.ShowConfirmImpl;
+    private readonly Func<string, (string label, object value)[], object> _originalShowChoiceImpl = DialogService.ShowChoiceImpl;
+    private readonly IUiThreadMarshaller _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+    public DialogServiceTests()
+    {
+        // The xunit test thread is never MainGlueWindow's UI thread, so DialogService's OnUiThread call
+        // always takes the marshaller branch. Default to an inline marshaller so tests that don't care about
+        // marshalling specifics don't need a live WinForms message loop; tests that DO care about the
+        // marshalling itself install their own RecordingInlineMarshaller.
+        TaskManager.UiThreadMarshaller = new RecordingInlineMarshaller();
+    }
+
+    public void Dispose()
+    {
+        DialogService.ShowMessageImpl = _originalShowMessageImpl;
+        DialogService.ShowConfirmImpl = _originalShowConfirmImpl;
+        DialogService.ShowChoiceImpl = _originalShowChoiceImpl;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+    }
+
+    private class RecordingInlineMarshaller : IUiThreadMarshaller
+    {
+        public int InvokeFuncCallCount;
+        public int InvokeActionCallCount;
+
+        public void Invoke(Action action) { InvokeActionCallCount++; action(); }
+        public T Invoke<T>(Func<T> func) { InvokeFuncCallCount++; return func(); }
+        public System.Threading.Tasks.Task Invoke(Func<System.Threading.Tasks.Task> func) => func();
+        public System.Threading.Tasks.Task<T> Invoke<T>(Func<System.Threading.Tasks.Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+
+    [Fact]
+    public void ShowMessage_ShouldInvokeShowMessageImpl_WithTheGivenText()
+    {
+        string passedText = null;
+        DialogService.ShowMessageImpl = text => passedText = text;
+
+        DialogService.ShowMessage("hello world");
+
+        passedText.ShouldBe("hello world");
+    }
+
+    [Fact]
+    public void ShowMessage_ShouldRouteThroughOnUiThread_WhenNotOnUiThread()
+    {
+        var marshaller = new RecordingInlineMarshaller();
+        TaskManager.UiThreadMarshaller = marshaller;
+        DialogService.ShowMessageImpl = _ => { };
+
+        TaskManager.Self.IsOnUiThread.ShouldBeFalse();
+        DialogService.ShowMessage("hello");
+
+        marshaller.InvokeActionCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ShowConfirm_ShouldPassTextAndButtons_AndReturnTheImplsResult()
+    {
+        string passedText = null;
+        DialogButton passedPrimary = default;
+        DialogButton passedSecondary = default;
+        DialogService.ShowConfirmImpl = (text, primary, secondary) =>
+        {
+            passedText = text;
+            passedPrimary = primary;
+            passedSecondary = secondary;
+            return DialogButton.Retry;
+        };
+
+        var result = DialogService.ShowConfirm("are you sure?", DialogButton.Ok, DialogButton.Cancel);
+
+        passedText.ShouldBe("are you sure?");
+        passedPrimary.ShouldBe(DialogButton.Ok);
+        passedSecondary.ShouldBe(DialogButton.Cancel);
+        result.ShouldBe(DialogButton.Retry);
+    }
+
+    [Fact]
+    public void ShowConfirm_ShouldDefaultToYesNo_WhenButtonsNotSpecified()
+    {
+        DialogButton passedPrimary = default;
+        DialogButton passedSecondary = default;
+        DialogService.ShowConfirmImpl = (text, primary, secondary) =>
+        {
+            passedPrimary = primary;
+            passedSecondary = secondary;
+            return null;
+        };
+
+        var result = DialogService.ShowConfirm("are you sure?");
+
+        passedPrimary.ShouldBe(DialogButton.Yes);
+        passedSecondary.ShouldBe(DialogButton.No);
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ShowConfirm_ShouldRouteThroughOnUiThread_WhenNotOnUiThread()
+    {
+        var marshaller = new RecordingInlineMarshaller();
+        TaskManager.UiThreadMarshaller = marshaller;
+        DialogService.ShowConfirmImpl = (_, __, ___) => DialogButton.Yes;
+
+        var result = DialogService.ShowConfirm("text");
+
+        result.ShouldBe(DialogButton.Yes);
+        marshaller.InvokeFuncCallCount.ShouldBe(1);
+    }
+
+    private enum FakeChoice
+    {
+        FirstOption,
+        SecondOption,
+        ThirdOption
+    }
+
+    [Fact]
+    public void ShowChoice_ShouldPassTextAndBoxedOptions_ToTheImpl_AndUnboxTheResult()
+    {
+        string passedText = null;
+        (string label, object value)[] passedOptions = null;
+        DialogService.ShowChoiceImpl = (text, options) =>
+        {
+            passedText = text;
+            passedOptions = options;
+            return FakeChoice.SecondOption;
+        };
+
+        var result = DialogService.ShowChoice("pick one",
+            ("First", FakeChoice.FirstOption),
+            ("Second", FakeChoice.SecondOption),
+            ("Third", FakeChoice.ThirdOption));
+
+        passedText.ShouldBe("pick one");
+        passedOptions.Length.ShouldBe(3);
+        passedOptions[1].label.ShouldBe("Second");
+        passedOptions[1].value.ShouldBe(FakeChoice.SecondOption);
+        result.ShouldBe(FakeChoice.SecondOption);
+    }
+
+    [Fact]
+    public void ShowChoice_ShouldReturnDefault_WhenImplReturnsNull()
+    {
+        DialogService.ShowChoiceImpl = (_, __) => null;
+
+        var result = DialogService.ShowChoice("pick one",
+            ("First", FakeChoice.FirstOption),
+            ("Second", FakeChoice.SecondOption));
+
+        result.ShouldBe(FakeChoice.FirstOption); // default(FakeChoice) == FirstOption (value 0)
+    }
+
+    [Fact]
+    public void ShowChoice_ShouldRouteThroughOnUiThread_WhenNotOnUiThread()
+    {
+        var marshaller = new RecordingInlineMarshaller();
+        TaskManager.UiThreadMarshaller = marshaller;
+        DialogService.ShowChoiceImpl = (_, __) => FakeChoice.ThirdOption;
+
+        var result = DialogService.ShowChoice("pick one",
+            ("First", FakeChoice.FirstOption),
+            ("Third", FakeChoice.ThirdOption));
+
+        result.ShouldBe(FakeChoice.ThirdOption);
+        marshaller.InvokeFuncCallCount.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the cross-thread WPF crash class where `ProjectLoader.CheckForMissingCustomFile` (and similar) construct a `MultiButtonMessageBoxWpf` directly on TaskManager's background thread. Adds `FlatRedBall.Glue.Controls.DialogService` (ShowMessage/ShowConfirm/ShowChoice), routed through `TaskManager.OnUiThread`, and migrates every direct `MultiButtonMessageBoxWpf`/`MessageBox.Show` call site in FRBDK/Glue/Glue to it. `DuplicateProjectEntryDialog` (#1921) now uses `DialogService.ShowChoice` instead of its own bespoke seam.

This sets the idiom for all future dialog code in Glue - no direct WPF/WinForms messagebox construction should remain outside `DialogService`'s own default impls.

Found and fixed a real bug along the way: `ReferencedFileSaveSetPropertyManager.CheckForExistingFileOfSameName` unconditionally cast `(DialogResult)mbmb.ClickedResult`, which threw a NullReferenceException on Escape. `DialogService.ShowChoice` returns `default(DialogResult)` instead, so it now falls through gracefully.

## Test plan
- [x] `dotnet build` on Glue.csproj - 0 errors
- [x] Full GlueUnitTests suite - 229/229 passing, no regressions
- [x] New `DialogServiceTests.cs` covers delegate-swap, UI-thread marshaling, and confirm/choice return-value threading
- [x] Grep for `MultiButtonMessageBoxWpf|MessageBox\.Show` across FRBDK/Glue/Glue confirms zero live call sites remain outside `DialogService`'s own implementation (only dead/commented-out code, doc comments, and the seam itself)