### PR TITLE
Disable the iOS and Android engines end to end

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -51,19 +51,19 @@ Engine/FRBDK versions are **date+time based, not semver**: `yyyy.M.d` + `.` + mi
 
 ## Build matrix (landmine)
 
-Engine.yml builds 5 platforms, each Debug *and* Release — but **only Debug is published to NuGet today**; Release is built and uploaded as a workflow artifact only (the YAML comment literally says "we don't (yet?) publish any release nuget packages"). Don't expect a Release NuGet to show up.
+Engine.yml builds each enabled platform Debug *and* Release — but **only Debug is published to NuGet today**; Release is built and uploaded as a workflow artifact only (the YAML comment literally says "we don't (yet?) publish any release nuget packages"). Don't expect a Release NuGet to show up.
 
 | Platform | Framework |
 |---|---|
 | Web (Kni) | net8.0 |
-| iOS | net8.0 |
-| Android | net8.0 |
 | FNA | net7.0 |
 | DesktopGL | net6.0 |
+| iOS | net8.0 — **can't build**, see below |
+| Android | net8.0 — **can't build**, see below |
+
+The mobile targets are `net8.0-ios`/`net8.0-android`, whose workloads are past end of life and are **no longer on the GitHub runner image**. `setup-dotnet` installs SDKs, not workloads, so the build fails with `NETSDK1140` — *"1.0 is not a valid TargetPlatformVersion for ios. Valid versions include: None."* Suppressing the EOL check (`CheckEolWorkloads=false`) only surfaces that underlying error; there is no workload to build against either way. Retargeting the mobile projects off net8 is the only real fix. Read Engine.yml itself for which platforms are currently wired up — the disabled steps are commented in place with restore instructions rather than deleted.
 
 All five NuGet pushes happen in a single step after every platform has compiled, so the matrix is all-or-nothing — a build failure on any platform means nothing reaches nuget.org. Don't reintroduce per-platform publishing; `dotnet nuget push` can't be undone, and interleaving it is what makes a mid-matrix failure leave a half-shipped release.
-
-The mobile builds pass `/p:CheckEolWorkloads=false`. `net8.0-ios`/`net8.0-android` are past their support window, and the runner image carries a newer SDK than `setup-dotnet` installs — SDK resolution picks that one and turns the end-of-life notice into a hard `NETSDK1202` **error**. Retargeting the mobile projects is the real fix; until then this suppression is load-bearing.
 
 glue.yml's build matrix only runs `Debug` (Release is commented out).
 

--- a/.github/workflows/Engine.yml
+++ b/.github/workflows/Engine.yml
@@ -73,43 +73,48 @@ jobs:
         path: FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.Kni.Web\bin\Release\net8.0-ios\
 
     ## -----------------------------------------------------------------------------------------------------
-    # CheckEolWorkloads=false on the mobile builds: net8.0-ios and net8.0-android are past their
-    # support window, and the runner image now carries a newer SDK than setup-dotnet installs, so
-    # SDK resolution picks that one and turns the end-of-life notice into a hard NETSDK1202 error.
-    # Suppressing it keeps shipping the net8 mobile targets; retargeting them is the actual fix.
-    - name: Build FlatRedBall iOS .NET 8 Debug
-      run: dotnet build -c Debug 'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.iOS.Net8.sln' /p:CheckEolWorkloads=false
-    - name: Package FlatRedBall iOS .NET 8
-      uses: actions/upload-artifact@v4
-      with:
-        name: iOSMonoGameNet8Debug
-        path: FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.iOSMonoGame\bin\Debug\net8.0-ios\
-    - name: Build FlatRedBall iOS .NET 8 Release
-      run: dotnet build -c Release 'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.iOS.Net8.sln' /p:CheckEolWorkloads=false
-      ## We don't (yet?) publish any release nuget packages, but we do this in preparation for this in the future
-    - name: Package FlatRedBall iOS .NET 8
-      uses: actions/upload-artifact@v4
-      with:
-        name: iOSMonoGameNet8Release
-        path: FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.iOSMonoGame\bin\Release\net8.0-ios\
-        
-    ## -----------------------------------------------------------------------------------------------------
-    - name: Build FlatRedBall Android .NET 8 Debug
-      run: dotnet build -c Debug 'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.Android.Net8.sln' /p:CheckEolWorkloads=false
-    - name: Package FlatRedBall Android .NET 8
-      uses: actions/upload-artifact@v4
-      with:
-        name: AndroidMonoGameNet8Debug
-        path: FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.AndroidMonoGame\bin\Debug\net8.0-android\
-    - name: Build FlatRedBall Android .NET 8 Release
-      run: dotnet build -c Release 'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.Android.Net8.sln' /p:CheckEolWorkloads=false
-      ## We don't (yet?) publish any release nuget packages, but we do this in preparation for this in the future
-    - name: Package FlatRedBall Android .NET 8
-      uses: actions/upload-artifact@v4
-      with:
-        name: AndroidMonoGameNet8Release
-        path: FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.AndroidMonoGame\bin\Release\net8.0-android\
-    
+    ## iOS and Android are disabled, not deleted.
+    ##
+    ## Both target net8.0-ios / net8.0-android. Those workloads are past end of life and are no longer
+    ## present on the GitHub runner image -- setup-dotnet installs SDKs, not workloads, so the build
+    ## fails with NETSDK1140 "1.0 is not a valid TargetPlatformVersion for ios. Valid versions include:
+    ## None". Suppressing the end-of-life check (CheckEolWorkloads=false) only surfaces that underlying
+    ## error; there is no workload to build against either way.
+    ##
+    ## Because the publish step below is all-or-nothing, leaving these in blocks every other platform
+    ## from shipping. They stay commented until the mobile projects are retargeted off net8, at which
+    ## point restoring these steps and their entries in the publish list re-enables them.
+    ##
+    # - name: Build FlatRedBall iOS .NET 8 Debug
+    #   run: dotnet build -c Debug 'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.iOS.Net8.sln'
+    # - name: Package FlatRedBall iOS .NET 8
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: iOSMonoGameNet8Debug
+    #     path: FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.iOSMonoGame\bin\Debug\net8.0-ios\
+    # - name: Build FlatRedBall iOS .NET 8 Release
+    #   run: dotnet build -c Release 'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.iOS.Net8.sln'
+    # - name: Package FlatRedBall iOS .NET 8
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: iOSMonoGameNet8Release
+    #     path: FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.iOSMonoGame\bin\Release\net8.0-ios\
+    #
+    # - name: Build FlatRedBall Android .NET 8 Debug
+    #   run: dotnet build -c Debug 'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.Android.Net8.sln'
+    # - name: Package FlatRedBall Android .NET 8
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: AndroidMonoGameNet8Debug
+    #     path: FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.AndroidMonoGame\bin\Debug\net8.0-android\
+    # - name: Build FlatRedBall Android .NET 8 Release
+    #   run: dotnet build -c Release 'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.Android.Net8.sln'
+    # - name: Package FlatRedBall Android .NET 8
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: AndroidMonoGameNet8Release
+    #     path: FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.AndroidMonoGame\bin\Release\net8.0-android\
+
 
 
     ## -----------------------------------------------------------------------------------------------------
