### PR TITLE
Add option to lock screen bounds to world space when editing screens

### DIFF
--- a/FRBDK/Glue/CompilerLibrary/Models/CompilerSettingsModel.cs
+++ b/FRBDK/Glue/CompilerLibrary/Models/CompilerSettingsModel.cs
@@ -22,6 +22,7 @@ namespace CompilerLibrary.Models
         public bool RestartScreenOnLevelContentChange { get; set; }
         public int PortNumber { get; set; } = 8021;
         public bool ShowScreenBounds { get; set; }
+        public bool LockScreenBoundsToWorldSpace { get; set; }
 
         public bool RestartOnFailedCommands { get; set; }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -468,6 +468,7 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     public class GlueViewSettingsDto
     {
         public bool ShowScreenBounds { get; set; }
+        public bool LockScreenBoundsToWorldSpace { get; set; }
 
         public bool ShowGrid { get; set; }
         public decimal GridAlpha { get; set; }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -1561,6 +1561,7 @@ namespace GlueControl
             EditingManager.Self.GridAlpha = dto.GridAlpha;
             EditingManager.Self.GuidesGridSpacing = (float)dto.GridSize;
             EditingManager.Self.ShowScreenBounds = dto.ShowScreenBounds;
+            EditingManager.Self.LockScreenBoundsToWorldSpace = dto.LockScreenBoundsToWorldSpace;
 
             if (dto.SetBackgroundColor)
             {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -453,6 +453,7 @@ namespace GlueControl.Dtos
     public class GlueViewSettingsDto
     {
         public bool ShowScreenBounds { get; set; }
+        public bool LockScreenBoundsToWorldSpace { get; set; }
 
         public bool ShowGrid { get; set; }
         public decimal GridAlpha { get; set; }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -141,6 +141,7 @@ namespace GlueControl.Editing
         /// entity this is centered on the entity, and when editing a screen it follows the edit mode camera.
         /// </summary>
         public bool ShowScreenBounds { get; set; }
+        public bool LockScreenBoundsToWorldSpace { get; set; }
 
         float snapSize = 8;
         public float SnapSize
@@ -569,7 +570,9 @@ namespace GlueControl.Editing
 
             if (ElementEditingMode == ElementEditingMode.EditingScreen)
             {
-                center = new Vector3(Camera.Main.X, Camera.Main.Y, 0);
+                center = LockScreenBoundsToWorldSpace
+                    ? Vector3.Zero
+                    : new Vector3(Camera.Main.X, Camera.Main.Y, 0);
             }
             else if ((ScreenManager.CurrentScreen as Screens.EntityViewingScreen)?.CurrentEntity is PositionedObject mainEntity)
             {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -699,6 +699,7 @@ namespace GameCommunicationPlugin.GlueControl
                 case nameof(ViewModels.GlueViewSettingsViewModel.EnableSnapping):
                 case nameof(ViewModels.GlueViewSettingsViewModel.PolygonPointSnapSize):
                 case nameof(ViewModels.GlueViewSettingsViewModel.ShowScreenBounds):
+                case nameof(ViewModels.GlueViewSettingsViewModel.LockScreenBoundsToWorldSpace):
                     await SendGlueViewSettingsToGame();
                     break;
             }
@@ -716,6 +717,7 @@ namespace GameCommunicationPlugin.GlueControl
                 GridAlpha = GlueViewSettingsViewModel.GridAlpha,
                 GridSize = GlueViewSettingsViewModel.GridSize,
                 ShowScreenBounds = GlueViewSettingsViewModel.ShowScreenBounds,
+                LockScreenBoundsToWorldSpace = GlueViewSettingsViewModel.LockScreenBoundsToWorldSpace,
                 SetBackgroundColor = GlueViewSettingsViewModel.SetBackgroundColor,
                 BackgroundRed = GlueViewSettingsViewModel.BackgroundRed,
                 BackgroundGreen = GlueViewSettingsViewModel.BackgroundGreen,

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/ViewModels/GlueViewSettingsViewModel.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/ViewModels/GlueViewSettingsViewModel.cs
@@ -37,6 +37,12 @@ namespace GameCommunicationPlugin.GlueControl.ViewModels
             set => Set(value);
         }
 
+        public bool LockScreenBoundsToWorldSpace
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
         public bool SetBackgroundColor
         {
             get => Get<bool>();
@@ -123,6 +129,7 @@ namespace GameCommunicationPlugin.GlueControl.ViewModels
             this.PortNumber = model.PortNumber;
             this.RestartOnFailedCommands = model.RestartOnFailedCommands;
             this.ShowScreenBounds = model.ShowScreenBounds;
+            this.LockScreenBoundsToWorldSpace = model.LockScreenBoundsToWorldSpace;
 
             this.ShowGrid = model.ShowGrid;
             this.GridAlpha = model.GridAlpha;
@@ -145,6 +152,7 @@ namespace GameCommunicationPlugin.GlueControl.ViewModels
             compilerSettings.PortNumber = this.PortNumber;
             compilerSettings.RestartOnFailedCommands = this.RestartOnFailedCommands;
             compilerSettings.ShowScreenBounds = this.ShowScreenBounds;
+            compilerSettings.LockScreenBoundsToWorldSpace = this.LockScreenBoundsToWorldSpace;
 
             compilerSettings.ShowGrid = this.ShowGrid;
             compilerSettings.GridAlpha = this.GridAlpha;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
@@ -124,6 +124,7 @@ namespace GameCommunicationPlugin.GlueControl.Views
 
             var lockScreenBoundsProperties = properties.GetOrCreateImdp(nameof(ViewModel.LockScreenBoundsToWorldSpace));
             lockScreenBoundsProperties.Category = Localization.Texts.GridAndMarkings;
+            lockScreenBoundsProperties.DisplayName = Localization.Texts.LockScreenBoundsToWorldSpace;
             lockScreenBoundsProperties.IsHiddenDelegate = (notused) => ViewModel.ShowScreenBounds == false;
 
             DataUiGrid.Apply(properties);

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
@@ -34,7 +34,36 @@ namespace GameCommunicationPlugin.GlueControl.Views
 
         private void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
+            if (e.PropertyName == nameof(GlueViewSettingsViewModel.ShowScreenBounds))
+            {
+                // DataUiGrid re-adds a member to the end of its category when a hidden delegate flips it
+                // back to visible, instead of preserving its original position, so put it back underneath
+                // ShowScreenBounds instead of letting it drift to the end of the category (after the
+                // background-color fields).
+                MoveLockScreenBoundsMemberUnderShowScreenBounds();
+            }
+
             this.DataUiGrid.Refresh();
+        }
+
+        private void MoveLockScreenBoundsMemberUnderShowScreenBounds()
+        {
+            var showScreenBoundsMember = GetMember(nameof(ViewModel.ShowScreenBounds));
+            var lockToWorldSpaceMember = GetMember(nameof(ViewModel.LockScreenBoundsToWorldSpace));
+
+            if (showScreenBoundsMember != null && lockToWorldSpaceMember != null)
+            {
+                var members = lockToWorldSpaceMember.Category.Members;
+                var currentIndex = members.IndexOf(lockToWorldSpaceMember);
+
+                if (currentIndex >= 0)
+                {
+                    members.RemoveAt(currentIndex);
+                    var showScreenBoundsIndex = members.IndexOf(showScreenBoundsMember);
+                    var insertIndex = showScreenBoundsIndex >= 0 ? showScreenBoundsIndex + 1 : members.Count;
+                    members.Insert(System.Math.Min(insertIndex, members.Count), lockToWorldSpaceMember);
+                }
+            }
         }
 
         public GlueViewSettings()

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
@@ -68,6 +68,7 @@ namespace GameCommunicationPlugin.GlueControl.Views
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.GridAlpha), Localization.Texts.GridAndMarkings);
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.GridSize), Localization.Texts.GridAndMarkings);
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.ShowScreenBounds), Localization.Texts.GridAndMarkings);
+            this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.LockScreenBoundsToWorldSpace), Localization.Texts.GridAndMarkings);
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.SetBackgroundColor), Localization.Texts.GridAndMarkings);
 
             this.DataUiGrid.MoveMemberToCategory(nameof(ViewModel.EnableSnapping), Localization.Texts.Snapping);
