### PR TITLE
1772 real regression test for entity-in-subfolder rename

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/NodeViewModel.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/NodeViewModel.cs
@@ -535,6 +535,13 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
         #endregion
 
 
+        /// <summary>
+        /// Builds the full element name (e.g. "Entities\\Weapons\\Sword") after a tree-view rename,
+        /// preserving every folder segment of <paramref name="oldFullName"/> and swapping only the leaf.
+        /// </summary>
+        internal static string BuildRenamedElementFullName(string oldFullName, string newLeafName) =>
+            oldFullName.Substring(0, oldFullName.LastIndexOf("\\") + 1) + newLeafName;
+
         private async void HandleRenameThroughEdit()
         {
             if(this.Text == textBeforeEditing)
@@ -543,8 +550,7 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
             }
             if(Tag is GlueElement element)
             {
-                var oldName = element.Name;
-                var newName = oldName.Substring(0, oldName.LastIndexOf("\\") + 1) + Text;
+                var newName = BuildRenamedElementFullName(element.Name, Text);
 
                 await GlueCommands.Self.GluxCommands.ElementCommands.RenameElement(element, newName);
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/NodeViewModelRenameTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/NodeViewModelRenameTests.cs
@@ -1,24 +1,20 @@
+using OfficialPlugins.TreeViewPlugin.ViewModels;
 using Shouldly;
 
 namespace GlueUnitTests.TreeViewPlugin;
 
 /// <summary>
-/// Tests for the element rename name-building logic in NodeViewModel.
-/// The fix changed IndexOf("\\") to LastIndexOf("\\") so that renaming an entity
-/// stored in a subfolder preserves the full subfolder path instead of collapsing
-/// to the root folder.
+/// Tests for NodeViewModel.BuildRenamedElementFullName, the production method the F2-rename flow
+/// (NodeViewModel.HandleRenameThroughEdit) calls to compute the new full element name. Regression
+/// coverage for #1871/#1872 (plain rename) and #1772 (duplicate-then-rename), both of which moved
+/// the renamed entity out of its subfolder.
 /// </summary>
 public class NodeViewModelRenameTests
 {
-    // Mirrors the fixed logic in NodeViewModel: preserve everything up to and
-    // including the last backslash, then append the new leaf name.
-    static string BuildNewName(string oldName, string newText) =>
-        oldName.Substring(0, oldName.LastIndexOf("\\") + 1) + newText;
-
     [Fact]
     public void Rename_EntityInSubfolder_PreservesSubfolder()
     {
-        var result = BuildNewName("Entities\\Weapons\\Sword", "Shield");
+        var result = NodeViewModel.BuildRenamedElementFullName("Entities\\Weapons\\Sword", "Shield");
 
         result.ShouldBe("Entities\\Weapons\\Shield");
     }
@@ -26,7 +22,7 @@ public class NodeViewModelRenameTests
     [Fact]
     public void Rename_EntityInRootFolder_PreservesRootFolder()
     {
-        var result = BuildNewName("Entities\\Player", "Hero");
+        var result = NodeViewModel.BuildRenamedElementFullName("Entities\\Player", "Hero");
 
         result.ShouldBe("Entities\\Hero");
     }
@@ -34,7 +30,7 @@ public class NodeViewModelRenameTests
     [Fact]
     public void Rename_EntityInDeeplyNestedSubfolder_PreservesFullPath()
     {
-        var result = BuildNewName("Entities\\Weapons\\Melee\\Sword", "Axe");
+        var result = NodeViewModel.BuildRenamedElementFullName("Entities\\Weapons\\Melee\\Sword", "Axe");
 
         result.ShouldBe("Entities\\Weapons\\Melee\\Axe");
     }
@@ -42,7 +38,7 @@ public class NodeViewModelRenameTests
     [Fact]
     public void Rename_Screen_PreservesScreensFolder()
     {
-        var result = BuildNewName("Screens\\GameScreen", "MainMenu");
+        var result = NodeViewModel.BuildRenamedElementFullName("Screens\\GameScreen", "MainMenu");
 
         result.ShouldBe("Screens\\MainMenu");
     }
@@ -50,8 +46,18 @@ public class NodeViewModelRenameTests
     [Fact]
     public void Rename_ScreenInSubfolder_PreservesSubfolder()
     {
-        var result = BuildNewName("Screens\\Levels\\Level1", "Level2");
+        var result = NodeViewModel.BuildRenamedElementFullName("Screens\\Levels\\Level1", "Level2");
 
         result.ShouldBe("Screens\\Levels\\Level2");
+    }
+
+    // #1772's exact repro: duplicate "Larva" in Entities\Enemies (producing "...\\LarvaCopy" per
+    // GluxCommands.CopyGlueElement, which just appends "Copy" to the full name), then F2-rename it.
+    [Fact]
+    public void Rename_DuplicatedEntityInSubfolder_PreservesSubfolder()
+    {
+        var result = NodeViewModel.BuildRenamedElementFullName("Entities\\Enemies\\LarvaCopy", "DeepOne_Panel");
+
+        result.ShouldBe("Entities\\Enemies\\DeepOne_Panel");
     }
 }


### PR DESCRIPTION
## Summary
- #1772's repro (duplicate an entity in a subfolder, F2-rename it) is already fixed on `NetStandard` — it's the same root cause as #1871/#1872 (F2-rename used `IndexOf` instead of `LastIndexOf`, collapsing nested folders to root).
- The regression test added with that fix duplicated the substring logic instead of calling production code, so it would pass even if the fix were reverted.
- Extracted the computation into `internal static NodeViewModel.BuildRenamedElementFullName` and replaced the test with real ones that call it directly, including #1772's exact name shape (`Entities\Enemies\LarvaCopy` → `DeepOne_Panel`).

## Test plan
- [x] Reverted `LastIndexOf` back to `IndexOf` locally and confirmed 4/6 new tests go red, then restored and confirmed green (real tripwire, not a hollow assertion).
- [x] Full `GlueUnitTests` suite: 230/230 green.

Manual test: not needed — behavior-preserving (no production logic changed beyond the extraction), fully covered by the unit tests above.

Part of #1772.
