### PR TITLE
Stop generating Text dropshadow channels and LocalizeText, and guard the whole bug class

### DIFF
--- a/FRBDK/Glue/.claude/skills/gum-codegen/SKILL.md
+++ b/FRBDK/Glue/.claude/skills/gum-codegen/SKILL.md
@@ -25,6 +25,16 @@ The two pipelines are:
 
 When you add a version gate, **always update both**. Searching for an existing skipped variable name (e.g. `"IgnoredByParentSize"`, `"StackSpacing"`) is the fastest way to spot every place that needs a parallel change — they typically appear in both `StandardsCodeGenerator.RefreshVariableNamesToSkipForProperties` and `StateCodeGenerator.RefreshVariableNamesToSkipBasedOnGlueVersion`.
 
+## The compiler can never catch a runtime mismatch (landmine)
+
+Glue has **no compile-time knowledge of the runtime types it generates against**. `mStandardElementToQualifiedTypes` holds fully-qualified type names as plain *strings*; `RenderingLibrary.Graphics.Text` is not a referenced assembly in any Glue project, and it is not among GumPlugin's embedded `LibraryFiles` resources either (`LineRectangle.cs` is embedded, `Text.cs` is not). So emitting `ContainedText.DropshadowBlur` for a member that doesn't exist compiles Glue perfectly and only fails in the *user's* game project, as CS1061.
+
+This is why the bug class recurs: Rectangle/Circle's fill/stroke family (#1907), the Arc/ColoredCircle gradient CS0266, and Text's dropshadow-channel + `LocalizeText` family were each found by a user's build breaking, not by CI.
+
+`GlueUnitTests/GumPlugin/GumRuntimeMemberContractTests.cs` is the guard: it builds the engine's Forms solution, reflects over the real `GumCore`/`SkiaInGum` assemblies, and asserts every `ContainedXxx.Member` the generator emits exists on the mapped runtime type. It's driven off `StandardsCodeGenerator.StandardElementToQualifiedTypes`, so a standard element added to that map is covered automatically. When Gum extends a standard element's schema, that test — not the compiler — is what tells you whether FRB's runtime can back it.
+
+Note the fix is per-member, not per-type: `Text` legitimately backs `HasDropshadow`/`DropshadowOffsetX`/`DropshadowOffsetY` (it has a single `DropshadowColor`) while having no per-channel color, no blur, and no `LocalizeText`. Skip only what's actually unbacked.
+
 ## Where it lives
 
 Property pipeline:

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
@@ -23,6 +23,15 @@ namespace GumPlugin.CodeGeneration
 
         Dictionary<string, string> mStandardElementToQualifiedTypes = new Dictionary<string, string>();
 
+        /// <summary>
+        /// Every standard element this generator can emit a runtime for, mapped to the fully-qualified
+        /// runtime type that backs it (null for Container, which can be any type). Exposed so tests can
+        /// check the generated members against the real runtime type without reaching into private state -
+        /// see GumRuntimeMemberContractTests, which exists because Glue has no compile-time reference to
+        /// these types and so the compiler can never catch a mismatch here.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> StandardElementToQualifiedTypes => mStandardElementToQualifiedTypes;
+
         Dictionary<string, string> mStandardVariableNameAliases = new Dictionary<string, string>();
 
         List<string> variablesToCallLayoutAfter = new List<string>();
@@ -167,6 +176,19 @@ namespace GumPlugin.CodeGeneration
                 "CustomRadiusTopLeft", "CustomRadiusTopRight", "CustomRadiusBottomLeft", "CustomRadiusBottomRight",
             };
             _typedVariableNamesToSkipForProperties.Add("Rectangle", rectangleVariablesToSkip);
+
+            // Text is a partial case rather than an all-or-nothing one. RenderingLibrary.Graphics.Text
+            // does have HasDropshadow/DropshadowOffsetX/DropshadowOffsetY (and a single DropshadowColor),
+            // so those keep generating - but it has no per-channel color, no blur, and no LocalizeText,
+            // all of which Gum's schema defines (StandardElementsManager's Text state calls
+            // AddDropshadowVariables, and adds LocalizeText separately). Generating these produced CS1061
+            // in every project containing a Text, which is essentially every project.
+            _typedVariableNamesToSkipForProperties.Add("Text", new List<string>
+            {
+                "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
+                "DropshadowBlur",
+                "LocalizeText",
+            });
 
 
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
@@ -143,6 +143,16 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         };
         typeSpecificVariableNamesToSkipForStates.Add("Rectangle", rectangleVariablesToSkip);
 
