### PR TITLE
Gate Rectangle Fill/Stroke state codegen on the instance's type, not the container (#1987)

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
@@ -556,6 +556,21 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
 
     #endregion
 
+    /// <summary>
+    /// The name of the element a state variable actually sets a value on: the container itself for an
+    /// unqualified variable, or the instance's base type for a "SomeInstance.SomeVariable" variable.
+    /// Returns null when the instance can't be resolved, which the callers treat as "not a match".
+    /// </summary>
+    private static string GetVariableTargetElementName(Gum.DataTypes.Variables.VariableSave variable, ElementSave container)
+    {
+        if (string.IsNullOrEmpty(variable.SourceObject))
+        {
+            return container.Name;
+        }
+
+        return container.GetInstance(variable.SourceObject)?.BaseType;
+    }
+
     private bool GetIfShouldGenerateVariableInStateSetter(Gum.DataTypes.Variables.VariableSave variable, ElementSave container)
     {
         bool toReturn = true;
@@ -582,10 +597,14 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
             toReturn = false;
         }
 
-        // Issue #1967 - mirrors StandardsCodeGenerator.GetIfShouldGenerateProperty's live check;
+        // Issue #1967 / #1987 - mirrors StandardsCodeGenerator.GetIfShouldGenerateProperty's live check;
         // see the comment on rectangleVariablesToSkip above for why this isn't a static skip entry.
-        if (toReturn && container.Name == "Rectangle" &&
-            GumPlugin.CodeGeneration.StandardsCodeGenerator.RectangleFillStrokeVariableNames.Contains(variableRootName))
+        // Keyed on the element the variable actually targets, not on the container: a Rectangle
+        // *instance* inside a component ("HighlightRectangle.StrokeBlue") is the common case, and
+        // gating on container.Name alone only ever covered RectangleRuntime's own generated file.
+        if (toReturn &&
+            GumPlugin.CodeGeneration.StandardsCodeGenerator.RectangleFillStrokeVariableNames.Contains(variableRootName) &&
+            GetVariableTargetElementName(variable, container) == "Rectangle")
         {
             toReturn = GumPlugin.CodeGeneration.StandardsCodeGenerator.IsRectangleFillStrokeSupported;
         }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumGeneratedCodeCompilesTests.cs
@@ -315,6 +315,103 @@ public class GumGeneratedCodeCompilesTests : IDisposable
         output.ShouldContain("OK");
     }
 
