### PR TITLE
Run GlueUnitTests non-parallel

### DIFF
--- a/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
+++ b/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
@@ -37,11 +37,11 @@ Also process-wide static state a test may need to control alongside the bootstra
 - **`ObjectFinder.Self.GlueProject`** — assign a `GlueProjectSave` for anything reaching `ObjectFinder`
   lookups (`GetEntitySaveUnqualified`, `GetAllReferencedFiles`).
 
-Every one of these is process-wide, so a test class that assigns one must join
-`TaskManagerSequentialCollection` (`GlueUnitTests/Tasks/TaskManagerSynchronousModeTests.cs`) — reuse that
-one collection rather than adding another. xunit parallelizes by collection, so two *separate* sequential
-collections still race each other; only the shared one actually serializes. The failure mode is a test
-that passes under `--filter` in isolation and fails in the full run.
+Every one of these is process-wide, which is why the whole assembly runs non-parallel — see
+`GlueUnitTests/AssemblyInfo.cs`. So cross-class interleaving isn't a hazard, but leakage still is: a test
+which assigns one of these must restore it (`IDisposable`/`try-finally`), or it silently changes the
+setup of whatever runs next. The failure mode is a test that passes under `--filter` and fails in the
+full run.
 
 ## Landmine — calling a real plugin method for the first time can pop a real dialog on the developer's desktop
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/AssemblyInfo.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+// Glue is built on process-wide singletons (GlueState.Self, GlueCommands.Self, ObjectFinder.Self,
+// TaskManager, PluginManager), so most test classes here have to assign shared static state to set up
+// their scenario. Running them in parallel means one class can overwrite another's setup mid-test - the
+// symptom is a test which passes under --filter and fails in the full run.
+//
+// Isolating that state properly would mean removing the singletons, which isn't happening in FRB1
+// maintenance mode. Serializing the whole assembly costs a few seconds on a sub-minute suite, so it's
+// the better trade than expecting every new test author to know which statics are shared.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
Follow-up to #1939, which surfaced a real cross-class race: `NamedObjectSaveCodeGeneratorTests` assigned `ObjectFinder.Self.GlueProject` outside the sequential collection, so it passed under `--filter` and failed in the full run once another class started assigning the same static.

Glue is built on process-wide singletons (`GlueState.Self`, `GlueCommands.Self`, `ObjectFinder.Self`, `TaskManager`, `PluginManager`), so most test classes have to assign shared static state to set up their scenario — 14 of ~23 classes already sat in `TaskManagerSequentialCollection` for exactly that reason. Isolating that properly means removing the singletons, which isn't happening in maintenance mode.

`[assembly: CollectionBehavior(DisableTestParallelization = true)]` removes the failure mode outright. Measured cost: 35s → 37s on 242 tests.

The per-class `[Collection]` attributes are kept — they're now no-ops for scheduling, but they record which classes touch shared statics.

Audited the rest of the suite while here: no other class was mutating a shared static outside the collection. Filesystem tests already use GUID-per-test temp directories.

Tests: 242/242 green.

Manual test: not needed — test-infrastructure only, and the suite passing is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
