### PR TITLE
Compile live edit's #if HasGum embedded regions in a gold project (#1986)

### DIFF
--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
@@ -1,9 +1,5 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
-using FlatRedBall.Glue.Managers;
-using FlatRedBall.Glue.Plugins.ExportedImplementations;
-using GameCommunicationPlugin.GlueControl.CodeGeneration;
-using GameCommunicationPlugin.GlueControl.CodeGeneration.GlueCalls;
 using GlueUnitTests.TestSupport;
 using Shouldly;
 using Xunit;
@@ -72,11 +68,21 @@ public class GoldProjectCompileTests
     // issue - GlueControlCodeGenerator asking the Gum plugin "HasGum" at generation time, which returned
     // null and silently compiled out every #if HasGum branch.
     //
+    // It also carries live edit's embedded closure, which is the other half of #1986. Beefball covers that
+    // closure's legacy configuration; this project is the only one that can compile its modern one - it has
+    // Gum, is at FileVersion 61, and references engine source by ProjectReference, so `#if HasGum` (four
+    // regions in InstanceLogic.cs alone, plus CameraLogic, SelectionLogic and CopyPasteManager),
+    // `#if SpriteManagerHasInsertLayer` (48) and `#if ... || REFERENCES_FRB_SOURCE` all switch on. Those
+    // Gum regions are exactly where the embedded code and the Gum runtime drift apart - see #1978.
+    //
+    // Embedding here rather than in a separate test is deliberate: a real project load is by far the most
+    // expensive part of a gold test, and everything the live edit closure needs is already loaded.
+    //
     // The build step was blocked until issue #1979: this project's NineSlice.gutx predates BorderScale and
     // IsTilingMiddleSections, and Glue never back-fills a loaded project's standard elements, so the
     // generated NineSliceRuntime declared Gum.Wireframe.INineSliceRuntime without implementing it (CS0535).
     [StaFact]