@@ -170,10 +175,12 @@ jobs:
     ## all-or-nothing: nothing reaches nuget.org unless everything built.
     - name: Publish NuGet packages
       run: |
+        # iOS and Android are absent on purpose -- see the disabled build steps above. Restore these
+        # two entries at the same time as those steps.
+        #   'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBalliOS\bin\Debug',
+        #   'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallAndroid\bin\Debug',
         $packageDirs = @(
           'FlatRedBall\Engines\FlatRedBallXNA\KniWeb\bin\Debug',
-          'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBalliOS\bin\Debug',
-          'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallAndroid\bin\Debug',
           'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBall.FNA\bin\Debug',
           'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\bin\Debug'
         )

--- a/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Data/AllData.cs
+++ b/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Data/AllData.cs
@@ -52,7 +52,13 @@ namespace BuildServerUploaderConsole.Data
                 engine.ReleaseFiles.Add(@"FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.AndroidMonoGame\bin\Release\net8.0-android\GumCoreAndroid.pdb");
 
 
-                Engines.Add(engine);
+                // Not registered: Engine.yml no longer builds Android, because the net8.0-android
+                // workload is end-of-life and absent from the build agents. Every file listed above
+                // would therefore be missing, and each process that walks AllData.Engines -- copying
+                // to the release folder, copying to templates, zipping templates -- would fail on it.
+                // Re-enable together with the Android steps in Engine.yml once the project is
+                // retargeted off net8.
+                // Engines.Add(engine);
             }
 
 
@@ -95,7 +101,9 @@ namespace BuildServerUploaderConsole.Data
                 engine.ReleaseFiles.Add(@"FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.iOSMonoGame\bin\Release\net8.0-ios\GumCoreiOS.pdb");
 
 
-                Engines.Add(engine);
+                // Not registered -- same reason as Android above: the net8.0-ios workload is
+                // end-of-life and absent from the build agents, so none of these files get built.
+                // Engines.Add(engine);
             }
 
 


### PR DESCRIPTION
Per the decision to ship this release without mobile.

## Why they can't build

Both target `net8.0-ios` / `net8.0-android`. Those workloads are past end of life and are **no longer on the GitHub runner image** — `setup-dotnet` installs SDKs, not workloads. The build fails with:

```
NETSDK1140: 1.0 is not a valid TargetPlatformVersion for ios. Valid versions include: None
```

"None" means there is no workload to build against. Suppressing the EOL check only surfaces this underlying error rather than avoiding it, so that suppression is removed again.

Since the NuGet publish is now all-or-nothing, leaving these in blocks Web, FNA and DesktopGL from shipping at all.

## Dropping them from Engine.yml alone is not enough

`BuildServerUploaderConsole` walks `AllData.Engines` to copy DLLs to the release folder, copy them into templates, and zip the templates. Its Android and iOS entries name exact `bin\Debug\net8.0-android` and `net8.0-ios` paths — with those platforms unbuilt, every one of those files is missing and each step fails.

**`copytotemplates` and `zipanduploadtemplates` only run when `IsBeta` is false**, so no amount of beta testing would have caught this. It would have surfaced on the production run *after* the packages were already pushed. Both engines are now left unregistered; the registered list matches exactly what `Engine.yml` builds.

Credit where due — this was spotted by the user, not by me.

## Reversibility

Everything is commented in place, not deleted. Retargeting the mobile projects off net8 and restoring the workflow steps, the publish-list entries, and the two `Engines.Add` calls is one change.

## Residual risk

The template-copy path still runs for real for the first time on the production release. Beta cannot exercise it by design.

Manual test: not needed — the uploader compiles and the registered engine list matches what the workflow builds.