### PR TITLE
Fix live-edit connection manager deadlocking the editor and resetting itself when idle

### DIFF
--- a/FRBDK/Glue/CompilerLibrary/OutputLineBuffer.cs
+++ b/FRBDK/Glue/CompilerLibrary/OutputLineBuffer.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+
+namespace CompilerLibrary
+{
+    /// <summary>
+    /// Collects output lines from any thread so a view can drain them on a timer.
+    /// </summary>
+    /// <remarks>
+    /// Exists so printing output never touches the UI thread at the call site. Callers include the live
+    /// edit connection manager, which prints while holding its connection lock - marshalling from there
+    /// with a blocking Invoke deadlocks the editor, and marshalling with a non-blocking post instead
+    /// queues an unbounded number of dispatcher operations when output is chatty. Buffering avoids both.
+    /// </remarks>
+    public class OutputLineBuffer
+    {
+        readonly List<OutputLine> lines = new List<OutputLine>();
+
+        public struct OutputLine
+        {
+            public string Text;
+            public bool IsError;
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (lines)
+                {
+                    return lines.Count;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Splits <paramref name="text"/> into lines and queues the non-blank ones. Null or empty text
+        /// queues nothing.
+        /// </summary>
+        public void Add(string text, bool isError)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
+            var split = text.Split('\n');
+
+            lock (lines)
+            {
+                foreach (var line in split)
+                {
+                    if (!string.IsNullOrWhiteSpace(line))
+                    {
+                        lines.Add(new OutputLine { Text = line, IsError = isError });
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns everything queued and empties the buffer.
+        /// </summary>
+        public OutputLine[] TakeAll()
+        {
+            lock (lines)
+            {
+                var toReturn = lines.ToArray();
+                lines.Clear();
+                return toReturn;
+            }
+        }
+
+        public void Clear()
+        {
+            lock (lines)
+            {
+                lines.Clear();
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml.cs
+++ b/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml.cs
@@ -26,6 +26,21 @@ namespace CompilerPlugin.Views
 
         OutputParser outputParser;
 
+        /// <summary>
+        /// Lines waiting to be shown. Filled from any thread, drained by <see cref="flushTimer"/>.
+        /// </summary>
+        readonly CompilerLibrary.OutputLineBuffer pendingLines = new();
+
+        readonly System.Windows.Threading.DispatcherTimer flushTimer;
+
+        /// <summary>
+        /// Cap on retained lines. Live edit can print continuously for hours, and an unbounded
+        /// FlowDocument grows without limit and gets progressively more expensive to lay out.
+        /// </summary>
+        public int MaxLinesOfText { get; set; } = 2000;
+
+        const int LinesToDropWhenOverCap = 200;
+
         #endregion
 
         #region Events
@@ -47,19 +62,24 @@ namespace CompilerPlugin.Views
 
             InitializeComponent();
 
-            TextBox.Document.Blocks.Add(new Paragraph());
-
             _foregroundBinding = new Binding("Foreground")
             {
                 Source = TextBox,
                 Mode = BindingMode.OneWay
             };
+
+            flushTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(100)
+            };
+            flushTimer.Tick += HandleFlushTimerTick;
+            flushTimer.Start();
         }
 
         private void HandleCompileClick()
         {
+            pendingLines.Clear();
             TextBox.Document.Blocks.Clear();
-            TextBox.Document.Blocks.Add(new Paragraph());
             BuildClicked?.Invoke(this, null);
         }
 
@@ -73,49 +93,53 @@ namespace CompilerPlugin.Views
             MSBuildSettingsClicked?.Invoke();
         }
 
-        public void PrintOutput(string text)
-        {
-            //////////////////////////////////// Early out ////////////////////////////////////////////
-            if (text == null) return;
-            //////////////////////////////////End Early Out////////////////////////////////////////////
+        /// <summary>
+        /// Queues output for display. Safe to call from any thread, and never blocks on the UI thread.
+        /// </summary>
+        public void PrintOutput(string text) => pendingLines.Add(text, isError: false);
 
-            // suppress warnings...
-            var split = text.Split('\n');
+        /// <inheritdoc cref="PrintOutput"/>
+        public void PrintError(string text) => pendingLines.Add(text, isError: true);
+
+        void HandleFlushTimerTick(object sender, EventArgs e)
+        {
+            if (pendingLines.Count == 0)
+            {
+                return;
+            }
+
+            var toAppend = pendingLines.TakeAll();
 
             try
             {
-                Glue.MainGlueWindow.Self.Invoke(() =>
+                foreach (var line in toAppend)
                 {
-                    var paragraph = TextBox.Document.Blocks.LastOrDefault() as Paragraph;
-                    if(paragraph == null)
+                    // Warnings are suppressed, same as before this was buffered.
+                    var outputType = line.IsError ? OutputType.Error : outputParser.GetOutputType(line.Text);
+                    if (outputType == OutputType.Warning)
                     {
-                        paragraph = new Paragraph();
-                        TextBox.Document.Blocks.Add(paragraph);
-                    }
-                    foreach (var line in split)
-                    {
-                        if(!string.IsNullOrWhiteSpace(line))
-                        {
-                            var outputType = outputParser.GetOutputType(line);
-                            if(outputType != OutputType.Warning)
-                            {
-                                Run run = new Run(line + "\r\n");
-                                paragraph.Inlines.Add(run);
-
-                                if (outputType == OutputType.Error)
-                                {
-                                    run.Foreground = Brushes.Red;
-                                } 
-                                else
-                                {
-                                    BindingOperations.SetBinding(run, ForegroundProperty, _foregroundBinding);
-                                }
-                            }
-                        }
+                        continue;
                     }
 
-                    TextBox.ScrollToEnd();
-                });
+                    var run = new Run(line.Text);
+                    if (outputType == OutputType.Error)
+                    {
+                        run.Foreground = Brushes.Red;
+                    }
+                    else
+                    {
+                        BindingOperations.SetBinding(run, ForegroundProperty, _foregroundBinding);
+                    }
+
+                    // One paragraph per line so the document can be trimmed by block. A single
+                    // ever-growing paragraph cannot be, and re-lays out in full on every append.
+                    var paragraph = new Paragraph(run) { Margin = new Thickness(0) };
+                    TextBox.Document.Blocks.Add(paragraph);
+                }
+
+                ShortenOutputIfNecessary();
+
+                TextBox.ScrollToEnd();
             }
             catch
             {
@@ -123,48 +147,22 @@ namespace CompilerPlugin.Views
             }
         }
 
-        public void PrintError(string text)
+        void ShortenOutputIfNecessary()
         {
-            //////////////////////////////////// Early out ////////////////////////////////////////////
-            if (string.IsNullOrEmpty(text)) return;
-            //////////////////////////////////End Early Out////////////////////////////////////////////
-
-            // suppress warnings...
-            var split = text.Split('\n');
-
-            try
+            if (TextBox.Document.Blocks.Count <= MaxLinesOfText)
             {
-                Glue.MainGlueWindow.Self.Invoke(() =>
-                {
-                    var paragraph = TextBox.Document.Blocks.LastOrDefault() as Paragraph;
-                    if (paragraph == null)
-                    {
-                        paragraph = new Paragraph();
-                        TextBox.Document.Blocks.Add(paragraph);
-                    }
-                    foreach (var line in split)
-                    {
-                        if (!string.IsNullOrWhiteSpace(line))
-                        {
-                            paragraph.Inlines.Add(new Run(line) { Foreground = Brushes.Red });
-                        }
-                    }
-                    if(split.Length > 0)
-                    {
-                        paragraph.Inlines.Add(new Run("\r\n") { Foreground = Brushes.Red });
-                    }
-
-                    TextBox.ScrollToEnd();
-                });
+                return;
             }
-            catch
+
+            for (int i = 0; i < LinesToDropWhenOverCap && TextBox.Document.Blocks.FirstBlock != null; i++)
             {
-                // could be exiting the app so tolerate the error, don't show a message to the user
+                TextBox.Document.Blocks.Remove(TextBox.Document.Blocks.FirstBlock);
             }
         }
 
         void Button_Click(object sender, RoutedEventArgs e)
         {
+            pendingLines.Clear();
             TextBox.Document.Blocks.Clear();
         }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/Common/GameConnectionManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/Common/GameConnectionManager.cs
@@ -30,33 +30,39 @@ namespace GameJsonCommunicationPlugin.Common
         private bool _isListening = false;
 
         private bool _isConnected = false;
-        public bool IsConnected
+        public bool IsConnected => _isConnected;
+
+        /// <summary>
+        /// Applies a connection state change, returning the notifications it produced (or null if the
+        /// state was already <paramref name="value"/>).
+        /// </summary>
+        /// <remarks>
+        /// The returned action must be invoked only AFTER <see cref="_lock"/> is released. Both the
+        /// diagnostic log and the plugin event reach the editor's UI thread and block until it services
+        /// them, while <see cref="StatusCheck"/> takes the same lock - so notifying while holding it
+        /// deadlocks the editor: the notifying thread waits on the UI thread, which waits on the lock.
+        /// </remarks>
+        private Action SetIsConnected(bool value)
         {
-            get
+            if (_isConnected == value)
             {
-                return _isConnected;
+                return null;
             }
+            _isConnected = value;
 
-            private set
-            {
-                if (_isConnected == value)
-                {
-                    return;
-                }
-                _isConnected = value;
-
-                if(_isConnected)
-                {
-                    LogDiagnostic("Connected (both sockets established)");
-                    _eventCaller("GameCommunication_Connected", "");
-                }
-                else
-                {
-                    LogDiagnostic("Disconnected");
-                    _eventCaller("GameCommunication_Disconnected", "");
-                }
-            }
+            return value
+                ? new Action(() =>
+                    {
+                        LogDiagnostic("Connected (both sockets established)");
+                        _eventCaller("GameCommunication_Connected", "");
+                    })
+                : new Action(() =>
+                    {
+                        LogDiagnostic("Disconnected");
+                        _eventCaller("GameCommunication_Disconnected", "");
+                    });
         }
+
         private CancellationTokenSource _periodicCheckTaskCancellationToken;
 
         #endregion
@@ -112,9 +118,20 @@ namespace GameJsonCommunicationPlugin.Common
         public static GameConnectionManager Self { get; set; }
 
         public GameConnectionManager(Action<string, string> eventCaller)
+            : this(eventCaller, 0)
+        {
+        }
+
+        /// <summary>
+        /// Preferred over setting <see cref="Port"/> after construction: the constructor starts
+        /// listening immediately, so assigning the port afterwards races the initial bind and can leave
+        /// the listener on the wrong port with nothing to re-listen it.
+        /// </summary>
+        public GameConnectionManager(Action<string, string> eventCaller, int port)
         {
             _eventCaller = eventCaller;
             _addr = IPAddress.Loopback;
+            _port = port;
             StartListening();
             _periodicCheckTaskCancellationToken = new CancellationTokenSource();
             Task task = StatusCheckTask(_periodicCheckTaskCancellationToken.Token);
@@ -156,9 +173,20 @@ namespace GameJsonCommunicationPlugin.Common
 
                                 HandleConnection(_listener.Accept());
                                 HandleConnection(_listener.Accept());
-                                IsConnected = true;
+
+                                Action notify;
+                                lock (_lock)
+                                {
+                                    notify = SetIsConnected(true);
+                                }
+                                notify?.Invoke();
                                 // Vic asks - do we still need this?
                                 _eventCaller("GameCommunication_Connected", "");
+
+                                // Only now that the connection is marked live - the loop guards on
+                                // IsConnected, so starting it any earlier races with the line above and
+                                // can exit immediately, leaving nothing draining the game's messages.
+                                StartGameToGlueReceiveLoop();
 
                                 _listener.Dispose();
                                 _listener = null;
@@ -213,6 +241,12 @@ namespace GameJsonCommunicationPlugin.Common
             Debug.WriteLine("Connected Game->Glue");
 
             gameToGlueSocket = socket;
+        }
+
+        private void StartGameToGlueReceiveLoop()
+        {
+            // Captured once: ResetConnection nulls the field, so reading it mid-loop can NRE.
+            var socket = gameToGlueSocket;
 
             Task.Run(async () =>
             {
@@ -220,7 +254,15 @@ namespace GameJsonCommunicationPlugin.Common
                 {
                     while (IsConnected)
                     {
-                        string stringFromGame = await ReceiveString(gameToGlueSocket);
+                        string stringFromGame = await ReceiveUnsolicitedString(socket);
+
+                        if (stringFromGame == null)
+                        {
+                            // Socket closed or shut down by the other end. Tear down so StatusCheck
+                            // re-handshakes rather than spinning on a dead socket.
+                            ResetConnection("game->glue socket closed");
+                            break;
+                        }
 
                         string toReturn = null;
 
@@ -256,7 +298,7 @@ namespace GameJsonCommunicationPlugin.Common
 
 
                         // todo - need to send the string...
-                        //gameToGlueSocket.Send(new byte[] { 0 });
+                        //socket.Send(new byte[] { 0 });
                         if (toReturn != null)
                         {
                             // This is a little noisy, but can be uncommented for more diagnostic info:
@@ -266,12 +308,12 @@ namespace GameJsonCommunicationPlugin.Common
 
                             //Send size
                             var bytesForSize = BitConverter.GetBytes(size);
-                            gameToGlueSocket.Send(bytesForSize);
+                            socket.Send(bytesForSize);
 
                             System.Diagnostics.Debug.WriteLine($"{DateTime.Now}-Sent long for {size} size ({bytesForSize.Length})");
 
                             //Send payload
-                            gameToGlueSocket.Send(sendBytes);
+                            socket.Send(sendBytes);
 
                             System.Diagnostics.Debug.WriteLine($"{DateTime.Now}-Sent body with {sendBytes.Length} bytes");
                         }
@@ -279,7 +321,7 @@ namespace GameJsonCommunicationPlugin.Common
                         {
 
                             var bytesForSize = BitConverter.GetBytes((long)0);
-                            var sentBytes = gameToGlueSocket.Send(bytesForSize);
+                            var sentBytes = socket.Send(bytesForSize);
 
                             System.Diagnostics.Debug.WriteLine($"{DateTime.Now}-Sent long(0) with {sentBytes} bytes");
 
@@ -292,7 +334,15 @@ namespace GameJsonCommunicationPlugin.Common
                 {
                     Debug.WriteLine($"Client Connection Failed: {ex}");
                 }
-                finally { IsConnected = false; }
+                finally
+                {
+                    Action notify;
+                    lock (_lock)
+                    {
+                        notify = SetIsConnected(false);
+                    }
+                    notify?.Invoke();
+                }
             });
         }
 
@@ -311,7 +361,7 @@ namespace GameJsonCommunicationPlugin.Common
                 //Send payload
                 socket.Send(sendBytes);
 
-                string responseString = await ReceiveString(socket);
+                string responseString = await ReceiveResponseString(socket);
                 return responseString;
             }
             catch (Exception ex) when (ex is SocketException || ex is ObjectDisposedException || ex is NullReferenceException)
@@ -333,6 +383,9 @@ namespace GameJsonCommunicationPlugin.Common
         /// </summary>
         private void ResetConnection(string reason)
         {
+            Action notify = null;
+            var didReset = false;
+
             lock (_lock)
             {
                 if (!_isConnected && glueToGameSocket == null && gameToGlueSocket == null)
@@ -341,36 +394,55 @@ namespace GameJsonCommunicationPlugin.Common
                     return;
                 }
 
-                LogDiagnostic($"Resetting connection: {reason}");
-
                 try { glueToGameSocket?.Dispose(); } catch { }
                 try { gameToGlueSocket?.Dispose(); } catch { }
                 glueToGameSocket = null;
                 gameToGlueSocket = null;
 
-                // Fires GameCommunication_Disconnected; StatusCheck then re-listens.
-                IsConnected = false;
+                // Produces GameCommunication_Disconnected; StatusCheck then re-listens.
+                notify = SetIsConnected(false);
+                didReset = true;
             }
+
+            // Outside the lock on purpose - see SetIsConnected. Logging blocks on the editor's UI
+            // thread, and StatusCheck runs on that thread taking this same lock.
+            if (didReset)
+            {
+                LogDiagnostic($"Resetting connection: {reason}");
+            }
+            notify?.Invoke();
+        }
+
+        /// <summary>
+        /// Where diagnostics go. Injectable so tests can observe connect/reset transitions without a
+        /// plugin host, and so the "never notify while holding the lock" guarantee above is testable.
+        /// </summary>
+        internal Action<string> LogAction { get; set; } = DefaultLogAction;
+
+        private static void DefaultLogAction(string message)
+        {
+            System.Diagnostics.Debug.WriteLine(message);
+            try { PluginManager.CallPluginMethod("Compiler Plugin", "HandleOutput", message); } catch { }
         }
 
         private void LogDiagnostic(string message)
         {
-            var full = $"[GameConnection] {message}";
-            System.Diagnostics.Debug.WriteLine(full);
-            try { PluginManager.CallPluginMethod("Compiler Plugin", "HandleOutput", full); } catch { }
+            try { LogAction($"[GameConnection] {message}"); } catch { }
         }
 
-        private async Task<string> ReceiveString(Socket socket)
+        /// <summary>
+        /// Reads a reply we are actively waiting for. A game that never answers (crashed mid-request,
+        /// deadlocked in its own CommandReceiver) must not leave this awaiting forever, so the read is
+        /// raced against <see cref="TimeoutInSeconds"/> and a timeout tears the connection down.
+        /// </summary>
+        private async Task<string> ReceiveResponseString(Socket socket)
         {
             try
             {
                 byte[] bufferSize = new byte[sizeof(long)];
-                //socket.Receive(bufferSize);
 
-                // The synchronous Receive calls below (the payload loop) honor ReceiveTimeout, but this
-                // header ReceiveAsync does not - without racing it against a timeout task, a game that
-                // never replies (crashed mid-request, deadlocked in its own CommandReceiver, etc.) leaves
-                // this awaiting forever with no thread blocked and no CPU used.
+                // The synchronous Receive calls in ReadPayload honor ReceiveTimeout, but ReceiveAsync
+                // does not - hence the explicit race below.
                 socket.ReceiveTimeout = (int)(TimeoutInSeconds * 1000);
 
                 ArraySegment<byte> buffer = new ArraySegment<byte>(bufferSize);
@@ -383,32 +455,66 @@ namespace GameJsonCommunicationPlugin.Common
                 }
                 await receiveTask;
 
-                var packetSize = BitConverter.ToInt64(bufferSize, 0);
-
-                string responseString = null;
-
-                using (MemoryStream stream = new MemoryStream())
-                {
-                    var remainingBytes = packetSize;
-                    while (remainingBytes > 0)
-                    {
-                        var pullSize = remainingBytes > 1024 ? 1024 : remainingBytes;
-                        byte[] bufferData = new byte[pullSize];
-                        socket.Receive(bufferData);
-                        stream.Write(bufferData, 0, bufferData.Length);
-                        remainingBytes -= pullSize;
-                    }
-
-                    responseString = Encoding.ASCII.GetString(stream.ToArray());
-                }
-
-                return responseString;
-
+                return ReadPayload(socket, BitConverter.ToInt64(bufferSize, 0));
             }
-            catch(SocketException)
+            catch (SocketException)
             {
                 // This can mean the socket was closed, so return null
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// Reads the next unsolicited message from the game, waiting as long as it takes.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately has no timeout. This socket is idle whenever the user is not interacting with
+        /// the game, which is most of the time, so applying the request/response timeout here would tear
+        /// down a perfectly healthy connection every <see cref="TimeoutInSeconds"/> and leave the editor
+        /// in a permanent reset/re-handshake loop. A genuinely dead socket still surfaces here promptly,
+        /// as a SocketException or ObjectDisposedException rather than as silence.
+        /// </remarks>
+        private async Task<string> ReceiveUnsolicitedString(Socket socket)
+        {
+            try
+            {
+                byte[] bufferSize = new byte[sizeof(long)];
+
+                // 0 means "no timeout" - the payload reads below should wait as long as the header did.
+                socket.ReceiveTimeout = 0;
+
+                var received = await socket.ReceiveAsync(new ArraySegment<byte>(bufferSize), SocketFlags.None);
+
+                if (received == 0)
+                {
+                    // Orderly shutdown by the other end.
+                    return null;
+                }
+
+                return ReadPayload(socket, BitConverter.ToInt64(bufferSize, 0));
+            }
+            catch (Exception ex) when (ex is SocketException || ex is ObjectDisposedException)
+            {
+                // The socket was closed, so return null and let the caller tear the connection down.
+                return null;
+            }
+        }
+
+        private static string ReadPayload(Socket socket, long packetSize)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                var remainingBytes = packetSize;
+                while (remainingBytes > 0)
+                {
+                    var pullSize = remainingBytes > 1024 ? 1024 : remainingBytes;
+                    byte[] bufferData = new byte[pullSize];
+                    socket.Receive(bufferData);
+                    stream.Write(bufferData, 0, bufferData.Length);
+                    remainingBytes -= pullSize;
+                }
+
+                return Encoding.ASCII.GetString(stream.ToArray());
             }
         }
 
@@ -417,11 +523,18 @@ namespace GameJsonCommunicationPlugin.Common
             while (!cancellation.IsCancellationRequested)
             {
                 StatusCheck();
-                await Task.Delay(100, cancellation);
+                // ConfigureAwait(false) keeps this loop off the editor's UI thread. Without it the
+                // continuation resumes on the captured WinForms context, so StatusCheck takes _lock on
+                // the UI thread ten times a second - one half of the deadlock SetIsConnected describes.
+                await Task.Delay(100, cancellation).ConfigureAwait(false);
             }
         }
 
-        private void StatusCheck()
+        /// <summary>
+        /// Re-listens if the connection is dead. Runs every 100ms; internal so tests can drive the
+        /// lock contention it creates against <see cref="ResetConnection"/>.
+        /// </summary>
+        internal void StatusCheck()
         {
             lock (_lock)
             {
@@ -467,6 +580,7 @@ namespace GameJsonCommunicationPlugin.Common
             try { _periodicCheckTaskCancellationToken.Cancel(); } catch { }
             try { _listener?.Dispose(); } catch { }
             try { glueToGameSocket?.Dispose(); } catch { }
+            try { gameToGlueSocket?.Dispose(); } catch { }
         }
 
         #endregion

--- a/FRBDK/Glue/GameCommunicationPlugin/MainGameCommunicationPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/MainGameCommunicationPlugin.cs
@@ -50,8 +50,7 @@ namespace GameCommunicationPlugin
         public override void StartUp()
         {
             Self = this;
-            _gameCommunicationManager = new GameConnectionManager(ReactToPluginEvent);
-            _gameCommunicationManager.Port = 8888;
+            _gameCommunicationManager = new GameConnectionManager(ReactToPluginEvent, 8888);
             _gameCommunicationManager.OnPacketReceived += HandleOnPacketReceived;
             GameConnectionManager.Self = _gameCommunicationManager;
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Controls/OutputLineBufferTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Controls/OutputLineBufferTests.cs
@@ -1,0 +1,92 @@
+using CompilerLibrary;
+using Shouldly;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.Controls
+{
+    public class OutputLineBufferTests
+    {
+        [Fact]
+        public void Add_SplitsOnNewlinesAndDropsBlankLines()
+        {
+            var buffer = new OutputLineBuffer();
+
+            buffer.Add("first\n\nsecond\n   \nthird", isError: false);
+
+            var lines = buffer.TakeAll();
+            lines.Select(x => x.Text).ShouldBe(new[] { "first", "second", "third" });
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Add_IgnoresEmptyText(string text)
+        {
+            var buffer = new OutputLineBuffer();
+
+            buffer.Add(text, isError: false);
+
+            buffer.Count.ShouldBe(0);
+        }
+
+        [Fact]
+        public void Add_RecordsWhetherTheLineWasErrorOutput()
+        {
+            var buffer = new OutputLineBuffer();
+
+            buffer.Add("normal", isError: false);
+            buffer.Add("bad", isError: true);
+
+            var lines = buffer.TakeAll();
+            lines.Single(x => x.Text == "normal").IsError.ShouldBeFalse();
+            lines.Single(x => x.Text == "bad").IsError.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TakeAll_EmptiesTheBuffer()
+        {
+            var buffer = new OutputLineBuffer();
+            buffer.Add("something", isError: false);
+
+            buffer.TakeAll().Length.ShouldBe(1);
+
+            buffer.Count.ShouldBe(0);
+            buffer.TakeAll().ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void Clear_DiscardsQueuedLines()
+        {
+            var buffer = new OutputLineBuffer();
+            buffer.Add("a\nb\nc", isError: false);
+
+            buffer.Clear();
+
+            buffer.Count.ShouldBe(0);
+        }
+
+        /// <summary>
+        /// The whole point of the buffer is that any thread can print without touching the UI thread, so
+        /// concurrent adds must not lose lines or corrupt the list.
+        /// </summary>
+        [Fact]
+        public void Add_IsSafeFromManyThreadsAtOnce()
+        {
+            var buffer = new OutputLineBuffer();
+            const int threadCount = 8;
+            const int linesPerThread = 500;
+
+            Parallel.For(0, threadCount, threadIndex =>
+            {
+                for (int i = 0; i < linesPerThread; i++)
+                {
+                    buffer.Add($"thread {threadIndex} line {i}", isError: false);
+                }
+            });
+
+            buffer.TakeAll().Length.ShouldBe(threadCount * linesPerThread);
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GameConnectionManagerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GameConnectionManagerTests.cs
@@ -1,0 +1,223 @@
+using GameJsonCommunicationPlugin.Common;
+using Shouldly;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin
+{
+    /// <summary>
+    /// Drives the real <see cref="GameConnectionManager"/> over loopback sockets, standing in for the
+    /// game side of live edit. No game process is launched - the handshake is just two sockets, each
+    /// identifying its direction with a single byte (1 = glue->game, 2 = game->glue).
+    /// </summary>
+    public class GameConnectionManagerTests
+    {
+        const double ShortTimeoutInSeconds = 0.3;
+
+        #region Harness
+
+        static int GetFreePort()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        /// <summary>
+        /// Performs the game side of the handshake and waits until the manager reports connected.
+        /// </summary>
+        static async Task<(Socket glueToGame, Socket gameToGlue)> ConnectAsGameAsync(GameConnectionManager manager, int port)
+        {
+            var glueToGame = await ConnectWithRetryAsync(port);
+            glueToGame.Send(new byte[] { 1 });
+
+            var gameToGlue = await ConnectWithRetryAsync(port);
+            gameToGlue.Send(new byte[] { 2 });
+
+            await WaitUntilAsync(() => manager.IsConnected, TimeSpan.FromSeconds(10));
+            manager.IsConnected.ShouldBeTrue("the handshake should have completed");
+
+            return (glueToGame, gameToGlue);
+        }
+
+        static async Task<Socket> ConnectWithRetryAsync(int port)
+        {
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+
+            while (true)
+            {
+                var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                try
+                {
+                    await socket.ConnectAsync(IPAddress.Loopback, port);
+                    return socket;
+                }
+                catch (SocketException)
+                {
+                    socket.Dispose();
+                    if (DateTime.UtcNow > deadline)
+                    {
+                        throw;
+                    }
+                    // The manager listens from a Task.Run started in its constructor, so the first
+                    // attempts can beat the bind.
+                    await Task.Delay(25);
+                }
+            }
+        }
+
+        static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (!condition() && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(25);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// An editor sitting in edit mode with nobody touching it sends and receives nothing. The
+        /// game->glue socket is idle by design, so the request/response timeout must not apply to it -
+        /// otherwise the connection is torn down and re-handshaked every TimeoutInSeconds forever.
+        /// </summary>
+        [Fact]
+        public async Task IdleConnection_IsNotTornDownByTheResponseTimeout()
+        {
+            var port = GetFreePort();
+            var logMessages = new ConcurrentQueue<string>();
+
+            using var manager = new GameConnectionManager((_, __) => { }, port)
+            {
+                TimeoutInSeconds = ShortTimeoutInSeconds,
+                LogAction = logMessages.Enqueue
+            };
+
+            var (glueToGame, gameToGlue) = await ConnectAsGameAsync(manager, port);
+
+            try
+            {
+                // Well over the timeout, with no traffic in either direction.
+                await Task.Delay(TimeSpan.FromSeconds(ShortTimeoutInSeconds * 8));
+
+                manager.IsConnected.ShouldBeTrue("an idle connection is healthy and must stay connected");
+                logMessages.Any(x => x?.Contains("Resetting connection") == true)
+                    .ShouldBeFalse("idle time is not a failure: " + string.Join(" | ", logMessages));
+            }
+            finally
+            {
+                glueToGame.Dispose();
+                gameToGlue.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// The other half of the above: a reply we are actively waiting for still has to time out, or a
+        /// game that died mid-request leaves the editor awaiting forever.
+        /// </summary>
+        [Fact]
+        public async Task UnansweredRequest_TimesOutAndResetsTheConnection()
+        {
+            var port = GetFreePort();
+            var logMessages = new ConcurrentQueue<string>();
+
+            using var manager = new GameConnectionManager((_, __) => { }, port)
+            {
+                TimeoutInSeconds = ShortTimeoutInSeconds,
+                LogAction = logMessages.Enqueue
+            };
+
+            var (glueToGame, gameToGlue) = await ConnectAsGameAsync(manager, port);
+
+            try
+            {
+                // Nothing on the far end reads this or replies to it.
+                await manager.SendItemWithResponse(new GameConnectionManager.Packet
+                {
+                    PacketType = "Test",
+                    Payload = "no one is going to answer this"
+                });
+
+                manager.IsConnected.ShouldBeFalse("an unanswered request should tear the connection down");
+                logMessages.Any(x => x?.Contains("No response received within") == true)
+                    .ShouldBeTrue("the reset reason should name the timeout: " + string.Join(" | ", logMessages));
+            }
+            finally
+            {
+                glueToGame.Dispose();
+                gameToGlue.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Reproduces the editor freeze: diagnostics reach the UI thread and block until it services
+        /// them, and StatusCheck takes the connection lock on that same UI thread ten times a second. If
+        /// a reset logs while holding the lock, the logging thread waits on the UI thread and the UI
+        /// thread waits on the lock - Glue hangs with no CPU use and nothing written to the output.
+        /// </summary>
+        [Fact]
+        public async Task ResetConnection_DoesNotLogWhileHoldingTheConnectionLock()
+        {
+            var port = GetFreePort();
+            var statusCheckFinished = new ManualResetEventSlim(false);
+            GameConnectionManager manager = null;
+
+            using (manager = new GameConnectionManager((_, __) => { }, port) { TimeoutInSeconds = ShortTimeoutInSeconds })
+            {
+                manager.LogAction = message =>
+                {
+                    if (message?.Contains("Resetting connection") != true)
+                    {
+                        return;
+                    }
+
+                    // Stands in for the UI thread this log call would be blocking on.
+                    var contender = new Thread(() =>
+                    {
+                        try
+                        {
+                            manager.StatusCheck();
+                        }
+                        finally
+                        {
+                            statusCheckFinished.Set();
+                        }
+                    })
+                    { IsBackground = true };
+
+                    contender.Start();
+                    statusCheckFinished.Wait(TimeSpan.FromSeconds(5));
+                };
+
+                var (glueToGame, gameToGlue) = await ConnectAsGameAsync(manager, port);
+
+                try
+                {
+                    // Times out with no reply, which triggers the reset and therefore the log above.
+                    await manager.SendItemWithResponse(new GameConnectionManager.Packet
+                    {
+                        PacketType = "Test",
+                        Payload = "no one is going to answer this"
+                    });
+
+                    statusCheckFinished.IsSet.ShouldBeTrue(
+                        "the reset logged while holding the connection lock, so a thread needing that lock could not proceed - this is the editor deadlock");
+                }
+                finally
+                {
+                    glueToGame.Dispose();
+                    gameToGlue.Dispose();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two defects in `GameConnectionManager`, both reachable any time a project is run in edit mode. Part of #2022.

## The deadlock

`ResetConnection` logged while holding the connection lock. That log reaches `BuildTabView.PrintOutput`, which marshalled with a blocking WinForms `Control.Invoke`. Meanwhile `StatusCheckTask` awaited `Task.Delay(100)` without `ConfigureAwait(false)`, so `StatusCheck` took the same lock on the UI thread ten times a second. Background thread holds the lock and waits on the UI thread, UI thread waits on the lock. Glue freezes with no CPU use, no memory growth, nothing written to the output, and a dead close button, which is exactly what was reported.

Fixed on all three edges so it takes more than one regression to come back:

- Connection state changes return their notifications instead of firing them inline, and callers run them after releasing the lock.
- The status check loop stays off the UI thread.
- Printing output buffers instead of marshalling at all.

`ResetConnection_DoesNotLogWhileHoldingTheConnectionLock` reproduces it: a log sink that waits on another thread needing the lock. Against the old ordering that thread never gets the lock and the test fails.

## Idle connections tearing themselves down

`1cad64a49` added a `TimeoutInSeconds` race to `ReceiveString`, but that method served two callers with opposite needs: the request/response path, where a timeout is right, and the inbound game->Glue receive loop, which is idle by design whenever the user is not interacting with the game. So an editor sitting in edit mode reset and re-handshaked every 10 seconds forever.

Split into `ReceiveResponseString` (keeps the timeout) and `ReceiveUnsolicitedString` (waits as long as it takes, still notices a closed socket). Both halves are pinned: `IdleConnection_IsNotTornDownByTheResponseTimeout` and `UnansweredRequest_TimesOutAndResetsTheConnection`.

## Also in here

- The Build tab document was never trimmed. It appended `Run` inlines into one ever-growing `Paragraph` for the whole session, which cannot be trimmed by block and re-lays out in full on every append. Now one paragraph per line, capped at 2000. Buffering extracted to `CompilerLibrary.OutputLineBuffer` so it is testable without WPF.
- `GameConnectionManager` gained a port-taking constructor. Assigning `Port` afterwards races the constructor's own `StartListening` and can leave the listener bound to the wrong port with nothing to re-listen it.
- The game->Glue receive loop no longer starts before the connection is marked live. It guards on `IsConnected` and could lose that race, exiting immediately and leaving nothing draining the game's messages.
- `Dispose` now disposes the game->Glue socket too.

## Testing

10 new tests, all green. Both defects verified red first by reverting each behavioral change with the test seams left in place.

Full suite: 350 passed, 3 failed. The 3 are `GoldProjectCompileTests`, which fail identically on clean `NetStandard` in a full-suite run and pass in isolation. Pre-existing order dependence, filed separately.

Manual test: needed, since the visible surface is the Build tab.

1. Open a project, enable Run In Edit Mode, launch the game.
2. Leave it alone for a couple of minutes without clicking anything. The Build tab should stay quiet. Before this, it filled with `Resetting connection: No response received within 10 seconds` every 10 seconds.
3. Confirm output still appears, errors are still red, and warnings are still suppressed. Output now appears in up to 100ms batches rather than instantly.
4. Close the game. The Build tab should report the disconnect and Glue should stay responsive.