-    public async Task FormsSampleProject_LoadInGlue_ThenBuild_ShouldSucceed()
+    public async Task FormsSampleProject_WithLiveEditCode_LoadInGlue_ThenBuild_ShouldSucceed()
     {
         GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
 
@@ -93,6 +99,8 @@ public class GoldProjectCompileTests
         // With the Gum plugin actually dispatched to, HasGum answers for real instead of returning null.
         FlatRedBall.Glue.Plugins.PluginManager.CallPluginMethod("Gum Plugin", "HasGum").ShouldBe(true);
 
+        GoldProject.EmbedLiveEditCode();
+
         // The Gum plugin's own generators ran, not just Glue's core ones: the Gum runtime wrappers, a Forms
         // component, and a standard element. None of these appear if the plugin is loaded but never
         // dispatched to, which is the failure mode behind this issue.
@@ -101,6 +109,20 @@ public class GoldProjectCompileTests
         generated.ShouldContain("FormsSampleProject/GumRuntimes/TextRuntime.Generated.cs");
         generated.ShouldContain("FormsSampleProject/Forms/Screens/MainMenuGumForms.Generated.cs");
         generated.ShouldContain("FormsSampleProject/Screens/MainMenu.Generated.cs");
+        generated.ShouldContain("FormsSampleProject/GlueControl/InstanceLogic.Generated.cs");
+        generated.ShouldContain("FormsSampleProject/GlueControl/Editing/SelectionLogic.Generated.cs");
+        generated.ShouldContain("FormsSampleProject/GlueControl/Editing/CameraLogic.Generated.cs");
+
+        // What makes this a different exercise from the Beefball live edit test rather than a slower copy of
+        // it. Without these, a regression that stops HasGum from being emitted (the Gum plugin not
+        // answering, the project losing its .gumx) turns every #if HasGum region back into dead text and the
+        // build still passes - covering nothing, silently.
+        var defines = GoldProject.EmbeddedDefines(
+            Path.Combine(project.Root, "FormsSampleProject", "GlueControl", "InstanceLogic.Generated.cs"));
+        defines.ShouldContain("HasGum");
+        defines.ShouldContain("SpriteManagerHasInsertLayer");
+        defines.ShouldContain("HasFrbServicesGraphicsDeviceManager");
+        defines.ShouldContain("ScreenHasCancellationToken");
 
         var (exitCode, output) = NestedDotnetCli.Run($"build \"{csproj}\" -c Debug");
         exitCode.ShouldBe(0, $"dotnet build failed for the regenerated gold project:\n{output}");
@@ -171,22 +193,7 @@ public class GoldProjectCompileTests
         GlueTestBootstrap.RecordedDialogMessages.ShouldBeEmpty();
         ErrorRecordingPlugin.Errors.ShouldBeEmpty();
 
-        // Both together, in this order, is what MainCompilerPlugin.HandleGluxLoaded does in production.
-        var wasSynchronous = TaskManager.SynchronousMode;
-        TaskManager.SynchronousMode = true;
-        try
-        {
-            EmbeddedCodeManager.EmbedAll(fullyGenerate: true);
-            GlueCallsCodeGenerator.GenerateAll();
-        }
-        finally
-        {
-            TaskManager.SynchronousMode = wasSynchronous;
-        }
-
-        // Beefball sets EnableDefaultCompileItems to false, so the embedded files only reach the compiler
-        // through the Compile items EmbedAll added to the in-memory project.
-        GlueCommands.Self.ProjectCommands.SaveProjects();
+        GoldProject.EmbedLiveEditCode();
 
         // Without these the build below would pass by compiling a project that simply has no live edit code
         // in it, which is indistinguishable from the embedding never having happened.
@@ -194,6 +201,21 @@ public class GoldProjectCompileTests
         generated.ShouldContain("Beefball/GlueControl/Editing/EditingManager.Generated.cs");
         generated.ShouldContain("Beefball/GlueControl/Screens/EntityViewingScreen.Generated.cs");
         generated.ShouldContain("Beefball/GlueControl/CommandReceiver.Generated.cs");
+
+        // Beefball has no .gumx, its gluj is FileVersion 42, and it references prebuilt engine DLLs rather
+        // than engine source. So this test compiles the *legacy* half of the embedded closure: the #else
+        // branches of `#if HasGum`, `#if SpriteManagerHasInsertLayer` (48), `#if
+        // HasFrbServicesGraphicsDeviceManager || REFERENCES_FRB_SOURCE` (57) and `#if
+        // ScreenHasCancellationToken || REFERENCES_FRB_SOURCE` (59). FormsSampleProject above covers the
+        // modern side. Pinning the absent defines keeps that split honest - if Beefball is ever upgraded or
+        // given a Gum project, the two tests quietly collapse onto the same branches.
+        var beefballDefines = GoldProject.EmbeddedDefines(
+            Path.Combine(project.Root, "Beefball", "GlueControl", "InstanceLogic.Generated.cs"));
+        beefballDefines.ShouldContain("SupportsEditMode");
+        beefballDefines.ShouldNotContain("HasGum");
+        beefballDefines.ShouldNotContain("SpriteManagerHasInsertLayer");
+        beefballDefines.ShouldNotContain("ScreenHasCancellationToken");
+        beefballDefines.ShouldNotContain("REFERENCES_FRB_SOURCE");
 
         var (exitCode, output) = NestedDotnetCli.Run($"build \"{csproj}\" -c Debug");
         exitCode.ShouldBe(0, $"dotnet build failed for the regenerated gold project:\n{output}");

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/GoldProjectCompileTests.cs
@@ -25,6 +25,7 @@ namespace GlueUnitTests.Projects;
 /// plugins are loaded.
 /// </summary>
 [Trait("Category", "BuildSmoke")]
+[TestCaseOrderer(LiveEditEmbedLastOrderer.TypeName, LiveEditEmbedLastOrderer.AssemblyName)]
 public class GoldProjectCompileTests
 {
     // StaFact, not Fact: plugin StartUp methods construct real WPF toolbars, which need an STA thread.

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GoldProject.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GoldProject.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GoldProject.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GoldProject.cs
@@ -4,6 +4,11 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using FlatRedBall.IO;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using GameCommunicationPlugin.GlueControl.CodeGeneration;
+using GameCommunicationPlugin.GlueControl.CodeGeneration.GlueCalls;
 
 namespace GlueUnitTests.TestSupport;
 
@@ -65,6 +70,61 @@ internal static class GoldProject
         ErrorRecordingPlugin.Output.Clear();
         await FlatRedBall.Glue.IO.ProjectLoader.Self.LoadProject(csprojPath);
     }
+
+    /// <summary>
+    /// Writes live edit's runtime half - the ~40 files <c>EmbeddedCodeManager</c> copies into a game
+    /// project's GlueControl folder - into the currently loaded project, exactly as
+    /// <c>MainCompilerPlugin.HandleGluxLoaded</c> does (both calls, in this order).
+    ///
+    /// Those files are <c>&lt;Compile Remove&gt;</c>d from GameCommunicationPlugin.csproj because they only
+    /// compile against a game project, and no checked-in sample has live edit turned on, so a typo in
+    /// <c>Embedded\**\*.cs</c> otherwise reaches every live-edit user before anything fails. See GitHub
+    /// issue #1986.
+    ///
+    /// EmbedAll is called directly rather than by turning live edit on in the copied CompilerSettings.json,
+    /// because the plugin that would react to that setting builds real WPF tabs and opens sockets on
+    /// registration and isn't seamed for the test host. What's at risk is whether the embedded closure
+    /// compiles, not whether the plugin decides to embed it.
+    /// </summary>
+    public static void EmbedLiveEditCode()
+    {
+        var wasSynchronous = TaskManager.SynchronousMode;
+        TaskManager.SynchronousMode = true;
+
+        // FileManager.RelativeDirectory is process-wide, and PluginManager pairs a push of it with a pop on
+        // every plugin call, reporting an error when the two disagree. In production EmbedAll runs inside the
+        // glux load that set it; called on its own here it leaves it pointing elsewhere, and the *next* gold
+        // project load in the process is what fails - naming a plugin that has nothing to do with this.
+        var relativeDirectory = FileManager.RelativeDirectory;
+        try
+        {
+            EmbeddedCodeManager.EmbedAll(fullyGenerate: true);
+            GlueCallsCodeGenerator.GenerateAll();
+
+            // The samples set EnableDefaultCompileItems to false, so the embedded files only reach the
+            // compiler through the Compile items EmbedAll added to the in-memory project.
+            GlueCommands.Self.ProjectCommands.SaveProjects();
+        }
+        finally
+        {
+            TaskManager.SynchronousMode = wasSynchronous;
+            FileManager.RelativeDirectory = relativeDirectory;
+        }
+    }
+
+    /// <summary>
+    /// The <c>#define</c> symbols at the top of an embedded GlueControl file, as emitted by
+    /// <c>GlueControlCodeGenerator</c>'s {CompilerDirectives} substitution. Use this rather than searching the
+    /// file text for "#define Foo": several defines prefix each other (<c>HasGum</c> is a prefix of the
+    /// GluxVersions member <c>HasGumSkiaElements</c>), so a substring assertion passes on the wrong line and
+    /// the conditional region it was meant to pin is never compiled.
+    /// </summary>
+    public static IReadOnlyCollection<string> EmbeddedDefines(string generatedFilePath) =>
+        File.ReadAllLines(generatedFilePath)
+            .Select(line => line.Trim())
+            .Where(line => line.StartsWith("#define "))
+            .Select(line => line.Substring("#define ".Length).Trim())
+            .ToHashSet();
 
     /// <summary>
     /// Deletes every *.Generated.cs under <paramref name="directory"/>, and returns how many were removed.

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveEditEmbedLastOrderer.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveEditEmbedLastOrderer.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace GlueUnitTests.TestSupport;
+
+/// <summary>
+/// Runs a gold project test whose name contains "WithLiveEditCode" after every other test in its class.
+///
+/// Embedding live edit's GlueControl closure writes ~40 files into the loaded project and saves it, and a
+/// *subsequent* real project load in the same process then hangs inside GumPlugin's HandleGluxLoad: that
+/// handler awaits inside a TaskManager task, TaskManager.SynchronousMode (forced on process-wide by
+/// GlueTestBootstrap) runs it by blocking the calling thread on the awaited task, and the continuation needs
+/// the STA thread the blocked call is sitting on. Nothing times out - the run sits there until the blame
+/// collector kills it 15 minutes later, which reads as a slow build rather than a deadlock.
+///
+/// That fragility is in Glue's own async-void-plus-blocking-TaskManager plumbing, not in anything the gold
+/// tests do wrong, and fixing it is well beyond adding compile coverage. Ordering these tests last means no
+/// load ever follows an embed. xUnit's default ordering is a hash of the test case's unique ID, so without
+/// this, renaming an unrelated test in the class is enough to reshuffle it back into the hang.
+/// </summary>
+public class LiveEditEmbedLastOrderer : ITestCaseOrderer
+{
+    public const string TypeName = "GlueUnitTests.TestSupport.LiveEditEmbedLastOrderer";
+    public const string AssemblyName = "GlueUnitTests";
+
+    public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+        where TTestCase : ITestCase =>
+        testCases
+            .OrderBy(testCase => Embeds(testCase) ? 1 : 0)
+            .ThenBy(testCase => testCase.TestMethod.Method.Name, StringComparer.Ordinal);
+
+    static bool Embeds(ITestCase testCase) =>
+        testCase.TestMethod.Method.Name.Contains("WithLiveEditCode", StringComparison.Ordinal);
+}


### PR DESCRIPTION
Part of #1986.

#1991 added a Beefball gold test that embeds live edit's GlueControl closure and builds it, which covers the ~40 embedded files as *text*. It does not cover their conditional compilation: Beefball has no `.gumx`, its gluj is FileVersion 42, and it references prebuilt engine DLLs, so every `#if HasGum` region (four in `InstanceLogic.cs`, plus `CameraLogic`, `SelectionLogic`, `CopyPasteManager`) and the FileVersion 48/57/59 + `REFERENCES_FRB_SOURCE` branches are dead text there.

This embeds the closure in the FormsSampleProject gold test too — Gum, FileVersion 61, engine source by ProjectReference — and pins the defines on both sides so the two tests can't quietly converge on the same branches.

Verified by breaking a call inside an `#if HasGum` region: FormsSampleProject fails with CS1061, Beefball passes.

Two things worth flagging:

- Assertions go through `GoldProject.EmbeddedDefines` instead of searching the file text. `"#define HasGum"` is a substring of the emitted `"#define HasGumSkiaElements"`, so a text search passes either way — the first version of this test was green for that reason.
- `EmbedLiveEditCode` restores `FileManager.RelativeDirectory`. In production `EmbedAll` runs inside the glux load that set it; called on its own it leaves `PluginManager`'s push/pop pair mismatched, and the *next* gold load in the process fails with "The relativeDirectory wasn't set properly in CanFileReferenceContent" naming an unrelated plugin.

Still uncovered: `#if WINDOWS` in `EditingManager.cs` and the FNA-only paths — no sample defines either.

Tests: 294 fast + 19 BuildSmoke green.


---

**Update (second commit):** the first push hung CI for 15 minutes in `DoorsDemoProject_LoadInGlue_ThenBuild_ShouldSucceed`. Embedding the closure writes ~40 files and saves the project; a *subsequent* load then deadlocks inside `GumPlugin.HandleGluxLoad` — it awaits inside a TaskManager task, `SynchronousMode` (forced on process-wide by `GlueTestBootstrap`) runs that by blocking the calling thread on the awaited task, and the continuation needs the STA thread that call is sitting on. Nothing times out.

That's Glue's own async-void-plus-blocking-TaskManager plumbing, not something the gold tests do wrong. Rather than fix it here, a `TestCaseOrderer` runs the embedding tests after every other test in the class, so no load ever follows an embed. Previously this was decided by xUnit's default hash-of-test-ID ordering — renaming the FormsSampleProject test is what moved it ahead of DoorsDemo and surfaced the hang.

Verified against the CI-shaped command (`dotnet test 'Glue with All.sln' --filter "Category=BuildSmoke"`), which reproduced the hang before and is 19/19 green after.
