### PR TITLE
Show screen bounds when editing screens, not just entities

### DIFF
--- a/FRBDK/Glue/CompilerLibrary/Models/CompilerSettingsModel.cs
+++ b/FRBDK/Glue/CompilerLibrary/Models/CompilerSettingsModel.cs
@@ -21,7 +21,7 @@ namespace CompilerLibrary.Models
 
         public bool RestartScreenOnLevelContentChange { get; set; }
         public int PortNumber { get; set; } = 8021;
-        public bool ShowScreenBoundsWhenViewingEntities { get; set; }
+        public bool ShowScreenBounds { get; set; }
 
         public bool RestartOnFailedCommands { get; set; }
 
@@ -42,7 +42,7 @@ namespace CompilerLibrary.Models
         public void SetDefaults()
         {
             EmbedGameInGameTab = true;
-            ShowScreenBoundsWhenViewingEntities = true;
+            ShowScreenBounds = true;
             RestartScreenOnLevelContentChange = true;
 
             EnableSnapping = true;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -467,7 +467,7 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     #region GlueViewSettingsDto
     public class GlueViewSettingsDto
     {
-        public bool ShowScreenBoundsWhenViewingEntities { get; set; }
+        public bool ShowScreenBounds { get; set; }
 
         public bool ShowGrid { get; set; }
         public decimal GridAlpha { get; set; }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -1535,7 +1535,7 @@ namespace GlueControl
             EditingManager.Self.ShowGrid = dto.ShowGrid;
             EditingManager.Self.GridAlpha = dto.GridAlpha;
             EditingManager.Self.GuidesGridSpacing = (float)dto.GridSize;
-            Screens.EntityViewingScreen.ShowScreenBounds = dto.ShowScreenBoundsWhenViewingEntities;
+            EditingManager.Self.ShowScreenBounds = dto.ShowScreenBounds;
 
             if (dto.SetBackgroundColor)
             {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -452,7 +452,7 @@ namespace GlueControl.Dtos
     #region GlueViewSettingsDto
     public class GlueViewSettingsDto
     {
-        public bool ShowScreenBoundsWhenViewingEntities { get; set; }
+        public bool ShowScreenBounds { get; set; }
 
         public bool ShowGrid { get; set; }
         public decimal GridAlpha { get; set; }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -136,6 +136,12 @@ namespace GlueControl.Editing
             set => Guides.GridSpacing = value;
         }
 
+        /// <summary>
+        /// Whether to draw a rectangle showing how much of the game the player would see. When editing an
+        /// entity this is centered on the entity, and when editing a screen it follows the edit mode camera.
+        /// </summary>
+        public bool ShowScreenBounds { get; set; }
+
         float snapSize = 8;
         public float SnapSize
         {
@@ -523,6 +529,8 @@ namespace GlueControl.Editing
                 {
                     UpdateMeasurementMarker();
                 }
+
+                DrawScreenBounds();
             }
             else
             {
@@ -544,6 +552,31 @@ namespace GlueControl.Editing
             wasGameActive = FlatRedBallServices.Game.IsActive;
 
 #endif
+        }
+
+        private void DrawScreenBounds()
+        {
+            if (!ShowScreenBounds)
+            {
+                return;
+            }
+
+            // When editing an entity the entity is the only thing on screen, so the bounds are centered on it
+            // to show how much of the game the player would see around it. When editing a screen there's no
+            // equivalent anchor - the runtime camera position comes from custom code - so the bounds follow
+            // the edit mode camera instead.
+            var center = Vector3.Zero;
+
+            if (ElementEditingMode == ElementEditingMode.EditingScreen)
+            {
+                center = new Vector3(Camera.Main.X, Camera.Main.Y, 0);
+            }
+            else if ((ScreenManager.CurrentScreen as Screens.EntityViewingScreen)?.CurrentEntity is PositionedObject mainEntity)
+            {
+                center = new Vector3(mainEntity.X, mainEntity.Y, 0);
+            }
+
+            EditorVisuals.Rectangle(CameraSetup.Data.ResolutionWidth, CameraSetup.Data.ResolutionHeight, center);
         }
 
         private void UpdateMeasurementMarker()

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Screens/EntityViewingScreen.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Screens/EntityViewingScreen.cs
@@ -18,8 +18,6 @@ namespace GlueControl.Screens
         public static string GameElementTypeToCreate { get; set; }
         public static NamedObjectSave InstanceToSelect { get; set; }
 
-        public static bool ShowScreenBounds { get; set; }
-
         bool isViewingAbstractEntity;
 
         System.Collections.Generic.List<System.Collections.IList> FactoryLists = new System.Collections.Generic.List<System.Collections.IList>();
@@ -109,13 +107,6 @@ namespace GlueControl.Screens
                 Editing.EditorVisuals.Text(
                     $"Error in edit mode for entity {CurrentEntity?.GetType().Name}\n{e}\n{e.InnerException}",
                     new Vector3(camera.X, camera.Y, 0));
-            }
-
-            if (ShowScreenBounds)
-            {
-                var width = CameraSetup.Data.ResolutionWidth;
-                var height = CameraSetup.Data.ResolutionHeight;
-                Editing.EditorVisuals.Rectangle(width, height, Vector3.Zero);
             }
         }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -429,6 +429,14 @@ namespace GameCommunicationPlugin.GlueControl
                 {
                     var text = System.IO.File.ReadAllText(filePath.FullPath);
                     compilerSettings = JsonConvert.DeserializeObject<CompilerSettingsModel>(text);
+
+                    // ShowScreenBounds used to only apply to entities, and was named accordingly. Carry the
+                    // old value forward so projects saved before the rename don't silently lose the setting.
+                    if (compilerSettings?.ShowScreenBounds == false)
+                    {
+                        var legacyValue = JObject.Parse(text)["ShowScreenBoundsWhenViewingEntities"];
+                        compilerSettings.ShowScreenBounds = legacyValue?.Value<bool>() == true;
+                    }
                 }
                 catch
                 {
@@ -690,7 +698,7 @@ namespace GameCommunicationPlugin.GlueControl
                 case nameof(ViewModels.GlueViewSettingsViewModel.SnapSize):
                 case nameof(ViewModels.GlueViewSettingsViewModel.EnableSnapping):
                 case nameof(ViewModels.GlueViewSettingsViewModel.PolygonPointSnapSize):
-                case nameof(ViewModels.GlueViewSettingsViewModel.ShowScreenBoundsWhenViewingEntities):
+                case nameof(ViewModels.GlueViewSettingsViewModel.ShowScreenBounds):
                     await SendGlueViewSettingsToGame();
                     break;
             }
@@ -707,7 +715,7 @@ namespace GameCommunicationPlugin.GlueControl
                 ShowGrid = GlueViewSettingsViewModel.ShowGrid,
                 GridAlpha = GlueViewSettingsViewModel.GridAlpha,
                 GridSize = GlueViewSettingsViewModel.GridSize,
-                ShowScreenBoundsWhenViewingEntities = GlueViewSettingsViewModel.ShowScreenBoundsWhenViewingEntities,
+                ShowScreenBounds = GlueViewSettingsViewModel.ShowScreenBounds,
                 SetBackgroundColor = GlueViewSettingsViewModel.SetBackgroundColor,
                 BackgroundRed = GlueViewSettingsViewModel.BackgroundRed,
                 BackgroundGreen = GlueViewSettingsViewModel.BackgroundGreen,

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/ViewModels/GlueViewSettingsViewModel.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/ViewModels/GlueViewSettingsViewModel.cs
@@ -31,7 +31,7 @@ namespace GameCommunicationPlugin.GlueControl.ViewModels
             set => Set(value);
         }
 
