### PR TITLE
Fix race in VisualStudioProject.IsFrbSourceLinked/HasProjectReference

### DIFF
--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -50,10 +50,17 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         {
             get
             {
-                // This makes it thread safe:
-                var clone = new List<ProjectItem>();
-                clone.AddRange(mProject.AllEvaluatedItems);
-                return clone;
+                // Cloning alone isn't enough to make this thread safe: mProject.AllEvaluatedItems is a
+                // live, non-thread-safe collection, and List.AddRange reads its Count then CopyTo's from
+                // it as two separate operations, so a mutation landing between them (e.g. a concurrent
+                // AddCodeBuildItem/RemoveItem/AddNugetPackage call, all of which take lock(this)) can
+                // still throw. Taking the same lock here is what actually makes it thread safe.
+                lock (this)
+                {
+                    var clone = new List<ProjectItem>();
+                    clone.AddRange(mProject.AllEvaluatedItems);
+                    return clone;
+                }
             }
         }
 
@@ -698,7 +705,10 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
         public override bool IsFrbSourceLinked()
         {
-            foreach(var item in mProject.AllEvaluatedItems)
+            // Use EvaluatedItems (a cloned snapshot), not mProject.AllEvaluatedItems directly - the
+            // latter can be mutated by a concurrent reevaluation on another thread (e.g. TaskManager's
+            // background codegen) while this enumerates it, throwing "Collection was modified".
+            foreach(var item in EvaluatedItems)
             {
                 if(item.ItemType == "ProjectReference")
                 {
@@ -1173,7 +1183,9 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 csprojName += ".csproj";
             }
 
-            return mProject.AllEvaluatedItems
+            // EvaluatedItems (a cloned snapshot), not mProject.AllEvaluatedItems directly - see
+            // IsFrbSourceLinked for why.
+            return EvaluatedItems
                 .Where(x => x.ItemType == "ProjectReference")
                 .Where(x => x.EvaluatedInclude.Contains(csprojName, StringComparison.OrdinalIgnoreCase))
                 .Any();

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/VisualStudioProjectItemEnumerationRaceTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/VisualStudioProjectItemEnumerationRaceTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+
+namespace GlueUnitTests.VSHelpers;
+
+// Pins https://github.com/vchelaru/FlatRedBall/issues/2014: rapid clicks on Glue's "Enable live edit"
+// checkbox re-enter MainCompilerPlugin's handler before the previous click's TaskManager-queued codegen
+// finishes. That codegen adds project items and reevaluates the MSBuild Project on TaskManager's
+// background thread while the re-entrant call is mid-`foreach` over
+// VisualStudioProject.IsFrbSourceLinked/HasProjectReference on the UI thread - "Collection was modified;
+// enumeration operation may not execute." VisualStudioProject.EvaluatedItems already solves this exact
+// hazard by cloning the list before returning it; these two methods just didn't use it.
+public class VisualStudioProjectItemEnumerationRaceTests : IDisposable
+{
+    private readonly string _directory;
+    private readonly ClassLibraryProject _project;
+
+    public VisualStudioProjectItemEnumerationRaceTests()
+    {
+        _project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _directory);
+    }
+
+    public void Dispose() => Directory.Delete(_directory, recursive: true);
+
+    [Fact]
+    public void IsFrbSourceLinked_ShouldReturnFalse_WhenProjectHasNoFrbProjectReference()
+    {
+        _project.IsFrbSourceLinked().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsFrbSourceLinked_ShouldReturnTrue_WhenProjectReferencesFlatRedBallDesktopGLNet6()
+    {
+        _project.Project.AddItem("ProjectReference", @"..\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj");
+        _project.Project.MarkDirty();
+        _project.Project.ReevaluateIfNecessary();
+
+        _project.IsFrbSourceLinked().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFrbSourceLinked_ShouldNotThrow_WhenProjectIsReevaluatedConcurrently()
+    {
+        RunConcurrentEnumerationRace(() => _project.IsFrbSourceLinked());
+    }
+
+    [Fact]
+    public void HasProjectReference_ShouldReturnFalse_WhenNoMatchingReferenceExists()
+    {
+        _project.HasProjectReference("SomeOther.csproj").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasProjectReference_ShouldReturnTrue_WhenMatchingReferenceExists()
+    {
+        _project.Project.AddItem("ProjectReference", @"..\SomeOther\SomeOther.csproj");
+        _project.Project.MarkDirty();
+        _project.Project.ReevaluateIfNecessary();
+
+        _project.HasProjectReference("SomeOther.csproj").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HasProjectReference_ShouldNotThrow_WhenProjectIsReevaluatedConcurrently()
+    {
+        RunConcurrentEnumerationRace(() => _project.HasProjectReference("SomeOther.csproj"));
+    }
+
+    // Mirrors the real crash's two sides: a writer thread that keeps adding items via
+    // VisualStudioProject's own (lock-protected) mutator - the same shape as TaskManager's codegen
+    // thread calling AddCodeBuildItem/AddNugetPackage/RemoveItem - racing a reader thread that keeps
+    // calling the given method (the UI thread's re-entrant handler). A large seeded item count widens
+    // the window each reevaluation/enumeration takes, which is what makes the race land reliably
+    // instead of rarely.
+    private void RunConcurrentEnumerationRace(Action callUnderTest)
+    {
+        for (var i = 0; i < 800; i++)
+        {
+            _project.Project.AddItem("Compile", $"seed{i}.cs");
+        }
+        _project.Project.MarkDirty();
+        _project.Project.ReevaluateIfNecessary();
+
+        using var stop = new CancellationTokenSource();
+        Exception readerException = null;
+
+        var writer = Task.Run(() =>
+        {
+            var i = 0;
+            while (!stop.IsCancellationRequested)
+            {
+                _project.AddNugetPackage($"Package{i++}", "1.0.0");
+            }
+        });
+
+        var reader = Task.Run(() =>
+        {
+            try
+            {
+                while (!stop.IsCancellationRequested)
+                {
+                    callUnderTest();
+                }
+            }
+            catch (Exception ex)
+            {
+                readerException = ex;
+            }
+        });
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(4);
+        while (DateTime.UtcNow < deadline && readerException == null)
+        {
+            Thread.Sleep(50);
+        }
+        stop.Cancel();
+        Task.WaitAll(writer, reader);
+
+        if (readerException != null)
+        {
+            throw readerException;
+        }
+    }
+}


### PR DESCRIPTION
Fixes a crash from rapid-clicking Glue's "Enable live edit" checkbox: `System.InvalidOperationException: Collection was modified` in `VisualStudioProject.IsFrbSourceLinked`.

## Root cause
Rapid clicks re-enter `MainCompilerPlugin.HandleGlueViewSettingsViewModelPropertyChanged` (an `async void` WPF handler) before the previous click's `TaskManager`-queued codegen finishes. That codegen mutates/reevaluates the same MSBuild `Project` on `TaskManager`'s background thread while the re-entrant call enumerates `mProject.AllEvaluatedItems` on the UI thread - a live, non-thread-safe collection.

`VisualStudioProject.EvaluatedItems` already exists as a "thread safe" clone of that list, but wasn't itself fully safe (`List.AddRange`'s Count-then-CopyTo isn't atomic against a live mutable source) and `IsFrbSourceLinked`/`HasProjectReference` didn't use it anyway. Both now go through `EvaluatedItems`, which now takes `lock(this)` - the same convention every mutator in this file already uses (`AddCodeBuildItem`, `RemoveItem`, `AddNugetPackage`).

## Testing
`VisualStudioProjectItemEnumerationRaceTests` pins this with a real MSBuild-backed project (`TestVisualStudioProjectFactory`): a writer thread continuously mutates the project through the same lock-protected API production code uses, while a reader thread continuously calls `IsFrbSourceLinked`/`HasProjectReference`. Pre-fix this reliably throws the exact production exception within ~100-500ms; post-fix it runs clean for the full 4s window.

Manual test: not needed - covered by the concurrency test plus the existing full unit test suite (316 passing, `Category!=BuildSmoke`).

Closes #2014
