### PR TITLE
Fix the nested-build hang that wedged the BuildSmoke test suite

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -42,13 +42,17 @@ jobs:
       run: dotnet build -c Debug 'FlatRedBall\FRBDK\Glue\Glue with All.sln'
 
     # Run via the .sln so $(SolutionDir) is defined (OfficialPlugins has a post-build step that needs it).
+    #
+    # --blame-hang-timeout is a backstop, not an expectation: these suites run in well under a minute each
+    # (see issue #1969), so a test sitting for 10 minutes is wedged and should fail the job rather than sit
+    # there until the runner's own limit kills it with no attribution. It also names the test that hung.
     - name: Run unit tests
-      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category!=BuildSmoke"
+      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category!=BuildSmoke" --blame-hang-timeout 10m
 
     # Slower: creates a project from each template and runs `dotnet build` on it. Needs the net9 SDK
     # (installed above) and network for the first NuGet restore.
     - name: Run new-project build smoke test
-      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category=BuildSmoke"
+      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category=BuildSmoke" --blame-hang-timeout 15m
 
     # Everything above this line covers the Glue editor only. The steps below cover the engine,
     # which otherwise gets compiled just once per release by Engine.yml -- long after the commit

--- a/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
+++ b/FRBDK/Glue/.claude/skills/glue-unit-test-bootstrap/SKILL.md
@@ -59,12 +59,39 @@ Fix: pass `SolutionDir` explicitly, pointed at `FRBDK/Glue/` (the directory cont
 dotnet test FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj -p:SolutionDir="<repo>\FRBDK\Glue\\"
 ```
 
-## Standing rule — clear stragglers before AND after every run, don't wait for a hang
+## What a healthy run costs — anything far past this is a hang, not slowness
 
-Don't treat the landmine below as something to diagnose only when a run already looks stuck. Every
-`dotnet test`/`dotnet build` invocation in this workflow — BuildSmoke included — spawns a process tree
-(`dotnet`, an MSBuild build server, `VBCSCompiler`, `testhost` per assembly) that does not self-clean on
-interruption. Run this **before starting** and **after finishing** every test/build round, unconditionally:
+Rough orders of magnitude on a warm dev machine, so "is it stuck or just slow?" is answerable without
+guessing. All with `--no-build` after a successful build:
+
+| Run | Roughly |
+| --- | --- |
+| Warm incremental build of `GlueUnitTests.csproj` | ~40s (a real build is most of a full run's wall clock) |
+| `--filter "Category!=BuildSmoke"` (~280 tests) | ~25s |
+| `--filter "Category=BuildSmoke"` (~10 tests) | ~60s |
+
+A BuildSmoke run sitting at 5+ minutes is not a slow build. Check whether the child `dotnet build` has
+already exited while `testhost` is still alive — that is the signature of the pipe hang below, not of work
+in progress.
+
+## Landmine — every nested `dotnet` call must go through `NestedDotnetCli`
+
+BuildSmoke tests shell out to real `dotnet build`/`dotnet run`. The obvious way to write that — redirect
+both streams, `StandardOutput.ReadToEnd()`, `WaitForExit()` — hangs for 10–15 minutes instead of failing,
+because `dotnet build` starts MSBuild worker nodes with `/nodeReuse:true` that outlive it while holding the
+inherited stdout pipe open, so `ReadToEnd()` never sees EOF. It is intermittent by nature: only the run that
+*starts* the nodes inherits the handles, so the same test hangs once and passes on an immediate retry.
+
+`GlueUnitTests/TestSupport/NestedDotnetCli.cs` is the only sanctioned way to spawn one — it disables the
+persistent build servers, pumps both streams concurrently, and kills the entire child tree on timeout.
+`NestedDotnetCliTests` fails the build if a redirected `Process.Start` reappears anywhere in the assembly.
+See GitHub issue #1969.
+
+## Standing rule — clear stragglers after an *interrupted* run
+
+A `dotnet test`/`dotnet build` that is cancelled or killed mid-flight leaves its tree (`dotnet`, MSBuild
+nodes, `VBCSCompiler`, `testhost`) behind; a run that completes normally now cleans up after itself. So
+this is a response to an interruption, not a ritual before every command:
 
 ```powershell
 Get-Process testhost,vstest.console,MSBuild,VBCSCompiler -ErrorAction SilentlyContinue | Stop-Process -Force
@@ -72,8 +99,7 @@ Get-Process testhost,vstest.console,MSBuild,VBCSCompiler -ErrorAction SilentlyCo
 
 Never end a turn (report status, stop) while a `dotnet test`/`dotnet build` is still running detached in
 the background — wait for it synchronously, or explicitly confirm it finished/kill it first. A background
-run left alive across a stop/resume cycle is exactly how the count climbs into the dozens over a long
-session: each new round piles on top of the last instead of reusing a clean slate.
+run left alive across a stop/resume cycle is how the count climbs into the dozens over a long session.
 
 ## Landmine — an orphaned `testhost` locks the output DLLs, and the next run looks like a hang
 

--- a/FRBDK/Glue/.claude/testing-incidents.md
+++ b/FRBDK/Glue/.claude/testing-incidents.md
@@ -32,3 +32,35 @@ the same failed attempts blind. Append newest entries at the bottom with a date.
   additive across a long session (60+ stray processes observed at one point). See
   `glue-unit-test-bootstrap`'s standing pre/post-run cleanup rule for the mitigation; this log is for
   *specific incidents*, that skill is for the *timeless procedure*.
+
+## 2026-08-05 — RESOLVED: root-caused to the BuildSmoke tests' own `Process` usage (#1969)
+
+Measured rather than inferred, which is what finally broke the loop. The three symptoms above turned out
+to be one bug plus one piece of local noise.
+
+- **Baselines first.** Fast suite (`Category!=BuildSmoke`, `--no-build`): 25s / 280 tests — never the
+  problem. Warm incremental build: ~40s. BuildSmoke, *with the MSBuild nodes already warm*: 48s / 10 tests,
+  all green. So the suite was fine whenever it was measured right after another build, which is exactly why
+  every attempt to reproduce on a "clean slate" kept coming back green or hanging unpredictably.
+- **Reproduced deterministically by killing every MSBuild worker node first**, then running a single
+  BuildSmoke test that had just taken 5.8s. It hung past 3 minutes. Process snapshot during the hang was
+  conclusive: the child `dotnet build` had **already exited**, `testhost.exe` was still blocked, and 9
+  `dotnet ... /nodemode:1` nodes plus `VBCSCompiler` were alive.
+- **Root cause:** all seven nested-build helpers used `StandardOutput.ReadToEnd()` on a redirected child.
+  `dotnet build` starts MSBuild worker nodes with `/nodeReuse:true`, and `Process`'s redirect pipes are
+  inheritable, so those nodes hold the stdout write handle open after the build exits. `ReadToEnd()` returns
+  on EOF, not on process exit — so it blocked until the nodes hit their 15 minute idle timeout. Only the run
+  that *starts* the nodes inherits the handles, hence "hangs once, passes on immediate retry" and hence the
+  earlier "even with a confirmed clean process slate it flatlined again": the clean slate was the trigger,
+  not the cure. A successful run also left 20 stray nodes behind, which is the accumulation.
+- The same helpers read stdout to EOF before touching stderr at all (deadlocks past ~4KB of stderr) and had
+  no timeout, so any of the above wedged the run instead of failing it.
+- **Fixed** by routing all seven through `GlueUnitTests/TestSupport/NestedDotnetCli.cs`. Same cold-node
+  single test: 3+ minutes → **7s, zero leftover processes**. Full BuildSmoke: 62s, 10/10.
+- **Unrelated local noise that made this harder to see:** three `RepoHygieneTests` were permanently red on
+  this machine because `.claude/worktrees/Gum` is a directory symlink to the sibling Gum checkout and
+  `Directory.EnumerateFiles` follows it. `.claude` is now in that test's ignore list.
+- Not reproduced: the "testhost process crashed" abort. It did not recur in any run here, including the
+  cold-node hang. Most likely the same bug seen through `--blame`'s eyes (a wedged host being torn down),
+  but that is unconfirmed — if it reappears **with the fix in**, it is a genuinely separate defect and this
+  entry should not be trusted to cover it.

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
@@ -316,21 +315,8 @@ public class GumGeneratedCodeCompilesTests : IDisposable
         output.ShouldContain("OK");
     }
 
