### PR TITLE
Fix derived/variant entity ignoring its own SourceFile on an ExposedInDerived file object

### DIFF
--- a/FRBDK/Glue/Glue/CodeGeneration/NamedObjectSaveCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/NamedObjectSaveCodeGenerator.cs
@@ -207,7 +207,8 @@ namespace FlatRedBall.Glue.CodeGeneration
 
             #region Perform instantiation
 
-            var shouldInstantiate = !namedObject.InstantiatedByBase;
+            var shouldInstantiate = !namedObject.InstantiatedByBase ||
+                ShouldReinstantiateDespiteInstantiatedByBase(namedObject, saveObject);
 
             if (shouldInstantiate)
             {
@@ -1149,6 +1150,26 @@ namespace FlatRedBall.Glue.CodeGeneration
                                                  copyRelativeToAbsolute));
                 }
             }
+        }
+
+        // An ExposedInDerived, InstantiatedByBase object is normally only instantiated once, by the base
+        // class - the derived class just reads the field the base already assigned, and skips its own
+        // instantiation code entirely. That's fine for properties that can still be changed post-construction,
+        // but SourceFile is only ever read at instantiation time, so a derived class that points a
+        // file-sourced object (e.g. a LayeredTileMap) at its own file would otherwise have that override
+        // silently ignored (see #1770). Re-instantiate in the derived in that one case so its file is
+        // actually the one that gets loaded.
+        internal static bool ShouldReinstantiateDespiteInstantiatedByBase(NamedObjectSave namedObject, IElement saveObject)
+        {
+            if (namedObject.SourceType != SourceType.File)
+            {
+                return false;
+            }
+
+            var baseNamedObject = ObjectFinder.Self.GetBaseElement(saveObject)?
+                .NamedObjects.FirstOrDefault(item => item.InstanceName == namedObject.InstanceName);
+
+            return baseNamedObject != null && baseNamedObject.SourceFile != namedObject.SourceFile;
         }
 
         private static bool GetIfCanAttach(NamedObjectSave namedObject, AssetTypeInfo ati, GlueElement container)

