### PR TITLE
Don't run the measurement marker when Glue isn't focused

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -514,7 +514,15 @@ namespace GlueControl.Editing
 
                 UpdateMarkers(didChangeItemOver);
 
-                UpdateMeasurementMarker();
+                // The measurement marker responds to right-drags, but unlike the left-button logic above
+                // it isn't inside the IsGameOrGlueActive block, and it doesn't check focus itself. Edit mode
+                // sets Cursor.RequiresGameWindowInFocus = false (the game window is reparented into Glue so it
+                // never gets normal focus), so without this check a right-drag anywhere on screen would draw
+                // the measurement overlay even with Glue behind another window.
+                if (IsGameOrGlueActive && (mouse.IsInGameWindow() || wasPushedInWindow))
+                {
+                    UpdateMeasurementMarker();
+                }
             }
             else
             {


### PR DESCRIPTION
Part of #1975.

`EditingManager.Update()` called `UpdateMeasurementMarker()` outside the `if (IsGameOrGlueActive)` block, and `MeasurementMarker.Update()` has no focus or in-window check of its own. Edit mode sets `Cursor.RequiresGameWindowInFocus = false` (needed, since the game window is reparented into Glue and never gets normal focus), so the cursor doesn't early-out either. A right-drag anywhere on screen therefore drew the measurement overlay, including with Glue behind another window.

Now gated on `IsGameOrGlueActive && (mouse.IsInGameWindow() || wasPushedInWindow)`, matching the camera logic a few lines above. The in-window half also stops a right-drag over Glue's own tree view from measuring.

Left-drag was never affected: grab, drag-select and rectangle-select all already sit inside the gate.

No unit test. `GlueControl/Embedded/Editing/EditingManager.cs` is `<Compile Remove>`'d from `GameCommunicationPlugin.csproj` (it's a template copied into game projects), so no assembly in this repo compiles it, and nothing can reach it from a test. Making it testable would mean a new assembly compiling game-side embedded code against fakes for the `ScreenManager` / `InputManager` / `GuiManager` statics, which is out of proportion to a one-line gate.

## Manual test

1. Open a project with a Screen that has visible objects, run it, switch to edit mode.
2. Put another window (Explorer, a browser) on top of Glue so Glue is not focused.
3. Right-drag over the area where the embedded game is. Nothing should happen. Before this change, the measurement overlay drew and followed the cursor.
4. Click back into Glue, right-drag in the game view. The measurement overlay should still work normally.