-    private static (int exitCode, string output) RunDotnetRun(string projectDirectory)
-    {
-        var startInfo = new ProcessStartInfo("dotnet", "run --project \"" + projectDirectory + "\" -c Debug")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        using var process = Process.Start(startInfo)!;
-        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-        process.WaitForExit();
-        return (process.ExitCode, output);
-    }
+    private static (int exitCode, string output) RunDotnetRun(string projectDirectory) =>
+        NestedDotnetCli.Run($"run --project \"{projectDirectory}\" -c Debug");
 
     // The standard elements Glue generates runtimes for, read straight off the generator's own map so an
     // element added there is covered the day it is added.
@@ -479,21 +465,8 @@ public class GumGeneratedCodeCompilesTests : IDisposable
         return match.Groups[1].Value;
     }
 
-    private static (int exitCode, string output) RunDotnetBuild(string projectPath)
-    {
-        var startInfo = new ProcessStartInfo("dotnet", $"build \"{projectPath}\" -c Debug")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        using var process = Process.Start(startInfo)!;
-        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-        process.WaitForExit();
-        return (process.ExitCode, output);
-    }
+    private static (int exitCode, string output) RunDotnetBuild(string projectPath) =>
+        NestedDotnetCli.Run($"build \"{projectPath}\" -c Debug");
 
     private static string FindRepoRoot()
     {

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeMemberContractTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeMemberContractTests.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -352,21 +351,8 @@ public class GumRuntimeMemberContractTests : IDisposable
         return types;
     }
 