@@ -91,6 +92,10 @@ namespace GameCommunicationPlugin.GlueControl.Views
                 colorProperties.IsHiddenDelegate = (notused) => ViewModel.SetBackgroundColor == false;
 
             }
+
+            var lockScreenBoundsProperties = properties.GetOrCreateImdp(nameof(ViewModel.LockScreenBoundsToWorldSpace));
+            lockScreenBoundsProperties.Category = Localization.Texts.GridAndMarkings;
+            lockScreenBoundsProperties.IsHiddenDelegate = (notused) => ViewModel.ShowScreenBounds == false;
 
             DataUiGrid.Apply(properties);
             DataUiGrid.Refresh();

--- a/FRBDK/Localization/Texts.Designer.cs
+++ b/FRBDK/Localization/Texts.Designer.cs
@@ -5118,6 +5118,15 @@ namespace Localization {
                 return ResourceManager.GetString("ShowScreenBounds", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Lock screen bounds to world space.
+        /// </summary>
+        public static string LockScreenBoundsToWorldSpace {
+            get {
+                return ResourceManager.GetString("LockScreenBoundsToWorldSpace", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Show State Categories.

--- a/FRBDK/Localization/Texts.de.resx
+++ b/FRBDK/Localization/Texts.de.resx
@@ -1485,6 +1485,9 @@
   <data name="ShowScreenBounds" xml:space="preserve">
     <value>Bildschirmgrenzen anzeigen</value>
   </data>
+  <data name="LockScreenBoundsToWorldSpace" xml:space="preserve">
+    <value>Bildschirmgrenzen an Weltraum sperren</value>
+  </data>
   <data name="SetBackgroundColor" xml:space="preserve">
     <value>Hintergrundfarbe festlegen</value>
   </data>

--- a/FRBDK/Localization/Texts.fr.resx
+++ b/FRBDK/Localization/Texts.fr.resx
@@ -1485,6 +1485,9 @@
   <data name="ShowScreenBounds" xml:space="preserve">
     <value>Afficher les limites de l'écran</value>
   </data>
+  <data name="LockScreenBoundsToWorldSpace" xml:space="preserve">
+    <value>Verrouiller les limites de l'écran à l'espace monde</value>
+  </data>
   <data name="SetBackgroundColor" xml:space="preserve">
     <value>Définir la couleur d'arrière-plan</value>
   </data>

--- a/FRBDK/Localization/Texts.nl.resx
+++ b/FRBDK/Localization/Texts.nl.resx
@@ -1485,6 +1485,9 @@
   <data name="ShowScreenBounds" xml:space="preserve">
     <value>Toon schermgrenzen</value>
   </data>
+  <data name="LockScreenBoundsToWorldSpace" xml:space="preserve">
+    <value>Vergrendel schermgrenzen op wereldruimte</value>
+  </data>
   <data name="SetBackgroundColor" xml:space="preserve">
     <value>Achtergrondkleur</value>
   </data>

--- a/FRBDK/Localization/Texts.resx
+++ b/FRBDK/Localization/Texts.resx
@@ -1486,6 +1486,9 @@ for {1}?</value>
   <data name="ShowScreenBounds" xml:space="preserve">
     <value>Show screen bounds</value>
   </data>
+  <data name="LockScreenBoundsToWorldSpace" xml:space="preserve">
+    <value>Lock screen bounds to world space</value>
+  </data>
   <data name="SetBackgroundColor" xml:space="preserve">
     <value>Set background color</value>
   </data>


### PR DESCRIPTION
## Summary
Screen bounds pan with the edit-mode camera when editing a screen (#1991) - fine for scrolling-camera games, but for a fixed-camera game (e.g. Beefball) the box is only useful pinned to the world origin.

Adds `LockScreenBoundsToWorldSpace`, a checkbox that appears under "Show Screen Bounds" (only when that's checked). When set, `EditingManager.DrawScreenBounds()` anchors the box at world-space `(0,0)` instead of the edit-mode camera position, for the screen-editing case only (entity editing is unaffected - it already centers on the entity).

Plumbed through `CompilerSettingsModel` -> `GlueViewSettingsViewModel` -> `GlueViewSettingsDto` -> `CommandReceiver` -> `EditingManager`, same path as `ShowScreenBounds`. Localized in all four locales.

## Test plan
- `Beefball_WithLiveEditCode_LoadInGlue_ThenBuild_ShouldSucceed` passes (embedded `Editing/*.cs` compiles against a real gold project).
- Manual test: needed (Glue UI change) - see chat reply for steps.

Closes #2000
