### PR TITLE
Synthesize a placeholder Screen to edit an abstract Screen with no derived Screen

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
+++ b/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
@@ -77,6 +77,7 @@
     <Compile Remove="GlueControl\Embedded\Models\StateSave.cs" />
     <Compile Remove="GlueControl\Embedded\Models\StateSaveCategory.cs" />
     <Compile Remove="GlueControl\Embedded\Runtime\DynamicEntity.cs" />
+    <Compile Remove="GlueControl\Embedded\Screens\AbstractScreenPlaceholderFactory.cs" />
     <Compile Remove="GlueControl\Embedded\Screens\EntityViewingScreen.cs" />
   </ItemGroup>
 
@@ -202,6 +203,7 @@
     <EmbeddedResource Include="GlueControl\Embedded\Models\StateSave.cs" />
     <EmbeddedResource Include="GlueControl\Embedded\Models\StateSaveCategory.cs" />
     <EmbeddedResource Include="GlueControl\Embedded\Runtime\DynamicEntity.cs" />
+    <EmbeddedResource Include="GlueControl\Embedded\Screens\AbstractScreenPlaceholderFactory.cs" />
     <EmbeddedResource Include="GlueControl\Embedded\Screens\EntityViewingScreen.cs" />
   </ItemGroup>
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CodeGeneration/EmbeddedCodeManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CodeGeneration/EmbeddedCodeManager.cs
@@ -78,7 +78,8 @@ namespace GameCommunicationPlugin.GlueControl.CodeGeneration
             "Models.StateSaveCategory.cs",
             
             "Runtime.DynamicEntity.cs",
-            
+
+            "Screens.AbstractScreenPlaceholderFactory.cs",
             "Screens.EntityViewingScreen.cs"
         };
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -492,6 +492,15 @@ namespace GlueControl
                 if (selectedNewScreen)
                 {
 #if SupportsEditMode
+                    // The selected Screen is abstract with no concrete derived Screen to fall back to
+                    // (BackupElementNameGlue is only populated when one exists - see
+                    // RefreshManager.PushGlueSelectionToGame). Its SetByDerived fields are just
+                    // default(T), so any concrete subclass is enough to view/edit it - #2006.
+                    if (ownerType.IsAbstract)
+                    {
+                        ownerType = Screens.AbstractScreenPlaceholderFactory.GetOrCreate(ownerType);
+                    }
+
                     ScreenManager.IsNextScreenInEditMode = ScreenManager.IsInEditMode;
 
                     void AfterInitializeLogic(Screen screen)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Screens/AbstractScreenPlaceholderFactory.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Screens/AbstractScreenPlaceholderFactory.cs
@@ -1,0 +1,40 @@
+{CompilerDirectives}
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace GlueControl.Screens
+{
+    // Selecting an abstract Screen with no concrete derived Screen (e.g. a base GameScreen with a
+    // SetByDerived object and nothing deriving from it - see FRB issue #2006) has no real Type to
+    // instantiate. SetByDerived fields on the base are just default(T), so any concrete subclass of
+    // the abstract Screen is enough to view/edit it. Rather than have Glue codegen a throwaway derived
+    // Screen file whose lifetime has to be tracked (added, then removed once a real derived Screen
+    // exists), synthesize an empty subclass at runtime - it costs nothing to recreate and there's
+    // nothing to clean up.
+    static class AbstractScreenPlaceholderFactory
+    {
+        static readonly ConcurrentDictionary<Type, Type> PlaceholderTypes = new ConcurrentDictionary<Type, Type>();
+
+        static readonly ModuleBuilder ModuleBuilder = AssemblyBuilder
+            .DefineDynamicAssembly(new AssemblyName("GlueControl.EditorPlaceholders"), AssemblyBuilderAccess.Run)
+            .DefineDynamicModule("GlueControl.EditorPlaceholders");
+
+        public static Type GetOrCreate(Type abstractScreenType) =>
+            PlaceholderTypes.GetOrAdd(abstractScreenType, CreatePlaceholderType);
+
+        static Type CreatePlaceholderType(Type abstractScreenType)
+        {
+            var typeBuilder = ModuleBuilder.DefineType(
+                abstractScreenType.FullName + "_EditorPlaceholder",
+                TypeAttributes.Public | TypeAttributes.Class,
+                abstractScreenType);
+
+            typeBuilder.DefineDefaultConstructor(MethodAttributes.Public);
+
+            return typeBuilder.CreateType();
+        }
+    }
+}

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
@@ -840,9 +840,12 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                     dto.BackupElementNameGlue = derived?.Name;
                 }
 
-                var canSend = !isAbstract || !string.IsNullOrEmpty(dto.BackupElementNameGlue);
+                // An abstract Screen with no concrete derived Screen still has something to show - the
+                // running game synthesizes a placeholder subclass at runtime to view/edit it
+                // (AbstractScreenPlaceholderFactory - #2006). Entities have no such fallback, so still
+                // don't try to select one if it's abstract with nothing derived from it.
+                var canSend = !isAbstract || !string.IsNullOrEmpty(dto.BackupElementNameGlue) || element is ScreenSave;
 
