### PR TITLE
Generate INineSliceRuntime's members, not just its declaration (#1979)

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/NineSliceCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/NineSliceCodeGenerator.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using Gum.DataTypes;
+using Gum.DataTypes.Variables;
 using static FlatRedBall.Glue.SaveClasses.GlueProjectSave;
 
 namespace GumPlugin.CodeGeneration;
@@ -29,6 +30,26 @@ public class NineSliceCodeGenerator
         _glueState = glueState;
     }
 
+    // Gum.Wireframe.INineSliceRuntime's full member surface, in declaration order. The interface is
+    // hand-written in the sibling Gum repo under #if FRB (Gum/Wireframe/CustomSetPropertyOnRenderable.cs)
+    // and exists so that shared file can push variable values into Glue's generated runtime rather than
+    // into the NineSlice renderable directly - so it grows as more of TrySetPropertyOnNineSlice migrates
+    // to the runtime. Glue cannot read it: it has no reference to GumCore at all (see
+    // mStandardElementToQualifiedTypes, which holds runtime type names as plain strings), so this list is
+    // the only way to state the contract here. GumGeneratedCodeCompilesTests is what keeps it honest -
+    // it compiles the generated runtime against the real built GumCore, so a member added to the
+    // interface fails there instead of in a user's game. Issue #1979.
+    internal static readonly IReadOnlyList<string> InterfaceMemberNames = new[]
+    {
+        "Blend",
+        "CustomFrameTextureCoordinateWidth",
+        "Red",
+        "Green",
+        "Blue",
+        "BorderScale",
+        "IsTilingMiddleSections",
+    };
+
     public void AddAdditionalInheritance(StandardElementSave standardElementSave, List<string> inheritanceList)
     {
         if (standardElementSave.Name != "NineSlice" || !HasFrbRuntimeInterfaces)
@@ -37,6 +58,49 @@ public class NineSliceCodeGenerator
         }
 
         inheritanceList.Add("global::Gum.Wireframe.INineSliceRuntime");
+    }
+
+    // Deliberately gated on the same bool as AddAdditionalInheritance above, not on a gate of its own:
+    // declaring the interface and implementing it must be one decision, or they drift apart again. There
+    // is no new version risk in generating these - Gum.Wireframe.INineSliceRuntime and
+    // RenderingLibrary.Graphics.NineSlice compile into the same assembly (GumCore, built from Gum source
+    // with FRB defined), so any project whose Gum runtime has the interface has the members it needs.
+    internal void AddTypeSpecificVariablesToAddForProperties(
+        Dictionary<string, List<VariableSave>> typedVariablesToAddForProperties)
+    {
+        if (!HasFrbRuntimeInterfaces)
+        {
+            return;
+        }
+
+        // Canonical VariableSaves rather than hand-authored ones, so each member's type, category and
+        // name-alias handling stay whatever Gum says they are - hand-writing them would be a second
+        // schema to keep in sync. Anything the .gutx already defines is dropped downstream, in
+        // StandardsCodeGenerator.GenerateTypeSpecificVariablesToAdd.
+        var canonicalDefaultState = Gum.Managers.StandardElementsManager.Self
+            .TryGetDefaultStateFor("NineSlice", throwExceptionOnMissing: false);
+
+        if (canonicalDefaultState == null)
+        {
+            return;
+        }
+
+        var variablesToAdd = new List<VariableSave>();
+
+        foreach (var memberName in InterfaceMemberNames)
+        {
+            var canonicalVariable = canonicalDefaultState.Variables
+                .FirstOrDefault(variable => variable.GetRootName() == memberName);
+
+            // Cloned because StandardElementsManager's default states are process-wide and shared with
+            // every other consumer of the schema.
+            if (canonicalVariable != null)
+            {
+                variablesToAdd.Add(canonicalVariable.Clone());
+            }
+        }
+
+        typedVariablesToAddForProperties["NineSlice"] = variablesToAdd;
     }
 
     internal void AddTypeSpecificVariableNamesToSkipForProperties(Dictionary<string, List<string>> typedVariableNamesToSkipForProperties)

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StandardsCodeGenerator.cs
@@ -41,6 +41,11 @@ namespace GumPlugin.CodeGeneration
 
         // These are new variables that don't appear in the base definitioin of the standard element, but we support in code for convenience
         List<VariableSave> variableNamesToAddForProperties = new List<VariableSave>();
