### PR TITLE
Delete vestigial packages.config files

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/packages.config
+++ b/Engines/FlatRedBallXNA/FlatRedBall/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
-</packages>

--- a/FRBDK/Glue/EntityPerformancePlugin/EntityPerformancePlugin/packages.config
+++ b/FRBDK/Glue/EntityPerformancePlugin/EntityPerformancePlugin/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
-</packages>

--- a/FRBDK/Glue/GumPlugin/GumPlugin/GumPlugin.csproj
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/GumPlugin.csproj
@@ -103,7 +103,6 @@
     <None Remove="GumCoreShared.FlatRedBall.projitems" />
     <None Remove="Icons\AddGumProject.png" />
     <None Remove="Icons\GumIcon.png" />
-    <None Remove="packages.config" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FRBDK/Glue/GumPlugin/GumPlugin/packages.config
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
-</packages>

--- a/FRBDK/Glue/TopDownPlugin/packages.config
+++ b/FRBDK/Glue/TopDownPlugin/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
-</packages>

--- a/Tiled/TMXGlueLib/TMXGlueLib.csproj
+++ b/Tiled/TMXGlueLib/TMXGlueLib.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="packages.config" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>

--- a/Tiled/TMXGlueLib/packages.config
+++ b/Tiled/TMXGlueLib/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MonoGame.Framework.DesktopGL.Core" version="3.8.0.1" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
Fixes Dependabot alert [#33](https://github.com/vchelaru/FlatRedBall/security/dependabot/33) (Newtonsoft.Json 12.0.2, CVE-2024-21907).

The vulnerable version was only ever in `GumPlugin/packages.config`, which nothing reads — GumPlugin is SDK-style and its actual `PackageReference` is already 13.0.2. All five `packages.config` files in the repo are leftovers from the PackageReference migration; two csprojs even carried a `<None Remove="packages.config" />` to keep them out of the project tree. Deleted the files and those two lines.

TopDownPlugin's stale file was also pinned at 12.0.2 and would have produced the same alert on the next scan, so it goes too.

Verified: `TMXGlueLib` and `GumPlugin` both still compile (GumPlugin's post-build copy fails on a standalone csproj build because `$(SolutionDir)` is undefined — pre-existing, unrelated).

Manual test: not needed — deletes files no build step consumes; covered by compilation.