--- a/FRBDK/Glue/Tests/GlueUnitTests/CodeGeneration/NamedObjectSaveCodeGeneratorTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CodeGeneration/NamedObjectSaveCodeGeneratorTests.cs
@@ -1,0 +1,112 @@
+using FlatRedBall.Glue.CodeGeneration;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+
+namespace GlueUnitTests.CodeGeneration;
+
+// Regression coverage for #1770: a derived (variant) entity's LayeredTileMap object, exposed from its
+// base with InstantiatedByBase = true, could have its SourceFile changed in the property grid, but the
+// override was silently ignored - the derived class never re-ran its instantiation code, so only the
+// base's own file was ever loaded. See ShouldReinstantiateDespiteInstantiatedByBase's doc comment in
+// NamedObjectSaveCodeGenerator.cs for the fix.
+public class NamedObjectSaveCodeGeneratorTests
+{
+    public NamedObjectSaveCodeGeneratorTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    private static (EntitySave baseEntity, EntitySave derivedEntity) CreateBaseAndDerivedEntities()
+    {
+        var glueProject = new GlueProjectSave();
+        ObjectFinder.Self.GlueProject = glueProject;
+
+        var baseEntity = new EntitySave { Name = "Entities\\BaseEntity" };
+        var derivedEntity = new EntitySave { Name = "Entities\\DerivedEntity", BaseEntity = baseEntity.Name };
+
+        glueProject.Entities.Add(baseEntity);
+        glueProject.Entities.Add(derivedEntity);
+
+        return (baseEntity, derivedEntity);
+    }
+
+    private static NamedObjectSave CreateFileSourcedNamedObject(string sourceFile, bool instantiatedByBase)
+    {
+        return new NamedObjectSave
+        {
+            InstanceName = "Map",
+            SourceType = SourceType.File,
+            SourceFile = sourceFile,
+            InstantiatedByBase = instantiatedByBase
+        };
+    }
+
+    [Fact]
+    public void ShouldReinstantiateDespiteInstantiatedByBase_ShouldReturnTrue_WhenDerivedSourceFileDiffersFromBase()
+    {
+        var (baseEntity, derivedEntity) = CreateBaseAndDerivedEntities();
+
+        baseEntity.NamedObjects.Add(CreateFileSourcedNamedObject("Content/Base.tmx", instantiatedByBase: false));
+        var derivedNos = CreateFileSourcedNamedObject("Content/Derived.tmx", instantiatedByBase: true);
+        derivedEntity.NamedObjects.Add(derivedNos);
+
+        NamedObjectSaveCodeGenerator.ShouldReinstantiateDespiteInstantiatedByBase(derivedNos, derivedEntity)
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldReinstantiateDespiteInstantiatedByBase_ShouldReturnFalse_WhenDerivedSourceFileMatchesBase()
+    {
+        var (baseEntity, derivedEntity) = CreateBaseAndDerivedEntities();
+
+        baseEntity.NamedObjects.Add(CreateFileSourcedNamedObject("Content/Base.tmx", instantiatedByBase: false));
+        var derivedNos = CreateFileSourcedNamedObject("Content/Base.tmx", instantiatedByBase: true);
+        derivedEntity.NamedObjects.Add(derivedNos);
+
+        NamedObjectSaveCodeGenerator.ShouldReinstantiateDespiteInstantiatedByBase(derivedNos, derivedEntity)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldReinstantiateDespiteInstantiatedByBase_ShouldReturnFalse_WhenSourceTypeIsNotFile()
+    {
+        var (baseEntity, derivedEntity) = CreateBaseAndDerivedEntities();
+
+        var baseNos = new NamedObjectSave
+        {
+            InstanceName = "Map",
+            SourceType = SourceType.FlatRedBallType,
+            InstantiatedByBase = false
+        };
+        baseEntity.NamedObjects.Add(baseNos);
+
+        var derivedNos = new NamedObjectSave
+        {
+            InstanceName = "Map",
+            SourceType = SourceType.FlatRedBallType,
+            InstantiatedByBase = true
+        };
+        derivedEntity.NamedObjects.Add(derivedNos);
+
+        NamedObjectSaveCodeGenerator.ShouldReinstantiateDespiteInstantiatedByBase(derivedNos, derivedEntity)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldReinstantiateDespiteInstantiatedByBase_ShouldReturnFalse_WhenThereIsNoBaseElement()
+    {
+        var glueProject = new GlueProjectSave();
+        ObjectFinder.Self.GlueProject = glueProject;
+
+        var entity = new EntitySave { Name = "Entities\\StandaloneEntity" };
+        glueProject.Entities.Add(entity);
+
+        var nos = CreateFileSourcedNamedObject("Content/Base.tmx", instantiatedByBase: true);
+        entity.NamedObjects.Add(nos);
+
+        NamedObjectSaveCodeGenerator.ShouldReinstantiateDespiteInstantiatedByBase(nos, entity)
+            .ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Problem

Part of #1770. A derived/variant entity whose base has a LayeredTileMap object marked `ExposedInDerived` could edit that object's `SourceFile` in the property grid, but the change had zero effect - the derived entity always displayed the base's tile map, whether that base had a real .tmx or none at all.

## Root cause

`ExposedInDerived` clones the NamedObjectSave into the derived entity with `InstantiatedByBase = true`. `NamedObjectSaveCodeGenerator.WriteCodeForNamedObjectInitialize` treats that flag as "the base already instantiated this, generate no instantiation code in the derived at all" - which is correct for properties that can still be changed after construction, but `SourceFile` is only ever read at the moment of instantiation. So a derived-only `SourceFile` override was silently dead data: nothing in the generated code ever read it.

## Fix

`NamedObjectSaveCodeGenerator` now re-instantiates in the derived class when the object is `SourceType.File` and its `SourceFile` differs from the value on its immediate base element's copy of the same object - i.e. only when the derived actually points at a different file. All other `InstantiatedByBase` behavior (non-file types, or a file-sourced object whose file matches the base) is unchanged.

## Testing

Added `NamedObjectSaveCodeGeneratorTests` covering: differing SourceFile → re-instantiate, matching SourceFile → skip (unchanged behavior), non-File source type → skip, and no base element → skip (no exception). Verified Red (assertions fail without the fix) then Green. Full `GlueUnitTests` suite: 235/235 passing.

**Manual test: needed** - this is a Glue codegen change with a runtime-visible effect (which .tmx a derived/variant entity's LayeredTileMap loads), not fully exercised by the unit test above (which pins the codegen decision, not full ATI/TMX file loading). Opening the solution for you:
1. Open `FRBDK/Glue/Glue with All.sln` in Visual Studio.
2. In Glue, create an entity with a LayeredTileMap object, set it to `ExposedInDerived`, and give it a source .tmx.
3. Create a derived entity (variant) of it, drag a *different* .tmx onto the derived's LayeredTileMap object to change its `SourceFile`.
4. Regenerate code and confirm the derived entity's generated `CustomInitialize`/`Initialize` now includes real instantiation code for the map (not a "skipping instantiation... InstantiatedByBase" comment), using the derived's own file.
5. Run the game and confirm the derived/variant entity shows the new tile map's visuals instead of the base's.

## Out of scope

The issue also reports a `KeyNotFoundException` in `NamedObjectVariableShowingLogic.UpdateShownVariables` (`CreateFieldsForNamedObjects` key missing) when switching selection in the property grid. That code has changed significantly since the issue was filed and looks like a separate, still-reproducible property-grid staleness bug unrelated to this codegen fix - left a comment on #1770 calling it out as still open rather than folding it into this PR.