+    // Issue #1987 - the field failure both Rectangle tests above miss, because both generate the standard
+    // element alone. A Rectangle *instance* inside a component goes through StateCodeGenerator with the
+    // component as its container, so the fill/stroke version gate (keyed on the element the variable
+    // targets) has to resolve through the instance's base type to fire at all. When it didn't, a v2
+    // project whose Rectangle.gutx carries the v3 variable family - what a user gets by opening an older
+    // Glue project in a current Gum Editor - generated ~500 CS1061s in the game build, all of the form
+    // "'RectangleRuntime' does not contain a definition for 'StrokeBlue'", and none of them in
+    // RectangleRuntime.Generated.cs itself.
+    //
+    // Compiling both files together is the point: either one alone compiles fine. The bug only exists in
+    // the disagreement between them.
+    [Fact]
+    public void V2ComponentWithRectangleInstance_ShouldCompileAgainstItsOwnV2RectangleRuntime()
+    {
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var gumProject = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+        gumProject.Version = (int)GumProjectSave.GumxVersions.AttributeVersion;
+
+        // Gum's canonical (v3-shaped) Rectangle schema sitting in a v2 project - the contaminated
+        // combination, not something either version produces on its own.
+        var rectangleDefaultState = GetGumsDefaultStateFor("Rectangle");
+        rectangleDefaultState.ShouldNotBeNull();
+
+        var rectangle = new StandardElementSave { Name = "Rectangle" };
+        rectangle.Initialize(rectangleDefaultState);
+        gumProject.StandardElements.Add(rectangle);
+
+        // The component's own base type, so StylesRuntime has a ContainerRuntime to derive from.
+        var containerDefaultState = GetGumsDefaultStateFor("Container");
+        containerDefaultState.ShouldNotBeNull();
+
+        var container = new StandardElementSave { Name = "Container" };
+        container.Initialize(containerDefaultState);
+        gumProject.StandardElements.Add(container);
+
+        var component = new ComponentSave { Name = "Styles", BaseType = "Container" };
+        component.Instances.Add(new InstanceSave { Name = "HighlightRectangle", BaseType = "Rectangle" });
+
+        var componentDefaultState = new Gum.DataTypes.Variables.StateSave { Name = "Default" };
+        component.States.Add(componentDefaultState);
+        foreach (var (variableName, type, value) in new (string, string, object)[]
+                 {
+                     ("StrokeRed", "int", 0), ("StrokeGreen", "int", 128), ("StrokeBlue", "int", 0),
+                     ("IsFilled", "bool", true),
+                     ("FillRed", "int", 0), ("FillGreen", "int", 0), ("FillBlue", "int", 0),
+                     ("StrokeWidth", "float", 0f),
+                 })
+        {
+            componentDefaultState.Variables.Add(new Gum.DataTypes.Variables.VariableSave
+            {
+                SetsValue = true,
+                Name = $"HighlightRectangle.{variableName}",
+                Type = type,
+                Value = value
+            });
+        }
+
+        component.Initialize(componentDefaultState);
+        gumProject.Components.Add(component);
+
+        var generated = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["Container"] = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(container),
+            ["Rectangle"] = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(rectangle),
+            ["Styles"] = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(component),
+        };
+
+        foreach (var pair in generated)
+        {
+            pair.Value.ShouldNotBeNullOrWhiteSpace($"Nothing was generated for {pair.Key}.");
+        }
+
+        // Fixture sanity: if the v2 Rectangle ever starts generating the fill/stroke properties, this test
+        // compiles trivially and stops pinning the disagreement it exists for.
+        generated["Rectangle"].ShouldContain("LineRectangle mContainedRectangle");
+        generated["Rectangle"].ShouldNotContain("public int StrokeBlue");
+
+        var scratchDirectory = Path.Combine(_tempProjectDirectory, "V2ComponentRectangleInstanceScratch");
+        WriteScratchProject(scratchDirectory, FindRepoRoot(), generated);
+
+        var (exitCode, output) = RunDotnetBuild(Path.Combine(scratchDirectory, "GumCodegenCompileScratch.csproj"));
+
+        var errors = output
+            .Split('\n')
+            .Where(line => line.Contains(": error ", StringComparison.Ordinal))
+            .Select(line => line.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        exitCode.ShouldBe(0,
+            "A component holding a Rectangle instance does not compile against the v2 RectangleRuntime " +
+            "generated from the same project:" + Environment.NewLine +
+            string.Join(Environment.NewLine, errors));
+    }
+
     // Issue #1979. The sweep at the top of this file builds its fixtures from Gum's *canonical* schema,
     // which is a current Gum Editor's output - so it never sees the case that actually breaks users. Glue
     // does not back-fill a loaded project's standard elements (it calls GumProjectSave.Load and never

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeCodegenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeCodegenTests.cs
@@ -80,6 +80,100 @@ public class RectangleFillStrokeCodegenTests : IDisposable
         };
     }
 
