### PR TITLE
Run Glue tests on every pull request

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -3,14 +3,9 @@ name: Glue Tests (PR)
 # Runs on pull requests so tests actually gate merges. The existing glue.yml / Engine.yml are
 # workflow_dispatch-only publish pipelines (they FTP-upload with secrets) and must not run per-PR.
 on:
-  # No branches: filter - that filters on the PR's *base*, so a PR stacked on another feature branch
-  # got no CI at all.
+  # Every pull request, whatever its base. No branches: filter, because that filters on the PR's *base*
+  # branch, so a PR stacked on another feature branch got no CI at all.
   pull_request:
-  # Post-merge signal. Deliberately not every branch: a feature branch with a PR open would then run
-  # this whole suite twice per push, for identical results.
-  push:
-    branches:
-      - NetStandard
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,7 +1,9 @@
 name: Glue Tests (PR)
 
-# Runs on pull requests so tests actually gate merges. The existing glue.yml / Engine.yml are
-# workflow_dispatch-only publish pipelines (they FTP-upload with secrets) and must not run per-PR.
+# Runs on pull requests to surface breakage. Advisory only: no check here blocks a merge unless it's
+# explicitly marked required in branch protection, which nothing currently is. The existing glue.yml /
+# Engine.yml are workflow_dispatch-only publish pipelines (they FTP-upload with secrets) and must not
+# run per-PR.
 on:
   # Every pull request, whatever its base. No branches: filter, because that filters on the PR's *base*
   # branch, so a PR stacked on another feature branch got no CI at all.

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -3,7 +3,12 @@ name: Glue Tests (PR)
 # Runs on pull requests so tests actually gate merges. The existing glue.yml / Engine.yml are
 # workflow_dispatch-only publish pipelines (they FTP-upload with secrets) and must not run per-PR.
 on:
+  # No branches: filter - that filters on the PR's *base*, so a PR stacked on another feature branch
+  # got no CI at all.
   pull_request:
+  # Post-merge signal. Deliberately not every branch: a feature branch with a PR open would then run
+  # this whole suite twice per push, for identical results.
+  push:
     branches:
       - NetStandard
   workflow_dispatch:


### PR DESCRIPTION
Runs the existing Glue test suite on every pull request. That's the whole change.

`pull_request`'s `branches:` filter matches the PR's **base** branch, not the head, so a PR stacked on another feature branch (#1957 on #1955) got no CI at all. Dropping the filter covers every PR regardless of base.

Non-blocking, and stays that way. `NetStandard` has no branch protection and the repo has no rulesets, so no check can block a merge until one is explicitly marked required in branch protection. That's a separate switch for later.

Manual test: not needed. This PR runs under the trigger it changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
