### PR TITLE
Add downstream build smoke script, fix dead SkiaInGum references, cover the engine in PR CI

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -47,3 +47,19 @@ jobs:
     # (installed above) and network for the first NuGet restore.
     - name: Run new-project build smoke test
       run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category=BuildSmoke"
+
+    # Everything above this line covers the Glue editor only. The steps below cover the engine,
+    # which otherwise gets compiled just once per release by Engine.yml -- long after the commit
+    # that broke it.
+    - name: Run engine unit tests
+      run: dotnet test 'FlatRedBall\Tests\EngineUnitTests\EngineUnitTests.sln' -c Debug
+
+    # TestProjectDesktopNet6 deliberately does not appear here. Its 440 *.Generated.cs files are
+    # gitignored, so it only compiles where Glue has already regenerated it -- a clean checkout
+    # cannot build it. scripts/Test-DownstreamBuilds.ps1 covers it locally instead.
+
+    # DebugAutoBuild is the configuration Glue uses to rebuild the engine during live edit, and the
+    # only one where FlatRedBall.Forms references SkiaGum at all. Plain Debug does not evaluate that
+    # reference, so a broken one survives every other check in this file.
+    - name: Build Forms under the Glue live-edit configuration
+      run: dotnet build 'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.DesktopGLNet6.sln' -c DebugAutoBuild

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ CLAUDE.local.md
 
 /temp/*
 !/temp/.gitkeep
+
+# Build logs from scripts/Test-DownstreamBuilds.ps1
+/artifacts/

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms All Platforms.sln
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms All Platforms.sln
@@ -19,7 +19,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StateInterpolation.DesktopN
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlatRedBall.Forms.DesktopGlNet6", "FlatRedBall.Forms.DesktopGlNet6\FlatRedBall.Forms.DesktopGlNet6.csproj", "{346E0CC5-D25F-4E9F-970F-678F4D019C9F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum", "..\..\..\..\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.csproj", "{7AE61851-BDC2-4B77-B159-BFF52550C423}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum", "..\..\SkiaGum\SkiaInGum.csproj", "{7AE61851-BDC2-4B77-B159-BFF52550C423}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FlatRedBallShared", "..\..\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.shproj", "{0BB8CBE3-8503-46C1-9272-D98E153A230E}"
 EndProject

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGLNet6.sln
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGLNet6.sln
@@ -19,7 +19,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StateInterpolation.DesktopN
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlatRedBall.Forms.DesktopGlNet6", "FlatRedBall.Forms.DesktopGlNet6\FlatRedBall.Forms.DesktopGlNet6.csproj", "{346E0CC5-D25F-4E9F-970F-678F4D019C9F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum", "..\..\..\..\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.csproj", "{7AE61851-BDC2-4B77-B159-BFF52550C423}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum", "..\..\SkiaGum\SkiaInGum.csproj", "{7AE61851-BDC2-4B77-B159-BFF52550C423}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FlatRedBallShared", "..\..\FlatRedBallXNA\FlatRedBall\FlatRedBallShared.shproj", "{0BB8CBE3-8503-46C1-9272-D98E153A230E}"
 EndProject

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGlNet6/FlatRedBall.Forms.DesktopGlNet6.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGlNet6/FlatRedBall.Forms.DesktopGlNet6.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\Gum\GumCore\GumCoreXnaPc\GumCore.DesktopGlNet6\GumCore.DesktopGlNet6.csproj" />
-    <ProjectReference Include="..\..\..\..\..\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.csproj" Condition="'$(Configuration)' == 'DebugAutoBuild' Or '$(Configuration)' == 'ReleaseAutoBuild'" />
+    <ProjectReference Include="..\..\..\SkiaGum\SkiaInGum.csproj" Condition="'$(Configuration)' == 'DebugAutoBuild' Or '$(Configuration)' == 'ReleaseAutoBuild'" />
   </ItemGroup>
   <Import Project="..\FlatRedBall.Forms.Shared\FlatRedBall.Forms.Shared.projitems" Label="Shared" />
 </Project>

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.FNA.sln
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.FNA.sln
@@ -17,7 +17,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlatRedBall.Forms.FNA", "Fl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GumCore.FNA", "..\..\..\..\Gum\GumCore\GumCoreXnaPc\GumCore.FNA\GumCore.FNA.csproj", "{CD9EBE44-31F1-4264-B063-E7382B276D37}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum.FNA", "..\..\..\..\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.FNA.csproj", "{840D15B2-071F-473F-A8E5-F4011BB48A01}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum.FNA", "..\..\SkiaGum\SkiaInGum.FNA.csproj", "{840D15B2-071F-473F-A8E5-F4011BB48A01}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StateInterpolation.FNA", "StateInterpolation\StateInterpolation.FNA\StateInterpolation.FNA.csproj", "{83AF3578-8DD1-42D7-A1EE-00BAD580F1C9}"
 EndProject

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.FNA/FlatRedBall.Forms.FNA.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.FNA/FlatRedBall.Forms.FNA.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\Gum\GumCore\GumCoreXnaPc\GumCore.FNA\GumCore.FNA.csproj" />
-    <ProjectReference Include="..\..\..\..\..\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.csproj" Condition="'$(Configuration)' == 'DebugAutoBuild' Or '$(Configuration)' == 'ReleaseAutoBuild'" />
+    <ProjectReference Include="..\..\..\SkiaGum\SkiaInGum.FNA.csproj" Condition="'$(Configuration)' == 'DebugAutoBuild' Or '$(Configuration)' == 'ReleaseAutoBuild'" />
     <ProjectReference Include="..\..\..\FlatRedBallXNA\3rd Party Libraries\FNA\FNA.Core.csproj" />
   </ItemGroup>
   <Import Project="..\FlatRedBall.Forms.Shared\FlatRedBall.Forms.Shared.projitems" Label="Shared" />

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Kni.DesktopGL/FlatRedBall.Forms.Kni.DesktopGL.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Kni.DesktopGL/FlatRedBall.Forms.Kni.DesktopGL.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\Gum\GumCore\GumCoreXnaPc\GumCore.Kni.DesktopGL\GumCore.Kni.DesktopGL.csproj" />
-    <ProjectReference Include="..\..\..\..\..\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.csproj" Condition="'$(Configuration)' == 'DebugAutoBuild' Or '$(Configuration)' == 'ReleaseAutoBuild'" />
+    <ProjectReference Include="..\..\..\SkiaGum\SkiaInGum.csproj" Condition="'$(Configuration)' == 'DebugAutoBuild' Or '$(Configuration)' == 'ReleaseAutoBuild'" />
   </ItemGroup>
   <Import Project="..\FlatRedBall.Forms.Shared\FlatRedBall.Forms.Shared.projitems" Label="Shared" />
 </Project>

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Shared/FlatRedBall.Forms.FNA.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Shared/FlatRedBall.Forms.FNA.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\Gum\GumCore\GumCoreXnaPc\GumCore.FNA\GumCore.FNA.csproj" />
-    <ProjectReference Include="..\..\..\..\..\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.csproj" Condition="'$(Configuration)' == 'DebugAutoBuild' Or '$(Configuration)' == 'ReleaseAutoBuild'" />
+    <ProjectReference Include="..\..\..\SkiaGum\SkiaInGum.FNA.csproj" Condition="'$(Configuration)' == 'DebugAutoBuild' Or '$(Configuration)' == 'ReleaseAutoBuild'" />
     <ProjectReference Include="..\..\..\FlatRedBallXNA\3rd Party Libraries\FNA\FNA.Core.csproj" />
   </ItemGroup>
   <Import Project="..\FlatRedBall.Forms.Shared\FlatRedBall.Forms.Shared.projitems" Label="Shared" />

--- a/Samples/FormsSampleProject/FormsSampleProject.sln
+++ b/Samples/FormsSampleProject/FormsSampleProject.sln
@@ -23,7 +23,7 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "GumCoreShared.FlatRedBall",
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "StateInterpolationShared", "..\..\FRBDK\Glue\StateInterpolationPlugin\StateInterpolationPlugin\StateInterpolationShared.shproj", "{D00D287D-385B-42FB-BF5F-04401E7D37D0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum", "..\..\..\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.csproj", "{65086525-A5DB-45F3-A855-409CD0F12E8D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum", "..\..\Engines\SkiaGum\SkiaInGum.csproj", "{65086525-A5DB-45F3-A855-409CD0F12E8D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Engine", "Engine", "{4CC888EE-9CE8-48FD-B955-7BDBA68D1A61}"
 EndProject

--- a/Samples/FormsSampleProject/FormsSampleProject/FormsSampleProject.csproj
+++ b/Samples/FormsSampleProject/FormsSampleProject/FormsSampleProject.csproj
@@ -597,7 +597,7 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
-    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Content\Shader.fx">
@@ -617,7 +617,7 @@
     <ProjectReference Include="../../../../Gum/GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj">
       <Name>GumCore.DesktopGlNet6</Name>
     </ProjectReference>
-    <ProjectReference Include="../../../../Gum/SvgPlugin/SkiaInGumShared/SkiaInGum.csproj">
+    <ProjectReference Include="../../../Engines/SkiaGum/SkiaInGum.csproj">
       <Name>SkiaInGum</Name>
     </ProjectReference>
     <ProjectReference Include="../../../Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj">

--- a/Samples/SkiaSampleProject/SkiaSampleProject.sln
+++ b/Samples/SkiaSampleProject/SkiaSampleProject.sln
@@ -23,7 +23,7 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "GumCoreShared.FlatRedBall",
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "StateInterpolationShared", "..\..\FRBDK\Glue\StateInterpolationPlugin\StateInterpolationPlugin\StateInterpolationShared.shproj", "{D00D287D-385B-42FB-BF5F-04401E7D37D0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaInGum", "..\..\..\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.csproj", "{90EA4899-F086-44EC-BD64-2C10236EE07E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaInGum", "..\..\Engines\SkiaGum\SkiaInGum.csproj", "{90EA4899-F086-44EC-BD64-2C10236EE07E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Samples/SkiaSampleProject/SkiaSampleProject/SkiaSampleProject.csproj
+++ b/Samples/SkiaSampleProject/SkiaSampleProject/SkiaSampleProject.csproj
@@ -562,7 +562,7 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
-    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Content\Shader.fx">
@@ -582,7 +582,7 @@
     <ProjectReference Include="../../../../Gum/GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj">
       <Name>GumCore.DesktopGlNet6</Name>
     </ProjectReference>
-    <ProjectReference Include="../../../../Gum/SvgPlugin/SkiaInGumShared/SkiaInGum.csproj">
+    <ProjectReference Include="../../../Engines/SkiaGum/SkiaInGum.csproj">
       <Name>SkiaInGum</Name>
     </ProjectReference>
     <ProjectReference Include="../../../Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj">

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6.sln
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6.sln
@@ -23,7 +23,7 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "GumCoreShared.FlatRedBall",
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "StateInterpolationShared", "..\..\FRBDK\Glue\StateInterpolationPlugin\StateInterpolationPlugin\StateInterpolationShared.shproj", "{D00D287D-385B-42FB-BF5F-04401E7D37D0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum", "..\..\..\Gum\Gum\SvgPlugin\SkiaInGumShared\SkiaInGum.csproj", "{0CA8DECB-646F-4D0D-ABFB-B903905E5F65}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkiaInGum", "..\..\Engines\SkiaGum\SkiaInGum.csproj", "{0CA8DECB-646F-4D0D-ABFB-B903905E5F65}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{7E66EE90-B406-4E14-88E5-6A1BBE53628F}"
 EndProject

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Screens/GumScreen.cs
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/Screens/GumScreen.cs
@@ -194,8 +194,8 @@ public partial class GumScreen
 
         inlineVariables.Count.ShouldBe(2);
 
-        var styledSubstring0 = textRenderable.GetStyledSubstrings(0, textRenderable.WrappedText[0], System.Drawing.Color.White);
-        var styledSubstring1 = textRenderable.GetStyledSubstrings(textRenderable.WrappedText[0].Length, textRenderable.WrappedText[1], System.Drawing.Color.White);
+        var styledSubstring0 = textRenderable.GetStyledSubstrings(0, textRenderable.WrappedText[0]);
+        var styledSubstring1 = textRenderable.GetStyledSubstrings(textRenderable.WrappedText[0].Length, textRenderable.WrappedText[1]);
 
         styledSubstring0[1].Substring.ShouldBe("1");
         styledSubstring1[1].Substring.ShouldBe("1");

--- a/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/TestProjectDesktopNet6.csproj
+++ b/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6/TestProjectDesktopNet6.csproj
@@ -2731,7 +2731,7 @@
     <ProjectReference Include="../../../../Gum/GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj">
       <Name>GumCore.DesktopGlNet6</Name>
     </ProjectReference>
-    <ProjectReference Include="../../../../Gum/Gum/SvgPlugin/SkiaInGumShared/SkiaInGum.csproj">
+    <ProjectReference Include="../../../Engines/SkiaGum/SkiaInGum.csproj">
       <Name>SkiaInGum</Name>
     </ProjectReference>
     <ProjectReference Include="../../../Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj">

--- a/scripts/Test-DownstreamBuilds.ps1
+++ b/scripts/Test-DownstreamBuilds.ps1
@@ -1,0 +1,262 @@
+<#
+.SYNOPSIS
+    Builds the downstream projects that gate an FRB release against the current working tree.
+
+.DESCRIPTION
+    Step 2 of the release checklist (docs.flatredball.com/flatredball/contributing/builds) is
+    "run tests to verify FRB Editor functionality" against a set of real games. Those games
+    reference FlatRedBall and Gum by ProjectReference into sibling checkouts, not by NuGet, so
+    they compile directly against whatever is in the working tree right now -- no package
+    publish required. That makes the compile half of step 2 scriptable, which is what this does.
+
+    Compiling is not the whole of step 2: it catches broken APIs, not broken pixels. Actually
+    running each game and looking at it is still a human job. But since pr-tests.yml covers only
+    the Glue editor, compiling these is currently the only automated check that an engine change
+    hasn't broken consumer code.
+
+    Targets outside this repo are skipped (not failed) when absent, so a contributor without the
+    game repos still gets a useful run over the in-repo targets.
+
+.PARAMETER Only
+    Build just the named targets. Accepts the Name column from the summary table.
+
+.PARAMETER Configuration
+    Build configuration. Defaults to Debug, which is what the release workflows publish.
+
+.PARAMETER Clean
+    Pass --no-incremental, forcing a full rebuild. Slower, but catches stale-artifact false
+    passes -- worth it for an actual release gate.
+
+.PARAMETER LogDirectory
+    Where per-target build logs are written. Defaults to a timestamped folder under the repo's
+    ignored artifacts directory.
+
+.EXAMPLE
+    ./scripts/Test-DownstreamBuilds.ps1
+    Full release gate: every available target, incremental.
+
+.EXAMPLE
+    ./scripts/Test-DownstreamBuilds.ps1 -Only EngineUnitTests,TestProject -Clean
+    Just the in-repo targets, from scratch.
+#>
+[CmdletBinding()]
+param(
+    [string[]]$Only,
+    [string]$Configuration = 'Debug',
+    [switch]$Clean,
+    [string]$LogDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot   = Split-Path -Parent $PSScriptRoot
+$githubRoot = Split-Path -Parent $repoRoot
+
+# Paths are relative to $githubRoot so the sibling-checkout layout is stated in one place.
+# Test=$true runs `dotnet test` instead of `dotnet build`.
+#
+# Targets are .sln where that works, but BattleCryptBombers is deliberately the game .csproj: its
+# .sln also carries a NarfoxGameTools project that no longer exists in that repo, so the solution
+# cannot restore at all. The game itself consumes NarfoxGameTools as a checked-in DLL and builds
+# fine. We want to know whether the game still compiles against FRB, not whether an unrelated
+# sibling repo has drifted.
+$targets = @(
+    @{ Name = 'EngineUnitTests'; Project = 'FlatRedBall/Tests/EngineUnitTests/EngineUnitTests.sln';                      Test = $true;  Note = 'Engine unit tests (no workflow runs these yet)' }
+    @{ Name = 'TestProject';     Project = 'FlatRedBall/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6.sln';        Test = $false; Note = 'The "Automated Test Project" from the checklist' }
+    @{ Name = 'KidDefense';      Project = 'KidDefense/GameProject/KidDefense.sln';                                      Test = $false; Note = 'net9.0 / MonoGame 3.8.5' }
+    @{ Name = 'CrankyChibi';     Project = 'Kimuzukash-chibi-kuto-urufu/CrankyChibiCthulu.sln';                          Test = $false; Note = 'net8.0 / MonoGame 3.8.4.1' }
+    @{ Name = 'BattleCrypt';     Project = 'BattleCryptBombers/BattleCryptBombers/BattleCryptBombers.csproj';            Test = $false; Note = 'net6.0 / MonoGame 3.8.1.303 -- oldest target, widest drift' }
+)
+
+if ($Only) {
+    $unknown = $Only | Where-Object { $_ -notin $targets.Name }
+    if ($unknown) {
+        Write-Host "Unknown target(s): $($unknown -join ', ')" -ForegroundColor Red
+        Write-Host "Available: $($targets.Name -join ', ')" -ForegroundColor Yellow
+        exit 1
+    }
+    $targets = $targets | Where-Object { $_.Name -in $Only }
+}
+
+if (-not $LogDirectory) {
+    $stamp = Get-Date -Format 'yyyy-MM-dd_HH-mm-ss'
+    $LogDirectory = Join-Path $repoRoot "artifacts/downstream-builds/$stamp"
+}
+New-Item -ItemType Directory -Force -Path $LogDirectory | Out-Null
+
+# ---------------------------------------------------------------------------
+# Pre-flight: report what we are actually building against.
+#
+# A green table means nothing if you can't say which Gum and which FRB produced it. Engine.yml
+# and pr-tests.yml check out Gum's *default branch*, while glue.yml bundles Gum's *latest
+# GitHub release* -- so "the Gum" is already ambiguous in CI. Local builds add a third
+# possibility (whatever you happen to have checked out). Print it rather than assume it.
+# ---------------------------------------------------------------------------
+
+function Get-RepoState {
+    param([string]$Path, [string]$Label)
+
+    if (-not (Test-Path (Join-Path $Path '.git'))) { return $null }
+
+    # Submodules are excluded: Gum carries Sokol.NET/FNA submodules that are routinely dirty or
+    # uninitialised, and that says nothing about whether Gum's own source is clean.
+    $dirty    = git -C $Path status --porcelain --ignore-submodules=all
+    $describe = git -C $Path describe --tags --always 2>$null
+    $branch   = git -C $Path rev-parse --abbrev-ref HEAD 2>$null
+
+    [pscustomobject]@{
+        Label    = $Label
+        Branch   = $branch
+        Describe = $describe
+        Dirty    = [bool]$dirty
+    }
+}
+
+Write-Host ''
+Write-Host 'Building against' -ForegroundColor Cyan
+Write-Host '----------------' -ForegroundColor Cyan
+
+$gumPath = Join-Path $githubRoot 'Gum'
+foreach ($state in @((Get-RepoState -Path $repoRoot -Label 'FlatRedBall'), (Get-RepoState -Path $gumPath -Label 'Gum'))) {
+    if (-not $state) { continue }
+    $flag = if ($state.Dirty) { ' (uncommitted changes)' } else { '' }
+    Write-Host ("  {0,-12} {1} @ {2}{3}" -f $state.Label, $state.Branch, $state.Describe, $flag)
+}
+
+# Gum is FRB's one hard external dependency, and shipping FRB against an unreleased Gum is a
+# silent failure mode: it compiles locally and then bundles a different Gum at release time.
+if (Test-Path $gumPath) {
+    $latestGumTag = git -C $gumPath tag --list 'Release_*' --sort=-creatordate | Select-Object -First 1
+    if ($latestGumTag) {
+        git -C $gumPath merge-base --is-ancestor $latestGumTag HEAD 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host ''
+            Write-Host "  WARNING: Gum HEAD does not contain its latest release tag ($latestGumTag)." -ForegroundColor Yellow
+            Write-Host "           These builds test FRB against unreleased Gum source, but glue.yml" -ForegroundColor Yellow
+            Write-Host "           bundles Gum's latest GitHub release. A pass here does not prove the" -ForegroundColor Yellow
+            Write-Host "           shipped combination works." -ForegroundColor Yellow
+        }
+    }
+}
+Write-Host ''
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+$results = @()
+
+foreach ($target in $targets) {
+    $projectPath = Join-Path $githubRoot $target.Project
+
+    if (-not (Test-Path $projectPath)) {
+        Write-Host ("SKIP  {0} -- not found at {1}" -f $target.Name, $target.Project) -ForegroundColor DarkGray
+        $results += [pscustomobject]@{
+            Name = $target.Name; Status = 'SKIPPED'; Duration = $null; Errors = 0; Warnings = 0; Log = $null
+        }
+        continue
+    }
+
+    $verb = if ($target.Test) { 'Testing' } else { 'Building' }
+    Write-Host ("{0} {1} ({2})..." -f $verb, $target.Name, $target.Note) -ForegroundColor Cyan
+
+    $log = Join-Path $LogDirectory "$($target.Name).log"
+
+    # WarningLevel=0 keeps third-party game code from burying real errors in noise. Errors are
+    # unaffected.
+    $common = @('-c', $Configuration, '/p:WarningLevel=0')
+
+    # Each entry is one `dotnet` invocation; they run in order and the first failure stops the
+    # target. Only -Clean on a test target needs more than one, because `dotnet test` rejects
+    # --no-incremental (it forwards to MSBuild's VSTest target, which doesn't accept the switch).
+    # So force the rebuild in its own build pass, then test without rebuilding.
+    $invocations = @()
+    if ($target.Test -and $Clean) {
+        $invocations += ,(@('build', $projectPath) + $common + '--no-incremental')
+        $invocations += ,(@('test',  $projectPath) + $common + '--no-build')
+    }
+    elseif ($target.Test) {
+        $invocations += ,(@('test', $projectPath) + $common)
+    }
+    else {
+        $buildArgs = @('build', $projectPath) + $common
+        if ($Clean) { $buildArgs += '--no-incremental' }
+        $invocations += ,$buildArgs
+    }
+
+    Remove-Item $log -ErrorAction SilentlyContinue
+
+    $started  = Get-Date
+    $exitCode = 0
+    foreach ($invocation in $invocations) {
+        & dotnet @invocation *>&1 | Tee-Object -FilePath $log -Append | Out-Null
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) { break }
+    }
+    $duration = (Get-Date) - $started
+
+    $logText = Get-Content $log -Raw -ErrorAction SilentlyContinue
+    if (-not $logText) { $logText = '' }
+
+    # Count distinct diagnostic codes, not raw lines: MSBuild repeats the same error once per
+    # project that consumes the failing one, which otherwise inflates a single break into dozens.
+    $errorCount = @([regex]::Matches($logText, '(?m)\berror\s+([A-Z]{2,}\d+)') |
+        ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique).Count
+    $warnCount  = @([regex]::Matches($logText, '(?m)\bwarning\s+([A-Z]{2,}\d+)') |
+        ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique).Count
+
+    $status = if ($exitCode -eq 0) { 'PASS' } else { 'FAIL' }
+    $color  = if ($exitCode -eq 0) { 'Green' } else { 'Red' }
+    Write-Host ("  {0} in {1:mm\:ss}" -f $status, $duration) -ForegroundColor $color
+
+    $results += [pscustomobject]@{
+        Name     = $target.Name
+        Status   = $status
+        Duration = $duration
+        Errors   = $errorCount
+        Warnings = $warnCount
+        Log      = $log
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host 'Downstream build summary' -ForegroundColor Cyan
+Write-Host '------------------------' -ForegroundColor Cyan
+Write-Host ('{0,-18} {1,-8} {2,8} {3,8} {4,9}' -f 'Target', 'Status', 'Errors', 'Warnings', 'Time')
+
+foreach ($result in $results) {
+    $color = switch ($result.Status) {
+        'PASS'    { 'Green' }
+        'FAIL'    { 'Red' }
+        default   { 'DarkGray' }
+    }
+    $time = if ($result.Duration) { '{0:mm\:ss}' -f $result.Duration } else { '-' }
+    Write-Host ('{0,-18} {1,-8} {2,8} {3,8} {4,9}' -f $result.Name, $result.Status, $result.Errors, $result.Warnings, $time) -ForegroundColor $color
+}
+
+$failed  = @($results | Where-Object Status -eq 'FAIL')
+$skipped = @($results | Where-Object Status -eq 'SKIPPED')
+
+Write-Host ''
+Write-Host "Logs: $LogDirectory" -ForegroundColor DarkGray
+
+if ($skipped) {
+    Write-Host "Skipped (repo not present): $($skipped.Name -join ', ')" -ForegroundColor Yellow
+}
+
+if ($failed) {
+    Write-Host ''
+    Write-Host "$($failed.Count) target(s) failed: $($failed.Name -join ', ')" -ForegroundColor Red
+    Write-Host 'Release checklist step 2 is NOT satisfied.' -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'All available targets compiled.' -ForegroundColor Green
+Write-Host 'Remaining manual work for step 2: actually run each game and confirm it plays correctly.' -ForegroundColor Yellow
+exit 0

--- a/scripts/Test-DownstreamBuilds.ps1
+++ b/scripts/Test-DownstreamBuilds.ps1
@@ -61,9 +61,20 @@ $githubRoot = Split-Path -Parent $repoRoot
 # cannot restore at all. The game itself consumes NarfoxGameTools as a checked-in DLL and builds
 # fine. We want to know whether the game still compiles against FRB, not whether an unrelated
 # sibling repo has drifted.
+#
+# A target may pin its own Config when the default configuration wouldn't exercise it. The Forms
+# projects only reference SkiaGum under DebugAutoBuild/ReleaseAutoBuild -- the configurations Glue
+# uses to rebuild the engine during live edit -- so plain Debug silently skips that reference and
+# a broken path there stays invisible.
+#
+# Samples/ is deliberately absent. *.Generated.cs is gitignored repo-wide with BeefballKni as the
+# only exception, so every other sample needs Glue to regenerate before it will compile. They pass
+# or fail based on whether stale generated files happen to be on the current disk, which is exactly
+# the kind of machine-dependent green a release gate must not report.
 $targets = @(
     @{ Name = 'EngineUnitTests'; Project = 'FlatRedBall/Tests/EngineUnitTests/EngineUnitTests.sln';                      Test = $true;  Note = 'Engine unit tests (no workflow runs these yet)' }
     @{ Name = 'TestProject';     Project = 'FlatRedBall/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6.sln';        Test = $false; Note = 'The "Automated Test Project" from the checklist' }
+    @{ Name = 'FormsAutoBuild';  Project = 'FlatRedBall/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGLNet6.sln'; Test = $false; Config = 'DebugAutoBuild'; Note = 'The config Glue live-edit builds; only here does Forms reference SkiaGum' }
     @{ Name = 'KidDefense';      Project = 'KidDefense/GameProject/KidDefense.sln';                                      Test = $false; Note = 'net9.0 / MonoGame 3.8.5' }
     @{ Name = 'CrankyChibi';     Project = 'Kimuzukash-chibi-kuto-urufu/CrankyChibiCthulu.sln';                          Test = $false; Note = 'net8.0 / MonoGame 3.8.4.1' }
     @{ Name = 'BattleCrypt';     Project = 'BattleCryptBombers/BattleCryptBombers/BattleCryptBombers.csproj';            Test = $false; Note = 'net6.0 / MonoGame 3.8.1.303 -- oldest target, widest drift' }
@@ -165,7 +176,8 @@ foreach ($target in $targets) {
 
     # WarningLevel=0 keeps third-party game code from burying real errors in noise. Errors are
     # unaffected.
-    $common = @('-c', $Configuration, '/p:WarningLevel=0')
+    $targetConfig = if ($target.ContainsKey('Config')) { $target.Config } else { $Configuration }
+    $common = @('-c', $targetConfig, '/p:WarningLevel=0')
 
     # Each entry is one `dotnet` invocation; they run in order and the first failure stops the
     # target. Only -Clean on a test target needs more than one, because `dotnet test` rejects

--- a/scripts/Test-DownstreamBuilds.ps1
+++ b/scripts/Test-DownstreamBuilds.ps1
@@ -71,6 +71,11 @@ $githubRoot = Split-Path -Parent $repoRoot
 # only exception, so every other sample needs Glue to regenerate before it will compile. They pass
 # or fail based on whether stale generated files happen to be on the current disk, which is exactly
 # the kind of machine-dependent green a release gate must not report.
+#
+# TestProjectDesktopNet6 has the same gitignored-codegen property (440 untracked *.Generated.cs),
+# which is why it lives here and not in pr-tests.yml -- a clean CI checkout cannot build it. It is
+# still worth running locally, since a developer's checkout does have the generated code and the
+# release checklist names it explicitly.
 $targets = @(
     @{ Name = 'EngineUnitTests'; Project = 'FlatRedBall/Tests/EngineUnitTests/EngineUnitTests.sln';                      Test = $true;  Note = 'Engine unit tests (no workflow runs these yet)' }
     @{ Name = 'TestProject';     Project = 'FlatRedBall/Tests/TestProjectDesktopNet6/TestProjectDesktopNet6.sln';        Test = $false; Note = 'The "Automated Test Project" from the checklist' }


### PR DESCRIPTION
Automates the compile half of release checklist [step 2](https://docs.flatredball.com/flatredball/contributing/builds), fixes the rot it found, and closes the gap that let that rot go unnoticed for months.

## 1. A local smoke script

`scripts/Test-DownstreamBuilds.ps1` builds the checklist's smoke targets against the current working tree:

| Target | Notes |
|---|---|
| `EngineUnitTests` | 26 tests |
| `TestProjectDesktopNet6` | the checklist's "Automated Test Project" |
| `FormsAutoBuild` | Forms under `DebugAutoBuild` — see below |
| Kid Defense | net9.0 / MonoGame 3.8.5 |
| Cranky Chibi Cthulhu | net8.0 / MonoGame 3.8.4.1 |
| BattleCrypt Bombers | net6.0 / MonoGame 3.8.1.303 |

The games reference FRB and Gum by `ProjectReference` into sibling checkouts, so they compile against the working tree with no package publish involved. Absent game repos are skipped, not failed. The script also warns when local Gum doesn't contain its latest release tag — `glue.yml` bundles Gum's *released* zip, so a local pass against unreleased Gum source proves less than it looks like it does.

Compiling is not all of step 2. It catches broken APIs, not broken pixels; running each game stays manual, and the script says so on exit.

## 2. Twelve dead `SkiaInGum` references

When FRB forked SkiaGum into `Engines/SkiaGum/`, twelve references were left pointing at Gum's old `SvgPlugin/SkiaInGumShared` location. None resolve — the path is missing a directory level, and the project moved repos anyway.

- **4 `FlatRedBall.Forms.*.csproj`** — conditional on `DebugAutoBuild`/`ReleaseAutoBuild`, so plain Debug never evaluates them and `Engine.yml` never noticed. The two FNA projects now reference `SkiaInGum.FNA.csproj` rather than the MonoGame variant; the dead reference pointed at the wrong one, but since it never resolved that was never exercised.
- **6 `.sln` project entries** — solutions carry their own copy of the path, so fixing only the `.csproj` files still left them unrestorable.
- **2 sample `.csproj`**, plus a SkiaSharp bump 2.88.6 → 3.116.1 to match the embedded SkiaGum (the mismatch was a hard `NU1605` downgrade error).

Also fixed in `TestProjectDesktopNet6`: `GetStyledSubstrings` lost its `Color` parameter when Gum extracted `StyledSubstringSplitter`.

## 3. Engine coverage in PR CI

`pr-tests.yml` built and tested `Glue with All.sln` and nothing else, so engine code was compiled exactly once per release by `Engine.yml` — long after the commit that broke it. Two cheap steps close most of that gap:

- **`EngineUnitTests`** — existed in the repo, run by no workflow at all.
- **Forms under `DebugAutoBuild`** — the configuration Glue uses to rebuild the engine during live edit, and the only one where Forms references SkiaGum. It was genuinely broken until this PR, and no existing check could see it.

## What is deliberately *not* gated

`*.Generated.cs` is gitignored repo-wide with `BeefballKni` the only exception, so any project relying on Glue codegen passes or fails based on whether stale generated files happen to sit on the current disk — a machine-dependent green a release gate must not report.

- **Samples** are fixed but not script targets.
- **`TestProjectDesktopNet6`** (440 untracked generated files) is a *local* script target only, never a CI step. A clean checkout cannot build it.

The split: CI gates what a clean checkout can build; the script gates what needs a developer's machine.

## Verification

All six script targets build clean locally (`-Clean`). Both new CI steps ran and passed on a clean checkout in this PR's own run.

Manual test: not needed — build tooling plus compile fixes, verified by CI and by the script itself.