+
+        // Same idea as variableNamesToAddForProperties, but keyed by standard element name - the mirror of
+        // _typedVariableNamesToSkipForProperties. Unlike that list this one is version-dependent, so it is
+        // rebuilt in RefreshVariableNamesToSkipForProperties rather than populated once in Initialize.
+        Dictionary<string, List<VariableSave>> _typedVariablesToAddForProperties = new Dictionary<string, List<VariableSave>>();
         private SpriteCodeGenerator _spriteCodeGenerator;
         private TextCodeGenerator _textCodeGenerator;
         private ContainerCodeGenerator _containerCodeGenerator;
@@ -139,6 +144,9 @@ namespace GumPlugin.CodeGeneration
         {
             mVariableNamesToSkipForProperties.Clear();
             _typedVariableNamesToSkipForProperties.Clear();
+            _typedVariablesToAddForProperties.Clear();
+
+            _nineSliceCodeGenerator.AddTypeSpecificVariablesToAddForProperties(_typedVariablesToAddForProperties);
 
             _textCodeGenerator.AddVariableNamesToSkipForProperties(mVariableNamesToSkipForProperties);
 
@@ -518,9 +526,51 @@ namespace GumPlugin.CodeGeneration
                 }
             }
 
+            GenerateTypeSpecificVariablesToAdd(standardElementSave, currentBlock, containedGraphicalObjectName);
+
             _textCodeGenerator.GenerateVariableProperties(standardElementSave, currentBlock, containedGraphicalObjectName);
 
             // Sprites handle this in GenerateAdditionalMethods
+        }
+
+        // Issue #1979. Variables a per-type generator requires regardless of what the project's own .gutx
+        // contains. Glue never reconciles a loaded project's standard elements against Gum's canonical
+        // schema: FileReferenceTracker.InitializeElements calls ElementSave.Initialize with the element's
+        // OWN default state ("only a subset of initialization ... for performance reasons"), which fixes
+        // up variable types but back-fills nothing, and GumProjectSave.Initialize - the call that would
+        // reconcile - is never made. So the loop above sees a .gutx exactly as the Gum Editor last wrote
+        // it, which for an older project predates whatever Gum has added since.
+        //
+        // That is fine for an ordinary variable (the user simply doesn't get a property they never
+        // authored), but not for a member of an interface the class also declares: the result is a class
+        // that doesn't implement its own interface, CS0535 in the user's game.
+        private void GenerateTypeSpecificVariablesToAdd(
+            StandardElementSave standardElementSave, ICodeBlock currentBlock, string containedGraphicalObjectName)
+        {
+            if (!_typedVariablesToAddForProperties.TryGetValue(standardElementSave.Name, out var variablesToAdd))
+            {
+                return;
+            }
+
+            // The project's own .gutx wins wherever it already defines the variable - generating it from
+            // both sources is a duplicate member (CS0102).
+            var alreadyGenerated = standardElementSave.DefaultState?.Variables
+                .Select(variable => variable.GetRootName())
+                .ToHashSet(StringComparer.Ordinal)
+                ?? new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var variable in variablesToAdd)
+            {
+                if (alreadyGenerated.Contains(variable.GetRootName()))
+                {
+                    continue;
+                }
+
+                if (GetIfShouldGenerateProperty(variable, standardElementSave))
+                {
+                    GenerateVariable(currentBlock, containedGraphicalObjectName, variable, standardElementSave);
+                }
+            }
         }
 
         // Issue #1967 - a v3 (ShapeVariableExpansion) Rectangle backs its Fill/Stroke variable

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
@@ -315,6 +315,117 @@ public class GumGeneratedCodeCompilesTests : IDisposable
         output.ShouldContain("OK");
     }
 
