### PR TITLE
Remove dead Gum-atlas bridge (ContentManagerWrapper/AtlasLoader)

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/Texture/AtlasLoader.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/Texture/AtlasLoader.cs
@@ -107,22 +107,6 @@ namespace FlatRedBall.Graphics.Texture
             return null;
         }
 
-        public static AtlasedTexture LoadAtlasedTextureByFileName(string fileName)
-        {
-            var fileNameToAtlasName = ConvertFileNameToAtlasName(fileName);
-
-            return LoadAtlasedTexture(fileNameToAtlasName, ignoreCase:true);
-        }
-
-        private static string ConvertFileNameToAtlasName(string fileName)
-        {
-            var directoryToBeRelativeTo = FileManager.DefaultRelativeDirectory + @"Content/";
-
-            var relativeToContent = FileManager.MakeRelative(fileName, directoryToBeRelativeTo).ToLowerInvariant() ;
-
-            return relativeToContent;
-        }
-
         private static void ClearDisposedAtlases()
         {
             for(int i = loadedAtlases.Count - 1; i > -1; i--)

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/ContentManagerWrapper.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/ContentManagerWrapper.cs
@@ -1,5 +1,4 @@
-﻿using RenderingLibrary.Graphics;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,32 +15,7 @@ namespace FlatRedBall.Gum
 
         public T TryLoadContent<T>(string contentName)
         {
-            if (typeof(T) == typeof(RenderingLibrary.Graphics.AtlasedTexture))
-            {
-                var frbAtlasedTexture = Graphics.Texture.AtlasLoader.LoadAtlasedTextureByFileName(contentName);
-
-                if (frbAtlasedTexture != null)
-                {
-                    RenderingLibrary.Graphics.AtlasedTexture toReturn = new RenderingLibrary.Graphics.AtlasedTexture(
-                        frbAtlasedTexture.Name,
-                        frbAtlasedTexture.Texture,
-                        frbAtlasedTexture.SourceRectangle.ToSystemDrawing(),
-                        frbAtlasedTexture.Size.ToSystemNumerics(),
-                        frbAtlasedTexture.Origin.ToSystemNumerics(),
-                        frbAtlasedTexture.IsRotated
-                        );
-
-                    return (T)(object)toReturn;
-                }
-                else
-                {
-                    return default(T);
-                }
-            }
-            else
-            {
-                return LoadContent<T>(contentName);
-            }
+            return LoadContent<T>(contentName);
         }
 
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/GumIdb.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/GumIdb.cs
@@ -276,9 +276,6 @@ namespace FlatRedBall.Gum
                 {
                     item.Initialize(item.DefaultState);
                 }
-                //for atlased colored rectangles
-                if (item.Name == "ColoredRectangle")
-                    RenderingLibrary.Graphics.SolidRectangle.AtlasedTextureName = "..\\Graphics\\Misc\\ColoredRectangle.png";
             }
 
             StandardElementsManager.Self.Initialize();


### PR DESCRIPTION
## Summary
Companion to https://github.com/vchelaru/Gum/pull/4059, which deletes Gum's `RenderingLibrary.Graphics.AtlasedTexture`/`Atlas` types as dead code. This PR removes the only producer of those types on the FRB side:
- `ContentManagerWrapper.TryLoadContent<T>` — drops the `AtlasedTexture` branch, just forwards to `LoadContent<T>`
- `GumIdb.cs` — drops the now-meaningless `SolidRectangle.AtlasedTextureName` assignment
- `AtlasLoader.LoadAtlasedTextureByFileName`/`ConvertFileNameToAtlasName` — removed (no other callers)

Per the Gum-side issue, this Gum↔FRB atlas bridge was never actually supported and is unused. FRB's own (non-Gum) atlas system for FRB sprites (`AtlasLoader.Load`, `AtiManager`, `AtlasPlugin`) is untouched.

Must merge together with the Gum PR (Gum core is consumed as source, so removing the type there breaks this bridge until it's removed here too).

## Test plan
- [x] `GumCore.DesktopGlNet6.csproj` builds clean against the paired Gum branch (this is the canary Gum's `frb-build-verification` skill uses to cover `GumCoreShared.projitems`)

Manual test: not needed — pure dead-code removal.