-        public bool ShowScreenBoundsWhenViewingEntities
+        public bool ShowScreenBounds
         {
             get => Get<bool>();
             set => Set(value);
@@ -122,7 +122,7 @@ namespace GameCommunicationPlugin.GlueControl.ViewModels
         {
             this.PortNumber = model.PortNumber;
             this.RestartOnFailedCommands = model.RestartOnFailedCommands;
-            this.ShowScreenBoundsWhenViewingEntities = model.ShowScreenBoundsWhenViewingEntities;
+            this.ShowScreenBounds = model.ShowScreenBounds;
 
             this.ShowGrid = model.ShowGrid;
             this.GridAlpha = model.GridAlpha;
@@ -144,7 +144,7 @@ namespace GameCommunicationPlugin.GlueControl.ViewModels
         {
             compilerSettings.PortNumber = this.PortNumber;
             compilerSettings.RestartOnFailedCommands = this.RestartOnFailedCommands;
-            compilerSettings.ShowScreenBoundsWhenViewingEntities = this.ShowScreenBoundsWhenViewingEntities;
+            compilerSettings.ShowScreenBounds = this.ShowScreenBounds;
 
             compilerSettings.ShowGrid = this.ShowGrid;
             compilerSettings.GridAlpha = this.GridAlpha;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
@@ -67,7 +67,7 @@ namespace GameCommunicationPlugin.GlueControl.Views
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.ShowGrid), Localization.Texts.GridAndMarkings);
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.GridAlpha), Localization.Texts.GridAndMarkings);
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.GridSize), Localization.Texts.GridAndMarkings);
-            this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.ShowScreenBoundsWhenViewingEntities), Localization.Texts.GridAndMarkings);
+            this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.ShowScreenBounds), Localization.Texts.GridAndMarkings);
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.SetBackgroundColor), Localization.Texts.GridAndMarkings);
 
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.EnableSnapping), Localization.Texts.Snapping);

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
@@ -1,5 +1,9 @@
 using System.IO;
 using System.Threading.Tasks;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using GameCommunicationPlugin.GlueControl.CodeGeneration;