-    private static (int exitCode, string output) RunDotnetBuild(string solutionPath)
-    {
-        var startInfo = new ProcessStartInfo("dotnet", $"build \"{solutionPath}\" -c Debug")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        using var process = Process.Start(startInfo)!;
-        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-        process.WaitForExit();
-        return (process.ExitCode, output);
-    }
+    private static (int exitCode, string output) RunDotnetBuild(string solutionPath) =>
+        NestedDotnetCli.Run($"build \"{solutionPath}\" -c Debug");
 
     private static string FindRepoRoot()
     {

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeSyntaxVersionReaderTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumRuntimeSyntaxVersionReaderTests.cs
@@ -1,6 +1,6 @@
-using System;
-using System.Diagnostics;
+﻿using System;
 using System.IO;
+using GlueUnitTests.TestSupport;
 using GumPlugin.Managers;
 using Shouldly;
 using Xunit;
@@ -107,19 +107,6 @@ public class GumRuntimeSyntaxVersionReaderTests
         throw new DirectoryNotFoundException("Could not locate the FlatRedBall repo root above " + AppContext.BaseDirectory);
     }
 
-    private static (int exitCode, string output) RunDotnetBuild(string projectPath)
-    {
-        var startInfo = new ProcessStartInfo("dotnet", $"build \"{projectPath}\" -c Debug -f net6.0")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        using var process = Process.Start(startInfo)!;
-        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-        process.WaitForExit();
-        return (process.ExitCode, output);
-    }
+    private static (int exitCode, string output) RunDotnetBuild(string projectPath) =>
+        NestedDotnetCli.Run($"build \"{projectPath}\" -c Debug -f net6.0");
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/FnaProjectCreationSmokeTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/FnaProjectCreationSmokeTests.cs
@@ -1,8 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using GlueUnitTests.TestSupport;
 using Npc;
 using Npc.ViewModels;
 using Shouldly;
@@ -77,21 +77,8 @@ public class FnaProjectCreationSmokeTests
         }
     }
 
-    private static (int exitCode, string output) RunDotnetBuild(string solutionPath)
-    {
-        var startInfo = new ProcessStartInfo("dotnet", $"build \"{solutionPath}\" -c Debug")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        using var process = Process.Start(startInfo)!;
-        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-        process.WaitForExit();
-        return (process.ExitCode, output);
-    }
+    private static (int exitCode, string output) RunDotnetBuild(string solutionPath) =>
+        NestedDotnetCli.Run($"build \"{solutionPath}\" -c Debug");
 
     // Walks up from the test assembly to the repo's Templates folder.
     private static string FindTemplatesRoot()

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/NewProjectCreationSmokeTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/NewProjectCreationSmokeTests.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using GlueUnitTests.TestSupport;
 using Npc;
 using Npc.ViewModels;
 using Shouldly;
@@ -74,21 +74,8 @@ public class NewProjectCreationSmokeTests
         }
     }
 
