### PR TITLE
Ship every engine assembly through NuGet

### DIFF
--- a/.github/workflows/Engine.yml
+++ b/.github/workflows/Engine.yml
@@ -175,14 +175,31 @@ jobs:
     ## all-or-nothing: nothing reaches nuget.org unless everything built.
     - name: Publish NuGet packages
       run: |
+        # Every assembly a template-created project references ships as its own package, so this
+        # list covers Forms, GumCore, StateInterpolation and SkiaInGum as well as the engine.
+        # GumCore is built out of the sibling Gum checkout but published by FlatRedBall.
+        # GlueUnitTests' EnginePackagingTests asserts this list covers every published project.
+        #
         # iOS and Android are absent on purpose -- see the disabled build steps above. Restore these
         # two entries at the same time as those steps.
         #   'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBalliOS\bin\Debug',
         #   'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallAndroid\bin\Debug',
         $packageDirs = @(
           'FlatRedBall\Engines\FlatRedBallXNA\KniWeb\bin\Debug',
+          'FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.Kni.Web\bin\Debug',
+          'Gum\GumCore\GumCoreXnaPc\GumCore.Kni.Web\bin\Debug',
+          'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.Kni.Web\bin\Debug',
+
           'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBall.FNA\bin\Debug',
-          'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\bin\Debug'
+          'FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.FNA\bin\Debug',
+          'Gum\GumCore\GumCoreXnaPc\GumCore.FNA\bin\Debug',
+          'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.FNA\bin\Debug',
+
+          'FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\bin\Debug',
+          'FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.DesktopGlNet6\bin\Debug',
+          'Gum\GumCore\GumCoreXnaPc\GumCore.DesktopGlNet6\bin\Debug',
+          'FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.DesktopGlNet6\bin\Debug',
+          'FlatRedBall\Engines\SkiaGum\bin\Debug'
         )
         # Collect and verify before pushing anything, so a platform that built but produced no package
         # fails the run instead of silently shipping an incomplete set.

--- a/Engines/FlatRedBallXNA/FlatRedBall.FNA/FlatRedBall.FNA.csproj
+++ b/Engines/FlatRedBallXNA/FlatRedBall.FNA/FlatRedBall.FNA.csproj
@@ -11,6 +11,7 @@
 	</PropertyGroup>
     <PropertyGroup>
         <Title>FlatRedBall (.NET FNA)</Title>
+        <Authors>FlatRedBall</Authors>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <Description>FlatRedBall Game Engine</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -21,9 +22,11 @@
       <PackageReference Include="AsepriteDotNet" Version="1.8.1" />
     </ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\3rd Party Libraries\FNA\FNA.Core.csproj">
+		<!-- FNA is not published on nuget.org. PrivateAssets="all" keeps it out of this package's
+		     dependency list; the target below embeds FNA.dll in lib/ instead, which is how every
+		     FNA-flavoured FlatRedBall package gets it. -->
+		<ProjectReference Include="..\3rd Party Libraries\FNA\FNA.Core.csproj" PrivateAssets="all">
 			<ReferenceOutputAssembly>true</ReferenceOutputAssembly>
-			<IncludeAssets>FNA.Core.dll</IncludeAssets>
 		</ProjectReference>
 	</ItemGroup>
 

--- a/Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj
+++ b/Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj
@@ -6,6 +6,7 @@
     
 		<DefineConstants>TRACE;MONOGAME; DESKTOP_GL; MONOGAME_381</DefineConstants>
 		<Title>FlatRedBall (.NET Desktop GL)</Title>
+		<Authors>FlatRedBall</Authors>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Description>FlatRedBall Game Engine</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Engines/FlatRedBallXNA/KniWeb/FlatRedBallKniWeb.csproj
+++ b/Engines/FlatRedBallXNA/KniWeb/FlatRedBallKniWeb.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <DefineConstants>TRACE;MONOGAME; DESKTOP_GL;MONOGAME_381;KNI;WEB;BLAZORGL</DefineConstants>
     <Title>FlatRedBall (Web)</Title>
