### PR TITLE
Fix NRE in AboutPlugin when no project is loaded

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueState.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueState.cs
@@ -423,6 +423,10 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations
             {
                 // for now we'll use the main project, but eventually we may want to include synced projects too:
                 var project = GlueState.Self.CurrentMainProject;
+                if (project == null)
+                {
+                    return null;
+                }
                 var referenceItems = project.EvaluatedItems.Where(item =>
                 {
                     return item.ItemType == "PackageReference" && item.EvaluatedInclude.StartsWith("FlatRedBall");

--- a/FRBDK/Glue/Tests/GlueUnitTests/ExportedImplementations/GlueStateEngineDllSyntaxVersionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/ExportedImplementations/GlueStateEngineDllSyntaxVersionTests.cs
@@ -1,0 +1,38 @@
+using System;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.ExportedImplementations;
+
+// Assigns GlueState.Self.CurrentMainProject, which is process-wide, so it runs in the sequential collection.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class GlueStateEngineDllSyntaxVersionTests : IDisposable
+{
+    private readonly VisualStudioProject _originalMainProject;
+
+    public GlueStateEngineDllSyntaxVersionTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+    }
+
+    [Fact]
+    public void EngineDllSyntaxVersion_ShouldReturnNull_WhenNoProjectIsLoaded()
+    {
+        // Reproduces #1999: Help -> About after closing a project (CurrentMainProject == null)
+        // used to throw a NullReferenceException instead of showing "<No Project Loaded>".
+        GlueState.Self.CurrentMainProject = null;
+
+        GlueState.Self.EngineDllSyntaxVersion.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
`GlueState.EngineDllSyntaxVersion` dereferenced `CurrentMainProject` without a null check. `AboutPlugin.RefreshAboutViewModel` reads this property on every `Help -> About` click, so About crashed with a `NullReferenceException` whenever no project was loaded (closed project or fresh Glue start).

## Fix
Return `null` from `EngineDllSyntaxVersion` when `CurrentMainProject` is null, matching how the rest of `RefreshAboutViewModel` already handles the no-project case ("`<No Project Loaded>`").

## Test plan
- Added `GlueStateEngineDllSyntaxVersionTests`, pinning the null-project case. Confirmed Red (reproduced the exact NRE from the issue) before the fix, Green after.
- Full fast suite (`Category!=BuildSmoke`): 298 passed, 0 failed.

Fixes #1999