+using GameCommunicationPlugin.GlueControl.CodeGeneration.GlueCalls;
 using GlueUnitTests.TestSupport;
 using Shouldly;
 using Xunit;
@@ -97,6 +101,58 @@ public class GoldProjectCompileTests
         generated.ShouldContain("FormsSampleProject/GumRuntimes/TextRuntime.Generated.cs");
         generated.ShouldContain("FormsSampleProject/Forms/Screens/MainMenuGumForms.Generated.cs");
         generated.ShouldContain("FormsSampleProject/Screens/MainMenu.Generated.cs");
+
+        var (exitCode, output) = NestedDotnetCli.Run($"build \"{csproj}\" -c Debug");
+        exitCode.ShouldBe(0, $"dotnet build failed for the regenerated gold project:\n{output}");
+    }
+
+    // Live edit's runtime half - the ~40 files EmbeddedCodeManager copies into a game project's GlueControl
+    // folder - is <Compile Remove>d from GameCommunicationPlugin.csproj because it only compiles against a
+    // game project. No checked-in sample has live edit turned on, so building any of them as-is skips that
+    // closure entirely and a typo in Embedded\**\*.cs reaches every live-edit user before anything fails.
+    //
+    // EmbedAll is called directly rather than by turning live edit on in the copied CompilerSettings.json,
+    // because the plugin that would react to that setting (MainCompilerPlugin) builds real WPF tabs and
+    // opens sockets on registration and isn't seamed for the test host. What's at risk here is whether the
+    // embedded closure compiles, not whether the plugin decides to embed it.
+    [StaFact]
+    public async Task Beefball_WithLiveEditCode_LoadInGlue_ThenBuild_ShouldSucceed()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var project = GoldProject.CopyOutOfRepo("Samples/Beefball");
+        var csproj = Path.Combine(project.Root, "Beefball", "Beefball.csproj");
+
+        GoldProject.DeleteGeneratedCode(project.Root);
+
+        await GoldProject.LoadInGlueAsync(csproj);
+
+        GlueTestBootstrap.RecordedDialogMessages.ShouldBeEmpty();
+        ErrorRecordingPlugin.Errors.ShouldBeEmpty();
+
+        // Both together, in this order, is what MainCompilerPlugin.HandleGluxLoaded does in production.
+        var wasSynchronous = TaskManager.SynchronousMode;
+        TaskManager.SynchronousMode = true;
+        try
+        {
+            EmbeddedCodeManager.EmbedAll(fullyGenerate: true);
+            GlueCallsCodeGenerator.GenerateAll();
+        }
+        finally
+        {
+            TaskManager.SynchronousMode = wasSynchronous;
+        }
+
+        // Beefball sets EnableDefaultCompileItems to false, so the embedded files only reach the compiler
+        // through the Compile items EmbedAll added to the in-memory project.
+        GlueCommands.Self.ProjectCommands.SaveProjects();
+
+        // Without these the build below would pass by compiling a project that simply has no live edit code
+        // in it, which is indistinguishable from the embedding never having happened.
+        var generated = GoldProject.GeneratedFiles(project.Root);
+        generated.ShouldContain("Beefball/GlueControl/Editing/EditingManager.Generated.cs");
+        generated.ShouldContain("Beefball/GlueControl/Screens/EntityViewingScreen.Generated.cs");
+        generated.ShouldContain("Beefball/GlueControl/CommandReceiver.Generated.cs");
 
         var (exitCode, output) = NestedDotnetCli.Run($"build \"{csproj}\" -c Debug");
         exitCode.ShouldBe(0, $"dotnet build failed for the regenerated gold project:\n{output}");

--- a/FRBDK/Localization/Texts.Designer.cs
+++ b/FRBDK/Localization/Texts.Designer.cs
@@ -5111,11 +5111,11 @@ namespace Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show screen bounds when viewing entities.
+        ///   Looks up a localized string similar to Show screen bounds.
         /// </summary>