-    private static (int exitCode, string output) RunDotnetBuild(string solutionPath)
-    {
-        var startInfo = new ProcessStartInfo("dotnet", $"build \"{solutionPath}\" -c Debug")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        using var process = Process.Start(startInfo)!;
-        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-        process.WaitForExit();
-        return (process.ExitCode, output);
-    }
+    private static (int exitCode, string output) RunDotnetBuild(string solutionPath) =>
+        NestedDotnetCli.Run($"build \"{solutionPath}\" -c Debug");
 
     // Walks up from the test assembly to the repo's Templates folder.
     private static string FindTemplatesRoot()

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/RepoHygieneTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/RepoHygieneTests.cs
@@ -21,7 +21,14 @@ namespace GlueUnitTests.Projects;
 public class RepoHygieneTests
 {
     // Folders whose contents are build output, tooling state, or third-party submodule source.
-    private static readonly string[] IgnoredFolders = { "bin", "obj", ".git", ".vs", "packages", "node_modules" };
+    //
+    // .claude holds agent tooling state, and in particular .claude/worktrees, where a directory symlink to
+    // another checkout is normal. Directory.EnumerateFiles follows those, so without this the sweep walks
+    // out of this repo and reports every cross-repo relative ProjectReference in the linked checkout as
+    // broken -- they only resolve from that checkout's real location, not through the link. Locally-red
+    // hygiene tests that nobody can fix are worse than no hygiene tests, so the whole folder is out.
+    private static readonly string[] IgnoredFolders =
+        { "bin", "obj", ".git", ".vs", ".claude", "packages", "node_modules" };
 
     [Fact]
     public void NoProjectShouldTargetBelowNet6()

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/WebProjectCreationSmokeTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/WebProjectCreationSmokeTests.cs
@@ -1,8 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using GlueUnitTests.TestSupport;
 using Npc;
 using Npc.ViewModels;
 using Shouldly;
@@ -76,21 +76,8 @@ public class WebProjectCreationSmokeTests
         }
     }
 