+        // Mirrors the Text entry in StandardsCodeGenerator - RenderingLibrary.Graphics.Text backs
+        // HasDropshadow/DropshadowOffsetX/DropshadowOffsetY but not the per-channel color, the blur, or
+        // LocalizeText. Both pipelines must agree here or the state switch assigns a property the
+        // property pipeline never generated (CS0103).
+        typeSpecificVariableNamesToSkipForStates.Add("Text", new List<string>
+        {
+            "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
+            "DropshadowBlur",
+            "LocalizeText",
+        });
     }
 
     public void RefreshVariableNamesToSkipBasedOnGlueVersion()

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeMemberContractTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeMemberContractTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using Gum.DataTypes;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using GumPlugin.CodeGeneration;
+using Shouldly;
+
+namespace GlueUnitTests.GumPluginTests;
+
+// The general guard for the "Glue generates a member the Gum runtime doesn't have" bug class.
+//
+// This class has now shipped three separate times: Rectangle/Circle's fill/stroke/gradient family
+// (#1907), the Arc/ColoredCircle/RoundedRectangle gradient CS0266, and Text's dropshadow channel +
+// LocalizeText family. Each was caught only after a real game project failed to compile, and each got a
+// test pinning that one element against that one hardcoded list of forbidden names - so each new test
+// only ever caught a regression someone already knew to look for. Nobody had written one for Text.
+//
+// Why this needs a real build rather than reflection over Glue's own output: Glue has NO compile-time
+// knowledge of the runtime types it generates against. RenderingLibrary.Graphics.Text is not a
+// referenced assembly in any Glue project, and it is not among GumPlugin's ~129 embedded LibraryFiles
+// resources either (LineRectangle.cs is embedded; Text.cs is not). StandardsCodeGenerator's
+// mStandardElementToQualifiedTypes holds nothing but *strings*. That is precisely why the compiler can
+// never catch this and why it keeps recurring - so the check has to be made against the compiled engine
+// assemblies, which is what this test does.
+//
+// Tagged BuildSmoke because it shells out to `dotnet build` for the engine, same as
+// NewProjectCreationSmokeTests. glue.yml and pr-tests.yml both already run Category=BuildSmoke, so this
+// gates a release with no workflow change.
+[Trait("Category", "BuildSmoke")]
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class GumRuntimeMemberContractTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly bool _originalSynchronousMode;
+    private readonly Gum.DataTypes.GumProjectSave _originalGumProjectSave;
+    private readonly string _tempProjectDirectory;
+
+    public GumRuntimeMemberContractTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalGumProjectSave = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+        GlueState.Self.CurrentMainProject = vsProject;
+
+        // A real, current project. GumSkiaRenderableCodegenSweepTests' header documents why FileVersion
+        // matters here: at the default 0 the version-gated Color conversion is not emitted.
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject = new GlueProjectSave
+        {
+            FileVersion = (int)GlueProjectSave.LatestVersion,
+        };
+        TaskManager.SynchronousMode = true;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = new Gum.DataTypes.GumProjectSave
+        {
+            FullFileName = Path.Combine(_tempProjectDirectory, "GumProject", "GumProject.gumx"),
+        };
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject = _originalGlueProject;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = _originalGumProjectSave;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public void EveryGeneratedContainedMemberShouldExistOnTheEngineRuntimeType()
+    {
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+        // The six Skia standard elements (Arc/ColoredCircle/LottieAnimation/RoundedRectangle/Svg/Canvas)
+        // are registered by MainGumPlugin.StartUp, not by StandardElementsManager.Initialize - same reason
+        // GumSkiaRenderableCodegenSweepTests calls this. Without it they aren't in the schema at all.
+        EnsureSkiaStandardElementsRegistered();
+
+        var repoRoot = FindRepoRoot();
+        var runtimeTypes = BuildAndLoadEngineRuntimeTypes(repoRoot);
+
+        var elementToRuntimeType = GetStandardElementToQualifiedTypeMap();
+
+        // Fixture sanity: if the map stops being readable this test would sweep nothing at all, which is
+        // the exact failure mode that made an earlier version of RectangleCircleCodegenTests worthless.
+        elementToRuntimeType.ShouldNotBeEmpty();
+        elementToRuntimeType.Keys.ShouldContain("Text");
+
+        var problems = new List<string>();
+        // A type the map names but the built engine doesn't have is a real coverage hole - fail on it.
+        var missingRuntimeTypes = new List<string>();
+        // Map keys that aren't user-facing Gum standard elements (LineRectangle/SolidRectangle are
+        // internal aliases with no schema of their own) - reported, but not a failure.
+        var noSchema = new List<string>();
+        var sweptElements = new List<string>();
+
+        foreach (var kvp in elementToRuntimeType.OrderBy(item => item.Key, StringComparer.Ordinal))
+        {
+            var elementName = kvp.Key;
+            var qualifiedTypeName = kvp.Value;
+
+            // Container maps to null on purpose ("This could be any type, so don't force it to line
+            // rectangle") - there is no single runtime type to check it against.
+            if (string.IsNullOrEmpty(qualifiedTypeName))
+            {
+                continue;
+            }
+
+            if (!runtimeTypes.TryGetValue(qualifiedTypeName, out var runtimeType))
+            {
+                missingRuntimeTypes.Add($"{elementName} -> {qualifiedTypeName} (type not found in the built engine assemblies)");
+                continue;
+            }
+
+            var defaultState = Gum.Managers.StandardElementsManager.Self
+                .TryGetDefaultStateFor(elementName, throwExceptionOnMissing: false);
+            if (defaultState == null)
+            {
+                noSchema.Add(elementName);
+                continue;
+            }
+
+            // Built the same way GumPluginCommands.AddStandardElement builds a real one - Initialize()'d
+            // from the canonical, always-current schema rather than a possibly-stale embedded template.
+            // RectangleCircleCodegenTests' header documents why that distinction is load-bearing: a
+            // fresh-project-creation fixture carries pre-v3 variables and would pin nothing.
+            var standardElementSave = new StandardElementSave { Name = elementName };
+            standardElementSave.Initialize(defaultState);
+
+            var codeBlock = new CodeBlockBase();
+            if (!StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock))
+            {
+                missingRuntimeTypes.Add($"{elementName} (GenerateStandardElementSaveCodeFor returned false)");
+                continue;
+            }
+
+            sweptElements.Add(elementName);
+
+            var containedPropertyName = "Contained" + elementName;
+            var referencedMembers = Regex
+                .Matches(codeBlock.ToString(), Regex.Escape(containedPropertyName) + @"\.(\w+)")
+                .Cast<Match>()
+                .Select(match => match.Groups[1].Value)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(name => name, StringComparer.Ordinal);
+
+            foreach (var memberName in referencedMembers)
+            {
+                if (!HasPublicMember(runtimeType, memberName))
+                {
+                    problems.Add(
+                        $"{elementName}Runtime.Generated.cs references {containedPropertyName}.{memberName}, " +
+                        $"but {qualifiedTypeName} has no public member by that name. " +
+                        "Any project using this element will fail to compile with CS1061.");
+                }
+            }
+        }
+
+        var coverageReport =
+            "Swept: " + string.Join(", ", sweptElements) + Environment.NewLine +
+            "No schema (not user-facing standard elements, expected): " +
+            (noSchema.Count == 0 ? "(none)" : string.Join(", ", noSchema));
+
+        // The actual point of the test - asserted first so a real unbacked member is what you see.
+        problems.ShouldBeEmpty(
+            string.Join(Environment.NewLine, problems) + Environment.NewLine + Environment.NewLine + coverageReport);
+
+        // Coverage sanity - a sweep that silently degenerates to nothing is worse than no test at all.
+        sweptElements.ShouldContain("Text", coverageReport);
+        sweptElements.ShouldContain("Sprite", coverageReport);
+        missingRuntimeTypes.ShouldBeEmpty(
+            "A standard element's runtime type is missing from the built engine assemblies, so it was " +
+            "not checked at all:" + Environment.NewLine +
+            string.Join(Environment.NewLine, missingRuntimeTypes) + Environment.NewLine + coverageReport);
+    }
+
+    // AddSkiaStandards() isn't idempotent (Dictionary.Add throws on a second call in the same process),
+    // so guard it the same way GumSkiaRenderableCodegenSweepTests does.
+    private static void EnsureSkiaStandardElementsRegistered()
+    {
+        if (!Gum.Managers.StandardElementsManager.Self.DefaultStates.ContainsKey("Svg"))
+        {
+            GumPlugin.Managers.SkiaStandardElementsManager.AddSkiaStandards();
+        }
+    }
+
+    private static bool HasPublicMember(Type type, string memberName)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy;
+
+        return type.GetProperty(memberName, flags) != null
+            || type.GetField(memberName, flags) != null
+            || type.GetMethods(flags).Any(method => method.Name == memberName);
+    }
+
+    // Builds the engine solution that produces the assemblies a generated Gum runtime actually compiles
+    // against, then loads them for reflection. This is the whole point of the test - see the header for
+    // why Glue's own output can't answer the question.
+    private static Dictionary<string, Type> BuildAndLoadEngineRuntimeTypes(string repoRoot)
+    {
+        var formsSolution = Path.Combine(repoRoot, "Engines", "Forms", "FlatRedBall.Forms", "FlatRedBall.Forms.DesktopGLNet6.sln");
+        File.Exists(formsSolution).ShouldBeTrue($"Expected the engine Forms solution at {formsSolution}");
+
+        var (exitCode, output) = RunDotnetBuild(formsSolution);
+        exitCode.ShouldBe(0, $"Could not build the engine Forms solution, so the runtime contract can't be checked:\n{output}");
+
+        // SkiaInGum builds to its own project folder rather than into the Forms output, because Forms
+        // only references it under the AutoBuild configurations.
+        var assemblyPaths = new[]
+        {
+            Path.Combine(repoRoot, "Engines", "Forms", "FlatRedBall.Forms", "FlatRedBall.Forms.DesktopGlNet6", "bin", "Debug", "net6.0", "GumCore.DesktopGlNet6.dll"),
+            Path.Combine(repoRoot, "Engines", "SkiaGum", "bin", "Debug", "net6.0", "SkiaInGum.dll"),
+        };
+
+        var types = new Dictionary<string, Type>(StringComparer.Ordinal);
+        foreach (var assemblyPath in assemblyPaths)
+        {
+            File.Exists(assemblyPath).ShouldBeTrue($"Expected a built engine assembly at {assemblyPath}");
+
+            var assembly = Assembly.LoadFrom(assemblyPath);
+            foreach (var type in assembly.GetTypes())
+            {
+                if (type.FullName != null)
+                {
+                    types[type.FullName] = type;
+                }
+            }
+        }
+
+        return types;
+    }
+
+    private static (int exitCode, string output) RunDotnetBuild(string solutionPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"build \"{solutionPath}\" -c Debug")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(startInfo)!;
+        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, output);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "Engines", "SkiaGum")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate the FlatRedBall repo root above " + AppContext.BaseDirectory);
+    }
+
+    private static Dictionary<string, string> GetStandardElementToQualifiedTypeMap()
+    {
+        // Read straight off the generator so this sweep can never drift out of sync with the set of
+        // standard elements Glue actually generates - a standard element added to that map is covered
+        // the day it is added, with no edit here.
+        return new Dictionary<string, string>(StandardsCodeGenerator.Self.StandardElementToQualifiedTypes);
+    }
+}


