### PR TITLE
Stop generating the singular Gum DropshadowBlur no FRB runtime type backs

### DIFF
--- a/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
+++ b/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
@@ -59,6 +59,18 @@ Fix: pass `SolutionDir` explicitly, pointed at `FRBDK/Glue/` (the directory cont
 dotnet test FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj -p:SolutionDir="<repo>\FRBDK\Glue\\"
 ```
 
+## Landmine — an orphaned `testhost` locks the output DLLs, and the next run looks like a hang
+
+A cancelled or timed-out `dotnet test` can leave `testhost.exe` alive holding `GlueUnitTests/bin/.../*.dll` open. The next run then can't copy dependencies into `bin`, and fails with `MSB3021`/`MSB3027` naming the holder (`The file is locked by: "testhost (PID)"`). The trap is that the *build* stalls through its 10 retries × 1s per file while producing no test output — piped through a `grep`, that buffers to nothing and reads as a hung test suite rather than a locked file.
+
+Before diagnosing a slow or silent run as a test problem, clear the holders:
+
+```powershell
+Get-Process testhost,vstest.console,MSBuild -ErrorAction SilentlyContinue | Stop-Process -Force
+```
+
+Then re-run with `--no-build` when nothing was recompiled since the last successful build — it skips the copy step the lock blocks, and the full non-BuildSmoke suite finishes in seconds.
+
 ## Deep dive
 
 For the full story of why each seam was needed and what's still NRE-prone (e.g. `AvailableAssetTypes.CommonAtis`

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
@@ -159,8 +159,8 @@ namespace GumPlugin.CodeGeneration
                 "GradientInnerRadius", "GradientInnerRadiusUnits",
                 "GradientOuterRadius", "GradientOuterRadiusUnits",
                 "Alpha2", "Red2", "Green2", "Blue2",
-                // dropshadow (AddDropshadowVariables)
-                "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY", "DropshadowBlur",
+                // dropshadow (AddDropshadowVariables) - "DropshadowBlur" is skipped globally below
+                "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY",
                 "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
                 // blend (AddBlendVariable) - LineRectangle/LineCircle's BlendState has no setter
                 "Blend",
@@ -186,7 +186,6 @@ namespace GumPlugin.CodeGeneration
             _typedVariableNamesToSkipForProperties.Add("Text", new List<string>
             {
                 "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
-                "DropshadowBlur",
                 "LocalizeText",
             });
 
@@ -206,6 +205,16 @@ namespace GumPlugin.CodeGeneration
             // want to support them.
             // If a variable is to be excluded only for certain types, see
             // GetIfShouldGenerateProperty
+            // No FRB runtime type backs a singular "DropshadowBlur" - the Skia renderables split it into
+            // DropshadowBlurX/DropshadowBlurY (RenderableSkiaObject), RenderingLibrary.Graphics.Text has no
+            // blur at all, and LineRectangle/LineCircle have no dropshadow surface whatsoever. A Gum Editor
+            // that writes the singular name into a .gutx therefore feeds codegen a variable nothing can back,
+            // producing CS1061 in the user's game - and because codegen emits from the project's variables
+            // rather than from FRB's own schema, no amount of keeping SkiaStandardElementsManager correct
+            // prevents it. Global (rather than per-type) so an element Gum adds dropshadow to later is
+            // covered on arrival; see GumSkiaRenderableCodegenSweepTests.
+            mVariableNamesToSkipForProperties.Add("DropshadowBlur");
+
             mVariableNamesToSkipForProperties.Add("Custom Texture Coordinates"); // replaced by texture address mode
             mVariableNamesToSkipForProperties.Add("CustomTextureCoordinates"); // replaced by texture address mode
             mVariableNamesToSkipForProperties.Add("Height Units");

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
@@ -105,6 +105,12 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         // (SpriteCodeGenerator.GenerateIRenderTargetTextureReferencerProperties), never state-switch driven.
         // Permanent, version-independent skip - the name is unique to Sprite so a global skip is safe.
         mVariableNamesToSkipForStates.Add("RenderTargetTextureSource");
+
+        // Mirrors the global property-pipeline skip in
+        // StandardsCodeGenerator.RefreshVariableNamesToSkipForProperties - see there for why nothing backs a
+        // singular "DropshadowBlur". Both pipelines must agree or the state switch assigns a property that
+        // was never generated (CS0103).
+        mVariableNamesToSkipForStates.Add("DropshadowBlur");
         //mVariableNamesToSkipForStates.Add("IsBold");
 
         // Eventually we'll support this but first Gum needs to support
@@ -129,7 +135,7 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
             "GradientInnerRadius", "GradientInnerRadiusUnits",
             "GradientOuterRadius", "GradientOuterRadiusUnits",
             "Alpha2", "Red2", "Green2", "Blue2",
-            "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY", "DropshadowBlur",
+            "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY",
             "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
             "Blend",
         };
@@ -150,7 +156,6 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         typeSpecificVariableNamesToSkipForStates.Add("Text", new List<string>
         {
             "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
-            "DropshadowBlur",
             "LocalizeText",
         });
     }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumSkiaRenderableCodegenSweepTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumSkiaRenderableCodegenSweepTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.Managers;
@@ -119,7 +120,11 @@ public class GumSkiaRenderableCodegenSweepTests : IDisposable
         }
     }
 
-    private static (bool Generated, string Source, HashSet<string> FixtureVariableNames) GenerateFor(string standardElementName)
+    private static (bool Generated, string Source, HashSet<string> FixtureVariableNames) GenerateFor(string standardElementName) =>
+        GenerateFor(standardElementName, extraVariables: null);
+
+    private static (bool Generated, string Source, HashSet<string> FixtureVariableNames) GenerateFor(
+        string standardElementName, IEnumerable<Gum.DataTypes.Variables.VariableSave> extraVariables)
     {
         GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
         EnsureSkiaStandardElementsRegistered();
@@ -129,6 +134,14 @@ public class GumSkiaRenderableCodegenSweepTests : IDisposable
         // stale) on-disk/embedded template. See RectangleCircleCodegenTests.cs's header for why this matters.
         var standardElementSave = new StandardElementSave { Name = standardElementName };
         standardElementSave.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor(standardElementName));
+
+        // A .gutx on disk carries whatever variables the Gum Editor that last saved it wrote, which is not
+        // necessarily what SkiaStandardElementsManager would have produced - see
+        // GenerateStandardElementSaveCodeFor_SkiaElement_SkipsGumEditorsSingularDropshadowBlur below.
+        if (extraVariables != null)
+        {
+            standardElementSave.DefaultState.Variables.AddRange(extraVariables);
+        }
 
         var fixtureVariableNames = standardElementSave.DefaultState.Variables.Select(v => v.GetRootName()).ToHashSet();
 
@@ -296,5 +309,68 @@ public class GumSkiaRenderableCodegenSweepTests : IDisposable
         // (proves this isn't an accidental blanket exclusion that would trivially pass the above).
         source.ShouldContain("Width = ");
         source.ShouldContain("Height = ");
+    }
+
+    // Matches the singular "DropshadowBlur" without also matching DropshadowBlurX/DropshadowBlurY, which
+    // are real, backed members and must keep generating.
+    private static readonly Regex SingularDropshadowBlur = new(@"DropshadowBlur(?![XY])\w*", RegexOptions.Compiled);
+
+    private static Gum.DataTypes.Variables.VariableSave SingularDropshadowBlurVariable() =>
+        new()
+        {
+            SetsValue = true,
+            Type = "float",
+            Value = 0f,
+            Name = "DropshadowBlur",
+            Category = "Dropshadow",
+        };
+
+    // Reported against GumEditor 2026.08.03: a project that had been opened in that editor failed to build
+    // with CS1061 on 'RenderableArc'/'RenderableCircle'/'RenderableRoundedRectangle' having no
+    // 'DropshadowBlur'. Same bug class as Text's dropshadow channels (#1948) and Rectangle/Circle's
+    // fill/stroke family (#1907), but arriving by a different route, which is why the sweep in
+    // GumRuntimeMemberContractTests could not catch it: that sweep builds its fixture from FRB's own
+    // SkiaStandardElementsManager schema, which uses the two-channel DropshadowBlurX/DropshadowBlurY that
+    // RenderableSkiaObject actually backs. Codegen, however, emits from the variables in the project's
+    // .gutx - whatever the Gum Editor that last saved it wrote there. A Gum Editor that collapses the two
+    // blur channels into one "DropshadowBlur" therefore feeds codegen a variable name no FRB runtime type
+    // has ever had, and nothing in FRB's own schema would ever reveal it.
+    //
+    // Injecting the variable (rather than asserting against the current schema) is the point: the fixture
+    // stands in for the .gutx, not for what FRB would have generated.
+    [Theory]
+    [InlineData("Arc")]
+    [InlineData("ColoredCircle")]
+    [InlineData("LottieAnimation")]
+    [InlineData("RoundedRectangle")]
+    [InlineData("Svg")]
+    [InlineData("Canvas")]
+    public void GenerateStandardElementSaveCodeFor_SkiaElement_SkipsGumEditorsSingularDropshadowBlur(string standardElementName)
+    {
+        var (generated, source, fixtureVariableNames) =
+            GenerateFor(standardElementName, new[] { SingularDropshadowBlurVariable() });
+        generated.ShouldBeTrue();
+
+        // Fixture sanity - if the injection stopped landing, the assertion below would pass vacuously.
+        fixtureVariableNames.ShouldContain("DropshadowBlur");
+
+        var offenders = SingularDropshadowBlur.Matches(source).Select(m => m.Value).Distinct().ToList();
+        offenders.ShouldBeEmpty(
+            $"No FRB runtime type backs a singular 'DropshadowBlur' (RenderableSkiaObject has " +
+            $"DropshadowBlurX/DropshadowBlurY), so generating it produces CS1061 in the user's game. " +
+            $"Emitted: {string.Join(", ", offenders)}");
+    }
+
+    [Fact]
+    public void GenerateStandardElementSaveCodeFor_ColoredCircle_KeepsBackedBlurChannelsWhenSingularBlurIsSkipped()
+    {
+        var (generated, source, _) = GenerateFor("ColoredCircle", new[] { SingularDropshadowBlurVariable() });
+        generated.ShouldBeTrue();
+
+        // Proves the skip is per-member rather than a blanket "drop anything named Dropshadow*" - the two
+        // channels RenderableSkiaObject really has must survive alongside the skipped singular name.
+        source.ShouldContain("ContainedColoredCircle.DropshadowBlurX");
+        source.ShouldContain("ContainedColoredCircle.DropshadowBlurY");
+        source.ShouldContain("ContainedColoredCircle.HasDropshadow");
     }
 }


### PR DESCRIPTION
A user's project failed to build with CS1061 on `RenderableArc`/`RenderableCircle`/`RenderableRoundedRectangle` having no `DropshadowBlur`, after being opened in GumEditor 2026.08.03.

Gum #2950 collapsed the per-axis `DropshadowBlurX`/`DropshadowBlurY` into a single scalar `DropshadowBlur` for the legacy shapes. `SkiaGum.Renderables.RenderableSkiaObject` only ever gained the two-channel form, and **no** FRB runtime type backs the scalar name — `RenderingLibrary.Graphics.Text` has no blur at all, and `LineRectangle`/`LineCircle` have no dropshadow surface. Gum's own source calls this out (`StandardElementsManager.cs`), naming FRB's frozen `RenderableArc` as the casualty and noting "there is no build in this repo that exercises FRB1's frozen consumer to catch a regression here."

The skip is global rather than per-type. `Text` already skipped `DropshadowBlur` (#1948) and Rectangle/Circle skipped it inside their fill/stroke family (#1907), so three sites were independently saying the same thing while the Skia elements said nothing. One global entry replaces those two occurrences and covers any element Gum adds dropshadow to later. Both pipelines are updated, since they must agree or a state assignment references a property the property pipeline never generated (CS0103).

### Why the existing guard missed it

`GumRuntimeMemberContractTests` builds its fixture from FRB's own `SkiaStandardElementsManager`, which hardcodes `DropshadowBlurX`/`DropshadowBlurY` — names the engine really has. It compared a self-consistent copy against itself and stayed green.

Codegen doesn't emit from that schema. It emits from the variables in the project's `.gutx`, i.e. whatever Gum Editor last wrote there. So the new tests inject the variable rather than asserting against FRB's schema: the fixture has to stand in for the `.gutx`, not for what FRB would have produced. Written first — all six Skia elements failed with exactly the reported symptom, and a companion test pins that the backed `DropshadowBlurX`/`DropshadowBlurY` still generate, so this isn't a blanket "drop anything named Dropshadow\*".

251/251 non-BuildSmoke tests green.

### Not fixed here

The same report also hit `CS0234` on a missing `LineRuntime` — Gum added a `Line` standard element that FRB has no runtime for at all. That's a separate break, still open.

Manual test: needed. The fix changes what Glue writes, so it only reaches users through a new FRBDK build. After `glue.yml` runs, create a project from the Desktop GL .NET 9 MonoGame template with Gum and Forms, open it in a current Gum Editor so the standard elements are rewritten, and confirm it still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
