### PR TITLE
Fix Camera objects added during live edit

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -1240,6 +1240,11 @@ namespace GlueControl.Editing
                 }
                 if (foundObject == null)
                 {
+                    foundObject = InstanceLogic.Self.GetCameraByName(objectName);
+                }
+
+                if (foundObject == null)
+                {
                     var screen = ScreenManager.CurrentScreen;
                     var instance = screen.GetInstance($"{objectName}", screen);
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/VariableAssignmentLogic.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/VariableAssignmentLogic.cs
@@ -518,7 +518,23 @@ namespace GlueControl.Editing
 
                 if (targetInstance == null)
                 {
-                    response.WasVariableAssigned = screen.ApplyVariable(variableName, variableValue);
+                    // If instanceName and variableName are the same then the variable was for the
+                    // element itself (such as "this.SomeScreenVariable"), so the screen is the
+                    // correct target. Otherwise the variable was for an object in the element
+                    // (such as "this.SomeInstance.X") which could not be found - assigning to the
+                    // screen would report a missing "X" rather than the missing instance.
+                    var wasVariableForInstance = !string.IsNullOrEmpty(instanceName) && instanceName != variableName;
+
+                    if (wasVariableForInstance)
+                    {
+                        response.WasVariableAssigned = false;
+                        response.Exception =
+                            $"Could not find an object named {instanceName} in {screen.GetType().Name}, so its {variableName} could not be assigned.";
+                    }
+                    else
+                    {
+                        response.WasVariableAssigned = screen.ApplyVariable(variableName, variableValue);
+                    }
                 }
                 else
                 {
@@ -727,6 +743,11 @@ namespace GlueControl.Editing
             {
                 targetInstance = InstanceLogic.Self.ShapeCollectionsAddedAtRuntime.FirstOrDefault(item =>
                     item.Name == objectName);
+            }
+
+            if (targetInstance == null)
+            {
+                targetInstance = InstanceLogic.Self.GetCameraByName(objectName);
             }
 
             // This was originally how we got instances, but this adds a ton of overhead when dealing with screens

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/InstanceLogic.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/InstanceLogic.cs
@@ -37,6 +37,21 @@ namespace GlueControl
         public List<IDestroyable> DestroyablesAddedAtRuntime = new List<IDestroyable>();
 
         /// <summary>
+        /// Cameras for Camera NamedObjectSaves added at runtime. This usually holds the main camera
+        /// (a Camera object refers to it unless IsNewCamera is set), so removal has to check before
+        /// taking anything out of SpriteManager.Cameras.
+        /// </summary>
+        public List<Camera> CamerasAddedAtRuntime = new List<Camera>();
+
+        /// <summary>
+        /// Returns a Camera added at runtime by its NamedObjectSave instance name, or null if there
+        /// is no such camera. Cameras live in SpriteManager.Cameras rather than in any of the managers
+        /// searched when resolving an object name, so they have to be looked up separately.
+        /// </summary>
+        public Camera GetCameraByName(string objectName) =>
+            CamerasAddedAtRuntime.FirstOrDefault(item => item.Name == objectName);
+
+        /// <summary>
         /// Dictionary of state categories added at runtime, where the key is the ElementGameType name.
         /// </summary>
         public Dictionary<string, List<StateSaveCategory>> StatesAddedAtRuntime = new Dictionary<string, List<StateSaveCategory>>();
@@ -201,6 +216,34 @@ namespace GlueControl
                                 asCollidable.Collision.Add(circle);
                             }
                             newPositionedObject = circle;
+                        }
+                        break;
+                    case "FlatRedBall.Camera":
+                    case "Camera":
+                        {
+                            // A Camera object normally refers to the main camera rather than creating
+                            // a new one - see NamedObjectSaveCodeGenerator, which generates
+                            // "= FlatRedBall.SpriteManager.Camera" unless IsNewCamera is set.
+                            // Assigning newObject rather than newPositionedObject keeps the camera out
+                            // of the attachment logic below, which must not run on the main camera.
+                            Camera camera;
+
+                            if (deserialized.IsNewCamera)
+                            {
+                                camera = new Camera(FlatRedBallServices.GlobalContentManager);
+                                SpriteManager.Cameras.Add(camera);
+                            }
+                            else
+                            {
+                                camera = Camera.Main;
+                            }
+
+                            // Cameras are in SpriteManager.Cameras rather than in any of the managers
+                            // searched when looking an object up by name, so they have to be tracked
+                            // here for the editor to find them - see GetCameraByName. The name itself
+                            // is assigned below by AssignVariablesOnNewlyCreatedObject.
+                            CamerasAddedAtRuntime.Add(camera);
+                            newObject = camera;
                         }
                         break;
                     case "FlatRedBall.Graphics.Layer":
@@ -1030,6 +1073,22 @@ namespace GlueControl
                 DestroyablesAddedAtRuntime[i].Destroy();
             }
 