-        public static string ShowScreenBoundsWhenViewingEntities {
+        public static string ShowScreenBounds {
             get {
-                return ResourceManager.GetString("ShowScreenBoundsWhenViewingEntities", resourceCulture);
+                return ResourceManager.GetString("ShowScreenBounds", resourceCulture);
             }
         }
         

--- a/FRBDK/Localization/Texts.de.resx
+++ b/FRBDK/Localization/Texts.de.resx
@@ -1482,8 +1482,8 @@
   <data name="PortNumber" xml:space="preserve">
     <value>Port-Nummer</value>
   </data>
-  <data name="ShowScreenBoundsWhenViewingEntities" xml:space="preserve">
-    <value>Beim Anzeigen von Entitäten Bildschirmgrenzen anzeigen</value>
+  <data name="ShowScreenBounds" xml:space="preserve">
+    <value>Bildschirmgrenzen anzeigen</value>
   </data>
   <data name="SetBackgroundColor" xml:space="preserve">
     <value>Hintergrundfarbe festlegen</value>

--- a/FRBDK/Localization/Texts.fr.resx
+++ b/FRBDK/Localization/Texts.fr.resx
@@ -1482,8 +1482,8 @@
   <data name="PortNumber" xml:space="preserve">
     <value>Numéro de port</value>
   </data>
-  <data name="ShowScreenBoundsWhenViewingEntities" xml:space="preserve">
-    <value>Afficher les limites de l'écran lors de la visualisation des entités</value>
+  <data name="ShowScreenBounds" xml:space="preserve">
+    <value>Afficher les limites de l'écran</value>
   </data>
   <data name="SetBackgroundColor" xml:space="preserve">
     <value>Définir la couleur d'arrière-plan</value>

--- a/FRBDK/Localization/Texts.nl.resx
+++ b/FRBDK/Localization/Texts.nl.resx
@@ -1482,8 +1482,8 @@
   <data name="PortNumber" xml:space="preserve">
     <value>Poortnummer</value>
   </data>
-  <data name="ShowScreenBoundsWhenViewingEntities" xml:space="preserve">
-    <value>Toon schermgrenzen bij het bekijken van entiteiten</value>
+  <data name="ShowScreenBounds" xml:space="preserve">
+    <value>Toon schermgrenzen</value>
   </data>
   <data name="SetBackgroundColor" xml:space="preserve">
     <value>Achtergrondkleur</value>

--- a/FRBDK/Localization/Texts.resx
+++ b/FRBDK/Localization/Texts.resx
@@ -1483,8 +1483,8 @@ for {1}?</value>
   <data name="PortNumber" xml:space="preserve">
     <value>Port number</value>
   </data>
-  <data name="ShowScreenBoundsWhenViewingEntities" xml:space="preserve">
-    <value>Show screen bounds when viewing entities</value>
+  <data name="ShowScreenBounds" xml:space="preserve">
+    <value>Show screen bounds</value>
   </data>
   <data name="SetBackgroundColor" xml:space="preserve">
     <value>Set background color</value>


### PR DESCRIPTION
The screen bounds rectangle was drawn inside `EntityViewingScreen`, so screens never got it, and the setting was named after where the code happened to live rather than after a decision.

Drawing moved to `EditingManager`, which runs in both modes:

- Editing an entity: centered on the entity (it moves with the entity now instead of being pinned to the origin).
- Editing a screen: follows the edit mode camera. There's no other sensible anchor - the runtime camera position comes from custom code - so this shows what the player would see around wherever you're looking. At 100% zoom it sits on the window edge; it earns its keep zoomed out.

Setting renamed `ShowScreenBoundsWhenViewingEntities` to `ShowScreenBounds`, label suffix dropped in all four locales. `CompilerSettings.json` files written under the old name are read forward on load, so nobody loses the setting on upgrade.

### Test

Also adds `Beefball_WithLiveEditCode_LoadInGlue_ThenBuild_ShouldSucceed`. The ~40 embedded live edit files are `<Compile Remove>`d from GameCommunicationPlugin and no checked-in sample has live edit enabled, so none of them were compiled by anything in CI - a typo in `Embedded\**\*.cs` shipped straight to live edit users. The test runs `EmbedAll` against Beefball and builds the result. Confirmed it fails by breaking `EditingManager.cs` first.

`EmbedAll` is called directly instead of flipping the setting in the copied `CompilerSettings.json`, because `MainCompilerPlugin` builds WPF tabs and opens sockets on registration and isn't seamed for the test host.

Manual test: launch a project into edit mode with Show screen bounds checked, confirm the rectangle appears in a screen and follows the camera, and still frames the entity when editing one.

Closes #1990
