### PR TITLE
Make the Gum-release check in Test-DownstreamBuilds actually discriminate

### DIFF
--- a/scripts/Test-DownstreamBuilds.ps1
+++ b/scripts/Test-DownstreamBuilds.ps1
@@ -142,16 +142,38 @@ foreach ($state in @((Get-RepoState -Path $repoRoot -Label 'FlatRedBall'), (Get-
 
 # Gum is FRB's one hard external dependency, and shipping FRB against an unreleased Gum is a
 # silent failure mode: it compiles locally and then bundles a different Gum at release time.
+#
+# Gum's release workflow tags a version-bump commit ("[create-pull-request] automated change", or
+# "Bump version to ..." on older tags) that never merges back, so a Gum release tag is *never* an
+# ancestor of Gum's main. Testing the tag itself for ancestry therefore fires on every run, which
+# trains you to ignore it. The commit a release was actually cut from is that tag's parent, so
+# that is what gets compared. A tag sitting directly on main is handled too, in case the release
+# workflow ever stops making the bump commit.
 if (Test-Path $gumPath) {
+    # Local tags go stale silently, and comparing against a release that is no longer the newest
+    # is the same wrong-and-quiet answer this check exists to catch. Best effort only: an offline
+    # run falls through to whatever tags are already local.
+    git -C $gumPath fetch --tags --quiet origin 2>$null | Out-Null
+
     $latestGumTag = git -C $gumPath tag --list 'Release_*' --sort=-creatordate | Select-Object -First 1
     if ($latestGumTag) {
         git -C $gumPath merge-base --is-ancestor $latestGumTag HEAD 2>$null
+        $releaseCommit = if ($LASTEXITCODE -eq 0) { $latestGumTag } else { "$latestGumTag^" }
+
+        git -C $gumPath merge-base --is-ancestor $releaseCommit HEAD 2>$null
         if ($LASTEXITCODE -ne 0) {
             Write-Host ''
-            Write-Host "  WARNING: Gum HEAD does not contain its latest release tag ($latestGumTag)." -ForegroundColor Yellow
-            Write-Host "           These builds test FRB against unreleased Gum source, but glue.yml" -ForegroundColor Yellow
-            Write-Host "           bundles Gum's latest GitHub release. A pass here does not prove the" -ForegroundColor Yellow
-            Write-Host "           shipped combination works." -ForegroundColor Yellow
+            Write-Host "  WARNING: Gum HEAD is missing commits that are in its latest release ($latestGumTag)." -ForegroundColor Yellow
+            Write-Host "           glue.yml bundles that release, so this run tests FRB against older Gum" -ForegroundColor Yellow
+            Write-Host "           source than actually ships." -ForegroundColor Yellow
+        }
+        else {
+            $ahead = git -C $gumPath rev-list --count "$releaseCommit..HEAD" 2>$null
+            if ($ahead -and [int]$ahead -gt 0) {
+                Write-Host ''
+                Write-Host ("  Note: Gum is {0} commit(s) ahead of its latest release ({1}). glue.yml bundles" -f $ahead, $latestGumTag) -ForegroundColor DarkGray
+                Write-Host "        the release, so unreleased Gum changes are not covered by this run." -ForegroundColor DarkGray
+            }
         }
     }
 }


### PR DESCRIPTION
`Test-DownstreamBuilds.ps1`'s pre-flight checked whether Gum's latest release tag was an ancestor of the Gum checkout's HEAD. Gum's release workflow tags a version-bump commit that never merges back, so that tag is never an ancestor of main, and the warning fired on every run. Verified across the last 6 Gum release tags: all have a single parent on main, none are themselves on main.

An always-on warning is worse than no warning. It came up during the August 5 release, where it was the only thing that would have flagged a genuinely stale Gum checkout.

Changes:

- Compare against the tag's parent, the commit the release was actually cut from. The direct-tag path is kept in case the release workflow ever drops the bump commit.
- Being ahead of the release is the normal development state, so that is now an informational note with the commit count, not a warning. The warning is reserved for a checkout that is *missing* commits present in the shipped release.
- Fetch tags before reading them. The tag list is local, so an unfetched checkout silently compared against an older release.

Verified both directions against the real Gum repo: on current main the old check warned and the new one is quiet; against a synthetic HEAD two commits before the release both warn.

No unit test. There is no Pester harness in this repo and adding one for a diagnostic message in a dev script isn't proportionate.