-                // If its abstract and there's no derived, don't try to select it
                 if (canSend)
                 {
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
@@ -64,4 +64,29 @@ public class LiveGameProcessTests
 
         (await game.GetCurrentScreenName()).ShouldBe("GlueControl.Screens.EntityViewingScreen");
     }
+
+    // Pins #2006: selecting an abstract Screen with no concrete derived Screen (EditorTest1's GameScreen -
+    // see the first test) previously had nothing to show - ScreenManager.LoadScreen can't instantiate an
+    // abstract type, and RefreshManager.PushGlueSelectionToGame refused to even send the selection when it
+    // found no concrete derived Screen to fall back to. The fix synthesizes a throwaway concrete subclass
+    // at runtime (AbstractScreenPlaceholderFactory) purely so the abstract Screen's own Initialize/
+    // AddToManagers can run - its SetByDerived fields are just default(T), same as any newly-created real
+    // derived Screen would show.
+    [StaFact]
+    public async Task EditorTest1_SelectingAbstractScreenWithNoDerivedScreen_LoadsPlaceholder()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe");
+
+        (await game.GetCurrentScreenName()).ShouldBe("", "the game should boot with no screen - see the first test");
+
+        var selectResponse = await game.SelectScreen("Screens\\GameScreen");
+        selectResponse.Succeeded.ShouldBeTrue(selectResponse.Message);
+
+        (await game.GetCurrentScreenName()).ShouldBe("EditorTest1.Screens.GameScreen_EditorPlaceholder");
+    }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
@@ -190,6 +190,32 @@ internal sealed class LiveGameProcess : IDisposable
         return await CommandSender.Self.Send(dto);
     }
 
+    /// <summary>
+    /// Sends the same SelectObjectDto Glue sends when the user clicks a Screen in the tree - see
+    /// SelectEntity's doc comment for why this builds the DTO by hand instead of going through
+    /// GlueState.Self.CurrentScreenSave / PushGlueSelectionToGame.
+    ///
+    /// Deliberately does NOT set BackupElementNameGlue - a real click on an abstract Screen with a
+    /// concrete derived Screen would carry the derived Screen's name there (see
+    /// RefreshManager.PushGlueSelectionToGame), but this is for driving the "no concrete derived Screen
+    /// exists" case (#2006) where production code now leaves it null too.
+    /// </summary>
+    public async Task<GeneralResponse<string>> SelectScreen(string screenNameGlue)
+    {
+        var screen = ObjectFinder.Self.GetScreenSave(screenNameGlue);
+        if (screen == null)
+        {
+            throw new InvalidOperationException($"No screen named \"{screenNameGlue}\" found in the loaded project.");
+        }
+
+        var dto = new SelectObjectDto
+        {
+            ElementNameGlue = screenNameGlue,
+            ScreenSave = screen,
+        };
+        return await CommandSender.Self.Send(dto);
+    }
+
     static string PatchGlueControlPort(string game1GeneratedContents, string game1GeneratedPath, int port)
     {
         // Exactly two literal call sites bake in the checked-in port (8846) - see CompilerSettings.json's


### PR DESCRIPTION
## Summary

Selecting an abstract Screen (a base `GameScreen` with a `SetByDerived` object) with no concrete derived Screen had nothing to show - `ScreenManager.LoadScreen` can't instantiate an abstract type, and `RefreshManager.PushGlueSelectionToGame` refused to even send the selection once it found no concrete derived Screen to fall back to (`BackupElementNameGlue` stays empty).

- `SetByDerived` fields on the abstract base are declared `protected` with no initializer - they're just `default(T)`, same as any brand-new derived Screen would show before the user sets a value. So any concrete subclass is enough to instantiate and edit the abstract Screen through.
- Rather than have Glue codegen a throwaway derived-Screen file whose lifetime has to be tracked (write it while no real derived Screen exists, delete it once one does), `AbstractScreenPlaceholderFactory` (new embedded file, `GlueControl/Embedded/Screens/`) synthesizes an empty subclass at runtime with `System.Reflection.Emit`, cached per abstract Type. Nothing is ever written to disk, so there's no lifecycle to manage - it's just recreated on demand.
- `RefreshManager.PushGlueSelectionToGame` (`RefreshManager.cs:843`) no longer blocks sending an abstract Screen selection with no derived Screen (Entities are unaffected - they have no such fallback and still don't send in that case). `CommandReceiver.HandleDto` swaps in the placeholder type whenever the resolved owner type is abstract.
- This is the same general selection path used for both a directly-selected abstract Screen and the abstract-`StartUpScreen` case - Glue already re-pushes the current selection once the game reconnects after launch (`GameHostController.cs:105/157`), so the placeholder shows up there too with no launch-arg changes needed.

Fixes #2006.

## Test plan
- [x] `Category=LiveGame` (3 tests, including new `EditorTest1_SelectingAbstractScreenWithNoDerivedScreen_LoadsPlaceholder`, launches real EditorTest1.exe)
- [x] `Category=BuildSmoke` (20 tests)
- [x] `Category!=BuildSmoke&Category!=LiveGame` (304 tests)

Manual test: not needed - covered by the `LiveGame` test above driving the real running-game protocol end to end (build, launch, select, verify the resulting screen type), same rigor as #2005.
