### PR TITLE
Reject Entity file names which hide an inherited member

### DIFF
--- a/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
+++ b/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
@@ -34,9 +34,14 @@ Also process-wide static state a test may need to control alongside the bootstra
   builds a real (not fake) `VisualStudioProject` from a minimal non-SDK `.csproj`, for tests that need
   `GlueState.CurrentMainProject` to be non-null.
 
-Both `TaskManager` statics mutate process-wide state, so test classes that touch them share a
-non-parallel xunit collection — see `TaskManagerSequentialCollection` in the file above and reuse it
-rather than inventing a new one.
+- **`ObjectFinder.Self.GlueProject`** — assign a `GlueProjectSave` for anything reaching `ObjectFinder`
+  lookups (`GetEntitySaveUnqualified`, `GetAllReferencedFiles`).
+
+Every one of these is process-wide, so a test class that assigns one must join
+`TaskManagerSequentialCollection` (`GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs`) — reuse that
+one collection rather than adding another. xunit parallelizes by collection, so two *separate* sequential
+collections still race each other; only the shared one actually serializes. The failure mode is a test
+that passes under `--filter` in isolation and fails in the full run.
 
 ## Landmine — calling a real plugin method for the first time can pop a real dialog on the developer's desktop
 

--- a/FRBDK/Glue/Glue/SaveClasses/NameVerifier.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/NameVerifier.cs
@@ -231,6 +231,11 @@ public class NameVerifier
 
         if (string.IsNullOrEmpty(whyItIsntValid))
         {
+            CheckForNameHidingContainerMember(name, container, ref whyItIsntValid);
+        }
+
+        if (string.IsNullOrEmpty(whyItIsntValid))
+        {
             CheckForExistingEntity(name, ref whyItIsntValid);
         }
 
@@ -272,6 +277,41 @@ public class NameVerifier
 
         bool returnValue = string.IsNullOrEmpty(whyItIsntValid);
         return returnValue;
+    }
+
+    /// <summary>
+    /// Reports a file name which matches a variable the containing Entity already inherits. Files are
+    /// generated as fields named after the file, so a file named "X" hides PositionedObject.X, and
+    /// generated code which assigns that variable (such as a state's "X = value.X;") no longer compiles.
+    /// </summary>
+    private void CheckForNameHidingContainerMember(string name, GlueElement container, ref string whyItIsntValid)
+    {
+        // Screens don't inherit from PositionedObject, so a file in a Screen has no member to hide.
+        if (container is EntitySave == false)
+        {
+            return;
+        }
+
+        if (ExposedVariableManager.PositionedObjectMembers == null)
+        {
+            // ExposedVariableManager hasn't been initialized, so there's nothing to compare against.
+            return;
+        }
+
+        var strippedName = FileManager.RemoveExtension(FileManager.RemovePath(name));
+
+        // Both lists are needed - together they cover every public member of PositionedObject, whether
+        // or not Glue lets that member be exposed as a variable.
+        var hidesMember =
+            ExposedVariableManager.IsMemberDefinedByPositionedObject(strippedName) ||
+            ExposedVariableManager.IsReservedPositionedPositionedObjectMember(strippedName);
+
+        if (hidesMember)
+        {
+            whyItIsntValid = $"The name {strippedName} matches a member which this Entity already has. Files are " +
+                "added to an Entity as fields using the file's name, so this file would hide that member and " +
+                "produce generated code which doesn't compile. Please rename the file.";
+        }
     }
 
     private void CheckForRfsWithMatchingFileName(GlueElement container, string name, ReferencedFileSave rfsToSkip, ref string whyItIsntValid)

--- a/FRBDK/Glue/Tests/GlueUnitTests/CodeGeneration/NamedObjectSaveCodeGeneratorTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CodeGeneration/NamedObjectSaveCodeGeneratorTests.cs
@@ -1,6 +1,7 @@
 using FlatRedBall.Glue.CodeGeneration;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.Tasks;
 using GlueUnitTests.TestSupport;
 using Shouldly;
 
@@ -11,6 +12,8 @@ namespace GlueUnitTests.CodeGeneration;
 // override was silently ignored - the derived class never re-ran its instantiation code, so only the
 // base's own file was ever loaded. See ShouldReinstantiateDespiteInstantiatedByBase's doc comment in
 // NamedObjectSaveCodeGenerator.cs for the fix.