+    <Authors>FlatRedBall</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>FlatRedBall Game Engine</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGlNet6/FlatRedBall.Forms.DesktopGlNet6.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGlNet6/FlatRedBall.Forms.DesktopGlNet6.csproj
@@ -2,11 +2,16 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <DefineConstants>MONOGAME;DESKTOP_GL;WINDOWS;MONOGAME_381;FRB</DefineConstants>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
+    <Title>FlatRedBall.Forms (.NET Desktop GL)</Title>
+    <Authors>FlatRedBall</Authors>
+    <Description>UI controls for FlatRedBall built on Gum</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>1.0.0</Version>
 
   </PropertyGroup>
 

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.FNA/FlatRedBall.Forms.FNA.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.FNA/FlatRedBall.Forms.FNA.csproj
@@ -2,9 +2,14 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DefineConstants>FNA;DESKTOP_GL;WINDOWS;FRB</DefineConstants>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
+    <Title>FlatRedBall.Forms (FNA)</Title>
+    <Authors>FlatRedBall</Authors>
+    <Description>UI controls for FlatRedBall built on Gum</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>1.0.0</Version>
 
   </PropertyGroup>
   <ItemGroup>
@@ -13,7 +18,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\Gum\GumCore\GumCoreXnaPc\GumCore.FNA\GumCore.FNA.csproj" />
     <ProjectReference Include="..\..\..\SkiaGum\SkiaInGum.FNA.csproj" Condition="'$(Configuration)' == 'DebugAutoBuild' Or '$(Configuration)' == 'ReleaseAutoBuild'" />
-    <ProjectReference Include="..\..\..\FlatRedBallXNA\3rd Party Libraries\FNA\FNA.Core.csproj" />
+    <!-- FNA is not published on nuget.org, so this must not become a package dependency.
+         FNA.dll reaches consumers embedded in the FlatRedBall.FNA package, picked up
+         transitively through GumCore.FNA -> StateInterpolation.FNA. -->
+    <ProjectReference Include="..\..\..\FlatRedBallXNA\3rd Party Libraries\FNA\FNA.Core.csproj" PrivateAssets="all" />
   </ItemGroup>
   <Import Project="..\FlatRedBall.Forms.Shared\FlatRedBall.Forms.Shared.projitems" Label="Shared" />
 </Project>

--- a/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Kni.Web/FlatRedBall.Forms.Kni.Web.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.Kni.Web/FlatRedBall.Forms.Kni.Web.csproj
@@ -4,6 +4,12 @@
 		<DefineConstants>DESKTOP_GL;KNI;WEB;BLAZORGL; FRB</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
+    <Title>FlatRedBall.Forms (Web)</Title>
+    <Authors>FlatRedBall</Authors>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Description>UI controls for FlatRedBall built on Gum</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>1.0.0</Version>
 
   </PropertyGroup>
 	<ItemGroup>

--- a/Engines/Forms/FlatRedBall.Forms/StateInterpolation/StateInterpolation.DesktopGlNet6/StateInterpolation.DesktopNet6.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/StateInterpolation/StateInterpolation.DesktopGlNet6/StateInterpolation.DesktopNet6.csproj
@@ -4,6 +4,13 @@
 	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
     <Nullable>enable</Nullable>
+    <PackageId>FlatRedBall.StateInterpolation.DesktopNet6</PackageId>
+    <Title>FlatRedBall State Interpolation (.NET Desktop GL)</Title>
+    <Authors>FlatRedBall</Authors>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Description>Tweening and state interpolation for FlatRedBall</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>1.0.0</Version>
 
   </PropertyGroup>
 

--- a/Engines/Forms/FlatRedBall.Forms/StateInterpolation/StateInterpolation.FNA/StateInterpolation.FNA.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/StateInterpolation/StateInterpolation.FNA/StateInterpolation.FNA.csproj
@@ -4,10 +4,19 @@
     <DefineConstants>FNA;XNA4</DefineConstants>
 	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>1591</NoWarn>
+    <PackageId>FlatRedBall.StateInterpolation.FNA</PackageId>
+    <Title>FlatRedBall State Interpolation (FNA)</Title>
+    <Authors>FlatRedBall</Authors>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Description>Tweening and state interpolation for FlatRedBall</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>1.0.0</Version>
 
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\FlatRedBallXNA\3rd Party Libraries\FNA\FNA.Core.csproj" />
+    <!-- FNA is not published on nuget.org, so this must not become a package dependency.
+         FNA.dll reaches consumers embedded in the FlatRedBall.FNA package below. -->
+    <ProjectReference Include="..\..\..\..\FlatRedBallXNA\3rd Party Libraries\FNA\FNA.Core.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\..\..\..\FlatRedBallXNA\FlatRedBall.FNA\FlatRedBall.FNA.csproj" />
   </ItemGroup>
   <Import Project="..\..\..\..\..\FRBDK\Glue\StateInterpolationPlugin\StateInterpolationPlugin\StateInterpolationShared.projitems" Label="Shared" />

