### PR TITLE
Fix DependentUpon not updating on element rename

### DIFF
--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -964,9 +964,15 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 LinkedDictionary[newName] = item;
             }
 
-            if (newName.Contains(".generated.cs"))
+            if (newName.EndsWith(".Generated.cs", StringComparison.OrdinalIgnoreCase))
             {
-                MakeBuildItemNested(item, FileManager.RemovePath(FileManager.RemoveExtension(newName)).Replace(".generated", "") + ".cs");
+                string parentFileName = FileManager.RemovePath(newName)
+                    .Replace(".Generated.cs", ".cs", StringComparison.OrdinalIgnoreCase);
+
+                // Unlike MakeBuildItemNested (which only sets DependentUpon if it's missing - the
+                // add-a-new-item case), a rename must always overwrite the existing value so it
+                // tracks the renamed parent .cs file (#1771).
+                item.SetMetadataValue("DependentUpon", parentFileName);
             }
 
         }

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/VisualStudioProjectRenameDependentUponTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/VisualStudioProjectRenameDependentUponTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+
+namespace GlueUnitTests.VSHelpers;
+
+// #1771: renaming an element (e.g. F2 rename of an Entity) updates the .Generated.cs project item's
+// Include, but left its DependentUpon metadata pointing at the old (pre-rename) .cs file name -
+// VisualStudioProject.RenameItem's Generated.cs detection was matching the literal ".generated.cs"
+// against the real, capitalized ".Generated.cs" file names Glue actually writes, so the block never ran.
+public class VisualStudioProjectRenameDependentUponTests
+{
+    [Fact]
+    public void RenameItem_ShouldUpdateDependentUpon_WhenRenamingAGeneratedCodeFile()
+    {
+        string? directory = null;
+        try
+        {
+            var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out directory);
+
+            project.AddCodeBuildItem("SeaGoatCopy.cs");
+            var generatedItem = project.AddCodeBuildItem("SeaGoatCopy.Generated.cs");
+            generatedItem.SetMetadataValue("DependentUpon", "SeaGoatCopy.cs");
+
+            project.RenameItem("SeaGoatCopy.cs", "DeepOne_Swarm.cs");
+            project.RenameItem("SeaGoatCopy.Generated.cs", "DeepOne_Swarm.Generated.cs");
+
+            generatedItem.GetMetadataValue("DependentUpon").ShouldBe("DeepOne_Swarm.cs");
+        }
+        finally
+        {
+            if (directory != null) Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Renaming an element (F2 rename of an Entity/Screen) left the `.Generated.cs` project item's `DependentUpon` metadata pointing at the pre-rename `.cs` file name. Root cause in `VisualStudioProject.RenameItem` (FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs):

- The `.Generated.cs` detection compared against the lowercase literal `.generated.cs`, but real file names are always `.Generated.cs` (capital G) — so the branch never ran on rename.
- Even if it had run, it delegated to `MakeBuildItemNested`, which only sets `DependentUpon` when missing — never overwrites an existing value, which a rename always needs.

Fix: match case-insensitively and set `DependentUpon` directly, overwriting the old value.

## Test plan
- [x] New regression test `VisualStudioProjectRenameDependentUponTests` reproduces the exact #1771 repro against a real MSBuild-backed project; confirmed Red before the fix, Green after.
- [x] Full Glue unit test suite: 228/228 passing.

Manual test: not needed — the fix is pure metadata-write logic on an in-memory MSBuild `Project`, fully covered by the new unit test; no separate runtime/UI path.

Part of #1771.
