### PR TITLE
Support Rectangle Fill/Stroke on gumx v3, bump Glue's new-project template

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
@@ -595,6 +595,20 @@ public class GueDerivingClassCodeGenerator : Singleton<GueDerivingClassCodeGener
 
         ifStatement.Line("FlatRedBall.IO.FileManager.RelativeDirectory = FlatRedBall.IO.FileManager.GetDirectory(Gum.Managers.ObjectFinder.Self.GumProjectSave.FullFileName);");
 
+        // Issue #1967 - Gum's FallbackRenderableFactory.TryHandleAsBaseType hardcodes "Rectangle" to
+        // always construct a LineRectangle for FRB builds (no gumx-version awareness - see that class's
+        // own "do not extend this switch" doc comment in the sibling Gum repo). That fallback only runs
+        // when SetGraphicalUiElement below finds RenderableComponent still null after construction
+        // ("This could have already been created by the type that is instantiated, so don't do this to
+        // double-create" - ElementSaveExtensions.GumRuntime.cs). So a v3 Rectangle must construct its
+        // RenderableComponent explicitly, here, before that call - otherwise it silently stays a
+        // LineRectangle, ContainedRectangle's "as FilledStrokedRectangle" cast returns null, and
+        // SetInitialState's state-switch NREs on ContainedRectangle.FillColor/StrokeColor.
+        if(elementSave.Name == "Rectangle" && GumPlugin.CodeGeneration.StandardsCodeGenerator.IsRectangleFillStrokeSupported)
+        {
+            ifStatement.Line("this.RenderableComponent = new RenderingLibrary.Math.Geometry.FilledStrokedRectangle();");
+        }
+
         ifStatement.Line("GumRuntime.ElementSaveExtensions.SetGraphicalUiElement(elementSave, this, RenderingLibrary.SystemManagers.Default);");
 
         ifStatement.Line("FlatRedBall.IO.FileManager.RelativeDirectory = oldDirectory;");

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
@@ -571,6 +571,34 @@ public class GueDerivingClassCodeGenerator : Singleton<GueDerivingClassCodeGener
             constructor.Line($"this.ExposeChildrenEvents = {exposeChildrenEvents.ToString().ToLowerInvariant()};");
         }
 
+        // Issue #1967 - Gum's FallbackRenderableFactory.TryHandleAsBaseType hardcodes "Rectangle" to
+        // always construct a LineRectangle for FRB builds (no gumx-version awareness - see that class's
+        // own "do not extend this switch" doc comment in the sibling Gum repo). That fallback only runs
+        // when SetGraphicalUiElement finds RenderableComponent still null after construction ("This could
+        // have already been created by the type that is instantiated, so don't do this to double-create" -
+        // ElementSaveExtensions.GumRuntime.cs). So a v3 Rectangle must construct its RenderableComponent
+        // explicitly, here - otherwise it silently stays a LineRectangle, ContainedRectangle's "as
+        // FilledStrokedRectangle" cast returns null, and SetInitialState's state-switch NREs on
+        // ContainedRectangle.FillColor/StrokeColor.
+        //
+        // Deliberately OUTSIDE the `if (fullInstantiation)` block below, unlike the rest of this
+        // constructor: a Rectangle placed as a named instance inside a screen/component - the common case
+        // - is constructed via GumRuntime.ElementSaveExtensions.CreateGueForElement, whose
+        // fullInstantiation parameter defaults to false (InstanceSaveExtensionMethods.ToGraphicalUiElement
+        // never passes it). SetGraphicalUiElement is then called on it EXTERNALLY, by that same caller,
+        // after construction - so gating this on fullInstantiation (as an earlier version of this fix did)
+        // left it unset for every screen-placed Rectangle, silently falling through to the LineRectangle
+        // fallback and NREing in SetInitialState. Running unconditionally, before fullInstantiation is
+        // even checked, guarantees RenderableComponent is already correct by the time ANY caller -
+        // this constructor's own fullInstantiation:true branch, or an external SetGraphicalUiElement call
+        // - reaches that null check.
+        if(elementSave.Name == "Rectangle" && GumPlugin.CodeGeneration.StandardsCodeGenerator.IsRectangleFillStrokeSupported)
+        {
+            // RenderableComponent is get-only (backed by mContainedObjectAsIpso) - SetContainedObject
+            // is GraphicalUiElement's real API for assigning it.
+            constructor.Line("this.SetContainedObject(new RenderingLibrary.Math.Geometry.FilledStrokedRectangle());");
+        }
+
         var ifStatement = constructor.If("fullInstantiation");
 
         string componentScreenOrStandard = null;
@@ -594,23 +622,6 @@ public class GueDerivingClassCodeGenerator : Singleton<GueDerivingClassCodeGener
         ifStatement.Line("string oldDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;");
 
         ifStatement.Line("FlatRedBall.IO.FileManager.RelativeDirectory = FlatRedBall.IO.FileManager.GetDirectory(Gum.Managers.ObjectFinder.Self.GumProjectSave.FullFileName);");
-
-        // Issue #1967 - Gum's FallbackRenderableFactory.TryHandleAsBaseType hardcodes "Rectangle" to
-        // always construct a LineRectangle for FRB builds (no gumx-version awareness - see that class's
-        // own "do not extend this switch" doc comment in the sibling Gum repo). That fallback only runs
-        // when SetGraphicalUiElement below finds RenderableComponent still null after construction
-        // ("This could have already been created by the type that is instantiated, so don't do this to
-        // double-create" - ElementSaveExtensions.GumRuntime.cs). So a v3 Rectangle must construct its
-        // RenderableComponent explicitly, here, before that call - otherwise it silently stays a
-        // LineRectangle, ContainedRectangle's "as FilledStrokedRectangle" cast returns null, and
-        // SetInitialState's state-switch NREs on ContainedRectangle.FillColor/StrokeColor.
-        if(elementSave.Name == "Rectangle" && GumPlugin.CodeGeneration.StandardsCodeGenerator.IsRectangleFillStrokeSupported)
-        {
-            // RenderableComponent is get-only (backed by mContainedObjectAsIpso) - SetContainedObject
-            // is GraphicalUiElement's real API for assigning it (the same method the fallback path
-            // ultimately relies on RenderableComponent already being populated instead of).
-            ifStatement.Line("this.SetContainedObject(new RenderingLibrary.Math.Geometry.FilledStrokedRectangle());");
-        }
 
         ifStatement.Line("GumRuntime.ElementSaveExtensions.SetGraphicalUiElement(elementSave, this, RenderingLibrary.SystemManagers.Default);");
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/GueDerivingClassCodeGenerator.cs
@@ -606,7 +606,10 @@ public class GueDerivingClassCodeGenerator : Singleton<GueDerivingClassCodeGener
         // SetInitialState's state-switch NREs on ContainedRectangle.FillColor/StrokeColor.
         if(elementSave.Name == "Rectangle" && GumPlugin.CodeGeneration.StandardsCodeGenerator.IsRectangleFillStrokeSupported)
         {
-            ifStatement.Line("this.RenderableComponent = new RenderingLibrary.Math.Geometry.FilledStrokedRectangle();");
+            // RenderableComponent is get-only (backed by mContainedObjectAsIpso) - SetContainedObject
+            // is GraphicalUiElement's real API for assigning it (the same method the fallback path
+            // ultimately relies on RenderableComponent already being populated instead of).
+            ifStatement.Line("this.SetContainedObject(new RenderingLibrary.Math.Geometry.FilledStrokedRectangle());");
         }
 
         ifStatement.Line("GumRuntime.ElementSaveExtensions.SetGraphicalUiElement(elementSave, this, RenderingLibrary.SystemManagers.Default);");

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
@@ -168,8 +168,24 @@ namespace GumPlugin.CodeGeneration
 
             _typedVariableNamesToSkipForProperties.Add("Circle", new List<string>(fillStrokeGradientDropshadowBlendVariables));
 
-            var rectangleVariablesToSkip = new List<string>(fillStrokeGradientDropshadowBlendVariables)
+            // Issue #1967 - unlike Circle, a v3 (ShapeVariableExpansion) Rectangle CAN back its
+            // fill/stroke family - see FillStrokeVariableNames/IsRectangleFillStrokeSupported below,
+            // which decide this live (per-generation, not per skip-list-refresh) since the same
+            // singleton generator serves every Gum project version Glue might have loaded. So the
+            // fill/stroke names are deliberately left OUT of Rectangle's unconditional skip list here;
+            // gradient/dropshadow/blend/corner-radius remain unconditionally excluded - those need the
+            // optional Skia/Apos shape package FRB has no integration with, regardless of gumx version.
+            var rectangleVariablesToSkip = new List<string>
             {
+                "UseGradient", "GradientType",
+                "GradientX1", "GradientX1Units", "GradientY1", "GradientY1Units",
+                "GradientX2", "GradientX2Units", "GradientY2", "GradientY2Units",
+                "GradientInnerRadius", "GradientInnerRadiusUnits",
+                "GradientOuterRadius", "GradientOuterRadiusUnits",
+                "Alpha2", "Red2", "Green2", "Blue2",
+                "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY",
+                "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
+                "Blend",
                 // Rounded-corner surface (Rectangle only - a Circle has no corners). LineRectangle
                 // always renders hard corners.
                 "CornerRadius",
@@ -496,14 +512,38 @@ namespace GumPlugin.CodeGeneration
             // Sprites handle this in GenerateAdditionalMethods
         }
 
