### PR TITLE
Unbreak the non-DesktopGL engine builds

### DIFF
--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.FNA/Clipboard/ClipboardImplementation.cs
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.FNA/Clipboard/ClipboardImplementation.cs
@@ -9,9 +9,9 @@ namespace FlatRedBall.Forms.Clipboard
 {
     internal class ClipboardImplementation
     {
-        internal static string GetText()
+        internal static string GetText(Action? callback = null)
         {
-            return ClipboardService.GetText(); 
+            return ClipboardService.GetText();
         }
 
         internal static void PushStringToClipboard(string text)

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Kni.DesktopGL/Clipboard/ClipboardImplementation.cs
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Kni.DesktopGL/Clipboard/ClipboardImplementation.cs
@@ -9,9 +9,9 @@ namespace FlatRedBall.Forms.Clipboard
 {
     internal class ClipboardImplementation
     {
-        internal static string GetText()
+        internal static string GetText(Action? callback = null)
         {
-            return ClipboardService.GetText(); 
+            return ClipboardService.GetText();
         }
 
         internal static void PushStringToClipboard(string text)

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Kni.Web/Clipboard/ClipboardImplementation.cs
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Kni.Web/Clipboard/ClipboardImplementation.cs
@@ -9,9 +9,12 @@ namespace FlatRedBall.Forms.Clipboard
 {
     internal class ClipboardImplementation
     {
-        internal static string GetText()
+        // The callback is accepted but unused, matching the DesktopGL implementation. Gum's shared
+        // Forms source calls GetText(HandlePaste) unconditionally under #if FRB, so every platform
+        // has to accept the parameter even where the clipboard read is synchronous.
+        internal static string GetText(Action? callback = null)
         {
-            return ClipboardService.GetText(); 
+            return ClipboardService.GetText();
         }
 
         internal static void PushStringToClipboard(string text)

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.iOSMonoGame/Clipboard/ClipboardImplementation.iOS.cs
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.iOSMonoGame/Clipboard/ClipboardImplementation.iOS.cs
@@ -15,7 +15,7 @@ namespace FlatRedBall.Forms.Clipboard
             // not implemented
         }
 
-        internal static string GetText()
+        internal static string GetText(Action? callback = null)
         {
             return null;
         }

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms/Clipboard/ClipboardImplementation.Android.cs
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms/Clipboard/ClipboardImplementation.Android.cs
@@ -19,7 +19,7 @@ namespace FlatRedBall.Forms.Clipboard
             // not implemented
         }
 
-        internal static string GetText()
+        internal static string GetText(Action? callback = null)
         {
             return null;
         }

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms/Clipboard/ClipboardImplementation.cs
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms/Clipboard/ClipboardImplementation.cs
@@ -110,7 +110,7 @@ namespace FlatRedBall.Forms.Clipboard
 
 
 
-        public static string GetText()
+        public static string GetText(Action callback = null)
         {
             if (!IsClipboardFormatAvailable(CF_UNICODETEXT))
                 return null;

--- a/Engines/SkiaGum/SkiaInGum.FNA.csproj
+++ b/Engines/SkiaGum/SkiaInGum.FNA.csproj
@@ -20,7 +20,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\FlatRedBall\Engines\FlatRedBallXNA\3rd Party Libraries\FNA\FNA.Core.csproj" />
 		<ProjectReference Include="..\..\..\FlatRedBall\Engines\FlatRedBallXNA\FlatRedBall.FNA\FlatRedBall.FNA.csproj" />
-		<ProjectReference Include="..\..\GumCore\GumCoreXnaPc\GumCore.FNA\GumCore.FNA.csproj" />
+		<ProjectReference Include="..\..\..\Gum\GumCore\GumCoreXnaPc\GumCore.FNA\GumCore.FNA.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
`Engine.yml` failed on its first platform during the release run. Two independent breaks, both invisible because the engine matrix only compiles at release time.

## 1. `ClipboardImplementation.GetText` signature drift

The optional `Action` parameter was added on **DesktopGlNet6 only**. Gum's shared Forms source calls `GetText(HandlePaste)` unconditionally under `#if FRB`, so Kni.Web, Kni.DesktopGL, FNA, iOS and Android all failed with `CS1501: No overload for method 'GetText' takes 1 arguments`.

Each platform now accepts the same optional parameter and ignores it, exactly as DesktopGL already does — no behavior change, the signature just has to exist.

## 2. `SkiaInGum.FNA.csproj` had a stale GumCore path

It referenced `..\..\GumCore\...`, which only made sense while the file lived in the Gum repo; from `Engines/SkiaGum` it resolves *inside* FlatRedBall, where no `GumCore` exists. Corrected to the sibling Gum checkout, matching the MonoGame variant.

This project had never compiled since the SkiaGum fork — the FNA solution pointed at Gum's copy until #1941 repointed it here, which turned a dead reference into a live broken one.

## Verification

| Platform | |
|---|---|
| Kni.Web | builds |
| FNA | builds |
| DesktopGLNet6 | builds |
| iOS | **not verifiable locally** |
| Android | **not verifiable locally** |

iOS and Android fail on this machine with `NETSDK1202`/`NETSDK1140` and a wholly missing `Microsoft.Xna.Framework` — workload and SDK artifacts on a Windows box carrying only the .NET 10 SDK, not FRB code. CI, with the net8 SDK and proper workloads, is the only place those two get real coverage.

Manual test: not needed — compile fixes, verified by building each platform solution `Engine.yml` builds.