+    // Issue #1979. The sweep at the top of this file builds its fixtures from Gum's *canonical* schema,
+    // which is a current Gum Editor's output - so it never sees the case that actually breaks users. Glue
+    // does not back-fill a loaded project's standard elements (it calls GumProjectSave.Load and never
+    // GumProjectSave.Initialize), so codegen emits from whatever an older Gum Editor last wrote into the
+    // .gutx, forever. Meanwhile ProjectLoader.LoadProject bumps the .gluj's FileVersion to LatestVersion on
+    // load, which switches on every version-gated decision - including declaring the
+    // Gum.Wireframe.I*Runtime interfaces. A stale .gutx plus a current FileVersion is the combination that
+    // produced CS0535: a runtime declaring an interface whose members its .gutx never mentioned.
+    //
+    // So this loads a real checked-in project's .gumx through the same GumProjectSave.Load call Glue makes
+    // and compiles what the generator produces for its standard elements. That covers the whole interface
+    // family (NineSlice/Sprite/Container/Polygon) with no list of member names anywhere - which matters
+    // because those interfaces are a migration surface in the sibling Gum repo (TrySetPropertyOnNineSlice
+    // moving from the renderable to the runtime), so they gain members over time. Every one of those
+    // additions lands here as a compile error instead of in a user's game.
+    [Fact]
+    public void LegacyGutxStandardElementRuntimes_ShouldCompileAgainstTheRealEngine()
+    {
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var repoRoot = FindRepoRoot();
+
+        var gumxPath = Path.Combine(repoRoot, "Samples", "FormsSampleProject", "FormsSampleProject",
+            "Content", "GumProject", "GumProject.gumx");
+        File.Exists(gumxPath).ShouldBeTrue($"Expected the FormsSampleProject Gum project at {gumxPath}");
+
+        var gumProject = Gum.DataTypes.GumProjectSave.Load(gumxPath, out var loadResult);
+        gumProject.ShouldNotBeNull($"Could not load {gumxPath}: {loadResult?.ErrorMessage}");
+
+        // The real call path: codegen reads the loaded project for version-gated decisions
+        // (StandardsCodeGenerator.IsRectangleFillStrokeSupported), so it has to be the sample's own
+        // project rather than the empty stand-in this class's constructor installs.
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = gumProject;
+
+        // Exactly what GumPlugin.Managers.FileReferenceTracker.InitializeElements does after Load, and the
+        // reason this whole bug exists. Note what it passes: the element's OWN default state, not
+        // StandardElementsManager's canonical one - so it resolves variable types (a .gutx stores enum
+        // values as plain ints, and without this the state setter emits "Blend.0") while reconciling
+        // against nothing. Glue's own comment there calls it "only a subset of initialization ... for
+        // performance reasons". Skipping this step here generated code no version of Glue would produce;
+        // skipping the canonical reconciliation is what leaves a real project's NineSlice.gutx permanently
+        // without BorderScale.
+        foreach (var standardElement in gumProject.StandardElements)
+        {
+            standardElement.Initialize(standardElement.DefaultState);
+        }
+
+        var nineSlice = gumProject.StandardElements
+            .FirstOrDefault(element => element.Name == "NineSlice");
+        nineSlice.ShouldNotBeNull("FormsSampleProject has no NineSlice standard element to check.");
+
+        // Fixture sanity, and the whole reason this test is distinct from the canonical-schema sweep
+        // above. If the sample is ever re-saved by a current Gum Editor these variables appear, the .gutx
+        // stops being "legacy", and this test silently degenerates into a duplicate of that sweep. Failing
+        // here is the correct outcome - point it at a project that is still old, or retire the test.
+        var nineSliceVariables = nineSlice.DefaultState.Variables
+            .Select(variable => variable.GetRootName())
+            .ToHashSet(StringComparer.Ordinal);
+        nineSliceVariables.ShouldNotContain("BorderScale",
+            "FormsSampleProject's NineSlice.gutx has been regenerated, so it no longer reproduces the " +
+            "stale-.gutx case this test exists for.");
+        nineSliceVariables.ShouldNotContain("IsTilingMiddleSections",
+            "FormsSampleProject's NineSlice.gutx has been regenerated, so it no longer reproduces the " +
+            "stale-.gutx case this test exists for.");
+
+        var generated = new Dictionary<string, string>(StringComparer.Ordinal);
+        var skipped = new List<string>();
+
+        foreach (var standardElement in gumProject.StandardElements.OrderBy(element => element.Name, StringComparer.Ordinal))
+        {
+            var source = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(standardElement);
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                skipped.Add(standardElement.Name + " (GenerateCodeFor produced nothing)");
+                continue;
+            }
+
+            generated[standardElement.Name] = source;
+        }
+
+        generated.ShouldNotBeEmpty();
+
+        // Fixture sanity: without the interface declaration there is no contract for the compile to check,
+        // and this test would pass against a runtime that promises nothing.
+        generated["NineSlice"].ShouldContain("global::Gum.Wireframe.INineSliceRuntime");
+
+        var scratchDirectory = Path.Combine(_tempProjectDirectory, "LegacyGutxCompileScratch");
+        WriteScratchProject(scratchDirectory, repoRoot, generated);
+
+        var (exitCode, output) = RunDotnetBuild(Path.Combine(scratchDirectory, "GumCodegenCompileScratch.csproj"));
+
+        var errors = output
+            .Split('\n')
+            .Where(line => line.Contains(": error ", StringComparison.Ordinal))
+            .Select(line => line.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var coverage =
+            "Compiled: " + string.Join(", ", generated.Keys.OrderBy(name => name, StringComparer.Ordinal)) +
+            Environment.NewLine +
+            "Not generated: " + (skipped.Count == 0 ? "(none)" : string.Join(", ", skipped));
+
+        exitCode.ShouldBe(0,
+            "The Gum standard element runtimes generated from a real project's own (older) .gutx do not " +
+            "compile against the real engine. A CS0535 here means Glue declared a Gum.Wireframe.I*Runtime " +
+            "interface it did not generate the members for:" + Environment.NewLine +
+            string.Join(Environment.NewLine, errors) + Environment.NewLine + Environment.NewLine + coverage);
+    }
+
     private static (int exitCode, string output) RunDotnetRun(string projectDirectory) =>
         NestedDotnetCli.Run($"run --project \"{projectDirectory}\" -c Debug");
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/NineSliceRuntimeInterfaceContractTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/NineSliceRuntimeInterfaceContractTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using Gum.DataTypes;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using GumPlugin.CodeGeneration;
+using Shouldly;
+
+namespace GlueUnitTests.GumPluginTests;
+
+// Issue #1979. Glue decides to declare Gum.Wireframe.INineSliceRuntime on the generated NineSliceRuntime
+// from the Glue file version alone (NineSliceCodeGenerator.AddAdditionalInheritance), but it generates the
+// *members* from the variables in the project's own NineSlice.gutx. Those are two different sources of
+// truth, and they disagree for every project written before Gum added BorderScale/IsTilingMiddleSections:
+// Glue never runs Gum's load-time standard-element back-fill (GumProjectSave.Initialize - it only calls
+// GumProjectSave.Load), so a stale .gutx is exactly what codegen sees, forever. The result is a class that
+// declares an interface it doesn't implement - CS0535 in the user's game, for a variable they never touched.
+//
+// The interface is hand-written in the sibling Gum repo under #if FRB (Gum/Wireframe/
+// CustomSetPropertyOnRenderable.cs) and is a migration surface: TrySetPropertyOnNineSlice is moving from
+// setting the NineSlice renderable directly to setting the runtime through this interface, so it grows as
+// that migration proceeds. Every member added there is a CS0535 in every FRB project until Glue catches up,
+// which is why the compile-level guard in GumGeneratedCodeCompilesTests matters more than these tests -
+// see LegacyGutxStandardElementRuntimes_ShouldCompileAgainstTheRealEngine. These pin the mechanism.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class NineSliceRuntimeInterfaceContractTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly bool _originalSynchronousMode;
+    private readonly Gum.DataTypes.GumProjectSave _originalGumProjectSave;
+    private readonly string _tempProjectDirectory;
+
+    public NineSliceRuntimeInterfaceContractTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalGumProjectSave = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+        GlueState.Self.CurrentMainProject = vsProject;
+
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject = new GlueProjectSave
+        {
+            FileVersion = GlueProjectSave.LatestVersion,
+        };
+        TaskManager.SynchronousMode = true;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = new Gum.DataTypes.GumProjectSave
+        {
+            FullFileName = System.IO.Path.Combine(_tempProjectDirectory, "GumProject", "GumProject.gumx"),
+        };
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject = _originalGlueProject;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = _originalGumProjectSave;
+
+        try
+        {
+            System.IO.Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    [Fact]
+    public void NineSlice_WithLegacyGutx_ShouldStillImplementEveryInterfaceMember()
+    {
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var generatedSource = GenerateNineSliceFrom(BuildLegacyGutxNineSliceState());
+
+        // The declaration side - unchanged by this fix, but if it ever stops being emitted the assertions
+        // below would pass vacuously against a class that has no contract to honor.
+        generatedSource.ShouldContain("global::Gum.Wireframe.INineSliceRuntime");
+
+        generatedSource.ShouldContain("public float BorderScale");
+        generatedSource.ShouldContain("public bool IsTilingMiddleSections");
+    }
+
+    [Fact]
+    public void NineSlice_WithCurrentGutx_ShouldNotDeclareInterfaceMembersTwice()
+    {
+        // The project's own .gutx has to win when it already defines the variable. Generating the member
+        // from both the .gutx and the interface contract is CS0102 (duplicate member) - the same way the
+        // "Color" entry in StandardsCodeGenerator.variableNamesToAddForProperties once produced one.
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var currentState = Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("NineSlice");
+
+        // Fixture sanity: this test only means something if the canonical schema really does carry the
+        // variables, i.e. if there is something to duplicate.
+        var variableNames = currentState.Variables.Select(variable => variable.GetRootName()).ToHashSet(StringComparer.Ordinal);
+        variableNames.ShouldContain("BorderScale");
+        variableNames.ShouldContain("IsTilingMiddleSections");
+
+        var generatedSource = GenerateNineSliceFrom(currentState);
+
+        CountPropertyDeclarations(generatedSource, "BorderScale").ShouldBe(1);
+        CountPropertyDeclarations(generatedSource, "IsTilingMiddleSections").ShouldBe(1);
+    }
+
+    [Fact]
+    public void NineSlice_BelowFrbRuntimeInterfaceVersion_ShouldNeitherDeclareNorImplementTheInterface()
+    {
+        // Below GluxVersions.GumHasFrbRuntimeInterfaces the interface is not declared, so there is no
+        // contract to honor - and the members must not appear either. An older project's Gum runtime may
+        // predate them entirely, which is the whole reason that gate exists.
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject.FileVersion =
+            (int)GlueProjectSave.GluxVersions.GumHasFrbRuntimeInterfaces - 1;
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var generatedSource = GenerateNineSliceFrom(BuildLegacyGutxNineSliceState());
+
+        generatedSource.ShouldNotContain("INineSliceRuntime");
+        generatedSource.ShouldNotContain("BorderScale");
+        generatedSource.ShouldNotContain("IsTilingMiddleSections");
+    }
+
+    private static string GenerateNineSliceFrom(Gum.DataTypes.Variables.StateSave defaultState)
+    {
+        var standardElementSave = new StandardElementSave { Name = "NineSlice" };
+        standardElementSave.Initialize(defaultState);
+
+        var codeBlock = new CodeBlockBase();
+        StandardsCodeGenerator.Self.GenerateStandardElementSaveCodeFor(standardElementSave, codeBlock)
+            .ShouldBeTrue();
+
+        return codeBlock.ToString();
+    }
+
+    // What a real project's NineSlice.gutx actually contains: the canonical schema minus the variables
+    // added after that file was last written by a Gum Editor. Checked against
+    // Samples/FormsSampleProject/FormsSampleProject/Content/GumProject/Standards/NineSlice.gutx, which has
+    // neither - and which Glue will never back-fill, because it only calls GumProjectSave.Load and never
+    // GumProjectSave.Initialize.
+    private static Gum.DataTypes.Variables.StateSave BuildLegacyGutxNineSliceState()
+    {
+        var canonical = Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("NineSlice");
+
+        var legacy = canonical.Clone();
+        legacy.Variables.RemoveAll(variable =>
+            variable.GetRootName() is "BorderScale" or "IsTilingMiddleSections");
+
+        return legacy;
+    }
+
+    // A generated property declaration is "<modifiers> <type> Name" alone on its line (ICodeBlock.Property),
+    // so anchoring on the end of the line distinguishes the declaration from the state-switch assignments
+    // and getter/setter bodies that also mention the name.
+    private static int CountPropertyDeclarations(string generatedSource, string memberName)
+    {
+        return System.Text.RegularExpressions.Regex.Matches(
+            generatedSource,
+            @"(?m)^\s*public\b[^\r\n;=]*?\b" + System.Text.RegularExpressions.Regex.Escape(memberName) + @"\s*$").Count;
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
@@ -68,13 +68,11 @@ public class GoldProjectCompileTests
     // issue - GlueControlCodeGenerator asking the Gum plugin "HasGum" at generation time, which returned
     // null and silently compiled out every #if HasGum branch.
     //
-    // No dotnet build step yet, unlike Beefball: regenerating any project containing a Gum NineSlice
-    // currently produces a NineSliceRuntime that declares Gum.Wireframe.INineSliceRuntime but does not
-    // implement BorderScale (which appears nowhere in Glue's Gum code generation) or
-    // IsTilingMiddleSections, so the build fails with CS0535 for reasons unrelated to any change under
-    // test. Add the build assertion once that contract is closed - see GitHub issue #1973.
+    // The build step was blocked until issue #1979: this project's NineSlice.gutx predates BorderScale and
+    // IsTilingMiddleSections, and Glue never back-fills a loaded project's standard elements, so the
+    // generated NineSliceRuntime declared Gum.Wireframe.INineSliceRuntime without implementing it (CS0535).
     [StaFact]
-    public async Task FormsSampleProject_LoadInGlue_ShouldRunGumCodeGeneration()
+    public async Task FormsSampleProject_LoadInGlue_ThenBuild_ShouldSucceed()
     {
         GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
 
@@ -99,5 +97,8 @@ public class GoldProjectCompileTests
         generated.ShouldContain("FormsSampleProject/GumRuntimes/TextRuntime.Generated.cs");
         generated.ShouldContain("FormsSampleProject/Forms/Screens/MainMenuGumForms.Generated.cs");
         generated.ShouldContain("FormsSampleProject/Screens/MainMenu.Generated.cs");
+
+        var (exitCode, output) = NestedDotnetCli.Run($"build \"{csproj}\" -c Debug");
+        exitCode.ShouldBe(0, $"dotnet build failed for the regenerated gold project:\n{output}");
     }
 }


### PR DESCRIPTION
Regenerating any project containing a Gum NineSlice produced a `NineSliceRuntime` that declared `Gum.Wireframe.INineSliceRuntime` without implementing `BorderScale` or `IsTilingMiddleSections`, so the game failed to compile with CS0535.

## Cause

Two different sources of truth. The interface is declared from the Glue file version alone (`NineSliceCodeGenerator.AddAdditionalInheritance`), but the members are generated from the variables in the project's own `NineSlice.gutx`.

Glue never reconciles a loaded project's standard elements against Gum's canonical schema — `FileReferenceTracker.InitializeElements` calls `ElementSave.Initialize` with each element's *own* default state ("only a subset of initialization ... for performance reasons"), which fixes up variable types but back-fills nothing, and `GumProjectSave.Initialize` is never called. So codegen sees a `.gutx` exactly as the Gum Editor last wrote it. Meanwhile `ProjectLoader.LoadProject` bumps `FileVersion` to `LatestVersion`, which switches the interface on. Every project older than those two variables hits it.

## Fix

`NineSliceCodeGenerator` contributes the interface's member set under the same `HasFrbRuntimeInterfaces` gate that emits the declaration — one decision, so the two can't drift apart again. Deduped against the `.gutx` so a current project doesn't get a duplicate member (CS0102), with `VariableSave`s taken from `StandardElementsManager` so types and name aliases stay canonical rather than hand-authored.

No new version risk: `INineSliceRuntime` and `RenderingLibrary.Graphics.NineSlice` compile into the same assembly (GumCore, Gum source built with `FRB` defined), so any project whose runtime has the interface has the members. Both are plain pass-throughs in Gum's own `NineSliceRuntime` too.

## Keeping it honest

The member list is hardcoded because Glue has no reference to GumCore and cannot reflect over the interface. `GumGeneratedCodeCompilesTests.LegacyGutxStandardElementRuntimes_ShouldCompileAgainstTheRealEngine` is the guard: it loads FormsSampleProject's real `.gumx` through the same `GumProjectSave.Load` + `InitializeElements` path Glue uses, generates, and compiles against the real built GumCore. Without the fix it reproduces both CS0535s exactly; the existing canonical-schema sweep never could, because its fixtures are what a *current* Gum Editor writes.

That matters beyond this bug: the `Gum.Wireframe.I*Runtime` interfaces are a migration surface — `TrySetPropertyOnNineSlice` is moving from setting the NineSlice renderable to setting the runtime — so they gain members over time, and each addition is a CS0535 in every FRB project until Glue catches up. This test turns that into a build failure here instead of in a user's game, for all four interfaces, with no member names in it.

Also enables the `dotnet build` step on the FormsSampleProject gold test, which this unblocks (issue #1973).

## Tests

300 green: 286 non-BuildSmoke, 14 BuildSmoke.

Closes #1979

🤖 Generated with [Claude Code](https://claude.com/claude-code)