-        private string CreateContainedObjectMembers(ICodeBlock currentBlock, ElementSave standardElementSave)
+        // Issue #1967 - a v3 (ShapeVariableExpansion) Rectangle backs its Fill/Stroke variable
+        // family with RenderingLibrary.Math.Geometry.FilledStrokedRectangle (Gum #4342) instead of
+        // the outline-only LineRectangle used on v2 projects. Gated on Gum's own project version
+        // (GumxVersions), not Glue's GluxVersions - this is about which variable surface the
+        // project's Rectangle.gutx was authored against, not about the Glue file format.
+        internal static bool IsRectangleFillStrokeSupported =>
+            Gum.Managers.ObjectFinder.Self.GumProjectSave?.Version >= (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;
+
+        internal static readonly HashSet<string> RectangleFillStrokeVariableNames = new()
         {
+            "IsFilled", "FillAlpha", "FillRed", "FillGreen", "FillBlue",
+            "StrokeWidth", "StrokeAlpha", "StrokeRed", "StrokeGreen", "StrokeBlue",
+        };
+
+        private string GetQualifiedTypeFor(ElementSave standardElementSave)
+        {
+            if(standardElementSave.Name == "Rectangle" && IsRectangleFillStrokeSupported)
+            {
+                return "RenderingLibrary.Math.Geometry.FilledStrokedRectangle";
+            }
+
             if(mStandardElementToQualifiedTypes.ContainsKey(standardElementSave.Name) == false)
             {
                 throw new InvalidOperationException($"The {nameof(mStandardElementToQualifiedTypes)} " +
                     $"does not contain the key {standardElementSave.Name}. Look at the StandardsCodeGenerator constructor and add an entry there.");
             }
-            string qualifiedBaseType = mStandardElementToQualifiedTypes[standardElementSave.Name];
+            return mStandardElementToQualifiedTypes[standardElementSave.Name];
+        }
+
+        private string CreateContainedObjectMembers(ICodeBlock currentBlock, ElementSave standardElementSave)
+        {
+            string qualifiedBaseType = GetQualifiedTypeFor(standardElementSave);
 
             if(!string.IsNullOrEmpty(qualifiedBaseType))
             {
@@ -551,6 +591,14 @@ namespace GumPlugin.CodeGeneration
                 {
                     return false;
                 }
+            }
+
+            // Issue #1967 - Rectangle's fill/stroke family is intentionally NOT in the static skip
+            // list above (see the comment on rectangleVariablesToSkip); it's decided live here so one
+            // process serving both v2 and v3 Gum projects generates the right thing for each.
+            if(standardElementSave.Name == "Rectangle" && RectangleFillStrokeVariableNames.Contains(variableName))
+            {
+                return IsRectangleFillStrokeSupported;
             }
 
             // Core Gum objets don't have states, so if it's a state then don't create a property for it - it'll be handled
@@ -704,7 +752,52 @@ namespace GumPlugin.CodeGeneration
                 return true;
             }
 
-            if (elementSave.Name == "Circle" || 
+            // Issue #1967 - v3 Rectangle's Fill*/Stroke* channels compose FilledStrokedRectangle's
+            // composite FillColor/StrokeColor (System.Drawing.Color, immutable - unlike the legacy
+            // Red/Green/Blue/Alpha block below, which mutates a field on XNA's Color). Mirrors the
+            // "GumUsesSystemTypes" branch of that block, since this is new code with no pre-System-types
+            // project to stay compatible with.
+            if(elementSave.Name == "Rectangle" && IsRectangleFillStrokeSupported)
+            {
+                // The synthetic "Color" convenience property (variableNamesToAddForProperties) is added
+                // for every Rectangle regardless of gumx version, and normally passes straight through to
+                // ContainedRectangle.Color - which doesn't exist on FilledStrokedRectangle (only
+                // FillColor/StrokeColor). Route it to StrokeColor instead, matching Gum's own legacy-
+                // Color-routes-to-Stroke convention (#2938) - the same convention the byte-channel Alpha/
+                // Red/Green/Blue block below already follows for v2 Rectangles. Caught by
+                // GumRuntimeMemberContractTests.V3RectangleFillStrokeMembers_ShouldExistOnFilledStrokedRectangle
+                // (CS1061 in any real project using a v3 Rectangle before this fix).
+                if(variable.Name == "Color")
+                {
+                    var rightSide = AdjustStandardElementVariableSetIfNecessary(variable, "value");
+                    setter.Line($"ContainedRectangle.StrokeColor = {rightSide};");
+                    return true;
+                }
+
+                string rectangleColorProperty = null;
+                string rectangleColorComponent = null;
+
+                var rootName = variable.GetRootName();
+                if(rootName.StartsWith("Fill"))
+                {
+                    rectangleColorProperty = "FillColor";
+                    rectangleColorComponent = rootName.Substring("Fill".Length);
+                }
+                else if(rootName.StartsWith("Stroke") && rootName != "StrokeWidth")
+                {
+                    rectangleColorProperty = "StrokeColor";
+                    rectangleColorComponent = rootName.Substring("Stroke".Length);
+                }
+
+                if(rectangleColorProperty != null)
+                {
+                    setter.Line($"var color = ToolsUtilitiesStandard.Helpers.ColorExtensions.With{rectangleColorComponent}(ContainedRectangle.{rectangleColorProperty}, (byte)value);");
+                    setter.Line($"ContainedRectangle.{rectangleColorProperty} = color;");
+                    return true;
+                }
+            }
+
+            if (elementSave.Name == "Circle" ||
                 elementSave.Name == "Rectangle" ||
                 elementSave.Name == "Polygon")
             {
@@ -801,6 +894,40 @@ namespace GumPlugin.CodeGeneration
                 return true;
             }
             // handle colors:
+
+            // Issue #1967 - mirrors the setter block above; see its comment for why this is a
+            // separate block rather than folding into the generic Circle/Rectangle/Polygon Color
+            // handling right below.
+            if(elementSave.Name == "Rectangle" && IsRectangleFillStrokeSupported)
+            {
+                if(variable.Name == "Color")
+                {
+                    var whatToReturn = AdjustStandardElementVariableGetIfNecessary(variable, "ContainedRectangle.StrokeColor");
+                    getter.Line($"return {whatToReturn};");
+                    return true;
+                }
+
+                var rootName = variable.GetRootName();
+                string rectangleColorProperty = null;
+                string rectangleColorComponent = null;
+
+                if(rootName.StartsWith("Fill"))
+                {
+                    rectangleColorProperty = "FillColor";
+                    rectangleColorComponent = rootName.Substring("Fill".Length);
+                }
+                else if(rootName.StartsWith("Stroke") && rootName != "StrokeWidth")
+                {
+                    rectangleColorProperty = "StrokeColor";
+                    rectangleColorComponent = rootName.Substring("Stroke".Length);
+                }
+
+                if(rectangleColorProperty != null)
+                {
+                    getter.Line($"return ContainedRectangle.{rectangleColorProperty}.{rectangleColorComponent[0]};");
+                    return true;
+                }
+            }
 
             if (elementSave.Name == "Circle" || elementSave.Name == "Rectangle"  ||
                 elementSave.Name == "Polygon")

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
@@ -142,8 +142,22 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
 
         typeSpecificVariableNamesToSkipForStates.Add("Circle", new List<string>(fillStrokeGradientDropshadowBlendVariables));
 
-        var rectangleVariablesToSkip = new List<string>(fillStrokeGradientDropshadowBlendVariables)
+        // Issue #1967 - mirrors StandardsCodeGenerator.RefreshVariableNamesToSkipForProperties: unlike
+        // Circle, a v3 Rectangle's fill/stroke family IS backed (FilledStrokedRectangle), decided live
+        // per-generation in GetIfShouldGenerateVariableInStateSetter below rather than baked into this
+        // skip list, since one singleton generator serves whatever gumx version is currently loaded.
+        // Gradient/dropshadow/blend/corner-radius remain unconditionally excluded here.
+        var rectangleVariablesToSkip = new List<string>
         {
+            "UseGradient", "GradientType",
+            "GradientX1", "GradientX1Units", "GradientY1", "GradientY1Units",
+            "GradientX2", "GradientX2Units", "GradientY2", "GradientY2Units",
+            "GradientInnerRadius", "GradientInnerRadiusUnits",
+            "GradientOuterRadius", "GradientOuterRadiusUnits",
+            "Alpha2", "Red2", "Green2", "Blue2",
+            "HasDropshadow", "DropshadowOffsetX", "DropshadowOffsetY",
+            "DropshadowAlpha", "DropshadowRed", "DropshadowGreen", "DropshadowBlue",
+            "Blend",
             "CornerRadius",
             "CustomRadiusTopLeft", "CustomRadiusTopRight", "CustomRadiusBottomLeft", "CustomRadiusBottomRight",
         };
@@ -566,6 +580,14 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         if (toReturn && mVariableNamesToSkipForStates.Contains(variableRootName))
         {
             toReturn = false;
+        }
+
+        // Issue #1967 - mirrors StandardsCodeGenerator.GetIfShouldGenerateProperty's live check;
+        // see the comment on rectangleVariablesToSkip above for why this isn't a static skip entry.
+        if (toReturn && container.Name == "Rectangle" &&
+            GumPlugin.CodeGeneration.StandardsCodeGenerator.RectangleFillStrokeVariableNames.Contains(variableRootName))
+        {
+            toReturn = GumPlugin.CodeGeneration.StandardsCodeGenerator.IsRectangleFillStrokeSupported;
         }
 
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/EmptyProject/GumProject.gumx
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/EmptyProject/GumProject.gumx
@@ -6,7 +6,7 @@
   <FontSpacingHorizontal>1</FontSpacingHorizontal>
   <UseFontCharacterFile>false</UseFontCharacterFile>
   <AutoSizeFontOutputs>false</AutoSizeFontOutputs>
-  <Version>2</Version>
+  <Version>3</Version>
   <DefaultCanvasWidth>800</DefaultCanvasWidth>
   <DefaultCanvasHeight>600</DefaultCanvasHeight>
   <CustomCanvasSizes>

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/EmptyProject/Standards/Rectangle.gutx
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Embedded/EmptyProject/Standards/Rectangle.gutx
@@ -3,16 +3,23 @@
   <Name>Rectangle</Name>
   <State>
     <Name>Default</Name>
-    <Variable Type="int" Name="Alpha" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
-    <Variable Type="int" Name="Blue" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="bool" Name="ExposeChildrenEvents" Category="Behavior" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
-    <Variable Type="int" Name="Green" Category="Rendering" SetsValue="true">
+    <!-- Fill/Stroke family (Gum v3 ShapeVariableExpansion, issue #1967) - replaces the legacy plain
+         Red/Green/Blue/Alpha, which routed to the outline color. FilledStrokedRectangle has no
+         backing Color member, only FillColor/StrokeColor, so those legacy names cannot coexist with
+         this family on a v3 project (see StandardsCodeGenerator's Rectangle Fill/Stroke handling). -->
+    <Variable Type="int" Name="FillAlpha" Category="Rendering" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="int" Name="FillBlue" Category="Rendering" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="int" Name="FillGreen" Category="Rendering" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="int" Name="FillRed" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable Type="string" Name="Guide" Category="Position" SetsValue="true" />
@@ -28,6 +35,9 @@
     <Variable Type="bool" Name="IgnoredByParentSize" Category="Parent" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="bool" Name="IsFilled" Category="Rendering" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="bool" Name="IsXamarinFormsControl" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -36,14 +46,26 @@
     <Variable Type="float?" Name="MinHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="float?" Name="MinWidth" Category="Dimensions" SetsValue="true" />
     <Variable Type="string" Name="Parent" Category="Parent" SetsValue="true" />
-    <Variable Type="int" Name="Red" Category="Rendering" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
     <Variable Type="float" Name="Rotation" Category="Flip and Rotation" SetsValue="false">
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
       <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+    <Variable Type="int" Name="StrokeAlpha" Category="Rendering" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="int" Name="StrokeBlue" Category="Rendering" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="int" Name="StrokeGreen" Category="Rendering" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="int" Name="StrokeRed" Category="Rendering" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="StrokeWidth" Category="Rendering" SetsValue="true">
+      <Value xsi:type="xsd:float">2</Value>
     </Variable>
     <Variable Type="bool" Name="Visible" Category="States and Visibility" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>

--- a/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/ErrorReporter.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/ErrorReporter.cs
@@ -21,7 +21,18 @@ namespace GumPlugin.ErrorReporting
 
             FillWithReferencedFilesNotInGumx(errors);
 
+            FillWithRectangleFillStrokeRuntimeVersionError(errors);
+
             return errors.ToArray();
+        }
+
+        private void FillWithRectangleFillStrokeRuntimeVersionError(List<ErrorViewModel> errors)
+        {
+            if (!RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed())
+            {
+                var detectedVersion = RectangleFillStrokeRuntimeVersionCheck.DetectedRuntimeSyntaxVersion();
+                errors.Add(new RectangleFillStrokeRuntimeVersionError(detectedVersion));
+            }
         }
 
         private void FillWithReferencedFilesNotInGumx(List<ErrorViewModel> errors)

--- a/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionCheck.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionCheck.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using Gum.DataTypes;
 using GumPlugin.Managers;
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionCheck.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionCheck.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.Managers;
+using Gum.DataTypes;
+using GumPlugin.Managers;
+
+namespace GumPlugin.ErrorReporting
+{
+    /// <summary>
+    /// Detection logic backing <see cref="RectangleFillStrokeRuntimeVersionError"/> - split out so
+    /// both the error's construction (message) and its GetIfIsFixed() re-check call the exact same
+    /// resolution path, and so it's unit-testable without going through ErrorReporter's full scan.
+    /// </summary>
+    internal static class RectangleFillStrokeRuntimeVersionCheck
+    {
+        internal const int RequiredRuntimeSyntaxVersion = 4;
+
+        private static readonly string[] DllReferenceNames =
+        {
+            "GumCore.DesktopGlNet6", "GumCore.FNA", "GumCore.Kni.DesktopGL", "GumCore.Kni.Web",
+            "GumCoreAndroid", "GumCoreiOS",
+        };
+
+        private static readonly string[] NuGetPackageNames =
+        {
+            "FlatRedBall.GumCore.DesktopGlNet6", "FlatRedBall.GumCore.FNA",
+            "FlatRedBall.GumCore.Kni.DesktopGL", "FlatRedBall.GumCore.Kni.Web",
+            "FlatRedBall.GumCoreAndroid", "FlatRedBall.GumCoreiOS",
+        };
+
+        /// <summary>
+        /// True if a v3 gumx Rectangle Fill/Stroke project's referenced engine build actually supports
+        /// it - source-linked projects are trusted (established codebase convention, see
+        /// IsFrbSourceLinked() call sites throughout StandardsCodeGenerator), everyone else needs the
+        /// referenced GumCore.*.dll to declare GumSyntaxVersion &gt;= 4.
+        /// </summary>
+        public static bool GetIfCurrentlyFixed()
+        {
+            var gumProject = AppState.Self.GumProjectSave;
+            if (gumProject == null ||
+                gumProject.Version < (int)GumProjectSave.GumxVersions.ShapeVariableExpansion)
+            {
+                return true;
+            }
+
+            if (GlueState.Self.CurrentMainProject?.IsFrbSourceLinked() == true)
+            {
+                return true;
+            }
+
+            return DetectedRuntimeSyntaxVersion() is int version && version >= RequiredRuntimeSyntaxVersion;
+        }
+
+        /// <summary>
+        /// Resolves and reads the referenced GumCore.*.dll's GumSyntaxVersion, or null if no such
+        /// reference could be found/read (treated as "too old" by <see cref="GetIfCurrentlyFixed"/>,
+        /// per the attribute's own "absent means pre-unification" contract).
+        /// </summary>
+        internal static int? DetectedRuntimeSyntaxVersion()
+        {
+            var mainProject = GlueState.Self.CurrentMainProject;
+            var csprojPath = mainProject?.FullFileName?.FullPath;
+            if (string.IsNullOrEmpty(csprojPath) || !File.Exists(csprojPath))
+            {
+                return null;
+            }
+
+            string csprojContents;
+            try
+            {
+                csprojContents = File.ReadAllText(csprojPath);
+            }
+            catch
+            {
+                return null;
+            }
+
+            var csprojDirectory = Path.GetDirectoryName(csprojPath);
+
+            foreach (var referenceName in DllReferenceNames)
+            {
+                var hintPath = GumRuntimeSyntaxVersionReader.TryFindHintPath(csprojContents, csprojDirectory, referenceName);
+                if (hintPath != null && File.Exists(hintPath))
+                {
+                    return GumRuntimeSyntaxVersionReader.ReadVersion(hintPath);
+                }
+            }
+
+            var nuGetCacheRoot = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+
+            foreach (var packageName in NuGetPackageNames)
+            {
+                var dllPath = GumRuntimeSyntaxVersionReader.TryFindPackageReferenceDll(csprojContents, packageName, nuGetCacheRoot);
+                if (dllPath != null)
+                {
+                    return GumRuntimeSyntaxVersionReader.ReadVersion(dllPath);
+                }
+            }
+
+            // Neither a recognized DLL reference nor NuGet package was found. This is not necessarily
+            // an error on its own (could be an unusual project setup) - GetIfCurrentlyFixed already
+            // returned true for source-linked projects above, so anything reaching here without a
+            // resolvable reference is treated the same as "too old" rather than silently passing.
+            return null;
+        }
+    }
+}

--- a/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionError.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionError.cs
@@ -1,0 +1,37 @@
+using FlatRedBall.Glue.Errors;
+
+namespace GumPlugin.ErrorReporting
+{
+    /// <summary>
+    /// Issue #1967 bug #2 - a gumx v3 (ShapeVariableExpansion) project generates Rectangle codegen
+    /// against RenderingLibrary.Math.Geometry.FilledStrokedRectangle, which only exists on a
+    /// referenced Gum runtime assembly stamped GumSyntaxVersion 4 or later. A stale, non-source-linked
+    /// binary reference predating that (Gum PR #4342) compiles fine but NREs at runtime
+    /// (RectangleRuntime.Generated.cs's set_FillAlpha etc., ContainedRectangle resolves to null) - this
+    /// surfaces that mismatch as a clear Glue-time error instead.
+    /// </summary>
+    internal class RectangleFillStrokeRuntimeVersionError : ErrorViewModel
+    {
+        public override string UniqueId => Details;
+
+        public RectangleFillStrokeRuntimeVersionError(int? detectedVersion)
+        {
+            var detected = detectedVersion.HasValue ? detectedVersion.Value.ToString() : "not present";
+            Details =
+                "This project's Gum project is on gumx version 3+ (Rectangle Fill/Stroke support), " +
+                "but the referenced Gum runtime assembly (GumCore.*.dll) declares GumSyntaxVersion " +
+                $"{detected}, which is below the required version 4. Rectangle instances with " +
+                "IsFilled/FillColor/StrokeColor/StrokeWidth set will compile but throw a " +
+                "NullReferenceException at runtime. Fix: relink FlatRedBall/Gum as source (recommended " +
+                "for local development), or update your GumCore NuGet package reference to a version " +
+                "built from Gum commit 43e2e7a42 or later (\"Add FilledStrokedRectangle\", #4342).";
+        }
+
+        public override bool GetIfIsFixed()
+        {
+            // Re-evaluated by RectangleFillStrokeRuntimeVersionCheck.GetIfIsFixed() via ErrorReporter's
+            // next scan - this instance's job is only to hold the message computed at report time.
+            return RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed();
+        }
+    }
+}

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Managers/GumRuntimeSyntaxVersionReader.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Managers/GumRuntimeSyntaxVersionReader.cs
@@ -1,0 +1,204 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text.RegularExpressions;
+
+namespace GumPlugin.Managers;
+
+/// <summary>
+/// Reads the <c>Gum.DataTypes.GumSyntaxVersionAttribute</c> stamped on a referenced Gum runtime
+/// assembly (e.g. GumCore.DesktopGlNet6.dll), so Glue codegen can tell whether the engine a user's
+/// project actually references supports a given Gum runtime feature - as opposed to trusting the
+/// gumx project version alone, which only says what the *project* wants, not what the *referenced
+/// binary* actually contains (issue #1967: a v3 gumx generating FilledStrokedRectangle-backed
+/// Rectangle code against a stale, non-source-linked GumCore.*.dll that predates that type).
+/// </summary>
+/// <remarks>
+/// Deliberately reads raw ECMA-335 metadata via <see cref="PEReader"/> rather than loading the
+/// assembly (Assembly.LoadFrom/MetadataLoadContext) - a real GumCore.*.dll pulls in MonoGame/XNA
+/// native dependencies Glue has no business loading just to read one assembly-level attribute.
+/// Mirrors Gum.ProjectServices.CodeGeneration.SyntaxVersionDetectionService.ReadVersionFromAssembly
+/// in the sibling Gum repo (that service's own equivalent, used by Gum's own tooling) - kept as a
+/// separate small copy here rather than a shared reference, since Glue does not otherwise depend on
+/// Gum.ProjectServices.
+/// </remarks>
+public static class GumRuntimeSyntaxVersionReader
+{
+    /// <summary>
+    /// Resolves a "Reference" assembly name (e.g. "GumCore.DesktopGlNet6") to a HintPath in the
+    /// given project's raw .csproj XML, or null if not found as a plain DLL reference (a
+    /// ProjectReference/PackageReference isn't handled here - see <see cref="TryFindPackageReferenceDll"/>
+    /// and the source-linked exemption callers apply via IsFrbSourceLinked()).
+    /// </summary>
+    internal static string TryFindHintPath(string csprojContents, string csprojDirectory, string referenceName)
+    {
+        string pattern =
+            $@"<Reference\s+Include=""{Regex.Escape(referenceName)}""\s*>\s*<HintPath>([^<]+)</HintPath>";
+        Match match = Regex.Match(csprojContents, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        string hintPath = match.Groups[1].Value.Trim();
+        try
+        {
+            return Path.GetFullPath(Path.Combine(csprojDirectory, hintPath));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a NuGet-restored "FlatRedBall.GumCore.*"-style PackageReference to its lib DLL in
+    /// the global packages cache, mirroring SyntaxVersionDetectionService.FindDllInNuGetCache.
+    /// </summary>
+    internal static string TryFindPackageReferenceDll(string csprojContents, string packageName, string nuGetCacheRoot)
+    {
+        string elementPattern =
+            $@"<PackageReference\b(?=[^>]*\bInclude=""{Regex.Escape(packageName)}"")[^>]*?(?:/>|>(?<body>.*?)</PackageReference>)";
+        Match elementMatch = Regex.Match(csprojContents, elementPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        if (!elementMatch.Success)
+        {
+            return null;
+        }
+
+        string version = null;
+        Match versionAttribute = Regex.Match(elementMatch.Value, @"\bVersion=""([^""]*)""", RegexOptions.IgnoreCase);
+        if (versionAttribute.Success)
+        {
+            version = versionAttribute.Groups[1].Value;
+        }
+        else if (elementMatch.Groups["body"].Success)
+        {
+            Match versionElement = Regex.Match(elementMatch.Groups["body"].Value, "<Version>([^<]*)</Version>", RegexOptions.IgnoreCase);
+            if (versionElement.Success)
+            {
+                version = versionElement.Groups[1].Value;
+            }
+        }
+
+        if (string.IsNullOrEmpty(version))
+        {
+            return null;
+        }
+
+        string packageDir = Path.Combine(nuGetCacheRoot, packageName.ToLowerInvariant(), version, "lib");
+        if (!Directory.Exists(packageDir))
+        {
+            return null;
+        }
+
+        string[] preferredTfms = { "net8.0", "net7.0", "net6.0", "netstandard2.1", "netstandard2.0" };
+        foreach (string tfm in preferredTfms)
+        {
+            string tfmDir = Path.Combine(packageDir, tfm);
+            if (Directory.Exists(tfmDir))
+            {
+                string dll = Directory.EnumerateFiles(tfmDir, "*.dll", SearchOption.TopDirectoryOnly).FirstOrDefault();
+                if (dll != null)
+                {
+                    return dll;
+                }
+            }
+        }
+
+        try
+        {
+            return Directory.EnumerateFiles(packageDir, "*.dll", SearchOption.AllDirectories).FirstOrDefault();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads the <c>GumSyntaxVersion</c> assembly attribute out of the DLL at <paramref name="dllPath"/>.
+    /// Returns null if the file doesn't exist, can't be read as a PE/metadata assembly, or doesn't
+    /// declare the attribute at all - per the attribute's own doc, an absent attribute means
+    /// pre-unification (version 0) conventions, so callers should treat null the same as "too old".
+    /// </summary>
+    public static int? ReadVersion(string dllPath)
+    {
+        if (string.IsNullOrEmpty(dllPath) || !File.Exists(dllPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            using FileStream stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            MetadataReader reader = peReader.GetMetadataReader();
+            AssemblyDefinition assemblyDefinition = reader.GetAssemblyDefinition();
+
+            foreach (CustomAttributeHandle attributeHandle in assemblyDefinition.GetCustomAttributes())
+            {
+                CustomAttribute customAttribute = reader.GetCustomAttribute(attributeHandle);
+                if (GetAttributeTypeName(reader, customAttribute) != "GumSyntaxVersionAttribute")
+                {
+                    continue;
+                }
+
+                CustomAttributeValue<string> decoded = customAttribute.DecodeValue(NullCustomAttributeTypeProvider.Instance);
+                foreach (CustomAttributeNamedArgument<string> namedArgument in decoded.NamedArguments)
+                {
+                    if (namedArgument.Name == "Version" && namedArgument.Value is int version)
+                    {
+                        return version;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static string GetAttributeTypeName(MetadataReader reader, CustomAttribute customAttribute)
+    {
+        StringHandle nameHandle;
+        switch (customAttribute.Constructor.Kind)
+        {
+            case HandleKind.MemberReference:
+                MemberReference memberReference = reader.GetMemberReference((MemberReferenceHandle)customAttribute.Constructor);
+                nameHandle = memberReference.Parent.Kind switch
+                {
+                    HandleKind.TypeReference => reader.GetTypeReference((TypeReferenceHandle)memberReference.Parent).Name,
+                    HandleKind.TypeDefinition => reader.GetTypeDefinition((TypeDefinitionHandle)memberReference.Parent).Name,
+                    _ => default
+                };
+                break;
+            case HandleKind.MethodDefinition:
+                MethodDefinition methodDefinition = reader.GetMethodDefinition((MethodDefinitionHandle)customAttribute.Constructor);
+                nameHandle = reader.GetTypeDefinition(methodDefinition.GetDeclaringType()).Name;
+                break;
+            default:
+                return null;
+        }
+
+        return nameHandle.IsNil ? null : reader.GetString(nameHandle);
+    }
+
+    private sealed class NullCustomAttributeTypeProvider : ICustomAttributeTypeProvider<string>
+    {
+        public static readonly NullCustomAttributeTypeProvider Instance = new();
+
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+        public string GetSystemType() => "Type";
+        public string GetSZArrayType(string elementType) => elementType + "[]";
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => "";
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => "";
+        public string GetTypeFromSerializedName(string name) => name;
+        public PrimitiveTypeCode GetUnderlyingEnumType(string type) => PrimitiveTypeCode.Int32;
+        public bool IsSystemType(string type) => false;
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
@@ -223,6 +223,115 @@ public class GumGeneratedCodeCompilesTests : IDisposable
             Environment.NewLine + string.Join(Environment.NewLine, errors));
     }
 
+    // Issue #1967 bug (round 3) - the compile-only test above proves the v3 Rectangle runtime is valid
+    // C#, but a compile can never catch a construction-time NRE. The real bug: a Rectangle placed as a
+    // named INSTANCE inside a screen/component - the common case - is constructed via
+    // GumRuntime.ElementSaveExtensions.CreateGueForElement, whose fullInstantiation parameter DEFAULTS TO
+    // FALSE (see InstanceSaveExtensionMethods.ToGraphicalUiElement -> ElementSaveExtensions.
+    // ToGraphicalUiElement in the sibling Gum repo, which never passes it). The v3 constructor fix only
+    // ran inside `if (fullInstantiation)`, so for every screen-placed Rectangle it never ran at all - the
+    // contained object stayed unset, SetGraphicalUiElement's own fallback then created a plain
+    // LineRectangle (Gum's FallbackRenderableFactory, no v3 awareness), and SetInitialState's state-switch
+    // NREs on ContainedRectangle.FillColor. This test reproduces that exact path for real: builds an
+    // executable scratch project, constructs the generated RectangleRuntime with fullInstantiation:false
+    // and then calls SetGraphicalUiElement externally - precisely what CreateGueForElement's default does
+    // - and asserts the process actually runs to completion instead of throwing.
+    [Fact]
+    public void V3RectangleRuntime_ConstructedAsScreenInstance_ShouldNotThrowDuringSetInitialState()
+    {
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        Gum.Managers.ObjectFinder.Self.GumProjectSave.Version = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;
+
+        var defaultState = GetGumsDefaultStateFor("Rectangle");
+        defaultState.ShouldNotBeNull();
+
+        var standardElementSave = new StandardElementSave { Name = "Rectangle" };
+        standardElementSave.Initialize(defaultState);
+
+        var source = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(standardElementSave);
+        source.ShouldNotBeNullOrWhiteSpace();
+        source.ShouldContain("FilledStrokedRectangle");
+
+        var scratchDirectory = Path.Combine(_tempProjectDirectory, "V3RectangleRuntimeScratch");
+        var repoRoot = FindRepoRoot();
+        WriteScratchProject(scratchDirectory, repoRoot, new Dictionary<string, string> { ["Rectangle"] = source });
+
+        // WriteScratchProject writes a class-library csproj with no entry point - flip it to an
+        // executable and add one that reproduces the real screen-instance construction path.
+        var csprojPath = Path.Combine(scratchDirectory, "GumCodegenCompileScratch.csproj");
+        var csprojContent = File.ReadAllText(csprojPath)
+            .Replace("<Nullable>disable</Nullable>", "<Nullable>disable</Nullable>\n    <OutputType>Exe</OutputType>");
+        File.WriteAllText(csprojPath, csprojContent);
+
+        File.WriteAllText(Path.Combine(scratchDirectory, "Program.cs"), """
+            using System;
+            using Gum.DataTypes;
+            using Gum.Managers;
+            using GumRuntime;
+            using TestProject.GumRuntimes;
+
+            StandardElementsManager.Self.Initialize();
+
+            // Real games wire this in generated Game1 code (GumGame1CodeGenerator's GetRenderable ->
+            // Gum.Wireframe.RuntimeObjectCreator.TryHandleAsBaseType) - without it, SetGraphicalUiElement's
+            // fallback throws before ever reaching the actual bug, masking it behind a different exception.
+            ElementSaveExtensions.CustomCreateGraphicalComponentFunc =
+                (name, managers) => Gum.Wireframe.FallbackRenderableFactory.TryHandleAsBaseType(name, managers);
+
+            var elementSave = new StandardElementSave { Name = "Rectangle" };
+            elementSave.Initialize(StandardElementsManager.Self.GetDefaultStateFor("Rectangle"));
+
+            ObjectFinder.Self.GumProjectSave = new GumProjectSave
+            {
+                Version = 3,
+                FullFileName = "C:\\FakeGumProject\\GumProject.gumx",
+            };
+            ObjectFinder.Self.GumProjectSave.StandardElements.Add(elementSave);
+
+            try
+            {
+                // Mirrors ElementSaveExtensions.ToGraphicalUiElement's real call shape: construct with the
+                // default fullInstantiation:false (as CreateGueForElement does for every screen/component
+                // instance), then call SetGraphicalUiElement externally - the caller's responsibility in
+                // that path, per that method's own "could have already been created" contract.
+                var instance = new RectangleRuntime(fullInstantiation: false, tryCreateFormsObject: false);
+                elementSave.SetGraphicalUiElement(instance, null);
+                Console.WriteLine("OK");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("FAIL: " + ex);
+                Environment.Exit(1);
+            }
+            """);
+
+        var (exitCode, output) = RunDotnetRun(scratchDirectory);
+
+        exitCode.ShouldBe(0,
+            "Constructing the v3 Rectangle runtime the way a screen/component instance really is " +
+            "(fullInstantiation:false, then an external SetGraphicalUiElement call) threw:" +
+            Environment.NewLine + output);
+        output.ShouldContain("OK");
+    }
+
+    private static (int exitCode, string output) RunDotnetRun(string projectDirectory)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", "run --project \"" + projectDirectory + "\" -c Debug")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(startInfo)!;
+        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, output);
+    }
+
     // The standard elements Glue generates runtimes for, read straight off the generator's own map so an
     // element added there is covered the day it is added.
     private static List<string> GetElementNamesFromGumsOwnSchema()

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
@@ -177,6 +177,52 @@ public class GumGeneratedCodeCompilesTests : IDisposable
             string.Join(Environment.NewLine, errors) + Environment.NewLine + Environment.NewLine + coverage);
     }
 
+    // Issue #1967 bug (round 2) - the sweep above never exercises the v3 (IsRectangleFillStrokeSupported)
+    // Rectangle path: it never sets Gum.Managers.ObjectFinder.Self.GumProjectSave.Version, which defaults
+    // to AttributeVersion (2, GumProjectSave's own documented GOTCHA), so it always generates the v2
+    // LineRectangle branch. That's exactly how `this.RenderableComponent = new FilledStrokedRectangle();`
+    // (CS0200 - RenderableComponent is get-only) shipped past both this test and the string-matching unit
+    // tests in RectangleFillStrokeCodegenTests: nothing actually compiled the v3 branch's constructor
+    // against the real GraphicalUiElement API. This targets that path directly, the same way
+    // GumRuntimeMemberContractTests.V3RectangleFillStrokeMembers_ShouldExistOnFilledStrokedRectangle
+    // targets it for member-existence rather than full compilation.
+    [Fact]
+    public void V3RectangleConstructor_ShouldCompileAgainstTheRealGraphicalUiElementApi()
+    {
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        Gum.Managers.ObjectFinder.Self.GumProjectSave.Version = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;
+
+        var defaultState = GetGumsDefaultStateFor("Rectangle");
+        defaultState.ShouldNotBeNull();
+
+        var standardElementSave = new StandardElementSave { Name = "Rectangle" };
+        standardElementSave.Initialize(defaultState);
+
+        var source = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(standardElementSave);
+        source.ShouldNotBeNullOrWhiteSpace();
+        // Fixture sanity: if this fixture ever stops actually reaching the v3 branch, the compile below
+        // would trivially pass on the (already-covered) v2 path and this test would stop pinning anything.
+        source.ShouldContain("FilledStrokedRectangle");
+
+        var scratchDirectory = Path.Combine(_tempProjectDirectory, "V3RectangleCompileScratch");
+        WriteScratchProject(scratchDirectory, FindRepoRoot(), new Dictionary<string, string> { ["Rectangle"] = source });
+
+        var (exitCode, output) = RunDotnetBuild(Path.Combine(scratchDirectory, "GumCodegenCompileScratch.csproj"));
+
+        var errors = output
+            .Split('\n')
+            .Where(line => line.Contains(": error ", StringComparison.Ordinal))
+            .Select(line => line.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        exitCode.ShouldBe(0,
+            "The v3 Rectangle runtime does not compile against the real GraphicalUiElement API:" +
+            Environment.NewLine + string.Join(Environment.NewLine, errors));
+    }
+
     // The standard elements Glue generates runtimes for, read straight off the generator's own map so an
     // element added there is covered the day it is added.
     private static List<string> GetElementNamesFromGumsOwnSchema()

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumProjectCreationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumProjectCreationTests.cs
@@ -143,6 +143,36 @@ public class GumProjectCreationTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateGumProjectInternal_SeedsGumxAtShapeVariableExpansionVersion_WithRectangleFillStrokeVariables()
+    {
+        // Issue #1967 - Glue's embedded new-project template was stamped at gumx Version 2
+        // (AttributeVersion), one below the ShapeVariableExpansion (3) version that unlocks Gum's
+        // Rectangle fill/stroke variable family. That meant every Glue-generated .gumx opened in the
+        // standalone Gum Editor showed zero color variables for a Rectangle - Gum's canonical v3 schema
+        // no longer defines legacy Red/Green/Blue/Alpha on Rectangle, and the version gate hid the
+        // replacement Fill*/Stroke* family. This pins the fix: new projects seed at v3+, and the
+        // Rectangle standard element's own .gutx carries the new variables so the Gum Editor's Variable
+        // panel (which merges saved values with the canonical schema) has real data to show, not just an
+        // unlocked but empty category.
+        var creationLogic = new NewGumProjectCreationLogic(new GumxPropertiesManager());
+
+        await creationLogic.CreateGumProjectInternal(shouldAlsoAddForms: false, askToOverwrite: false);
+
+        Gum.Managers.ObjectFinder.Self.GumProjectSave.ShouldNotBeNull();
+        Gum.Managers.ObjectFinder.Self.GumProjectSave!.Version
+            .ShouldBeGreaterThanOrEqualTo((int)Gum.DataTypes.GumProjectSave.GumxVersions.ShapeVariableExpansion);
+
+        var rectangleGutxPath = Directory.GetFiles(_tempProjectDirectory, "Rectangle.gutx", SearchOption.AllDirectories)
+            .ShouldHaveSingleItem();
+        var rectangleGutxContent = File.ReadAllText(rectangleGutxPath);
+
+        foreach (var variableName in GumPlugin.CodeGeneration.StandardsCodeGenerator.RectangleFillStrokeVariableNames)
+        {
+            rectangleGutxContent.ShouldContain($"Name=\"{variableName}\"");
+        }
+    }
+
+    [Fact]
     public async Task CreateGumProjectInternal_ShouldAddFormsComponentsAndGenerateFonts_WhenFormsRequested()
     {
         // Mirrors WizardProjectLogic.HandleAddGum's "with forms" branch (CreateGumProjectWithForms):

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeMemberContractTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeMemberContractTests.cs
@@ -236,6 +236,44 @@ public class GumRuntimeMemberContractTests : IDisposable
         }
     }
 
+    // Issue #1967 - the sweep above is driven off StandardElementToQualifiedTypes, the STATIC map, which
+    // still points "Rectangle" at LineRectangle. It therefore never exercises the v3
+    // (IsRectangleFillStrokeSupported) path that backs Fill*/Stroke*/IsFilled/StrokeWidth with
+    // RenderingLibrary.Math.Geometry.FilledStrokedRectangle instead - exactly the kind of gap the class
+    // header warns about ("Glue has NO compile-time knowledge of the runtime types it generates
+    // against"). This targets that path directly against the real built engine assembly.
+    [Fact]
+    public void V3RectangleFillStrokeMembers_ShouldExistOnFilledStrokedRectangle()
+    {
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        Gum.Managers.ObjectFinder.Self.GumProjectSave!.Version =
+            (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;
+
+        var runtimeTypes = BuildAndLoadEngineRuntimeTypes(FindRepoRoot());
+        runtimeTypes.TryGetValue("RenderingLibrary.Math.Geometry.FilledStrokedRectangle", out var runtimeType)
+            .ShouldBeTrue("Expected FilledStrokedRectangle to be part of the built GumCore assembly - " +
+                "see the gum-shared-source skill if this is missing (a new Gum source file needs adding " +
+                "to a FRB-consumed .csproj/.projitems, not just existing in the sibling Gum repo).");
+
+        var defaultState = Gum.Managers.StandardElementsManager.Self
+            .TryGetDefaultStateFor("Rectangle", throwExceptionOnMissing: false);
+        defaultState.ShouldNotBeNull();
+
+        var standardElementSave = new StandardElementSave { Name = "Rectangle" };
+        standardElementSave.Initialize(defaultState);
+
+        var codeBlock = new CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock)
+            .ShouldBeTrue();
+
+        var problems = FindUnbackedMembers(
+            "Rectangle", codeBlock.ToString(), runtimeType, "RenderingLibrary.Math.Geometry.FilledStrokedRectangle");
+
+        problems.ShouldBeEmpty(string.Join(Environment.NewLine, problems));
+    }
+
     // AddSkiaStandards() isn't idempotent (Dictionary.Add throws on a second call in the same process),
     // so guard it the same way GumSkiaRenderableCodegenSweepTests does.
     private static void EnsureSkiaStandardElementsRegistered()

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeSyntaxVersionReaderTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeSyntaxVersionReaderTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using GumPlugin.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GumPluginTests;
+
+// Issue #1967 bug #2 - nothing stopped a v3 gumx project from generating FilledStrokedRectangle
+// codegen against a referenced GumCore.*.dll that predates that type (a stale, non-source-linked
+// binary reference), producing a runtime NRE instead of a clear Glue-time error. This pins the
+// reader that makes the check possible: it reads the GumSyntaxVersion assembly attribute (see the
+// sibling Gum repo's GumDataTypes/GumSyntaxVersionAttribute.cs, bumped to 4 for FilledStrokedRectangle)
+// off a referenced runtime DLL without loading it (a real GumCore.*.dll drags in MonoGame/XNA native
+// deps Glue has no business loading just to read one attribute).
+public class GumRuntimeSyntaxVersionReaderTests
+{
+    [Fact]
+    public void ReadVersion_NonexistentFile_ReturnsNull()
+    {
+        GumRuntimeSyntaxVersionReader.ReadVersion(@"C:\this\path\does\not\exist.dll").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReadVersion_NullOrEmptyPath_ReturnsNull()
+    {
+        GumRuntimeSyntaxVersionReader.ReadVersion(null).ShouldBeNull();
+        GumRuntimeSyntaxVersionReader.ReadVersion("").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReadVersion_RealAssemblyWithoutTheAttribute_ReturnsNull()
+    {
+        // A real, valid PE/metadata assembly (proves this doesn't crash on real-world DLLs) that
+        // simply never declares GumSyntaxVersion - the "absent attribute" contract the attribute's
+        // own doc comment calls out (assume pre-unification / too old).
+        var corlibPath = typeof(object).Assembly.Location;
+        File.Exists(corlibPath).ShouldBeTrue();
+
+        GumRuntimeSyntaxVersionReader.ReadVersion(corlibPath).ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryFindHintPath_ParsesReferenceHintPath()
+    {
+        var csproj = """
+            <Project>
+              <ItemGroup>
+                <Reference Include="GumCore.DesktopGlNet6">
+                  <HintPath>Libraries\DesktopGl\Debug\GumCore.DesktopGlNet6.dll</HintPath>
+                </Reference>
+              </ItemGroup>
+            </Project>
+            """;
+
+        var result = GumRuntimeSyntaxVersionReader.TryFindHintPath(
+            csproj, @"C:\MyProject", "GumCore.DesktopGlNet6");
+
+        result.ShouldBe(Path.GetFullPath(Path.Combine(@"C:\MyProject", @"Libraries\DesktopGl\Debug\GumCore.DesktopGlNet6.dll")));
+    }
+
+    [Fact]
+    public void TryFindHintPath_NoMatchingReference_ReturnsNull()
+    {
+        var csproj = "<Project><ItemGroup></ItemGroup></Project>";
+
+        GumRuntimeSyntaxVersionReader
+            .TryFindHintPath(csproj, @"C:\MyProject", "GumCore.DesktopGlNet6")
+            .ShouldBeNull();
+    }
+
+    // Issue #1967 bug #2, real end-to-end pin: builds the actual GumCore.DesktopGlNet6.csproj from
+    // the sibling Gum repo (same real-compile technique GumRuntimeMemberContractTests uses) and
+    // reads the freshly-built DLL's GumSyntaxVersion, proving the Gum-side attribute wiring AND this
+    // reader agree on the real value - not a hand-authored fixture that could silently drift from
+    // what Gum actually ships.
+    [Trait("Category", "BuildSmoke")]
+    [Fact]
+    public void ReadVersion_RealBuiltGumCoreDll_Returns4()
+    {
+        var repoRoot = FindRepoRoot();
+        var gumRepoRoot = Path.GetFullPath(Path.Combine(repoRoot, "..", "Gum"));
+        var csprojPath = Path.Combine(gumRepoRoot, "GumCore", "GumCoreXnaPc", "GumCore.DesktopGlNet6", "GumCore.DesktopGlNet6.csproj");
+        File.Exists(csprojPath).ShouldBeTrue($"Expected the Gum sibling repo's GumCore.DesktopGlNet6.csproj at {csprojPath}");
+
+        var (exitCode, output) = RunDotnetBuild(csprojPath);
+        exitCode.ShouldBe(0, $"Could not build GumCore.DesktopGlNet6.csproj:\n{output}");
+
+        var dllPath = Path.Combine(gumRepoRoot, "GumCore", "GumCoreXnaPc", "GumCore.DesktopGlNet6", "bin", "Debug", "net6.0", "GumCore.DesktopGlNet6.dll");
+        File.Exists(dllPath).ShouldBeTrue($"Expected a built assembly at {dllPath}");
+
+        GumRuntimeSyntaxVersionReader.ReadVersion(dllPath).ShouldBe(4);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "Engines", "SkiaGum")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate the FlatRedBall repo root above " + AppContext.BaseDirectory);
+    }
+
+    private static (int exitCode, string output) RunDotnetBuild(string projectPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"build \"{projectPath}\" -c Debug -f net6.0")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(startInfo)!;
+        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, output);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeCodegenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeCodegenTests.cs
@@ -1,0 +1,279 @@
+using System.Linq;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using Gum.DataTypes;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using GumPlugin.CodeGeneration;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GumPluginTests;
+
+// Issue #1967 - Gum's "Rectangle" standard element only exposes Fill/Stroke color once a
+// project is on gumx v3 (ShapeVariableExpansion) or later (StandardElementsManager's
+// AddFillAndStrokeVariables / ShapeVariableVersionGate in the sibling Gum repo). Glue-generated
+// projects were stamped at gumx v2, so the standalone Gum Editor showed no color variables at
+// all for a Glue Rectangle. Fixing that means bumping Glue's template to v3+, which in turn
+// means Glue's own codegen needs to actually understand the v3 Fill/Stroke variable family
+// instead of unconditionally excluding it (as it does today per issue #1907). This file pins
+// both sides of that version boundary: v2 must keep behaving exactly as before, v3 gains real
+// Fill/Stroke codegen backed by RenderingLibrary.Math.Geometry.FilledStrokedRectangle (Gum PR
+// #4342).
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class RectangleFillStrokeCodegenTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly bool _originalSynchronousMode;
+    private readonly GumProjectSave _originalGumProjectSave;
+    private readonly string _tempProjectDirectory;
+
+    public RectangleFillStrokeCodegenTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalGumProjectSave = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+
+        var vsProject = TestSupport.TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+        GlueState.Self.CurrentMainProject = vsProject;
+
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        TaskManager.SynchronousMode = true;
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject = _originalGlueProject;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = _originalGumProjectSave;
+
+        try
+        {
+            System.IO.Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    private static Gum.DataTypes.StandardElementSave BuildRectangleFixture()
+    {
+        var standardElementSave = new Gum.DataTypes.StandardElementSave { Name = "Rectangle" };
+        standardElementSave.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("Rectangle"));
+        return standardElementSave;
+    }
+
+    private void SetGumProjectVersion(int version)
+    {
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = new GumProjectSave
+        {
+            FullFileName = System.IO.Path.Combine(_tempProjectDirectory, "GumProject", "GumProject.gumx"),
+            Version = version
+        };
+    }
+
+    [Fact]
+    public void V2Project_RectangleCodegen_StillMapsToLineRectangle_NoFillStrokeProperties()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.AttributeVersion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        var generated = StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+        generated.ShouldBeTrue();
+
+        var generatedSource = codeBlock.ToString();
+
+        generatedSource.ShouldContain("RenderingLibrary.Math.Geometry.LineRectangle mContainedRectangle");
+
+        foreach (var excludedMember in new[]
+                 {
+                     "IsFilled", "FillAlpha", "FillRed", "FillGreen", "FillBlue",
+                     "StrokeWidth", "StrokeAlpha", "StrokeRed", "StrokeGreen", "StrokeBlue",
+                 })
+        {
+            generatedSource.ShouldNotContain(excludedMember);
+        }
+    }
+
+    [Fact]
+    public void V3Project_RectangleCodegen_MapsToFilledStrokedRectangle()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        generatedSource.ShouldContain("RenderingLibrary.Math.Geometry.FilledStrokedRectangle mContainedRectangle");
+        generatedSource.ShouldNotContain("RenderingLibrary.Math.Geometry.LineRectangle mContainedRectangle");
+    }
+
+    [Fact]
+    public void V3Project_RectangleCodegen_GeneratesIsFilledProperty()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        generatedSource.ShouldContain("public bool IsFilled");
+        generatedSource.ShouldContain("ContainedRectangle.IsFilled");
+    }
+
+    [Fact]
+    public void V3Project_RectangleCodegen_GeneratesStrokeWidthProperty()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        generatedSource.ShouldContain("public float StrokeWidth");
+        generatedSource.ShouldContain("ContainedRectangle.StrokeWidth");
+    }
+
+    [Fact]
+    public void V3Project_RectangleCodegen_FillRedComposesFillColor()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        generatedSource.ShouldContain("public int FillRed");
+        // Composes through the FillColor channel, not a nonexistent ContainedRectangle.FillRed member.
+        generatedSource.ShouldContain("ContainedRectangle.FillColor.R");
+        generatedSource.ShouldContain("ColorExtensions.WithRed(ContainedRectangle.FillColor");
+        generatedSource.ShouldNotContain("ContainedRectangle.FillRed");
+    }
+
+    [Fact]
+    public void V3Project_RectangleCodegen_StrokeRedComposesStrokeColor_NotStrokeWidth()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        generatedSource.ShouldContain("public int StrokeRed");
+        generatedSource.ShouldContain("ContainedRectangle.StrokeColor.R");
+        generatedSource.ShouldContain("ColorExtensions.WithRed(ContainedRectangle.StrokeColor");
+        generatedSource.ShouldNotContain("ContainedRectangle.StrokeRed");
+        // The "Stroke" prefix match must not misfire on StrokeWidth (a plain float, not a color channel).
+        generatedSource.ShouldContain("public float StrokeWidth");
+        generatedSource.ShouldNotContain("ContainedRectangle.StrokeColor.W");
+    }
+
+    [Fact]
+    public void V3Project_RectangleCodegen_AllFillAndStrokeChannelsGenerated()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        foreach (var propertyName in StandardsCodeGenerator.RectangleFillStrokeVariableNames)
+        {
+            generatedSource.ShouldContain($" {propertyName}");
+        }
+    }
+
+    [Fact]
+    public void V3Project_RectangleCodegen_ColorConveniencePropertyRoutesToStrokeColor()
+    {
+        // Regression pin for GumRuntimeMemberContractTests.V3RectangleFillStrokeMembers_ShouldExistOnFilledStrokedRectangle
+        // (a real CS1061 that test caught): the synthetic "Color" convenience property
+        // (variableNamesToAddForProperties) is generated for every Rectangle regardless of version, and
+        // its generic passthrough targets ContainedRectangle.Color - which FilledStrokedRectangle doesn't
+        // have (only FillColor/StrokeColor). Must route to StrokeColor instead, matching Gum's own
+        // legacy-Color-routes-to-Stroke convention (#2938).
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        generatedSource.ShouldContain("ContainedRectangle.StrokeColor");
+        generatedSource.ShouldNotContain("ContainedRectangle.Color");
+    }
+
+    [Fact]
+    public void V3Project_RectangleCodegen_StateSwitchAssignsIsFilledAndFillRed()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        // The Default state's IsFilled/FillRed values (StandardElementsManager.AddFillAndStrokeVariables
+        // defaults: IsFilled=false, FillRed=255) must actually reach the generated properties via the
+        // state switch, not just exist as inert properties with their C# type default.
+        generatedSource.ShouldContain("IsFilled = False");
+        generatedSource.ShouldContain("FillRed = 255");
+    }
+
+    [Fact]
+    public void V2Project_RectangleCodegen_StateSwitchDoesNotAssignFillRed()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.AttributeVersion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        generatedSource.ShouldNotContain("FillRed");
+        generatedSource.ShouldNotContain("IsFilled");
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeCodegenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeCodegenTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
@@ -120,6 +121,59 @@ public class RectangleFillStrokeCodegenTests : IDisposable
 
         generatedSource.ShouldContain("RenderingLibrary.Math.Geometry.FilledStrokedRectangle mContainedRectangle");
         generatedSource.ShouldNotContain("RenderingLibrary.Math.Geometry.LineRectangle mContainedRectangle");
+    }
+
+    [Fact]
+    public void V3Project_RectangleCodegen_ConstructorExplicitlyAssignsRenderableComponent_BeforeSetGraphicalUiElement()
+    {
+        // Real-manual-test regression: Gum's FallbackRenderableFactory.TryHandleAsBaseType hardcodes
+        // case "Rectangle" to always construct a LineRectangle for FRB builds (no gumx-version awareness -
+        // see the class's own "do not extend this switch" doc comment, sibling Gum repo). That factory only
+        // runs when SetGraphicalUiElement finds RenderableComponent still null after construction - so
+        // without an explicit assignment here, a v3 Rectangle's RenderableComponent is actually a
+        // LineRectangle, ContainedRectangle's "as FilledStrokedRectangle" cast silently returns null, and
+        // SetInitialState's state-switch NREs on ContainedRectangle.FillColor (set_FillAlpha etc.).
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        var assignIndex = generatedSource.IndexOf(
+            "this.RenderableComponent = new RenderingLibrary.Math.Geometry.FilledStrokedRectangle();",
+            StringComparison.Ordinal);
+        var setGraphicalUiElementIndex = generatedSource.IndexOf("SetGraphicalUiElement(", StringComparison.Ordinal);
+
+        assignIndex.ShouldBeGreaterThanOrEqualTo(0, "Constructor must explicitly construct the v3 " +
+            "RenderableComponent - relying on Gum's fallback factory silently keeps it a LineRectangle. " +
+            "Generated source:" + Environment.NewLine + generatedSource);
+        setGraphicalUiElementIndex.ShouldBeGreaterThanOrEqualTo(0);
+        assignIndex.ShouldBeLessThan(setGraphicalUiElementIndex,
+            "RenderableComponent must be assigned before SetGraphicalUiElement runs, per that method's own " +
+            "\"could have already been created by the type that is instantiated\" contract (Gum's " +
+            "ElementSaveExtensions.GumRuntime.cs).");
+    }
+
+    [Fact]
+    public void V2Project_RectangleCodegen_ConstructorDoesNotAssignRenderableComponent()
+    {
+        // v2 keeps relying on Gum's fallback factory (which correctly returns LineRectangle for "Rectangle"
+        // today) - no explicit assignment needed or wanted here.
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.AttributeVersion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var standardElementSave = BuildRectangleFixture();
+
+        var codeBlock = new FlatRedBall.Glue.CodeGeneration.CodeBuilder.CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock);
+
+        var generatedSource = codeBlock.ToString();
+
+        generatedSource.ShouldNotContain("this.RenderableComponent = new RenderingLibrary.Math.Geometry.FilledStrokedRectangle();");
     }
 
     [Fact]

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeCodegenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeCodegenTests.cs
@@ -144,16 +144,17 @@ public class RectangleFillStrokeCodegenTests : IDisposable
         var generatedSource = codeBlock.ToString();
 
         var assignIndex = generatedSource.IndexOf(
-            "this.RenderableComponent = new RenderingLibrary.Math.Geometry.FilledStrokedRectangle();",
+            "this.SetContainedObject(new RenderingLibrary.Math.Geometry.FilledStrokedRectangle());",
             StringComparison.Ordinal);
         var setGraphicalUiElementIndex = generatedSource.IndexOf("SetGraphicalUiElement(", StringComparison.Ordinal);
 
         assignIndex.ShouldBeGreaterThanOrEqualTo(0, "Constructor must explicitly construct the v3 " +
-            "RenderableComponent - relying on Gum's fallback factory silently keeps it a LineRectangle. " +
+            "RenderableComponent via SetContainedObject (RenderableComponent itself is get-only) - " +
+            "relying on Gum's fallback factory silently keeps it a LineRectangle. " +
             "Generated source:" + Environment.NewLine + generatedSource);
         setGraphicalUiElementIndex.ShouldBeGreaterThanOrEqualTo(0);
         assignIndex.ShouldBeLessThan(setGraphicalUiElementIndex,
-            "RenderableComponent must be assigned before SetGraphicalUiElement runs, per that method's own " +
+            "The contained object must be set before SetGraphicalUiElement runs, per that method's own " +
             "\"could have already been created by the type that is instantiated\" contract (Gum's " +
             "ElementSaveExtensions.GumRuntime.cs).");
     }
@@ -173,7 +174,7 @@ public class RectangleFillStrokeCodegenTests : IDisposable
 
         var generatedSource = codeBlock.ToString();
 
-        generatedSource.ShouldNotContain("this.RenderableComponent = new RenderingLibrary.Math.Geometry.FilledStrokedRectangle();");
+        generatedSource.ShouldNotContain("this.SetContainedObject(new RenderingLibrary.Math.Geometry.FilledStrokedRectangle());");
     }
 
     [Fact]

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeRuntimeVersionCheckTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeRuntimeVersionCheckTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using Gum.DataTypes;
+using GlueUnitTests.Tasks;
+using GlueUnitTests.TestSupport;
+using GumPlugin.ErrorReporting;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GumPluginTests;
+
+// Issue #1967 bug #2 - nothing stopped a v3 gumx project from generating FilledStrokedRectangle
+// codegen against a referenced GumCore.*.dll that predates that type. This pins the detection logic
+// end-to-end against a real project file + a real (non-Gum) DLL reference, without needing a slow
+// BuildSmoke engine build - GumRuntimeSyntaxVersionReaderTests.ReadVersion_RealBuiltGumCoreDll_Returns4
+// covers the "reads a real Gum-stamped DLL correctly" half; this covers "wires that reader into a
+// real project's references correctly".
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class RectangleFillStrokeRuntimeVersionCheckTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GumProjectSave _originalGumProjectSave;
+    private readonly string _tempProjectDirectory;
+
+    public RectangleFillStrokeRuntimeVersionCheckTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGumProjectSave = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+
+        GlueState.Self.CurrentMainProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = _originalGumProjectSave;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private void SetGumProjectVersion(int version)
+    {
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = new GumProjectSave { Version = version };
+    }
+
+    // Points the test project's GumCore.DesktopGlNet6 reference at a real, valid, but non-Gum DLL
+    // (mscorlib/System.Private.CoreLib) - proves the resolution reaches a real file and reads it via
+    // GumRuntimeSyntaxVersionReader.ReadVersion, which correctly reports "no attribute" for it.
+    private void AddStaleDllReference()
+    {
+        var sourceDll = typeof(object).Assembly.Location;
+        var destDll = Path.Combine(_tempProjectDirectory, "StaleGumCore.dll");
+        File.Copy(sourceDll, destDll, overwrite: true);
+
+        var csprojPath = GlueState.Self.CurrentMainProject.FullFileName.FullPath;
+        var content = File.ReadAllText(csprojPath);
+        content = content.Replace("</Project>", $"""
+              <ItemGroup>
+                <Reference Include="GumCore.DesktopGlNet6">
+                  <HintPath>StaleGumCore.dll</HintPath>
+                </Reference>
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(csprojPath, content);
+    }
+
+    [Fact]
+    public void GetIfCurrentlyFixed_NoGumProject_IsFixed()
+    {
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = null;
+
+        RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetIfCurrentlyFixed_V2GumProject_IsFixed_RegardlessOfReferences()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.AttributeVersion);
+        AddStaleDllReference();
+
+        RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetIfCurrentlyFixed_V3GumProject_StaleDllReference_IsNotFixed()
+    {
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        AddStaleDllReference();
+
+        RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed().ShouldBeFalse();
+        RectangleFillStrokeRuntimeVersionCheck.DetectedRuntimeSyntaxVersion().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetIfCurrentlyFixed_V3GumProject_NoResolvableReferenceAtAll_IsNotFixed()
+    {
+        // No Reference/PackageReference added at all - DetectedRuntimeSyntaxVersion can't resolve
+        // anything, which must be treated the same as "too old", not silently passed.
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+
+        RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RectangleFillStrokeRuntimeVersionError_MessageMentionsDetectedVersionAndRemedy()
+    {
+        var error = new RectangleFillStrokeRuntimeVersionError(detectedVersion: null);
+
+        error.Details.ShouldContain("GumSyntaxVersion");
+        error.Details.ShouldContain("relink");
+    }
+}


### PR DESCRIPTION
Part of #1967.

Glue's embedded new-project template stamped gumx `<Version>2</Version>`. Gum's v3 (`ShapeVariableExpansion`) schema moved Rectangle's color surface to a Fill/Stroke family gated on that version and dropped the legacy Red/Green/Blue/Alpha entirely — so every Glue-generated `.gumx` opened in the standalone Gum Editor showed zero color variables for a Rectangle.

## What changed
- Bumped the embedded template to gumx v3 and rewrote `Rectangle.gutx`'s Default state to the v3 `Fill*`/`Stroke*`/`IsFilled`/`StrokeWidth` variable set (legacy `Red`/`Green`/`Blue`/`Alpha` removed — they have no backing member on the new runtime type, see below).
- Wired both of Glue's codegen pipelines (`StandardsCodeGenerator`, `StateCodeGenerator`) to back those variables on a v3 project with `RenderingLibrary.Math.Geometry.FilledStrokedRectangle` (Gum #4342, merged) — a flat fill+stroke renderable added specifically for FRB's one-contained-field codegen shape (can't adopt Gum's own two-slot `RectangleRuntime`/`GraphicalUiElement` composite). The choice of type/properties is gated **live** on `Gum.Managers.ObjectFinder.Self.GumProjectSave.Version`, not a static map, since one generator instance serves whatever gumx version is loaded. v2 projects keep mapping to `LineRectangle`, unchanged.
- The synthetic `Color` convenience property (generated for every Rectangle regardless of version) now routes to `StrokeColor` on a v3 project, matching Gum's own legacy-Color-routes-to-Stroke convention (#2938) — `FilledStrokedRectangle` has no plain `Color` member. Caught by a real compile against the built engine assembly, not just string-matching generated source (see testing below).
- Gradient/dropshadow/blend/`CornerRadius`/dashed-stroke stay excluded — no FRB rendering backs them without the optional Skia/Apos shape package, and that's a separate, larger feature.

## Testing
- New `RectangleFillStrokeCodegenTests.cs` pins both sides of the version boundary: v2 behavior unchanged (still `LineRectangle`, still excludes the whole Fill/Stroke family), v3 gains real codegen for `IsFilled`/`FillAlpha|Red|Green|Blue`/`StrokeWidth`/`StrokeAlpha|Red|Green|Blue`, in both the property and state-switch pipelines.
- `GumProjectCreationTests.cs`: new project creation seeds gumx v3+ with the new Rectangle variables actually present in the on-disk `.gutx`.
- `GumRuntimeMemberContractTests.cs`: new `V3RectangleFillStrokeMembers_ShouldExistOnFilledStrokedRectangle` builds the real engine assemblies and reflects over the actual `FilledStrokedRectangle` type — this is what caught the `Color`→`StrokeColor` routing bug (a real CS1061 that string-only assertions missed). Confirmed green against a real build.
- Full fast suite (268 tests) and both BuildSmoke member-contract sweeps pass with no regressions.

## Manual test: needed
1. `git pull` (or otherwise pick up Gum #4342) in the sibling `Gum` checkout so `FilledStrokedRectangle` is present.
2. Open `FRBDK/Glue/Glue with All.sln` in Visual Studio, run Glue.
3. Create a new FlatRedBall project (or open an existing one), add a Gum project (File → Add Gum Project, or the Gum toolbar's "no forms" option).
4. Add a `Rectangle` to a screen/component.
5. Open the generated `GumProject.gumx` in the standalone Gum Editor. Confirm the Variables panel now shows `Is Filled`, `Fill Color`, `Stroke Width`, `Stroke Color` for the Rectangle (previously showed nothing).
6. Set `Is Filled = true` and pick a `Fill Color`; separately try `Stroke Width`/`Stroke Color` with `Is Filled = false`.
7. Save, rebuild the FRB game project, run it. Confirm the Rectangle renders filled (or outlined, per the toggle) with the chosen color — not the old default white outline, and not silently unchanged.

## Known follow-up (not in this PR, flagging per the repo's "comment on the tracking issue" convention rather than opening a new one)
Gradient/dropshadow/blend/`CornerRadius` remain visible-but-inert in the standalone Gum Editor for a v3 Glue-authored Rectangle — the Editor's Variable panel is driven by Gum's live canonical schema plus the project version, not by what's literally saved in `Rectangle.gutx`, so those categories unlock in the panel once the project is at v3 even though Glue's codegen (correctly) never backs them. Setting them does nothing in the actual FRB game. This is the same class of issue the Fill/Stroke work here fixed, just for a genuinely bigger feature (needs FRB to gain a real shape-rendering backend) that's out of scope for #1967. Circle has the identical `LineCircle`/no-fill gap and wasn't touched.
