### PR TITLE
Say what actually went wrong when a Gum project's element names come back empty

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/GumIdb.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/GumIdb.cs
@@ -129,6 +129,61 @@ namespace FlatRedBall.Gum
             this.element.AssignReferences();
         }
 
+        /// <summary>
+        /// Builds the exception text for a Gum project that loaded with missing element files.
+        /// </summary>
+        /// <remarks>
+        /// Separated from StaticInitialize so it can be tested directly, and because the message needs to
+        /// distinguish two very different situations that the old "Missing files starting with X" text
+        /// blurred together.
+        ///
+        /// A missing file whose name is *empty* (".gusx" with nothing in front of it) does not mean a file
+        /// was deleted. It means the reference in the .gumx deserialized with a blank Name, which happens
+        /// when the .gumx is in a newer format than this build of GumCore can read - Gum's compact/v2
+        /// format stores Name as an XML attribute, and a GumCore that predates it falls back to a
+        /// serializer expecting a child element, silently producing blank names for every reference.
+        /// Reporting that as a missing file sends people looking for a file that was never absent.
+        /// </remarks>
+        public static string GetMissingFilesMessage(IList<string> missingFiles, string projectFileName)
+        {
+            if (missingFiles == null || missingFiles.Count == 0)
+            {
+                return null;
+            }
+
+            var hasEmptyName = missingFiles.Any(item =>
+                string.IsNullOrEmpty(System.IO.Path.GetFileNameWithoutExtension(item ?? string.Empty)));
+
+            var builder = new StringBuilder();
+
+            if (hasEmptyName)
+            {
+                builder.AppendLine(
+                    "The Gum project " + projectFileName + " loaded, but its element references came back " +
+                    "with empty names, so no screens or components could be found.");
+                builder.AppendLine();
+                builder.AppendLine(
+                    "This almost always means the .gumx was saved in a newer format than this build of the " +
+                    "engine can read - not that any file is actually missing. Update the FlatRedBall / Gum " +
+                    "libraries this project references (Libraries\\ folder and NuGet packages) to match the " +
+                    "version of the FRB Editor that saved the project.");
+            }
+            else
+            {
+                builder.AppendLine(
+                    "The Gum project " + projectFileName + " references " + missingFiles.Count +
+                    " file(s) that could not be found:");
+            }
+
+            builder.AppendLine();
+            foreach (var missingFile in missingFiles)
+            {
+                builder.AppendLine("  " + missingFile);
+            }
+
+            return builder.ToString().TrimEnd();
+        }
+
         public static void StaticInitialize(string projectFileName)
         {
             ///////////////////Early Out///////////////////////////
@@ -239,9 +294,11 @@ namespace FlatRedBall.Gum
 
             if (result.MissingFiles.Count != 0)
             {
-                throw new Exception("Missing files starting with " + result.MissingFiles[0]);
+                throw new Exception(GetMissingFilesMessage(result.MissingFiles, mProjectFileName));
             }
 #endif
+
+            // (see GetMissingFilesMessage for why an empty name in that list is worth calling out)
 
             // Now we can set the directory to Gum's root:
             ToolsUtilities.FileManager.RelativeDirectory = ToolsUtilities.FileManager.GetDirectory(mProjectFileName);

--- a/Tests/EngineUnitTests/Gum/GumIdbMissingFilesMessageTests.cs
+++ b/Tests/EngineUnitTests/Gum/GumIdbMissingFilesMessageTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using FlatRedBall.Gum;
+using Shouldly;
+using Xunit;
+
+namespace EngineUnitTests.Gum;
+
+// A Gum project saved in a format newer than the running GumCore deserializes every element reference
+// with a blank Name, and the loader then reports paths like "...\Screens\.gusx" - a real path built
+// around an empty string. The old message ("Missing files starting with " + first entry) presented that
+// as a missing file, which sends people looking for a file that was never absent, and hid both the count
+// and the actual cause.
+public class GumIdbMissingFilesMessageTests
+{
+    [Fact]
+    public void EmptyElementName_ShouldReportAFormatMismatchRatherThanAMissingFile()
+    {
+        var missingFiles = new List<string>
+        {
+            @"C:\Game\bin\Debug\net9.0\Content\GumProject\Screens\.gusx",
+        };
+
+        var message = GumIdb.GetMissingFilesMessage(missingFiles, @"C:\Game\Content\GumProject\GumProject.gumx");
+
+        // The whole point: don't call this a missing file, and say what to actually do about it.
+        message.ShouldContain("empty names");
+        message.ShouldContain("newer format");
+        message.ShouldContain("Update the FlatRedBall / Gum libraries");
+        // The project being loaded is named, so the reader knows which .gumx is at fault.
+        message.ShouldContain("GumProject.gumx");
+        // The offending path is still shown - it's the evidence, just no longer the headline.
+        message.ShouldContain(@"Screens\.gusx");
+    }
+
+    [Fact]
+    public void GenuinelyMissingFiles_ShouldListThemAllWithACount()
+    {
+        var missingFiles = new List<string>
+        {
+            @"C:\Game\Content\GumProject\Screens\MainMenu.gusx",
+            @"C:\Game\Content\GumProject\Components\Button.gucx",
+        };
+
+        var message = GumIdb.GetMissingFilesMessage(missingFiles, @"C:\Game\Content\GumProject\GumProject.gumx");
+
+        message.ShouldContain("2 file(s)");
+        // Both are listed - the old message only ever showed the first, so a multi-file problem looked
+        // like a single-file one and got fixed one round-trip at a time.
+        message.ShouldContain("MainMenu.gusx");
+        message.ShouldContain("Button.gucx");
+        // Must NOT misreport a real missing file as a version problem.
+        message.ShouldNotContain("newer format");
+    }
+
+    [Fact]
+    public void NoMissingFiles_ShouldProduceNoMessage()
+    {
+        GumIdb.GetMissingFilesMessage(new List<string>(), "anything.gumx").ShouldBeNull();
+        GumIdb.GetMissingFilesMessage(null, "anything.gumx").ShouldBeNull();
+    }
+}


### PR DESCRIPTION
Loading a `.gumx` saved in a newer format than the running GumCore deserializes every element reference with a blank Name (Gum's compact format stores Name as an XML attribute; an older GumCore falls back to a serializer expecting a child element). The loader then reports paths built around that empty string, and the old message surfaced the first one verbatim:

```
Missing files starting with ...\Content\GumProject\Screens\.gusx
```

A real path with a hole in the middle, presented as a missing file. Nothing is missing. It also showed only the first entry, so a project with several unresolved references looked like it had one.

Now an empty element name is called out as a format mismatch, names the `.gumx`, and says to update the libraries to match the editor that saved the project. Genuinely missing files still report as missing, with a count and the full list.

Message building is extracted from `StaticInitialize` so it's testable without a renderer and content pipeline — `EngineUnitTests` already references `GumCore.DesktopGlNet6`. Verified the tests have teeth by disabling the empty-name detection: the case it covers fails, the genuinely-missing-file case still passes.

29/29 engine tests green.

Manual test: not needed — both branches are covered, and the change is confined to text on an already-failing path.