### PR DESCRIPTION
Every project containing a Gum Text failed to compile with CS1061 on `DropshadowAlpha/Red/Green/Blue`, `DropshadowBlur` and `LocalizeText`. Gum's schema defines all six on Text; `RenderingLibrary.Graphics.Text` backs none of them (single `DropshadowColor`, no blur, no `LocalizeText`). It *does* back `HasDropshadow` and `DropshadowOffsetX/Y`, so the skip is per-member rather than the all-or-nothing exclusion Rectangle/Circle get. Both pipelines updated, since they must agree or a state assignment references an ungenerated property.

### Why a new kind of test

Third time this bug class has shipped, after Rectangle/Circle (#1907) and the Arc gradient CS0266. Each previous fix pinned one element against one hardcoded list of forbidden names, so each only caught a regression someone already knew to look for. Nobody had written one for Text.

It recurs because **Glue has no compile-time knowledge of the runtime types it generates against**: `mStandardElementToQualifiedTypes` holds strings, `RenderingLibrary.Graphics.Text` is not a referenced assembly in any Glue project, and it is not among GumPlugin's embedded `LibraryFiles` resources. Emitting a nonexistent member compiles Glue perfectly and only breaks the user's game.

`GumRuntimeMemberContractTests` builds the engine Forms solution, reflects over the real `GumCore`/`SkiaInGum` assemblies, and asserts every `ContainedXxx.Member` the generator emits exists on the mapped runtime type. Sweeps all 13 standard elements that have a schema, driven off the map itself so a new element is covered the day it's added. Written first; it failed with exactly the six reported errors and no others. Tagged `BuildSmoke`, which `pr-tests.yml` and `glue.yml` already run.

`StandardsCodeGenerator` gained a public read-only view of that map so the test doesn't reach into private state.

239/239 non-BuildSmoke tests green.

Manual test: needed. The fix changes what Glue writes, so it only reaches users through a new FRBDK build. After `glue.yml` runs, create a new project from the Desktop GL .NET 9 MonoGame template with Gum and Forms and confirm it builds.
