### PR TITLE
Compile the generated Gum runtimes against the real engine

### DIFF
--- a/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
+++ b/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
@@ -59,6 +59,18 @@ Fix: pass `SolutionDir` explicitly, pointed at `FRBDK/Glue/` (the directory cont
 dotnet test FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj -p:SolutionDir="<repo>\FRBDK\Glue\\"
 ```
 
+## Landmine — an orphaned `testhost` locks the output DLLs, and the next run looks like a hang
+
+A cancelled or timed-out `dotnet test` can leave `testhost.exe` alive holding `GlueUnitTests/bin/.../*.dll` open. The next run then can't copy dependencies into `bin`, and fails with `MSB3021`/`MSB3027` naming the holder (`The file is locked by: "testhost (PID)"`). The trap is that the *build* stalls through its 10 retries × 1s per file while producing no test output — piped through a `grep`, that buffers to nothing and reads as a hung test suite rather than a locked file.
+
+Before diagnosing a slow or silent run as a test problem, clear the holders:
+
+```powershell
+Get-Process testhost,vstest.console,MSBuild -ErrorAction SilentlyContinue | Stop-Process -Force
+```
+
+Then re-run with `--no-build` when nothing was recompiled since the last successful build — it skips the copy step the lock blocks, and the full non-BuildSmoke suite finishes in seconds.
+
 ## Deep dive
 
 For the full story of why each seam was needed and what's still NRE-prone (e.g. `AvailableAssetTypes.CommonAtis`

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
@@ -159,8 +159,8 @@ namespace GumPlugin.CodeGeneration
                 "GradientInnerRadius", "GradientInnerRadiusUnits",
                 "GradientOuterRadius", "GradientOuterRadiusUnits",
                 "Alpha2", "Red2", "Green2", "Blue2",
-                // dropshadow (AddDropshadowVariables)
-                "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY", "DropshadowBlur",
+                // dropshadow (AddDropshadowVariables) - "DropshadowBlur" is skipped globally below
+                "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY",
                 "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
                 // blend (AddBlendVariable) - LineRectangle/LineCircle's BlendState has no setter
                 "Blend",
@@ -186,7 +186,6 @@ namespace GumPlugin.CodeGeneration
             _typedVariableNamesToSkipForProperties.Add("Text", new List<string>
             {
                 "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
-                "DropshadowBlur",
                 "LocalizeText",
             });
 
@@ -206,6 +205,16 @@ namespace GumPlugin.CodeGeneration
             // want to support them.
             // If a variable is to be excluded only for certain types, see
             // GetIfShouldGenerateProperty
+            // No FRB runtime type backs a singular "DropshadowBlur" - the Skia renderables split it into
+            // DropshadowBlurX/DropshadowBlurY (RenderableSkiaObject), RenderingLibrary.Graphics.Text has no
+            // blur at all, and LineRectangle/LineCircle have no dropshadow surface whatsoever. A Gum Editor
+            // that writes the singular name into a .gutx therefore feeds codegen a variable nothing can back,
+            // producing CS1061 in the user's game - and because codegen emits from the project's variables
+            // rather than from FRB's own schema, no amount of keeping SkiaStandardElementsManager correct
+            // prevents it. Global (rather than per-type) so an element Gum adds dropshadow to later is
+            // covered on arrival; see GumSkiaRenderableCodegenSweepTests.
+            mVariableNamesToSkipForProperties.Add("DropshadowBlur");
+
             mVariableNamesToSkipForProperties.Add("Custom Texture Coordinates"); // replaced by texture address mode
             mVariableNamesToSkipForProperties.Add("CustomTextureCoordinates"); // replaced by texture address mode
             mVariableNamesToSkipForProperties.Add("Height Units");

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
@@ -105,6 +105,12 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         // (SpriteCodeGenerator.GenerateIRenderTargetTextureReferencerProperties), never state-switch driven.
         // Permanent, version-independent skip - the name is unique to Sprite so a global skip is safe.
         mVariableNamesToSkipForStates.Add("RenderTargetTextureSource");
+
+        // Mirrors the global property-pipeline skip in
+        // StandardsCodeGenerator.RefreshVariableNamesToSkipForProperties - see there for why nothing backs a
+        // singular "DropshadowBlur". Both pipelines must agree or the state switch assigns a property that
+        // was never generated (CS0103).
+        mVariableNamesToSkipForStates.Add("DropshadowBlur");
         //mVariableNamesToSkipForStates.Add("IsBold");
 
         // Eventually we'll support this but first Gum needs to support
@@ -129,7 +135,7 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
             "GradientInnerRadius", "GradientInnerRadiusUnits",
             "GradientOuterRadius", "GradientOuterRadiusUnits",
             "Alpha2", "Red2", "Green2", "Blue2",
-            "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY", "DropshadowBlur",
+            "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY",
             "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
             "Blend",
         };
@@ -150,7 +156,6 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         typeSpecificVariableNamesToSkipForStates.Add("Text", new List<string>
         {
             "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
-            "DropshadowBlur",
             "LocalizeText",
         });
     }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
@@ -134,14 +134,19 @@ public class GumGeneratedCodeCompilesTests : IDisposable
                 var standardElementSave = new StandardElementSave { Name = elementName };
                 standardElementSave.Initialize(defaultState);
 
-                var codeBlock = new CodeBlockBase();
-                if (!StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock))
+                // The production entry point CodeGeneratorManager uses, so the file this test compiles is
+                // byte-for-byte what Glue writes into a user's GumRuntimes folder - including the
+                // `using System.Linq;` and namespace wrapper that GenerateStandardElementSaveCodeFor alone
+                // doesn't emit. Reconstructing that wrapper by hand here would be a second thing to keep in
+                // sync with production, which is the mistake this whole test exists to stop making.
+                var source = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(standardElementSave);
+                if (string.IsNullOrWhiteSpace(source))
                 {
-                    skipped.Add(elementName + " (GenerateStandardElementSaveCodeFor returned false)");
+                    skipped.Add(elementName + " (GenerateCodeFor produced nothing)");
                     continue;
                 }
 
-                generated[elementName] = codeBlock.ToString();
+                generated[elementName] = source;
             }
         }
 
@@ -298,18 +303,9 @@ public class GumGeneratedCodeCompilesTests : IDisposable
 
         File.WriteAllText(Path.Combine(scratchDirectory, "GumCodegenCompileScratch.csproj"), csproj);
 
-        // StandardsCodeGenerator emits the class body only; CodeGeneratorManager's saving path is what puts
-        // it inside a namespace in a real project. The generated code refers to its siblings by fully
-        // qualified name (global::<ProjectNamespace>.GumRuntimes.XxxRuntime), so without the same wrapper
-        // every cross-reference fails with CS0400 and drowns out the errors this test is looking for.
-        var runtimeNamespace = GueDerivingClassCodeGenerator.GueRuntimeNamespace;
-
         foreach (var pair in generated)
         {
-            var wrapped = $"namespace {runtimeNamespace}{Environment.NewLine}{{{Environment.NewLine}" +
-                          pair.Value + Environment.NewLine + "}" + Environment.NewLine;
-
-            File.WriteAllText(Path.Combine(scratchDirectory, pair.Key + "Runtime.Generated.cs"), wrapped);
+            File.WriteAllText(Path.Combine(scratchDirectory, pair.Key + "Runtime.Generated.cs"), pair.Value);
         }
     }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
@@ -1,0 +1,360 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using Gum.DataTypes;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using GumPlugin.CodeGeneration;
+using Shouldly;
+
+namespace GlueUnitTests.GumPluginTests;
+
+// The guard the Rectangle/Circle (#1907), Arc-gradient, Text-dropshadow (#1948) and Skia-DropshadowBlur
+// bugs all needed and none of them had: it *compiles* the generated Gum runtimes against the real engine
+// instead of checking their members against a list.
+//
+// Why compiling is the thing. GumRuntimeMemberContractTests reflects over the built engine and asserts
+// every ContainedXxx.Member the generator emits exists on the mapped runtime type. That catches CS1061,
+// but only for variables it knows to feed in - and it builds its fixture from FRB's *own* schema
+// (Gum.Managers.StandardElementsManager plus GumPlugin.Managers.SkiaStandardElementsManager). FRB's copy
+// of the Skia schema is hand-maintained and has diverged from Gum's, so that sweep compared a
+// self-consistent copy against itself and stayed green while real projects broke.
+//
+// Codegen does not emit from FRB's schema. It emits from the variables in the project's .gutx - whatever
+// the Gum Editor that last saved it wrote there. So this test feeds the generator *Gum's* canonical
+// states (StandardElementsManager.RegisterExtendedDefaultStates, which is what the editor writes) and then
+// asks the C# compiler, rather than a name list, whether the result is valid. That covers the whole class
+// in one assertion: missing members (CS1061), missing types (CS0234/CS0246), and type drift (CS0029/CS0266).
+//
+// The scratch project ProjectReferences the engine rather than hand-listing assemblies deliberately:
+// MonoGame.Framework.dll (which the generated "Color" property needs) is not in the engine's build output
+// at all, it comes from NuGet. Letting MSBuild resolve the closure avoids pinning a MonoGame version here.
+//
+// Tagged BuildSmoke because it shells out to `dotnet build`, same as GumRuntimeMemberContractTests and
+// NewProjectCreationSmokeTests. glue.yml and pr-tests.yml already run Category=BuildSmoke.
+[Trait("Category", "BuildSmoke")]
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class GumGeneratedCodeCompilesTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly bool _originalSynchronousMode;
+    private readonly Gum.DataTypes.GumProjectSave _originalGumProjectSave;
+    private readonly string _tempProjectDirectory;
+
+    public GumGeneratedCodeCompilesTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalGumProjectSave = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+        GlueState.Self.CurrentMainProject = vsProject;
+
+        // LatestVersion stands in for a real, current project - see GumSkiaRenderableCodegenSweepTests'
+        // header for why the Color property's ToXNA conversion makes this load-bearing rather than cosmetic.
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject = new GlueProjectSave
+        {
+            FileVersion = GlueProjectSave.LatestVersion,
+        };
+        TaskManager.SynchronousMode = true;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = new Gum.DataTypes.GumProjectSave
+        {
+            FullFileName = Path.Combine(_tempProjectDirectory, "GumProject", "GumProject.gumx"),
+        };
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject = _originalGlueProject;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = _originalGumProjectSave;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public void GeneratedStandardElementRuntimes_ShouldCompileAgainstTheRealEngine()
+    {
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var repoRoot = FindRepoRoot();
+
+        var elementNames = GetElementNamesFromGumsOwnSchema();
+
+        // Coverage sanity - a sweep that degenerates to nothing is worse than no test at all.
+        elementNames.ShouldContain("Text");
+        elementNames.ShouldContain("Sprite");
+
+        var generated = new Dictionary<string, string>(StringComparer.Ordinal);
+        var skipped = new List<string>();
+
+        using (new GumSchemaWins())
+        {
+            // Fixture sanity: prove we're generating from the editor's schema, not FRB's shadowing copy.
+            // Without this the test can pass vacuously - see GumSchemaWins for why that's the whole
+            // ballgame. FRB's Arc has no dropshadow family at all and its sibling Skia shapes use the
+            // per-axis DropshadowBlurX; Gum's Arc has the dropshadow family with the single scalar
+            // DropshadowBlur. If Gum renames this again, this assertion failing is the correct outcome -
+            // it means the fixture stopped tracking the editor.
+            var arcVariables = GetGumsDefaultStateFor("Arc").ShouldNotBeNull()
+                .Variables.Select(variable => variable.GetRootName()).ToHashSet(StringComparer.Ordinal);
+            arcVariables.ShouldContain("DropshadowBlur",
+                "Gum's Arc schema is not what's driving generation - FRB's copy is still shadowing it.");
+            arcVariables.ShouldNotContain("DropshadowBlurX",
+                "FRB's own Arc schema is still shadowing Gum's, so this test would check FRB against itself.");
+
+            foreach (var elementName in elementNames)
+            {
+                var defaultState = GetGumsDefaultStateFor(elementName);
+                if (defaultState == null)
+                {
+                    skipped.Add(elementName + " (Gum has no default state for it)");
+                    continue;
+                }
+
+                var standardElementSave = new StandardElementSave { Name = elementName };
+                standardElementSave.Initialize(defaultState);
+
+                var codeBlock = new CodeBlockBase();
+                if (!StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock))
+                {
+                    skipped.Add(elementName + " (GenerateStandardElementSaveCodeFor returned false)");
+                    continue;
+                }
+
+                generated[elementName] = codeBlock.ToString();
+            }
+        }
+
+        generated.ShouldNotBeEmpty();
+
+        var scratchDirectory = Path.Combine(_tempProjectDirectory, "CompileScratch");
+        WriteScratchProject(scratchDirectory, repoRoot, generated);
+
+        var (exitCode, output) = RunDotnetBuild(Path.Combine(scratchDirectory, "GumCodegenCompileScratch.csproj"));
+
+        var errors = output
+            .Split('\n')
+            .Where(line => line.Contains(": error ", StringComparison.Ordinal))
+            .Select(line => line.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        // Report which elements were and weren't covered, so a shrinking sweep is visible rather than silent.
+        var coverage =
+            "Compiled: " + string.Join(", ", generated.Keys.OrderBy(name => name, StringComparer.Ordinal)) +
+            Environment.NewLine +
+            "Not generated: " + (skipped.Count == 0 ? "(none)" : string.Join(", ", skipped));
+
+        exitCode.ShouldBe(0,
+            "The generated Gum standard element runtimes do not compile against the real engine. Every " +
+            "error below is one a user would hit in their own game after opening their project in a " +
+            "current Gum Editor:" + Environment.NewLine +
+            string.Join(Environment.NewLine, errors) + Environment.NewLine + Environment.NewLine + coverage);
+    }
+
+    // The standard elements Glue generates runtimes for, read straight off the generator's own map so an
+    // element added there is covered the day it is added.
+    private static List<string> GetElementNamesFromGumsOwnSchema()
+    {
+        return StandardsCodeGenerator.Self.StandardElementToQualifiedTypes
+            .Where(pair => !string.IsNullOrEmpty(pair.Value))
+            .Select(pair => pair.Key)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    // Gum's canonical default state - what a current Gum Editor writes into a .gutx. RegisterExtendedDefaultStates
+    // surfaces the shape/Skia types (Arc/ColoredCircle/RoundedRectangle/Line/Canvas/Svg/LottieAnimation) to
+    // consumers that don't load Gum's WPF Skia plugin, which is exactly this test's situation.
+    private static Gum.DataTypes.Variables.StateSave GetGumsDefaultStateFor(string elementName)
+    {
+        return Gum.Managers.StandardElementsManager.Self
+            .TryGetDefaultStateFor(elementName, throwExceptionOnMissing: false);
+    }
+
+    // THE load-bearing part of this fixture. TryGetDefaultStateFor checks DefaultStates before falling
+    // through to CustomGetDefaultState, and MainGumPlugin.StartUp (and any sibling test that calls
+    // SkiaStandardElementsManager.AddSkiaStandards) puts FRB's own hand-maintained copies of the Skia
+    // schemas into DefaultStates. DefaultStates is process-wide, so whether they're present here depends on
+    // what else ran first.
+    //
+    // If FRB's copies win the lookup, this test compiles FRB's schema against FRB's engine, finds them
+    // trivially consistent, and goes green forever - precisely how the previous guard missed the
+    // DropshadowBlurX/DropshadowBlur divergence.
+    //
+    // Overwrite rather than remove: codegen re-reads DefaultStates mid-generation
+    // (StateCodeGenerator.GetIfShouldGenerateVariableInStateSetter) and throws KeyNotFoundException if the
+    // element is absent, so the entry has to be present - just holding Gum's version, which is what a .gutx
+    // written by a current editor actually contains.
+    private sealed class GumSchemaWins : IDisposable
+    {
+        private readonly Dictionary<string, Gum.DataTypes.Variables.StateSave> _replaced = new(StringComparer.Ordinal);
+        private readonly List<string> _added = new();
+
+        public GumSchemaWins()
+        {
+            var manager = Gum.Managers.StandardElementsManager.Self;
+            manager.RegisterExtendedDefaultStates();
+
+            foreach (var elementName in ElementsGumCanAnswerFor)
+            {
+                // Bypasses TryGetDefaultStateFor deliberately - that would hand back FRB's shadowing copy,
+                // which is the thing being replaced.
+                var gumState = manager.CustomGetDefaultState?.Invoke(elementName);
+                if (gumState == null)
+                {
+                    continue;
+                }
+
+                if (manager.DefaultStates.TryGetValue(elementName, out var frbCopy))
+                {
+                    _replaced[elementName] = frbCopy;
+                }
+                else
+                {
+                    _added.Add(elementName);
+                }
+
+                manager.DefaultStates[elementName] = gumState;
+            }
+        }
+
+        public void Dispose()
+        {
+            var defaultStates = Gum.Managers.StandardElementsManager.Self.DefaultStates;
+            foreach (var pair in _replaced)
+            {
+                defaultStates[pair.Key] = pair.Value;
+            }
+            foreach (var elementName in _added)
+            {
+                defaultStates.Remove(elementName);
+            }
+        }
+    }
+
+    // Mirrors Gum's GetExtendedDefaultState switch - the types Gum can supply, and therefore the ones whose
+    // FRB duplicate must not shadow it.
+    private static readonly string[] ElementsGumCanAnswerFor =
+    {
+        "Arc", "ColoredCircle", "RoundedRectangle", "Line", "Canvas", "Svg", "LottieAnimation",
+    };
+
+    private static void WriteScratchProject(
+        string scratchDirectory, string repoRoot, Dictionary<string, string> generated)
+    {
+        Directory.CreateDirectory(scratchDirectory);
+
+        var formsProject = Path.Combine(repoRoot, "Engines", "Forms", "FlatRedBall.Forms",
+            "FlatRedBall.Forms.DesktopGlNet6", "FlatRedBall.Forms.DesktopGlNet6.csproj");
+        var skiaProject = Path.Combine(repoRoot, "Engines", "SkiaGum", "SkiaInGum.csproj");
+
+        File.Exists(formsProject).ShouldBeTrue($"Expected the engine Forms project at {formsProject}");
+        File.Exists(skiaProject).ShouldBeTrue($"Expected the SkiaInGum project at {skiaProject}");
+
+        // The engine projects mark their MonoGame PackageReference private, so it doesn't flow through
+        // ProjectReference and Microsoft.Xna.Framework.Color (the generated "Color" property's type) won't
+        // resolve without naming it here. Read the version out of the engine project rather than pinning a
+        // copy, so a MonoGame bump there can't silently turn this test into a framework-mismatch failure.
+        var monoGameVersion = ReadNet6MonoGameVersion(skiaProject);
+
+        // net6.0 to match what the engine projects build - a mismatch here fails as a framework error rather
+        // than as the codegen errors this test exists to surface.
+        var csproj = $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net6.0</TargetFramework>
+                <Nullable>disable</Nullable>
+                <LangVersion>latest</LangVersion>
+                <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="{formsProject}" />
+                <ProjectReference Include="{skiaProject}" />
+                <PackageReference Include="MonoGame.Framework.DesktopGL" Version="{monoGameVersion}" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        File.WriteAllText(Path.Combine(scratchDirectory, "GumCodegenCompileScratch.csproj"), csproj);
+
+        // StandardsCodeGenerator emits the class body only; CodeGeneratorManager's saving path is what puts
+        // it inside a namespace in a real project. The generated code refers to its siblings by fully
+        // qualified name (global::<ProjectNamespace>.GumRuntimes.XxxRuntime), so without the same wrapper
+        // every cross-reference fails with CS0400 and drowns out the errors this test is looking for.
+        var runtimeNamespace = GueDerivingClassCodeGenerator.GueRuntimeNamespace;
+
+        foreach (var pair in generated)
+        {
+            var wrapped = $"namespace {runtimeNamespace}{Environment.NewLine}{{{Environment.NewLine}" +
+                          pair.Value + Environment.NewLine + "}" + Environment.NewLine;
+
+            File.WriteAllText(Path.Combine(scratchDirectory, pair.Key + "Runtime.Generated.cs"), wrapped);
+        }
+    }
+
+    // Mirrors the net6 arm of the engine's conditional MonoGame reference (3.8.4.1 is net8-only, see the
+    // comment in SkiaInGum.csproj).
+    private static string ReadNet6MonoGameVersion(string skiaProjectPath)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(
+            File.ReadAllText(skiaProjectPath),
+            """<PackageReference\s+Include="MonoGame\.Framework\.DesktopGL"\s+Version="([^"]+)"\s+Condition="'\$\(TargetFramework\)'\s*!=\s*'net8\.0'""");
+
+        match.Success.ShouldBeTrue(
+            $"Could not read the net6 MonoGame version out of {skiaProjectPath}. If the engine's MonoGame " +
+            "reference was restructured, this test's scratch project needs to follow it.");
+
+        return match.Groups[1].Value;
+    }
+
+    private static (int exitCode, string output) RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"build \"{projectPath}\" -c Debug")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(startInfo)!;
+        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, output);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "Engines", "SkiaGum")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate the FlatRedBall repo root above " + AppContext.BaseDirectory);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumSkiaRenderableCodegenSweepTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumSkiaRenderableCodegenSweepTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.Managers;
@@ -119,7 +120,11 @@ public class GumSkiaRenderableCodegenSweepTests : IDisposable
         }
     }
 
-    private static (bool Generated, string Source, HashSet<string> FixtureVariableNames) GenerateFor(string standardElementName)
+    private static (bool Generated, string Source, HashSet<string> FixtureVariableNames) GenerateFor(string standardElementName) =>
+        GenerateFor(standardElementName, extraVariables: null);
+
+    private static (bool Generated, string Source, HashSet<string> FixtureVariableNames) GenerateFor(
+        string standardElementName, IEnumerable<Gum.DataTypes.Variables.VariableSave> extraVariables)
     {
         GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
         EnsureSkiaStandardElementsRegistered();
@@ -129,6 +134,14 @@ public class GumSkiaRenderableCodegenSweepTests : IDisposable
         // stale) on-disk/embedded template. See RectangleCircleCodegenTests.cs's header for why this matters.
         var standardElementSave = new StandardElementSave { Name = standardElementName };
         standardElementSave.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor(standardElementName));
+
+        // A .gutx on disk carries whatever variables the Gum Editor that last saved it wrote, which is not
+        // necessarily what SkiaStandardElementsManager would have produced - see
+        // GenerateStandardElementSaveCodeFor_SkiaElement_SkipsGumEditorsSingularDropshadowBlur below.
+        if (extraVariables != null)
+        {
+            standardElementSave.DefaultState.Variables.AddRange(extraVariables);
+        }
 
         var fixtureVariableNames = standardElementSave.DefaultState.Variables.Select(v => v.GetRootName()).ToHashSet();
 
@@ -296,5 +309,68 @@ public class GumSkiaRenderableCodegenSweepTests : IDisposable
         // (proves this isn't an accidental blanket exclusion that would trivially pass the above).
         source.ShouldContain("Width = ");
         source.ShouldContain("Height = ");
+    }
+
+    // Matches the singular "DropshadowBlur" without also matching DropshadowBlurX/DropshadowBlurY, which
+    // are real, backed members and must keep generating.
+    private static readonly Regex SingularDropshadowBlur = new(@"DropshadowBlur(?![XY])\w*", RegexOptions.Compiled);
+
+    private static Gum.DataTypes.Variables.VariableSave SingularDropshadowBlurVariable() =>
+        new()
+        {
+            SetsValue = true,
+            Type = "float",
+            Value = 0f,
+            Name = "DropshadowBlur",
+            Category = "Dropshadow",
+        };
+
+    // Reported against GumEditor 2026.08.03: a project that had been opened in that editor failed to build
+    // with CS1061 on 'RenderableArc'/'RenderableCircle'/'RenderableRoundedRectangle' having no
+    // 'DropshadowBlur'. Same bug class as Text's dropshadow channels (#1948) and Rectangle/Circle's
+    // fill/stroke family (#1907), but arriving by a different route, which is why the sweep in
+    // GumRuntimeMemberContractTests could not catch it: that sweep builds its fixture from FRB's own
+    // SkiaStandardElementsManager schema, which uses the two-channel DropshadowBlurX/DropshadowBlurY that
+    // RenderableSkiaObject actually backs. Codegen, however, emits from the variables in the project's
+    // .gutx - whatever the Gum Editor that last saved it wrote there. A Gum Editor that collapses the two
+    // blur channels into one "DropshadowBlur" therefore feeds codegen a variable name no FRB runtime type
+    // has ever had, and nothing in FRB's own schema would ever reveal it.
+    //
+    // Injecting the variable (rather than asserting against the current schema) is the point: the fixture
+    // stands in for the .gutx, not for what FRB would have generated.
+    [Theory]
+    [InlineData("Arc")]
+    [InlineData("ColoredCircle")]
+    [InlineData("LottieAnimation")]
+    [InlineData("RoundedRectangle")]
+    [InlineData("Svg")]
+    [InlineData("Canvas")]
+    public void GenerateStandardElementSaveCodeFor_SkiaElement_SkipsGumEditorsSingularDropshadowBlur(string standardElementName)
+    {
+        var (generated, source, fixtureVariableNames) =
+            GenerateFor(standardElementName, new[] { SingularDropshadowBlurVariable() });
+        generated.ShouldBeTrue();
+
+        // Fixture sanity - if the injection stopped landing, the assertion below would pass vacuously.
+        fixtureVariableNames.ShouldContain("DropshadowBlur");
+
+        var offenders = SingularDropshadowBlur.Matches(source).Select(m => m.Value).Distinct().ToList();
+        offenders.ShouldBeEmpty(
+            $"No FRB runtime type backs a singular 'DropshadowBlur' (RenderableSkiaObject has " +
+            $"DropshadowBlurX/DropshadowBlurY), so generating it produces CS1061 in the user's game. " +
+            $"Emitted: {string.Join(", ", offenders)}");
+    }
+
+    [Fact]
+    public void GenerateStandardElementSaveCodeFor_ColoredCircle_KeepsBackedBlurChannelsWhenSingularBlurIsSkipped()
+    {
+        var (generated, source, _) = GenerateFor("ColoredCircle", new[] { SingularDropshadowBlurVariable() });
+        generated.ShouldBeTrue();
+
+        // Proves the skip is per-member rather than a blanket "drop anything named Dropshadow*" - the two
+        // channels RenderableSkiaObject really has must survive alongside the skipped singular name.
+        source.ShouldContain("ContainedColoredCircle.DropshadowBlurX");
+        source.ShouldContain("ContainedColoredCircle.DropshadowBlurY");
+        source.ShouldContain("ContainedColoredCircle.HasDropshadow");
     }
 }


### PR DESCRIPTION
Stacked on #1955 — review/merge that first.

Compiles every generated Gum standard-element runtime against the real engine, so the C# compiler decides whether codegen is valid instead of a hand-maintained list of member names. One assertion covers the whole recurring class: missing members (CS1061), missing types (CS0234/CS0246), and type drift (CS0029/CS0266).

The generated files go into a scratch `.csproj` that `ProjectReference`s `SkiaInGum` and `FlatRedBall.Forms`, which is then built. Letting MSBuild resolve the closure avoids pinning a MonoGame version here — `MonoGame.Framework.dll` isn't in the engine's build output at all, so a hand-listed reference set would have needed one.

### Why this catches what the existing sweep can't

`GumRuntimeMemberContractTests` builds its fixture from FRB's own `SkiaStandardElementsManager`, which hardcodes the per-axis `DropshadowBlurX`/`DropshadowBlurY`. Gum #2950 collapsed those into a scalar `DropshadowBlur`. That sweep therefore compared a self-consistent copy against itself and stayed green while real projects broke — because codegen emits from the `.gutx`, written by whatever Gum Editor last saved it, not from FRB's schema.

So this test feeds the generator **Gum's** canonical states (`RegisterExtendedDefaultStates`). Keeping FRB's duplicate is fine and intended — the Skia rendering has genuinely diverged — but the guard has to be fed the editor's schema or it verifies nothing.

Two things that make that work:

- `GumSchemaWins` **overwrites** rather than removes the shadowing entries. Codegen re-reads `DefaultStates` mid-generation and throws `KeyNotFoundException` if an element is absent.
- `DefaultStates` is process-wide, so whether FRB's copies are present depends on what ran first. A fixture-sanity assertion pins that Arc really carries Gum's `DropshadowBlur` and not FRB's `DropshadowBlurX`. Without it this test can pass vacuously — precisely the failure mode it exists to replace.

It calls the production `GueDerivingClassCodeGenerator.GenerateCodeFor` entry point, so the compiled file is byte-for-byte what Glue writes, including the `using`/namespace wrapper. Reconstructing that by hand was a second thing to keep in sync with production.

### Verification

Reverting the `DropshadowBlur` skip turns it red with exactly the reported `CS1061`s on `RenderableArc`/`RenderableCircle`/`RenderableRoundedRectangle`, and it independently rediscovers the `Text` (#1948) and `LineCircle`/`LineRectangle` (#1907) instances of the same class. 251/251 non-BuildSmoke green; 3/3 BuildSmoke Gum tests green.

### Known gap

The element list is driven off `StandardsCodeGenerator.StandardElementToQualifiedTypes`, so this covers what FRB claims to support. Gum's `Line` standard element isn't in that map at all — which is itself the unfixed `CS0234: 'LineRuntime' does not exist` half of the original report. This harness will not catch it, and it stays open.

Manual test: not needed — test-only change, and it's verified by the red/green flip above rather than by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