+// Assigns ObjectFinder.Self.GlueProject, which is process-wide, so it runs in the sequential collection.
+[Collection(nameof(TaskManagerSequentialCollection))]
 public class NamedObjectSaveCodeGeneratorTests
 {
     public NamedObjectSaveCodeGeneratorTests()

--- a/FRBDK/Glue/Tests/GlueUnitTests/SaveClasses/NameVerifierTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/SaveClasses/NameVerifierTests.cs
@@ -1,0 +1,68 @@
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.Tasks;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+
+namespace GlueUnitTests.SaveClasses;
+
+// Assigns ObjectFinder.Self.GlueProject, which is process-wide, so it runs in the sequential collection.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class NameVerifierTests
+{
+    NameVerifier _sut;
+    EntitySave _entity;
+
+    public NameVerifierTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+
+        _entity = new EntitySave { Name = "Entities\\Piece" };
+        ObjectFinder.Self.GlueProject.Entities.Add(_entity);
+
+        _sut = new NameVerifier();
+    }
+
+    [Theory]
+    [InlineData("X")]
+    [InlineData("Y")]
+    [InlineData("Z")]
+    [InlineData("RotationZ")]
+    // Velocity isn't exposable as a Glue variable, but the generated Entity still has it, so a file
+    // using that name hides it just the same.
+    [InlineData("Velocity")]
+    public void IsReferencedFileNameValid_ShouldReturnFalse_WhenNameMatchesInheritedEntityMember(string name)
+    {
+        // A file added to an Entity generates a static field named after the file. If that name matches
+        // a member the generated Entity already has (PositionedObject.X, for example), the field hides
+        // the member and generated code like "X = value.X;" no longer compiles.
+        var isValid = _sut.IsReferencedFileNameValid(name, null, null, _entity, out string whyItIsntValid);
+
+        isValid.ShouldBeFalse();
+        whyItIsntValid.ShouldContain(name);
+    }
+
+    [Fact]
+    public void IsReferencedFileNameValid_ShouldReturnTrue_WhenNameDoesNotMatchInheritedEntityMember()
+    {
+        var isValid = _sut.IsReferencedFileNameValid("Empty", null, null, _entity, out string whyItIsntValid);
+
+        isValid.ShouldBeTrue();
+        whyItIsntValid.ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void IsReferencedFileNameValid_ShouldReturnTrue_WhenNameMatchesPositionedObjectMemberButContainerIsScreen()
+    {
+        // Screens don't inherit from PositionedObject, so there's nothing for the generated field to hide.
+        var screen = new ScreenSave { Name = "Screens\\GameScreen" };
+        ObjectFinder.Self.GlueProject.Screens.Add(screen);
+
+        var isValid = _sut.IsReferencedFileNameValid("X", null, null, screen, out string whyItIsntValid);
+
+        isValid.ShouldBeTrue();
+        whyItIsntValid.ShouldBeNullOrEmpty();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs
@@ -8,6 +8,9 @@ namespace GlueUnitTests.Tasks;
 // TaskManager is a process-wide singleton (see Singleton<T>) and TaskManager.SynchronousMode /
 // UiThreadMarshaller are process-wide static state. Both test classes in this file mutate that state,
 // so they share a non-parallel xunit collection to avoid interleaving with each other.
+// It's also the collection for any other test class which mutates process-wide state (for example
+// ObjectFinder.Self.GlueProject) - one shared collection is what actually keeps them apart, since two
+// separate sequential collections still run in parallel with each other.
 [CollectionDefinition(nameof(TaskManagerSequentialCollection), DisableParallelization = true)]
 public class TaskManagerSequentialCollection { }
 


### PR DESCRIPTION
Adding a file named `X.png` to an Entity generated `protected static Texture2D X`, which hid `PositionedObject.X`. Generated state code then emitted `X = value.X;`, failing with `CS0029: Cannot implicitly convert type 'float' to 'Texture2D'`. Reported against a project with `Empty.png`/`O.png`/`X.png` in an Entity plus a state category.

`NameVerifier.IsReferencedFileNameValid` now rejects a file name matching any public member of `PositionedObject` (both `ExposedVariableManager.IsMemberDefinedByPositionedObject` and `IsReservedPositionedPositionedObjectMember`, which together cover the exposable and non-exposable halves). Entity containers only — Screens don't inherit `PositionedObject`.

Validation-only: it prevents new occurrences, it doesn't repair a project that already has such a file. That still needs a rename.

Also moved `NamedObjectSaveCodeGeneratorTests` and the new test class into `TaskManagerSequentialCollection`. Both assign `ObjectFinder.Self.GlueProject`, which is process-wide, and running in parallel made the existing test fail intermittently in the full run while passing under `--filter`.

Tests: 242/242 green.

Manual test: not needed — the check is pure and fully covered by the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