--- a/Engines/Forms/FlatRedBall.Forms/StateInterpolation/StateInterpolation.Kni.Web/StateInterpolation.Kni.Web.csproj
+++ b/Engines/Forms/FlatRedBall.Forms/StateInterpolation/StateInterpolation.Kni.Web/StateInterpolation.Kni.Web.csproj
@@ -4,6 +4,13 @@
     <DefineConstants>FNA;WEB;BLAZORGL</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
+    <PackageId>FlatRedBall.StateInterpolation.Kni.Web</PackageId>
+    <Title>FlatRedBall State Interpolation (Web)</Title>
+    <Authors>FlatRedBall</Authors>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Description>Tweening and state interpolation for FlatRedBall</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>1.0.0</Version>
 
   </PropertyGroup>
   <Import Project="..\..\..\..\..\FRBDK\Glue\StateInterpolationPlugin\StateInterpolationPlugin\StateInterpolationShared.projitems" Label="Shared" />

--- a/Engines/SkiaGum/SkiaInGum.csproj
+++ b/Engines/SkiaGum/SkiaInGum.csproj
@@ -8,6 +8,13 @@
 		<DefineConstants>FAST_GL_SKIA_RENDERING;INCLUDE_SVG</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>1591</NoWarn>
+		<PackageId>FlatRedBall.SkiaInGum</PackageId>
+		<Title>SkiaInGum (.NET Desktop GL)</Title>
+		<Authors>FlatRedBall</Authors>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Description>Skia-backed rendering for Gum inside FlatRedBall</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Version>1.0.0</Version>
 
 	</PropertyGroup>
 

--- a/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Data/AllData.cs
+++ b/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Data/AllData.cs
@@ -12,6 +12,38 @@ namespace BuildServerUploaderConsole.Data
 
         public static List<EngineData> Engines { get; private set; } = new List<EngineData>();
 