+            for (int i = CamerasAddedAtRuntime.Count - 1; i > -1; i--)
+            {
+                var camera = CamerasAddedAtRuntime[i];
+
+                if (camera == Camera.Main)
+                {
+                    // The main camera outlives objects added at runtime - only the name given to it
+                    // when the Camera object was added belongs to us.
+                    camera.Name = null;
+                }
+                else
+                {
+                    SpriteManager.Cameras.Remove(camera);
+                }
+            }
+
             foreach (var list in ListsAddedAtRuntime)
             {
                 for (int i = list.Count - 1; i > -1; i--)
@@ -1056,6 +1115,7 @@ namespace GlueControl
             ShapesAddedAtRuntime.Clear();
             SpritesAddedAtRuntime.Clear();
             DestroyablesAddedAtRuntime.Clear();
+            CamerasAddedAtRuntime.Clear();
             ListsAddedAtRuntime.Clear();
             TextsAddedAtRuntime.Clear();
         }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Models/NamedObjectSave.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Models/NamedObjectSave.cs
@@ -206,6 +206,17 @@ namespace GlueControl.Models
             set;
         }
 
+        /// <summary>
+        /// Whether a Camera object should be a new Camera rather than the main camera. This matches
+        /// the codegen in NamedObjectSaveCodeGenerator - a Camera is assigned SpriteManager.Camera
+        /// unless this is set.
+        /// </summary>
+        public bool IsNewCamera
+        {
+            get;
+            set;
+        }
+
         public string SourceFile
         {
             get;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
@@ -515,9 +515,7 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                 {
                     if(!shouldSkipPositioning)
                     {
-                        var firstPositionedObject = newObjectList.FirstOrDefault(item =>
-                            item.SourceType == SourceType.Entity ||
-                            item.GetAssetTypeInfo()?.IsPositionedObject == true);
+                        var firstPositionedObject = newObjectList.FirstOrDefault(ShouldPositionNewObjectAtCamera);
 
                         if (firstPositionedObject != null)
                         {
@@ -557,6 +555,29 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                 ContainerName = nosList?.InstanceName
             });
             return addObjectDto;
+        }
+
+        /// <summary>
+        /// Returns whether a newly-added object should be moved to the camera's position so that it
+        /// shows up on screen.
+        /// </summary>
+        /// <remarks>
+        /// Cameras are excluded even though their AssetTypeInfo reports IsPositionedObject. A Camera
+        /// NamedObjectSave is a handle on the main camera (NamedObjectSaveCodeGenerator generates
+        /// "= FlatRedBall.SpriteManager.Camera" for it), so positioning it would move the camera the
+        /// user is looking through instead of bringing a new object into view.
+        /// </remarks>
+        public static bool ShouldPositionNewObjectAtCamera(NamedObjectSave namedObject)
+        {
+            if (namedObject.SourceType == SourceType.Entity)
+            {
+                return true;
+            }
+
+            var assetTypeInfo = namedObject.GetAssetTypeInfo();
+
+            return assetTypeInfo?.IsPositionedObject == true &&
+                assetTypeInfo != AvailableAssetTypes.CommonAtis?.Camera;
         }
 
         private async Task AdjustNewObjectToCameraPosition(NamedObjectSave newNamedObject, Vector2? forcedNextObjectPosition)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
@@ -149,7 +149,7 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                         var exception = response?.Data.FirstOrDefault(item => !string.IsNullOrEmpty(item.Exception)).Exception;
                         if(exception != null)
                         {
-                            GlueCommands.Self.PrintError("Error returned frm game when sending variable:\n" + exception);
+                            GlueCommands.Self.PrintError("Error returned from game when sending variable:\n" + exception);
                             Output.Print(exception);
                         }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/NewObjectCameraPositioningTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/NewObjectCameraPositioningTests.cs
@@ -1,0 +1,66 @@
+﻿using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GameCommunicationPlugin.GlueControl.Managers;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin;
+
+/// <summary>
+/// When an object is added while the game runs in edit mode, Glue moves it to the camera's
+/// position so it lands in view. A Camera named object is a handle on the main camera
+/// (see NamedObjectSaveCodeGenerator - it generates "= FlatRedBall.SpriteManager.Camera"),
+/// so "positioning" it would move the camera the user is looking through. See issue #1984.
+/// </summary>
+public class NewObjectCameraPositioningTests
+{
+    public NewObjectCameraPositioningTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    static NamedObjectSave CreateFlatRedBallTypeNos(AssetTypeInfo ati) => new NamedObjectSave
+    {
+        InstanceName = "TestInstance",
+        SourceType = SourceType.FlatRedBallType,
+        SourceClassType = ati.QualifiedRuntimeTypeName.QualifiedType
+    };
+
+    [Fact]
+    public void ShouldPositionNewObjectAtCamera_ShouldBeTrue_ForSprite()
+    {
+        var nos = CreateFlatRedBallTypeNos(AvailableAssetTypes.CommonAtis.Sprite);
+
+        RefreshManager.ShouldPositionNewObjectAtCamera(nos).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldPositionNewObjectAtCamera_ShouldBeTrue_ForEntity()
+    {
+        var nos = new NamedObjectSave
+        {
+            InstanceName = "PlayerInstance",
+            SourceType = SourceType.Entity,
+            SourceClassType = "Entities\\Player"
+        };
+
+        RefreshManager.ShouldPositionNewObjectAtCamera(nos).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldPositionNewObjectAtCamera_ShouldBeFalse_ForCamera()
+    {
+        var nos = CreateFlatRedBallTypeNos(AvailableAssetTypes.CommonAtis.Camera);
+
+        RefreshManager.ShouldPositionNewObjectAtCamera(nos).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldPositionNewObjectAtCamera_ShouldBeFalse_ForNonPositionedType()
+    {
+        var nos = CreateFlatRedBallTypeNos(AvailableAssetTypes.CommonAtis.Layer);
+
+        RefreshManager.ShouldPositionNewObjectAtCamera(nos).ShouldBeFalse();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableAssignmentLogicEnumConversionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableAssignmentLogicEnumConversionTests.cs
@@ -228,6 +228,8 @@ public class VariableAssignmentLogicEnumConversionTests : IDisposable
                     public System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<GlueControl.Models.CustomVariable>> CustomVariablesAddedAtRuntime { get; } = new();
                     public System.Collections.Generic.List<object> ListsAddedAtRuntime { get; } = new();
                     public System.Collections.Generic.List<FlatRedBall.Math.Geometry.ShapeCollection> ShapeCollectionsAddedAtRuntime { get; } = new();
+                    public System.Collections.Generic.List<FlatRedBall.Camera> CamerasAddedAtRuntime { get; } = new();
+                    public FlatRedBall.Camera GetCameraByName(string objectName) => null;
                     public System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<GlueControl.Models.StateSaveCategory>> StatesAddedAtRuntime { get; } = new();
                 }
 


### PR DESCRIPTION
Adding a `Camera` object to a screen while the game runs in edit mode threw a `MemberAccessException` about a member named `X`. Three problems stack up to produce that, all fixed here.

**`InstanceLogic` couldn't create a Camera at runtime.** Its switch over creatable types had no `FlatRedBall.Camera` case, so the object never existed in the running game. It now resolves to the main camera, or a new one when `IsNewCamera` is set, matching what `NamedObjectSaveCodeGenerator` emits. Cameras live in `SpriteManager.Cameras` rather than in any of the managers searched during name lookup, so they're tracked in `CamerasAddedAtRuntime` and found through a new `GetCameraByName`, which both `VariableAssignmentLogic` and `EditingManager` consult.

**Glue auto-positioned the new object, and positioning a camera moves the main camera.** `RefreshManager` places every newly added positioned object at the current camera position so it lands in view, and Camera's `AssetTypeInfo` reports `IsPositionedObject` — so Glue positioned the camera at itself and sent `this.CameraInstance.X=16`. That's where the failing assignment came from; nobody typed it. The filter is now `ShouldPositionNewObjectAtCamera`, which excludes Cameras.

**A missing target instance was reported as the wrong error.** `VariableAssignmentLogic` fell back to `screen.ApplyVariable` with only the last segment of the variable path, so a failed lookup of `CameraInstance` surfaced as a missing `X` on the Screen. It now names the instance it couldn't find, and keeps the screen fallback only for element-level variables like `this.SomeScreenVariable`.

### Tests

`NewObjectCameraPositioningTests` covers the positioning predicate (Sprite and Entity position, Camera and Layer don't). Verified red first: reverting the Camera exclusion fails `ShouldPositionNewObjectAtCamera_ShouldBeFalse_ForCamera`.

The three embedded files are templates excluded from Glue's own compile, so they only build inside a game project. `VariableAssignmentLogicEnumConversionTests` (BuildSmoke) already embeds and compiles `VariableAssignmentLogic.Generated.cs` and the models against the real engine, which covers two of them; its `InstanceLogic` stub picked up the new member. `InstanceLogic.Generated.cs` and `EditingManager.Generated.cs` aren't in that scratch project, so they're covered by the manual test rather than by CI.

### Manual test

1. Open `Samples/Beefball/Beefball/Beefball.gluj` in Glue and run it into edit mode.
2. Add a `Camera` object to the screen.
3. The camera should not jump, and the Output tab should show no `MemberAccessException` and no "Tried to get object by name ... but couldn't find anything".
4. Set X or Y on the new Camera object in the property grid — the view should move, and the value should stick across a restart.

Closes #1984