-    private static (int exitCode, string output) RunDotnetBuild(string solutionPath)
-    {
-        var startInfo = new ProcessStartInfo("dotnet", $"build \"{solutionPath}\" -c Debug")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        using var process = Process.Start(startInfo)!;
-        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-        process.WaitForExit();
-        return (process.ExitCode, output);
-    }
+    private static (int exitCode, string output) RunDotnetBuild(string solutionPath) =>
+        NestedDotnetCli.Run($"build \"{solutionPath}\" -c Debug");
 
     // Walks up from the test assembly to the repo's Templates folder.
     private static string FindTemplatesRoot()

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCli.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCli.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace GlueUnitTests.TestSupport;
+
+/// <summary>
+/// Runs a nested <c>dotnet build</c>/<c>dotnet run</c> for the <c>Category=BuildSmoke</c> tests.
+///
+/// Every BuildSmoke test shells out to a real dotnet CLI invocation, and the obvious way to write that -
+/// redirect both streams, <c>StandardOutput.ReadToEnd()</c>, then <c>WaitForExit()</c> - hangs for tens of
+/// minutes rather than failing. Three separate reasons, all of which this helper exists to avoid:
+///
+///  - <b>MSBuild node reuse.</b> A plain <c>dotnet build</c> starts worker nodes with <c>/nodeReuse:true</c>
+///    and they outlive it by design (15 minute idle timeout). Because <see cref="Process"/> creates the
+///    redirect pipes as inheritable handles, those surviving nodes hold the write end of stdout/stderr open
+///    after the build itself has exited - so <c>ReadToEnd()</c>, which returns on EOF and not on process
+///    exit, blocks until the nodes idle out. This is why the symptom was intermittent: only the run that
+///    *starts* the nodes inherits the handles, so the same test hangs once and then passes on an immediate
+///    retry against the now-warm nodes. It is also the orphan-accumulation mechanism - a single successful
+///    BuildSmoke pass left 20 stray <c>dotnet ... /nodemode:1</c> processes behind.
+///  - <b>Sequential stream reads.</b> Draining stdout to EOF before reading stderr at all deadlocks the
+///    moment the child writes more than a pipe buffer (~4 KB) of stderr: the child blocks writing, so it
+///    never exits, so stdout never reaches EOF. Both streams have to be pumped concurrently.
+///  - <b>No timeout.</b> An unbounded <c>WaitForExit()</c> turns any of the above into a wedged test run
+///    that has to be killed from outside, leaving the whole child tree orphaned.
+///
+/// See GitHub issue #1969.
+/// </summary>
+internal static class NestedDotnetCli
+{
+    /// <summary>
+    /// Generous relative to a warm build (the whole BuildSmoke suite runs in ~50s once the engine and the
+    /// NuGet cache are warm) but well short of the 15 minute node idle timeout, so a regression of the
+    /// hang above surfaces as a failing test with captured output rather than as a wedged run.
+    /// </summary>
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+
+    // Only reached after the process has already exited, so the readers are draining what is left in the
+    // pipes rather than waiting on the child.
+    private static readonly TimeSpan StreamFlushTimeout = TimeSpan.FromSeconds(15);
+
+    public static (int exitCode, string output) Run(string arguments, TimeSpan? timeout = null)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            // Closed immediately after start: a child that decides to prompt (a NuGet credential provider,
+            // say) gets EOF and fails, instead of blocking forever on a console nobody is attached to.
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        // Environment variables become global MSBuild properties, so this covers `dotnet run` (which does
+        // not accept `-nodeReuse:false` on its command line - unrecognized arguments there are forwarded to
+        // the app being run) as well as `dotnet build`.
+        foreach (var pair in NoPersistentBuildServers)
+        {
+            startInfo.Environment[pair.Key] = pair.Value;
+        }
+
+        var output = new StringBuilder();
+        using var stdoutClosed = new ManualResetEventSlim(false);
+        using var stderrClosed = new ManualResetEventSlim(false);
+
+        using var process = new Process { StartInfo = startInfo };
+        process.OutputDataReceived += (_, e) => Collect(e, output, stdoutClosed);
+        process.ErrorDataReceived += (_, e) => Collect(e, output, stderrClosed);
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.StandardInput.Close();
+
+        var limit = timeout ?? DefaultTimeout;
+        if (!process.WaitForExit((int)limit.TotalMilliseconds))
+        {
+            // entireProcessTree: the CLI is a launcher - killing it alone would leave the MSBuild worker
+            // nodes and the compiler server it started still running, which is the accumulation this whole
+            // helper exists to prevent.
+            try { process.Kill(entireProcessTree: true); } catch { /* already gone */ }
+            try { process.WaitForExit((int)StreamFlushTimeout.TotalMilliseconds); } catch { }
+
+            return (TimedOutExitCode,
+                $"`dotnet {arguments}` did not finish within {limit.TotalMinutes:0.#} minutes and was killed." +
+                Environment.NewLine + Snapshot(output));
+        }
+
+        stdoutClosed.Wait(StreamFlushTimeout);
+        stderrClosed.Wait(StreamFlushTimeout);
+
+        return (process.ExitCode, Snapshot(output));
+    }
+
+    /// <summary>
+    /// Distinct from any exit code the dotnet CLI itself produces, so a timeout is never mistaken for a
+    /// build failure in a test's assertion message.
+    /// </summary>
+    public const int TimedOutExitCode = -9009;
+
+    private static readonly Dictionary<string, string> NoPersistentBuildServers = new()
+    {
+        // The build's MSBuild worker nodes exit with it instead of lingering for 15 minutes holding the
+        // inherited stdout/stderr pipe handles open.
+        ["MSBUILDDISABLENODEREUSE"] = "1",
+        // Same for the Roslyn compiler server (VBCSCompiler.exe), which otherwise survives ~10 minutes.
+        ["UseSharedCompilation"] = "false",
+        // ...and for the SDK's own persistent MSBuild server process.
+        ["DOTNET_CLI_USE_MSBUILD_SERVER"] = "0",
+    };
+
+    private static void Collect(DataReceivedEventArgs e, StringBuilder output, ManualResetEventSlim closed)
+    {
+        // A null Data is the stream-closed signal, not a blank line.
+        if (e.Data == null)
+        {
+            closed.Set();
+            return;
+        }
+
+        lock (output)
+        {
+            output.AppendLine(e.Data);
+        }
+    }
+
+    private static string Snapshot(StringBuilder output)
+    {
+        lock (output)
+        {
+            return output.ToString();
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCliTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCliTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Shouldly;
+
+namespace GlueUnitTests.TestSupport;
+
+// Guards the helper every Category=BuildSmoke test shells out through. See NestedDotnetCli's own doc
+// comment and GitHub issue #1969 for what went wrong without it: a nested `dotnet build` left MSBuild
+// worker nodes holding the inherited stdout pipe open, so a ReadToEnd() that should have returned in
+// seconds blocked for the nodes' 15 minute idle timeout instead - which read as "the test suite hangs".
+public class NestedDotnetCliTests
+{
+    [Fact]
+    public void Run_ShouldCaptureOutputAndReturnTheChildsExitCode_WhenTheCommandFails()
+    {
+        // The dotnet CLI reports an unknown command on stderr, so an empty result here means only one
+        // stream is being drained - the shape that deadlocks once a real build fills the other one.
+        var (exitCode, output) = NestedDotnetCli.Run("--definitely-not-a-real-dotnet-command", TimeSpan.FromMinutes(1));
+
+        exitCode.ShouldNotBe(0);
+        exitCode.ShouldNotBe(NestedDotnetCli.TimedOutExitCode, "This should have failed fast, not timed out.");
+        output.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void EveryNestedDotnetInvocation_ShouldGoThroughNestedDotnetCli()
+    {
+        // The bug was copy-pasted into seven files before anyone noticed, and running the tests cannot
+        // catch it - the deadlocking version passes whenever the MSBuild nodes happen to already be warm.
+        // So this is checked against the source instead.
+        var offenders = Directory
+            .EnumerateFiles(FindTestProjectRoot(), "*.cs", SearchOption.AllDirectories)
+            .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+            .Where(file => !Path.GetFileName(file).StartsWith("NestedDotnetCli", StringComparison.Ordinal))
+            .Where(file => File.ReadAllText(file).Contains("RedirectStandardOutput", StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        offenders.ShouldBeEmpty(
+            "These test files start a redirected child process directly instead of calling " +
+            $"{nameof(NestedDotnetCli)}.{nameof(NestedDotnetCli.Run)}, which is how the nested-build hang " +
+            "in issue #1969 reached seven files at once:" + Environment.NewLine +
+            string.Join(Environment.NewLine, offenders));
+    }
+
+    // Spawns a real nested MSBuild, which is what the BuildSmoke tag means; kept out of the fast suite for
+    // the same reason as the rest, since it has to sit through its own timeout to prove anything.
+    [Trait("Category", "BuildSmoke")]
+    [Fact]
+    public void Run_ShouldTimeOutAndKillTheWholeProcessTree_WhenTheCommandOutlivesItsTimeout()
+    {
+        // Killing the dotnet CLI process alone would leave MSBuild and its Exec grandchild running - the
+        // orphan accumulation this helper exists to prevent - so the grandchild is what gets asserted on.
+        using var project = new TempProjectThatRunsForever();
+
+        var timeout = TimeSpan.FromSeconds(20);
+        var stopwatch = Stopwatch.StartNew();
+        var (exitCode, output) = NestedDotnetCli.Run($"build \"{project.CsprojPath}\"", timeout);
+        stopwatch.Stop();
+
+        exitCode.ShouldBe(NestedDotnetCli.TimedOutExitCode,
+            "Expected a timeout, got:" + Environment.NewLine + output);
+        stopwatch.Elapsed.ShouldBeLessThan(timeout + TimeSpan.FromMinutes(1),
+            "The timeout did not actually bound the wait.");
+
+        var grandchild = project.GrandchildProcessId;
+        grandchild.ShouldNotBeNull(
+            "The grandchild never started, so this run proves nothing about killing it. Output:" +
+            Environment.NewLine + output);
+        IsAlive(grandchild.Value).ShouldBeFalse(
+            "The grandchild outlived the kill, so the child tree is being orphaned rather than reaped.");
+    }
+
+    private static bool IsAlive(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            // No process with that id - it is gone, which is the outcome being checked for.
+            return false;
+        }
+    }
+
+    private static string FindTestProjectRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "GlueUnitTests.csproj")))
+            {
+                return directory.FullName;
+            }
+            directory = directory.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate GlueUnitTests.csproj above " + AppContext.BaseDirectory);
+    }
+
+    private sealed class TempProjectThatRunsForever : IDisposable
+    {
+        private readonly string _root;
+        private readonly string _pidFile;
+
+        public string CsprojPath { get; }
+
+        public TempProjectThatRunsForever()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "FrbNestedCliTimeout_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+
+            _pidFile = Path.Combine(_root, "grandchild.pid");
+            CsprojPath = Path.Combine(_root, "RunsForever.csproj");
+
+            // No Sdk attribute and an explicit Build target: nothing to restore and no compiler to run, so
+            // the only thing this project can spend time on is the Exec. The grandchild records its own pid
+            // before sleeping, which is how the test identifies it without guessing from a process name.
+            File.WriteAllText(CsprojPath, $"""
+                <Project>
+                  <Target Name="Build">
+                    <Exec Command="powershell -NoProfile -NonInteractive -Command &quot;Set-Content -LiteralPath '{_pidFile}' -Value $PID; Start-Sleep -Seconds 600&quot;" />
+                  </Target>
+                </Project>
+                """);
+        }
+
+        /// <summary>
+        /// The pid the Exec grandchild wrote before going to sleep, or null if it never got that far.
+        /// </summary>
+        public int? GrandchildProcessId =>
+            File.Exists(_pidFile) && int.TryParse(File.ReadAllText(_pidFile).Trim(), out var pid) ? pid : null;
+
+        public void Dispose()
+        {
+            // Belt and braces: if the kill under test failed, don't leave the sleeper running for 10 minutes.
+            var pid = GrandchildProcessId;
+            if (pid != null)
+            {
+                try
+                {
+                    using var process = Process.GetProcessById(pid.Value);
+                    process.Kill(entireProcessTree: true);
+                }
+                catch { /* already gone, which is the expected case */ }
+            }
+
+            try { Directory.Delete(_root, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+}


### PR DESCRIPTION
Part of #1969.

## What was actually wrong

All seven BuildSmoke helpers spawned `dotnet` with both streams redirected and called `StandardOutput.ReadToEnd()`. `dotnet build` starts MSBuild worker nodes with `/nodeReuse:true`, and `Process`'s redirect pipes are inheritable, so those nodes keep the stdout write handle open after the build itself exits. `ReadToEnd()` returns on EOF, not on process exit, so it blocked until the nodes hit their 15 minute idle timeout.

Only the run that *starts* the nodes inherits the handles. That is why the same test hung once and passed on an immediate retry, and why killing every stray process before a run made things worse rather than better: a clean process slate was the trigger, not the cure.

Proof, captured during a reproduction: the child `dotnet build` had already exited, `testhost.exe` was still blocked, and 9 `dotnet ... /nodemode:1` nodes plus `VBCSCompiler` were alive holding the pipe.

Two lesser bugs in the same helpers: stdout was drained to EOF before stderr was read at all (deadlocks past ~4KB of stderr), and there was no timeout, so any of the above wedged the run instead of failing it.

## Fix

All seven now go through `NestedDotnetCli`: persistent build servers disabled, both streams pumped concurrently, 5 minute timeout, entire child tree killed on timeout. `NestedDotnetCliTests` fails the build if a redirected `Process.Start` reappears anywhere in the assembly, since running the tests cannot catch this (the broken version passes whenever the nodes are already warm).

| | Before | After |
| --- | --- | --- |
| Single BuildSmoke test, no warm nodes | 3+ min, still climbing | 7s |
| Full BuildSmoke suite | 48s warm / wedged cold | 62s, 10/10 |
| Stray processes after a successful run | 20 | 0 |

Fast suite is unchanged at ~25s for 280 tests. It was never the problem, despite the issue's first bullet.

## Also in here

- `.claude` added to `RepoHygieneTests`'s ignore list. A `.claude/worktrees` directory symlink to a sibling checkout makes `Directory.EnumerateFiles` walk out of the repo and report that checkout's cross-repo `ProjectReference`s as broken, which left three tests permanently red locally.
- `--blame-hang-timeout` on both `pr-tests.yml` test steps, so a wedged run fails with the hung test named instead of running out the job limit.

## Not fixed

The "test host process crashed" abort from the issue did not reproduce here, including under the cold-node hang. Plausibly the same bug seen through `--blame`'s eyes, but that is unconfirmed. If it reappears with this merged, it is a separate defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