+    /// <summary>
+    /// A component holding a single Rectangle instance whose Default state sets the v3 fill/stroke
+    /// variables on it - i.e. the shape a real .gucx has, as opposed to the standard element's own
+    /// .gutx that every other test in this file generates. Registers both elements on the loaded
+    /// GumProjectSave so ObjectFinder can resolve the instance's base type during generation.
+    /// </summary>
+    private static Gum.DataTypes.ComponentSave BuildComponentWithRectangleInstanceFixture(
+        string instanceName = "HighlightRectangle")
+    {
+        var rectangle = BuildRectangleFixture();
+
+        var component = new Gum.DataTypes.ComponentSave { Name = "Styles", BaseType = "Container" };
+        component.Instances.Add(new Gum.DataTypes.InstanceSave
+        {
+            Name = instanceName,
+            BaseType = "Rectangle"
+        });
+
+        var defaultState = new Gum.DataTypes.Variables.StateSave { Name = "Default" };
+        component.States.Add(defaultState);
+
+        // Types are Gum's own type names as they appear in a real .gucx ("int", not "Int32") - the
+        // generator prefixes unrecognized type names onto the value, so a CLR name here silently
+        // produces "= Int32.128" instead of "= 128".
+        foreach (var (variableName, type, value) in new (string, string, object)[]
+                 {
+                     ("StrokeRed", "int", 0), ("StrokeGreen", "int", 128), ("StrokeBlue", "int", 0),
+                     ("IsFilled", "bool", true),
+                     ("FillRed", "int", 0), ("FillGreen", "int", 0), ("FillBlue", "int", 0),
+                     ("StrokeWidth", "float", 0f),
+                     // A variable that is valid on any gumx version, so a test asserting the fill/stroke
+                     // family is gone can still tell "gated correctly" apart from "generated nothing".
+                     ("Visible", "bool", false),
+                 })
+        {
+            defaultState.Variables.Add(new Gum.DataTypes.Variables.VariableSave
+            {
+                SetsValue = true,
+                Name = $"{instanceName}.{variableName}",
+                Type = type,
+                Value = value
+            });
+        }
+
+        component.Initialize(defaultState);
+
+        var gumProject = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+        gumProject.StandardElements.Add(rectangle);
+        gumProject.Components.Add(component);
+
+        return component;
+    }
+
+    [Fact]
+    public void V2Project_ComponentWithRectangleInstance_DoesNotAssignFillStrokeVariables()
+    {
+        // Issue #1987 - the property pipeline correctly omits Fill*/Stroke* from a v2 RectangleRuntime,
+        // so a component's state switch must not assign them on a Rectangle instance either (CS1061:
+        // 'RectangleRuntime' does not contain a definition for 'StrokeBlue'). The gate used to key on
+        // container.Name == "Rectangle", which is only ever true for RectangleRuntime's own file.
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.AttributeVersion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var component = BuildComponentWithRectangleInstanceFixture();
+
+        var generatedSource = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(component);
+
+        // Fixture sanity: generation actually ran and reached this instance's variables.
+        generatedSource.ShouldContain("HighlightRectangle.Visible");
+
+        foreach (var excludedMember in StandardsCodeGenerator.RectangleFillStrokeVariableNames)
+        {
+            generatedSource.Contains($"HighlightRectangle.{excludedMember}").ShouldBeFalse(
+                $"A v2 RectangleRuntime has no {excludedMember} property, so assigning it here is a CS1061 " +
+                "in the user's game build.");
+        }
+    }
+
+    [Fact]
+    public void V3Project_ComponentWithRectangleInstance_AssignsFillStrokeVariables()
+    {
+        // The other side of the same gate: on v3 the properties do exist (backed by
+        // FilledStrokedRectangle), so the component must keep setting the values the user authored.
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var component = BuildComponentWithRectangleInstanceFixture();
+
+        var generatedSource = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(component);
+
+        generatedSource.ShouldContain("HighlightRectangle.StrokeGreen = 128");
+        generatedSource.ShouldContain("HighlightRectangle.IsFilled = True");
+    }
+
     [Fact]
     public void V2Project_RectangleCodegen_StillMapsToLineRectangle_NoFillStrokeProperties()
     {


### PR DESCRIPTION
A gumx v2 project whose `Rectangle.gutx` carries the v3 Fill/Stroke variable family — what a user gets by opening an older Glue project in a current Gum Editor — produced ~500 `CS1061`s in the game build:

```
'RectangleRuntime' does not contain a definition for 'StrokeBlue'
'RectangleRuntime' does not contain a definition for 'FillBlue'
'RectangleRuntime' does not contain a definition for 'IsFilled'
```

All in component/screen runtimes, none in `RectangleRuntime.Generated.cs` itself.

## Cause

`StateCodeGenerator`'s fill/stroke version gate (added in #1968) keyed on `container.Name == "Rectangle"`, which is only true while generating the standard element's own file. For a Rectangle *instance* inside a component — `HighlightRectangle.StrokeBlue` — the container is the component, so the gate never fired and the state switch assigned properties the property pipeline had correctly refused to generate. Circle avoids this because its exclusions live in `typeSpecificVariableNamesToSkipForStates`, which the `SourceObject` block already resolves through `instanceSave.BaseType`.

## Fix

Key the gate on the element the variable actually targets: the container for an unqualified variable, the instance's base type for a qualified one.

## Tests

- `RectangleFillStrokeCodegenTests` — both sides of the gate for a component-with-Rectangle-instance fixture.
- `GumGeneratedCodeCompilesTests` (BuildSmoke) — compiles the generated component and its own v2 `RectangleRuntime` together against the real engine. Either file alone compiles fine; the bug only exists in the disagreement.

Both verified red against the old gate. Full suite green (292 non-BuildSmoke, 16 BuildSmoke).

Manually verified end to end: the reporting project regenerates through a headless `ProjectLoader.LoadProject` and builds clean, 496 errors to 0.

## Note

This restores compilation but drops the fill/stroke values the user authored, because a v2 Rectangle maps to `LineRectangle`, which can't back them. The real resolution for such a project is bumping it to gumx v3 with a runtime new enough to have `FilledStrokedRectangle` — which `RectangleFillStrokeRuntimeVersionCheck` already reports.

Fixes #1987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
