### PR TITLE
Register the Screen and Entity Input Movement plugins in the test harness (#1988)

### DIFF
--- a/FRBDK/Glue/Tests/GlueUnitTests/CodeGeneration/ScreenDefaultLayerCodeGenerationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CodeGeneration/ScreenDefaultLayerCodeGenerationTests.cs
@@ -1,0 +1,54 @@
+using FlatRedBall.Glue.CodeGeneration;
+using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.Tasks;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+
+namespace GlueUnitTests.CodeGeneration;
+
+// Regression coverage for #1988. A Screen's DefaultLayer is not an ordinary custom variable: the Screen
+// Plugin registers a VariableDefinition for it on the Screen ATI with UsesCustomCodeGeneration, which is
+// what stops CustomVariableCodeGenerator from declaring a `public string DefaultLayer;` field that would
+// shadow FlatRedBall.Screens.Screen.DefaultLayer (a Layer).
+//
+// So the suppression is only as real as the plugin being loaded, which makes this a test of the harness as
+// much as of the generator - see GoldProjectCompileTests.DoorsDemoProject_* for the end-to-end proof that
+// a project regenerated without the plugin does not compile.
+//
+// Assigns ObjectFinder.Self.GlueProject, which is process-wide, so it runs in the sequential collection.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class ScreenDefaultLayerCodeGenerationTests
+{
+    public ScreenDefaultLayerCodeGenerationTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    // StaFact: EnsureGameProjectPluginsRegistered runs real plugin StartUp methods, which build WPF toolbars.
+    [StaFact]
+    public void ScreenDefaultLayerVariable_ShouldNotGenerateAMember()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        var glueProject = new GlueProjectSave { FileVersion = GlueProjectSave.LatestVersion };
+        ObjectFinder.Self.GlueProject = glueProject;
+
+        var screen = new ScreenSave { Name = "Screens\\GameScreen" };
+        var variable = new CustomVariable
+        {
+            Name = nameof(FlatRedBall.Screens.Screen.DefaultLayer),
+            Type = "string",
+            Category = "Layer",
+        };
+        screen.CustomVariables.Add(variable);
+        glueProject.Screens.Add(screen);
+
+        ICodeBlock codeBlock = new CodeDocument();
+        CustomVariableCodeGenerator.AppendCodeForMember(screen, codeBlock, variable);
+
+        // Anything at all here is a member declaration shadowing the base class's Layer-typed property.
+        codeBlock.ToString().Trim().ShouldBeEmpty();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
@@ -101,6 +101,47 @@ public class GoldProjectCompileTests
         generated.ShouldContain("FormsSampleProject/GumRuntimes/TextRuntime.Generated.cs");
         generated.ShouldContain("FormsSampleProject/Forms/Screens/MainMenuGumForms.Generated.cs");
         generated.ShouldContain("FormsSampleProject/Screens/MainMenu.Generated.cs");
+
+        var (exitCode, output) = NestedDotnetCli.Run($"build \"{csproj}\" -c Debug");
+        exitCode.ShouldBe(0, $"dotnet build failed for the regenerated gold project:\n{output}");
+    }
+
+    // Covers the shape #1988 was filed against, which neither project above has: a Screen that both sets
+    // DefaultLayer and holds lists of factory-created entities, at a FileVersion past ScreensHaveDefaultLayer.
+    // That combination is what turns a missing Screen Plugin into a compile error rather than a harmless
+    // shadowing field - InitializeFactoriesAndSorting emits `Factories.DoorFactory.DefaultLayer =
+    // this.DefaultLayer;`, which is CS0029 the moment `this.DefaultLayer` resolves to a generated string
+    // field instead of the base Screen's Layer.
+    //
+    // Unlike the two above, this project references the engine through the FlatRedBallDesktopGLNet6 NuGet
+    // package rather than engine source, so it also covers "today's generated code against a released
+    // engine" - a shipped-package mismatch fails here and nowhere else.
+    [StaFact]
+    public async Task DoorsDemoProject_LoadInGlue_ThenBuild_ShouldSucceed()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var project = GoldProject.CopyOutOfRepo("Samples/Platformer/DoorsDemo");
+        var csproj = Path.Combine(project.Root, "DoorsDemo", "DoorsDemo.csproj");
+
+        GoldProject.DeleteGeneratedCode(project.Root);
+
+        await GoldProject.LoadInGlueAsync(csproj);
+
+        GlueTestBootstrap.RecordedDialogMessages.ShouldBeEmpty();
+        ErrorRecordingPlugin.Errors.ShouldBeEmpty();
+
+        var generated = GoldProject.GeneratedFiles(project.Root);
+        generated.ShouldContain("DoorsDemo/Screens/GameScreen.Generated.cs");
+        generated.ShouldContain("DoorsDemo/Factories/DoorFactory.Generated.cs");
+        generated.ShouldContain("DoorsDemo/Factories/PlayerFactory.Generated.cs");
+
+        // Pins the fixture, not the fix: if DoorsDemo ever loses its Screen DefaultLayer variable or its
+        // entity factories, the build below keeps passing while covering nothing.
+        var gameScreen = File.ReadAllText(Path.Combine(project.Root, "DoorsDemo", "Screens", "GameScreen.Generated.cs"));
+        gameScreen.ShouldContain("Factories.DoorFactory.DefaultLayer = this.DefaultLayer;");
+        gameScreen.Contains("public string DefaultLayer").ShouldBeFalse(
+            "The Screen Plugin's VariableDefinition is not suppressing the field - see #1988.");
 
         var (exitCode, output) = NestedDotnetCli.Run($"build \"{csproj}\" -c Debug");
         exitCode.ShouldBe(0, $"dotnet build failed for the regenerated gold project:\n{output}");

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,7 +17,9 @@ using FlatRedBall.Glue.Services;
 using FlatRedBall.Glue.Plugins.EmbeddedPlugins;
 using GlueFormsCore.ViewModels;
 using GumPlugin;
+using EntityInputMovementPlugin;
 using OfficialPlugins.CollisionPlugin;
+using OfficialPlugins.ScreenPlugin;
 using OfficialPlugins.MonoGameContent;
 using TileGraphicsPlugin;
 using Glue;
@@ -116,6 +118,8 @@ internal static class GlueTestBootstrap
     static bool _headlessProjectLoadReady;
     static bool _gumPluginRegisteredWithPluginManager;
     static bool _tiledPluginRegisteredWithPluginManager;
+    static bool _screenPluginRegisteredWithPluginManager;
+    static bool _entityInputMovementPluginRegisteredWithPluginManager;
 
     /// <summary>
     /// Every message production code sent through <see cref="DialogService"/> since
@@ -407,6 +411,8 @@ internal static class GlueTestBootstrap
     {
         EnsureGumPluginRegisteredWithPluginManager();
         EnsureCollisionPluginRegisteredWithPluginManager();
+        EnsureScreenPluginRegisteredWithPluginManager();
+        EnsureEntityInputMovementPluginRegisteredWithPluginManager();
 
         lock (_lock)
         {
@@ -418,6 +424,53 @@ internal static class GlueTestBootstrap
 
             PluginManager.RegisterPluginForTesting(new MainTiledPluginClass());
             PluginManager.RegisterPluginForTesting(new MainContentPipelinePlugin());
+        }
+    }
+
+    /// <summary>
+    /// Opt-in: constructs a real <see cref="MainScreenPlugin"/> and registers it with
+    /// <see cref="PluginManager.RegisterPluginForTesting"/>, running its real <c>StartUp</c>.
+    ///
+    /// Its whole StartUp is one <c>VariableDefinition</c> added to the Screen ATI, which is easy to read as
+    /// editor-only polish and is not: <c>DefaultLayer</c> is declared <c>UsesCustomCodeGeneration</c>, and
+    /// that flag is what stops <c>CustomVariableCodeGenerator</c> from emitting a <c>public string
+    /// DefaultLayer;</c> field shadowing the base <c>Screen.DefaultLayer</c> (a <c>Layer</c>). Without this
+    /// plugin, any screen that sets DefaultLayer and holds a factory-created entity list regenerates into
+    /// code that cannot compile - CS0029 on <c>Factories.XFactory.DefaultLayer = this.DefaultLayer;</c>.
+    /// GitHub issue #1988.
+    /// </summary>
+    public static void EnsureScreenPluginRegisteredWithPluginManager()
+    {
+        lock (_lock)
+        {
+            if (_screenPluginRegisteredWithPluginManager)
+            {
+                return;
+            }
+            _screenPluginRegisteredWithPluginManager = true;
+
+            PluginManager.RegisterPluginForTesting(new MainScreenPlugin());
+        }
+    }
+
+    /// <summary>
+    /// Opt-in: constructs a real <see cref="MainEntityInputMovementPlugin"/> and registers it with
+    /// <see cref="PluginManager.RegisterPluginForTesting"/>, running its real <c>StartUp</c>. This is what
+    /// writes a platformer/top-down project's <c>Platformer/*.Generated.cs</c> and <c>TopDown/*.Generated.cs</c>
+    /// files - which the .csproj still lists, so a project regenerated without it fails to build with
+    /// CS2001 on the missing sources rather than with anything naming a plugin.
+    /// </summary>
+    public static void EnsureEntityInputMovementPluginRegisteredWithPluginManager()
+    {
+        lock (_lock)
+        {
+            if (_entityInputMovementPluginRegisteredWithPluginManager)
+            {
+                return;
+            }
+            _entityInputMovementPluginRegisteredWithPluginManager = true;
+
+            PluginManager.RegisterPluginForTesting(new MainEntityInputMovementPlugin());
         }
     }
 


### PR DESCRIPTION
Fixes #1988.

The CS0029 is a test-harness artifact, not a bug real users hit. `MainScreenPlugin.StartUp` adds a `DefaultLayer` `VariableDefinition` (with `UsesCustomCodeGeneration`) to the Screen ATI, and that flag is the only thing stopping `CustomVariableCodeGenerator` from declaring `public string DefaultLayer;` over the base `Screen.DefaultLayer`. `GlueTestBootstrap` never registered that plugin, so headless regeneration emitted code Glue itself never emits.

## Proof, not assertion

Registering the plugin, then removing *only* that one line and rebuilding DoorsDemo:

```
GameScreen.Generated.cs(356,52): error CS0029: Cannot implicitly convert type 'string' to 'FlatRedBall.Graphics.Layer'
GameScreen.Generated.cs(358,50): error CS0029: Cannot implicitly convert type 'string' to 'FlatRedBall.Graphics.Layer'
```

Those are the `Factories.DoorFactory.DefaultLayer` / `Factories.PlayerFactory.DefaultLayer` assignments in `InitializeFactoriesAndSorting`.

## Changes

- `GlueTestBootstrap`: register `MainScreenPlugin` and `MainEntityInputMovementPlugin` in `EnsureGameProjectPluginsRegistered`.
- New gold project: DoorsDemo — the only checked-in project with the failing shape (a Screen that sets `DefaultLayer`, holds factory-created entity lists, and is past `ScreensHaveDefaultLayer`). It also references the engine via NuGet rather than source, so it covers today's codegen against a released package.
- New fast test pinning the generator behaviour directly, so this doesn't only fail as a 3-minute build smoke.

Entity Input Movement was needed to get DoorsDemo building at all: it writes `Platformer/*.Generated.cs`, which the `.csproj` still lists, so its absence surfaced as CS2001 on missing sources rather than as anything naming a plugin.

Full suite green: 293 non-BuildSmoke, 18 BuildSmoke.