+        /// <summary>
+        /// Every package published by a release, deduplicated. The DesktopGL entries below share a
+        /// package set across two templates, so the same csproj is listed more than once in
+        /// <see cref="Engines"/>.
+        /// </summary>
+        public static IEnumerable<PackageData> AllPackages =>
+            Engines.SelectMany(engine => engine.Packages)
+                   .GroupBy(package => package.PackageId)
+                   .Select(group => group.First());
+
+        static PackageData Package(string packageId, string csProjLocation) => new PackageData
+        {
+            PackageId = packageId,
+            CsProjLocation = csProjLocation,
+        };
+
+        // Both DesktopGL templates (.NET 6 and .NET 9) build against the same multi-targeted
+        // projects, so they ship the same packages.
+        static void AddDesktopGlPackages(EngineData engine)
+        {
+            engine.Packages.Add(Package("FlatRedBallDesktopGLNet6",
+                @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj"));
+            engine.Packages.Add(Package("FlatRedBall.StateInterpolation.DesktopNet6",
+                @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.DesktopGlNet6\StateInterpolation.DesktopNet6.csproj"));
+            engine.Packages.Add(Package("FlatRedBall.GumCore.DesktopGlNet6",
+                @"Gum\GumCore\GumCoreXnaPc\GumCore.DesktopGlNet6\GumCore.DesktopGlNet6.csproj"));
+            engine.Packages.Add(Package("FlatRedBall.Forms.DesktopGlNet6",
+                @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.DesktopGlNet6\FlatRedBall.Forms.DesktopGlNet6.csproj"));
+            engine.Packages.Add(Package("FlatRedBall.SkiaInGum",
+                @"FlatRedBall\Engines\SkiaGum\SkiaInGum.csproj"));
+        }
+
         static AllData()
         {
             // Android (.NET 8)
@@ -19,7 +51,8 @@ namespace BuildServerUploaderConsole.Data
                 var engine = new EngineData();
                 engine.Name = "Android .NET 8.0";
 
-                engine.EngineCSProjLocation = @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallAndroid\FlatRedBallAndroid.csproj";
+                engine.Packages.Add(Package("FlatRedBallAndroid",
+                    @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallAndroid\FlatRedBallAndroid.csproj"));
 
                 engine.RelativeToLibrariesDebugFolder = @"Android\Debug";
                 engine.RelativeToLibrariesReleaseFolder = @"Android\Release";
@@ -67,7 +100,8 @@ namespace BuildServerUploaderConsole.Data
                 var engine = new EngineData();
                 engine.Name = "iOS .NET 8.0";
 
-                engine.EngineCSProjLocation = @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBalliOS\FlatRedBalliOS.csproj";
+                engine.Packages.Add(Package("FlatRedBalliOS",
+                    @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBalliOS\FlatRedBalliOS.csproj"));
 
                 engine.RelativeToLibrariesDebugFolder = @"iOS\Debug";
                 engine.RelativeToLibrariesReleaseFolder = @"iOS\Release";
@@ -112,12 +146,12 @@ namespace BuildServerUploaderConsole.Data
                 var engine = new EngineData();
                 engine.Name = "MonoGame DesktopGL .NET 6.0";
 
-                engine.EngineCSProjLocation = @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj";
+                AddDesktopGlPackages(engine);
 
                 engine.RelativeToLibrariesDebugFolder = @"DesktopGl\Debug";
                 engine.RelativeToLibrariesReleaseFolder = @"DesktopGl\Release";
                 engine.TemplateCsProjFolder = @"FlatRedBallDesktopGlNet6Template\FlatRedBallDesktopGlNet6Template\";
-                                       
+
                 // This is the built folder when building FlatRedBall.Forms sln
                 // All files below (DebugFiles and ReleaseFiles) should be contained
                 // in that output folder because the project should reference those files
@@ -168,7 +202,9 @@ namespace BuildServerUploaderConsole.Data
                 var engine = new EngineData();
                 engine.Name = "MonoGame DesktopGL .NET 9.0+";
 
-                engine.EngineCSProjLocation = @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj";
+                // Same projects and therefore the same packages as the .NET 6 template above -- the
+                // DesktopGL projects multi-target net6.0 and net8.0, so one package serves both.
+                AddDesktopGlPackages(engine);
 
                 engine.RelativeToLibrariesDebugFolder = @"DesktopGl\Debug";
                 engine.RelativeToLibrariesReleaseFolder = @"DesktopGl\Release";
@@ -221,7 +257,14 @@ namespace BuildServerUploaderConsole.Data
                 var engine = new EngineData();
                 engine.Name = "FNA DesktopGL .NET 7.0";
 
-                engine.EngineCSProjLocation = @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBall.FNA\FlatRedBall.FNA.csproj";
+                engine.Packages.Add(Package("FlatRedBall.FNA",
+                    @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBall.FNA\FlatRedBall.FNA.csproj"));
+                engine.Packages.Add(Package("FlatRedBall.StateInterpolation.FNA",
+                    @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.FNA\StateInterpolation.FNA.csproj"));
+                engine.Packages.Add(Package("FlatRedBall.GumCore.FNA",
+                    @"Gum\GumCore\GumCoreXnaPc\GumCore.FNA\GumCore.FNA.csproj"));
+                engine.Packages.Add(Package("FlatRedBall.Forms.FNA",
+                    @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.FNA\FlatRedBall.Forms.FNA.csproj"));
 
                 engine.RelativeToLibrariesDebugFolder = @"FNA\Debug";
                 engine.RelativeToLibrariesReleaseFolder = @"FNA\Release";
@@ -274,7 +317,14 @@ namespace BuildServerUploaderConsole.Data
                 var engine = new EngineData();
                 engine.Name = "Web";
 
-                engine.EngineCSProjLocation = @"FlatRedBall\Engines\FlatRedBallXNA\KniWeb\FlatRedBallKniWeb.csproj";
+                engine.Packages.Add(Package("FlatRedBallKniWeb",
+                    @"FlatRedBall\Engines\FlatRedBallXNA\KniWeb\FlatRedBallKniWeb.csproj"));
+                engine.Packages.Add(Package("FlatRedBall.StateInterpolation.Kni.Web",
+                    @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.Kni.Web\StateInterpolation.Kni.Web.csproj"));
+                engine.Packages.Add(Package("FlatRedBall.GumCore.Kni.Web",
+                    @"Gum\GumCore\GumCoreXnaPc\GumCore.Kni.Web\GumCore.Kni.Web.csproj"));
+                engine.Packages.Add(Package("FlatRedBall.Forms.Kni.Web",
+                    @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.Kni.Web\FlatRedBall.Forms.Kni.Web.csproj"));
 
                 engine.RelativeToLibrariesDebugFolder = @"Web\Debug";
                 engine.RelativeToLibrariesReleaseFolder = @"Web\Release";

--- a/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Data/EngineData.cs
+++ b/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Data/EngineData.cs
@@ -25,7 +25,12 @@ namespace BuildServerUploaderConsole.Data
         public string RelativeToLibrariesReleaseFolder { get; set; }
         public string TemplateCsProjFolder { get; set; }
 
-        public string EngineCSProjLocation { get; set; }
+        /// <summary>
+        /// Every NuGet package this engine ships. All of them are versioned together at release
+        /// time and pushed in one step, so a project restores a matched set instead of pairing a
+        /// current engine package with whatever Gum happened to be in its Libraries folder.
+        /// </summary>
+        public List<PackageData> Packages { get; set; } = new List<PackageData>();
 
         public string TemplateName
         {

--- a/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Data/PackageData.cs
+++ b/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Data/PackageData.cs
@@ -1,0 +1,25 @@
+﻿namespace BuildServerUploaderConsole.Data
+{
+    /// <summary>
+    /// One NuGet package shipped as part of an engine. Every assembly a template-created project
+    /// references is published this way, so the whole set moves together on restore rather than
+    /// half of it coming from a Libraries folder baked into the template zip.
+    /// </summary>
+    public class PackageData
+    {
+        /// <summary>
+        /// The .csproj that produces the package, relative to the checkout folder (the one holding
+        /// both FlatRedBall\ and Gum\). Its &lt;Version&gt; is stamped at release time.
+        /// </summary>
+        public string CsProjLocation { get; set; }
+
+        /// <summary>
+        /// The NuGet package id. This is not always the assembly name: assemblies whose names read
+        /// as belonging to another project (GumCore, SkiaInGum) get a FlatRedBall-scoped id so the
+        /// package says who publishes it.
+        /// </summary>
+        public string PackageId { get; set; }
+
+        public override string ToString() => PackageId;
+    }
+}

--- a/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Processes/UpdateAssemblyVersions.cs
+++ b/FRBDK/BuildServerUploader/BuildServerUploaderConsole/Processes/UpdateAssemblyVersions.cs
@@ -68,13 +68,12 @@ namespace BuildServerUploaderConsole.Processes
                         }
                     }
 
-                    var enginesWithCSProjLocation = AllData.Engines
-                        .Where(item => !string.IsNullOrEmpty(item.EngineCSProjLocation))
-                        .ToArray();
-                    // If we list a csproj, then update that:
-                    foreach (var engine in enginesWithCSProjLocation)
+                    // Every published package is stamped with the same version, including the ones
+                    // built out of the sibling Gum checkout. That is the point of the whole set
+                    // shipping through NuGet: a project resolves a matched set or none of it.
+                    foreach (var package in AllData.AllPackages)
                     {
-                        var csProjAbsolute = DirectoryHelper.CheckoutDirectory + engine.EngineCSProjLocation;
+                        var csProjAbsolute = DirectoryHelper.CheckoutDirectory + package.CsProjLocation;
                         ModifyCsprojAssemblyInfoVersion(csProjAbsolute, GetVersionString(IsBeta));
                         Results.WriteMessage("Modified " + csProjAbsolute + " to " + GetVersionString(IsBeta));
                     }
@@ -122,19 +121,16 @@ namespace BuildServerUploaderConsole.Processes
                     templateName = templateName.Substring(0, templateName.Length - 1);
                 }
 
-                var strippedEngineName = FileManager.RemoveExtension( FileManager.RemovePath(engine.EngineCSProjLocation));
+                var templateLocation = engine.TemplateCsProjFolder + templateName + ".csproj";
+                var fullTemplateCsprojLocation = DirectoryHelper.TemplateDirectory + templateLocation;
 
-                UpdateTemplateNuget(strippedEngineName, templateName, engine);
+                // A template only references the packages it actually needs, so a package the
+                // template doesn't list simply doesn't match and is left alone.
+                foreach (var package in engine.Packages)
+                {
+                    ModifyNugetVersionInAssembly(fullTemplateCsprojLocation, package.PackageId, GetVersionString(IsBeta));
+                }
             }
-        }
-
-        private void UpdateTemplateNuget(string engineName, string templateName, EngineData engine)
-        {
-            var templateLocation = engine.TemplateCsProjFolder + templateName + ".csproj";
-
-            var fullTemplateCsprojLocation = DirectoryHelper.TemplateDirectory + templateLocation;
-
-            ModifyNugetVersionInAssembly(fullTemplateCsprojLocation, engineName, GetVersionString(IsBeta));
         }
 
         private static void ModifyAssemblyInfoVersion(string assemblyInfoLocation, string versionString)
@@ -176,14 +172,21 @@ namespace BuildServerUploaderConsole.Processes
 
             string csprojText = FileManager.FromFileText(templateCsprojLocation);
 
-            csprojText = System.Text.RegularExpressions.Regex.Replace(csprojText,
-                        $"<PackageReference Include=\"{packageName}\" Version=\"[0-9]*.[0-9]*.[0-9]*.[0-9]*\" />",
+            var escapedPackageName = System.Text.RegularExpressions.Regex.Escape(packageName);
+
+            var updatedText = System.Text.RegularExpressions.Regex.Replace(csprojText,
+                        $"<PackageReference Include=\"{escapedPackageName}\" Version=\"[^\"]*\" />",
                         $"<PackageReference Include=\"{packageName}\" Version=\"{versionString}\" />");
 
-            Results.WriteMessage("Modified " + templateCsprojLocation + $" to have FlatRedBall Nuget package {versionString}");
+            if (updatedText == csprojText)
+            {
+                // Not every template references every package for its engine, so this is normal.
+                return;
+            }
 
+            Results.WriteMessage("Modified " + templateCsprojLocation + $" to reference {packageName} {versionString}");
 
-            FileManager.SaveText(csprojText, templateCsprojLocation);
+            FileManager.SaveText(updatedText, templateCsprojLocation);
         }
 
     }

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/EnginePackagingTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/EnginePackagingTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Shouldly;
+
+namespace GlueUnitTests.Projects;
+
+// A template-created project used to get its engine from two places at once: FlatRedBallDesktopGLNet6
+// from NuGet, and GumCore / Forms / SkiaInGum / StateInterpolation as loose DLLs shipped inside the
+// template zip. The two halves versioned independently, and a project whose bundled GumCore predated
+// a .gumx format change simply failed to load its own UI at runtime (GitHub issue #1951).
+//
+// Every one of those assemblies now ships as its own NuGet package. These tests pin the three things
+// that have to stay true for that to hold, none of which the compiler checks:
+//   * each project actually produces a package, with a <Version> the release tooling can stamp
+//   * Engine.yml pushes all of them
+//   * no package declares a dependency on something we don't publish
+//
+// All of it is read off disk, so no Glue bootstrap is needed and it stays in the fast unit run.
+public class EnginePackagingTests
+{
+    // Package id -> csproj path relative to the checkout folder (the one holding FlatRedBall\ and Gum\).
+    // This is the set a project created from a template must be able to restore. It is deliberately
+    // spelled out here rather than derived: "which projects are published" is a decision, and the
+    // point of the test is to catch a project quietly joining or leaving that set.
+    private static readonly Dictionary<string, string> PublishedPackages = new()
+    {
+        // DesktopGL (serves both the .NET 6 and .NET 9 templates -- the projects multi-target)
+        ["FlatRedBallDesktopGLNet6"] = @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj",
+        ["FlatRedBall.StateInterpolation.DesktopNet6"] = @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.DesktopGlNet6\StateInterpolation.DesktopNet6.csproj",
+        ["FlatRedBall.GumCore.DesktopGlNet6"] = @"Gum\GumCore\GumCoreXnaPc\GumCore.DesktopGlNet6\GumCore.DesktopGlNet6.csproj",
+        ["FlatRedBall.Forms.DesktopGlNet6"] = @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.DesktopGlNet6\FlatRedBall.Forms.DesktopGlNet6.csproj",
+        ["FlatRedBall.SkiaInGum"] = @"FlatRedBall\Engines\SkiaGum\SkiaInGum.csproj",
+
+        // FNA
+        ["FlatRedBall.FNA"] = @"FlatRedBall\Engines\FlatRedBallXNA\FlatRedBall.FNA\FlatRedBall.FNA.csproj",
+        ["FlatRedBall.StateInterpolation.FNA"] = @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.FNA\StateInterpolation.FNA.csproj",
+        ["FlatRedBall.GumCore.FNA"] = @"Gum\GumCore\GumCoreXnaPc\GumCore.FNA\GumCore.FNA.csproj",
+        ["FlatRedBall.Forms.FNA"] = @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.FNA\FlatRedBall.Forms.FNA.csproj",
+
+        // Web (Kni)
+        ["FlatRedBallKniWeb"] = @"FlatRedBall\Engines\FlatRedBallXNA\KniWeb\FlatRedBallKniWeb.csproj",
+        ["FlatRedBall.StateInterpolation.Kni.Web"] = @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.Kni.Web\StateInterpolation.Kni.Web.csproj",
+        ["FlatRedBall.GumCore.Kni.Web"] = @"Gum\GumCore\GumCoreXnaPc\GumCore.Kni.Web\GumCore.Kni.Web.csproj",
+        ["FlatRedBall.Forms.Kni.Web"] = @"FlatRedBall\Engines\Forms\FlatRedBall.Forms\FlatRedBall.Forms.Kni.Web\FlatRedBall.Forms.Kni.Web.csproj",
+    };
+
+    // What UpdateAssemblyVersions.ModifyCsprojAssemblyInfoVersion looks for when stamping the release
+    // version. A packable project whose <Version> this doesn't match ships as 1.0.0 forever.
+    private static readonly Regex StampableVersion = new(@"<Version>[0-9]*.[0-9]*.[0-9]*.[0-9]*</Version>");
+
+    [Fact]
+    public void EveryPublishedProject_ShouldBePackable_AndCarryAStampableVersion()
+    {
+        foreach (var (packageId, relativePath) in PublishedPackages)
+        {
+            var csproj = LoadCsproj(relativePath);
+
+            string.Equals(GetProperty(csproj, "GeneratePackageOnBuild"), "True", StringComparison.OrdinalIgnoreCase)
+                .ShouldBeTrue($"{packageId} is referenced by a template but its project does not produce a package.");
+
+            var declaredId = GetProperty(csproj, "PackageId") ?? Path.GetFileNameWithoutExtension(relativePath);
+            declaredId.ShouldBe(packageId,
+                $"{relativePath} would publish as '{declaredId}', not '{packageId}'.");
+
+            var version = GetProperty(csproj, "Version");
+            version.ShouldNotBeNull($"{packageId} has no <Version> for the release to stamp.");
+            StampableVersion.IsMatch($"<Version>{version}</Version>").ShouldBeTrue(
+                $"{packageId}'s <Version>{version}</Version> does not match the pattern " +
+                "UpdateAssemblyVersions rewrites, so a release would leave it unchanged.");
+        }
+    }
+
+    [Fact]
+    public void EveryPublishedProject_ShouldBePushedByEngineYml()
+    {
+        var workflow = File.ReadAllText(Path.Combine(FindFrbRoot(), ".github", "workflows", "Engine.yml"));
+
+        // The publish step lists output folders, one quoted path per line, and commented-out entries
+        // are the disabled mobile platforms -- those must not count as published.
+        var publishedFolders = Regex.Matches(workflow, @"^\s*'([^']+bin\\Debug)',?\s*$", RegexOptions.Multiline)
+            .Select(match => match.Groups[1].Value)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        publishedFolders.ShouldNotBeEmpty("Could not find the package list in Engine.yml's publish step.");
+
+        foreach (var (packageId, relativePath) in PublishedPackages)
+        {
+            var expectedFolder = Path.GetDirectoryName(relativePath) + @"\bin\Debug";
+            publishedFolders.ShouldContain(expectedFolder,
+                $"Engine.yml does not push {packageId}. A release would ship the rest of the set without it.");
+        }
+    }
+
+    [Fact]
+    public void EveryPublishedProject_ShouldOnlyDependOnThingsWeAlsoPublish()
+    {
+        foreach (var (packageId, relativePath) in PublishedPackages)
+        {
+            var csproj = LoadCsproj(relativePath);
+            var projectDirectory = Path.GetDirectoryName(Path.Combine(FindCheckoutRoot(), relativePath))!;
+
+            foreach (var reference in csproj.Descendants("ProjectReference"))
+            {
+                // Configuration-conditional references (SkiaInGum under the live-edit configurations)
+                // are not present in the Debug build that gets packed.
+                if (reference.Attribute("Condition") != null)
+                {
+                    continue;
+                }
+
+                // PrivateAssets="all" deliberately keeps a reference out of the package's dependency
+                // list -- that is how FNA, which is not on nuget.org, is handled.
+                if (string.Equals((string)reference.Attribute("PrivateAssets"), "all", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var referencedProject = Path.GetFullPath(Path.Combine(projectDirectory,
+                    ((string)reference.Attribute("Include")).Replace('\\', Path.DirectorySeparatorChar)));
+
+                var isPublished = PublishedPackages.Values.Any(published =>
+                    string.Equals(Path.GetFullPath(Path.Combine(FindCheckoutRoot(), published)),
+                        referencedProject, StringComparison.OrdinalIgnoreCase));
+
+                isPublished.ShouldBeTrue(
+                    $"{packageId} declares a package dependency on {Path.GetFileName(referencedProject)}, " +
+                    "which is not published. Restoring the package would fail. Either publish it too, " +
+                    "or mark the reference PrivateAssets=\"all\" so its output is embedded instead.");
+            }
+        }
+    }
+
+    private static XDocument LoadCsproj(string relativePath)
+    {
+        var fullPath = Path.Combine(FindCheckoutRoot(), relativePath);
+        File.Exists(fullPath).ShouldBeTrue($"Expected a project at {fullPath}");
+        return XDocument.Load(fullPath);
+    }
+
+    private static string GetProperty(XDocument csproj, string name) =>
+        csproj.Descendants(name).FirstOrDefault(element => element.Parent?.Name == "PropertyGroup")?.Value;
+
+    // The folder holding both the FlatRedBall and Gum checkouts. Every path above is relative to it,
+    // matching how BuildServerUploaderConsole's AllData addresses the same files.
+    private static string FindCheckoutRoot()
+    {
+        var checkoutRoot = Directory.GetParent(FindFrbRoot())!.FullName;
+        Directory.Exists(Path.Combine(checkoutRoot, "Gum")).ShouldBeTrue(
+            $"Expected a sibling Gum checkout at {Path.Combine(checkoutRoot, "Gum")}. " +
+            "GumCore is built from Gum's source but published by FlatRedBall.");
+        return checkoutRoot;
+    }
+
+    private static string FindFrbRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (Directory.Exists(Path.Combine(directory.FullName, "Templates")) &&
+                File.Exists(Path.Combine(directory.FullName, ".github", "workflows", "Engine.yml")))
+            {
+                return directory.FullName;
+            }
+            directory = directory.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate the FlatRedBall repo root above " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
A template-created project referenced its engine two ways at once. `FlatRedBallDesktopGLNet6` came from NuGet; `FlatRedBall.Forms`, `GumCore`, `SkiaInGum` and `StateInterpolation` were loose DLLs shipped inside the template zip. Only the engine csproj set `GeneratePackageOnBuild`, so the other four never appeared in the package and versioned independently of it. A user whose bundled GumCore predated a `.gumx` format change could not load their own UI, and updating the engine package did not help — GumCore was not in it.

This is step 1 of #1951: make every one of those assemblies ship through NuGet. It does not touch the templates yet (see Sequencing below).

## What changed

- All four now produce packages, on DesktopGL, FNA and Web alike.
- Package ids are `FlatRedBall.`-scoped where the assembly name reads as belonging to another project (`FlatRedBall.GumCore.*`, `FlatRedBall.SkiaInGum`, `FlatRedBall.StateInterpolation.*`), so the id says who publishes it. Assembly names are unchanged.
- `Engine.yml` pushes all 13 packages in the same single all-or-nothing step — no new push points.
- `UpdateAssemblyVersions` stamps every published csproj, driven off a new `AllData.AllPackages` list rather than one hardcoded csproj per engine. That includes the GumCore projects in the sibling Gum checkout, so the whole set can only move together. Its template `PackageReference` rewrite is now per-package and no longer silently fails on a `-beta` version string.

The dependency graph does the work: `FlatRedBall.SkiaInGum` → `Forms` → `GumCore` → engine + `StateInterpolation`, verified by unpacking the real `.nupkg`s.

FNA is not on nuget.org, so references to it are `PrivateAssets="all"` and `FNA.dll` ships embedded in `FlatRedBall.FNA`'s `lib/` folder, as it already did. `FlatRedBall.FNA` was previously suppressing that dependency via `<IncludeAssets>FNA.Core.dll</IncludeAssets>` — not a valid asset kind, so it happened to resolve to "no assets" and worked by accident. Now it says what it means; the produced package is unchanged.

## Test

`EnginePackagingTests` pins the three things the compiler cannot: each published project actually packs and carries a `<Version>` the release tooling's regex will rewrite; `Engine.yml` pushes all of them; and no package declares a dependency on something we do not publish. All three fail on `NetStandard` and pass here. The third one is what found the `IncludeAssets` problem above.

## Sequencing

Depends on vchelaru/Gum#4308, which must merge first — CI here checks out Gum's default branch.

Step 2 (templates → `PackageReference`, delete `Libraries\`) cannot land until a release actually publishes these packages, because `NewProjectCreationSmokeTests` restores the template's pinned versions from nuget.org. Order is: Gum#4308 → this → an `Engine.yml` run → the template PR.

## Note on local BuildSmoke

One local `Category=BuildSmoke` run had `GumRuntimeMemberContractTests.Sweep_ShouldCatchAVariableAddedToTheSchemaLater` fail. It did not reproduce: that run followed a `git stash push`/`pop` of the engine csprojs, so the sweep reflected over engine assemblies built from mixed state. Repeat runs on this branch and on clean `NetStandard` are both 5/5, as is CI here.

Part of #1951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
