### PR TITLE
Add opt-in resource diagnostics to the Build tab

### DIFF
--- a/FRBDK/Glue/CompilerLibrary/Diagnostics/ResourceDiagnosticsReporter.cs
+++ b/FRBDK/Glue/CompilerLibrary/Diagnostics/ResourceDiagnosticsReporter.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace CompilerLibrary.Diagnostics
+{
+    /// <summary>
+    /// Decides which resource samples are worth telling the user about.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately holds no timers, no P/Invoke and no file access, so the reporting rules can be
+    /// tested directly. <see cref="Observe"/> reports a counter only when it sets a new high-water mark:
+    /// a healthy editor reaches its working ceiling and then goes quiet, while a leak keeps producing
+    /// lines. Continuous output is therefore the signal, not noise to be tuned away.
+    /// </remarks>
+    public class ResourceDiagnosticsReporter
+    {
+        /// <summary>
+        /// Per-process cap on USER and GDI objects. Hitting it is what makes PostMessage fail with
+        /// ERROR_NOT_ENOUGH_QUOTA (Win32 1816).
+        /// </summary>
+        public const int UserObjectLimit = 10000;
+
+        /// <summary>
+        /// A UI thread quiet for longer than this is not merely busy.
+        /// </summary>
+        public long StallWarningMilliseconds { get; set; } = 2000;
+
+        bool hasBaseline;
+
+        int highestUserObjects;
+        int highestGdiObjects;
+        int highestHandles;
+        int highestThreads;
+
+        long lastReportedStall;
+
+        readonly List<int> reportedLimitPercentages = new List<int>();
+
+        static readonly int[] LimitPercentagesToWarnAt = { 50, 75, 90 };
+
+        /// <summary>
+        /// Returns the lines worth surfacing for this sample, which is usually none.
+        /// </summary>
+        public IReadOnlyList<string> Observe(ResourceSample sample)
+        {
+            var lines = new List<string>();
+
+            if (!hasBaseline)
+            {
+                hasBaseline = true;
+                highestUserObjects = sample.UserObjectCount;
+                highestGdiObjects = sample.GdiObjectCount;
+                highestHandles = sample.HandleCount;
+                highestThreads = sample.ThreadCount;
+
+                lines.Add(
+                    $"Resource baseline: {sample.UserObjectCount} USER objects, {sample.GdiObjectCount} GDI objects, " +
+                    $"{sample.HandleCount} handles, {sample.ThreadCount} threads.");
+
+                AddLimitWarnings(sample.UserObjectCount, lines);
+
+                return lines;
+            }
+
+            ReportNewPeak("USER objects", sample.UserObjectCount, ref highestUserObjects, lines);
+            ReportNewPeak("GDI objects", sample.GdiObjectCount, ref highestGdiObjects, lines);
+            ReportNewPeak("handles", sample.HandleCount, ref highestHandles, lines);
+            ReportNewPeak("threads", sample.ThreadCount, ref highestThreads, lines);
+
+            AddLimitWarnings(sample.UserObjectCount, lines);
+            AddStallWarnings(sample.UiThreadStallMilliseconds, lines);
+
+            return lines;
+        }
+
+        static void ReportNewPeak(string name, int value, ref int highest, List<string> lines)
+        {
+            if (value <= highest)
+            {
+                return;
+            }
+
+            lines.Add($"New peak {name}: {value} (up {value - highest}).");
+            highest = value;
+        }
+
+        void AddLimitWarnings(int userObjectCount, List<string> lines)
+        {
+            foreach (var percentage in LimitPercentagesToWarnAt)
+            {
+                if (reportedLimitPercentages.Contains(percentage))
+                {
+                    continue;
+                }
+
+                if (userObjectCount * 100L / UserObjectLimit >= percentage)
+                {
+                    reportedLimitPercentages.Add(percentage);
+                    lines.Add(
+                        $"WARNING: USER objects at {userObjectCount} of the {UserObjectLimit} per-process limit " +
+                        $"({percentage}%). At the limit the editor stops drawing and stops responding to input.");
+                }
+            }
+        }
+
+        void AddStallWarnings(long stallMilliseconds, List<string> lines)
+        {
+            if (stallMilliseconds < StallWarningMilliseconds)
+            {
+                if (lastReportedStall > 0)
+                {
+                    lines.Add($"UI thread responded again after {lastReportedStall}ms.");
+                    lastReportedStall = 0;
+                }
+                return;
+            }
+
+            // Only on the first breach and each doubling after it, so a long freeze produces a handful
+            // of lines rather than one per sample.
+            if (lastReportedStall != 0 && stallMilliseconds < lastReportedStall * 2)
+            {
+                return;
+            }
+
+            lines.Add($"WARNING: UI thread has not run for {stallMilliseconds}ms.");
+            lastReportedStall = stallMilliseconds;
+        }
+
+        /// <summary>
+        /// One fixed-shape line per sample for the log file, which records every sample rather than only
+        /// the notable ones. A frozen editor cannot be read or copied from on screen, so the file is the
+        /// only copy that survives the failure being diagnosed.
+        /// </summary>
+        public static string FormatForFile(DateTime timestampUtc, ResourceSample sample) =>
+            string.Format(
+                CultureInfo.InvariantCulture,
+                "{0:yyyy-MM-dd HH:mm:ss.fff}\tuser={1}\tgdi={2}\thandles={3}\tthreads={4}\tuiStallMs={5}",
+                timestampUtc,
+                sample.UserObjectCount,
+                sample.GdiObjectCount,
+                sample.HandleCount,
+                sample.ThreadCount,
+                sample.UiThreadStallMilliseconds);
+    }
+}

--- a/FRBDK/Glue/CompilerLibrary/Diagnostics/ResourceSample.cs
+++ b/FRBDK/Glue/CompilerLibrary/Diagnostics/ResourceSample.cs
@@ -1,0 +1,35 @@
+namespace CompilerLibrary.Diagnostics
+{
+    /// <summary>
+    /// One reading of the editor process's window-system and thread resource usage.
+    /// </summary>
+    public struct ResourceSample
+    {
+        /// <summary>
+        /// USER objects held by the process (windows, menus, hooks, timers). Capped per process at
+        /// <see cref="ResourceDiagnosticsReporter.UserObjectLimit"/>; exhausting it makes PostMessage
+        /// fail with ERROR_NOT_ENOUGH_QUOTA and leaves the UI unable to draw or take input.
+        /// </summary>
+        public int UserObjectCount;
+
+        /// <summary>
+        /// GDI objects held by the process (brushes, pens, bitmaps, device contexts). Same per-process
+        /// cap as <see cref="UserObjectCount"/>.
+        /// </summary>
+        public int GdiObjectCount;
+
+        /// <summary>
+        /// All kernel handles held by the process. Grows with leaked files, sockets and processes, none
+        /// of which show up as memory.
+        /// </summary>
+        public int HandleCount;
+
+        public int ThreadCount;
+
+        /// <summary>
+        /// How long since the UI thread last ran anything. Stays near the sampling interval while the
+        /// editor is healthy and climbs without bound once the UI thread is blocked or deadlocked.
+        /// </summary>
+        public long UiThreadStallMilliseconds;
+    }
+}

--- a/FRBDK/Glue/CompilerLibrary/Diagnostics/ResourceSampler.cs
+++ b/FRBDK/Glue/CompilerLibrary/Diagnostics/ResourceSampler.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace CompilerLibrary.Diagnostics
+{
+    /// <summary>
+    /// Reads the current process's window-system and thread resource counts.
+    /// </summary>
+    public static class ResourceSampler
+    {
+        [DllImport("user32.dll")]
+        static extern int GetGuiResources(IntPtr hProcess, int uiFlags);
+
+        const int GR_GDIOBJECTS = 0;
+        const int GR_USEROBJECTS = 1;
+
+        /// <summary>
+        /// Takes a reading. <paramref name="uiThreadStallMilliseconds"/> is supplied by the caller since
+        /// only the caller knows when the UI thread last ran.
+        /// </summary>
+        public static ResourceSample Take(long uiThreadStallMilliseconds)
+        {
+            using var process = Process.GetCurrentProcess();
+            var handle = process.Handle;
+
+            return new ResourceSample
+            {
+                UserObjectCount = GetGuiResources(handle, GR_USEROBJECTS),
+                GdiObjectCount = GetGuiResources(handle, GR_GDIOBJECTS),
+                HandleCount = process.HandleCount,
+                ThreadCount = process.Threads.Count,
+                UiThreadStallMilliseconds = uiThreadStallMilliseconds
+            };
+        }
+    }
+}

--- a/FRBDK/Glue/CompilerLibrary/OutputLineBuffer.cs
+++ b/FRBDK/Glue/CompilerLibrary/OutputLineBuffer.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+
+namespace CompilerLibrary
+{
+    /// <summary>
+    /// Collects output lines from any thread so a view can drain them on a timer.
+    /// </summary>
+    /// <remarks>
+    /// Exists so printing output never touches the UI thread at the call site. Callers include the live
+    /// edit connection manager, which prints while holding its connection lock - marshalling from there
+    /// with a blocking Invoke deadlocks the editor, and marshalling with a non-blocking post instead
+    /// queues an unbounded number of dispatcher operations when output is chatty. Buffering avoids both.
+    /// </remarks>
+    public class OutputLineBuffer
+    {
+        readonly List<OutputLine> lines = new List<OutputLine>();
+
+        public struct OutputLine
+        {
+            public string Text;
+            public bool IsError;
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (lines)
+                {
+                    return lines.Count;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Splits <paramref name="text"/> into lines and queues the non-blank ones. Null or empty text
+        /// queues nothing.
+        /// </summary>
+        public void Add(string text, bool isError)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
+            var split = text.Split('\n');
+
+            lock (lines)
+            {
+                foreach (var line in split)
+                {
+                    if (!string.IsNullOrWhiteSpace(line))
+                    {
+                        lines.Add(new OutputLine { Text = line, IsError = isError });
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns everything queued and empties the buffer.
+        /// </summary>
+        public OutputLine[] TakeAll()
+        {
+            lock (lines)
+            {
+                var toReturn = lines.ToArray();
+                lines.Clear();
+                return toReturn;
+            }
+        }
+
+        public void Clear()
+        {
+            lock (lines)
+            {
+                lines.Clear();
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/CompilerLibrary/ViewModels/CompilerViewModel.cs
+++ b/FRBDK/Glue/CompilerLibrary/ViewModels/CompilerViewModel.cs
@@ -409,6 +409,16 @@ namespace CompilerLibrary.ViewModels
             set => Set(value);
         }
 
+        /// <summary>
+        /// Whether to sample the editor's window-system resource usage and UI thread responsiveness.
+        /// Off by default - this is for diagnosing hangs and leaks, not for everyday use.
+        /// </summary>
+        public bool IsResourceDiagnosticsChecked
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
         public ObservableCollection<ToolbarEntityAndStateViewModel> ToolbarEntitiesAndStates
         {
             get => Get<ObservableCollection<ToolbarEntityAndStateViewModel>>();

--- a/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
+++ b/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
@@ -75,6 +75,7 @@ namespace CompilerPlugin
         private Compiler _compiler;
         private Runner _runner;
         private CompilerViewModel _compilerViewModel;
+        private ResourceDiagnosticsManager _resourceDiagnosticsManager;
 
         FlatRedBall.IO.FilePath BuildSettingsUserFilePath => GlueState.Self.ProjectSpecificSettingsFolder + "BuildSettings.user.json";
 
@@ -87,6 +88,10 @@ namespace CompilerPlugin
 
                 case nameof(CompilerViewModel.IsRunning):
                     //CommandSender.CancelConnect();
+                    break;
+
+                case nameof(CompilerViewModel.IsResourceDiagnosticsChecked):
+                    _resourceDiagnosticsManager.SetEnabled(_compilerViewModel.IsResourceDiagnosticsChecked);
                     break;
             }
         }
@@ -121,6 +126,7 @@ namespace CompilerPlugin
             MainControl = new BuildTabView();
             MainControl.DataContext = _compilerViewModel;
             _compilerViewModel.Configuration = "Debug";
+            _resourceDiagnosticsManager = new ResourceDiagnosticsManager(MainControl.PrintOutput);
             _compilerViewModel.PropertyChanged += HandleCompilerViewModelPropertyChanged;
 
             buildTab = CreateTab(MainControl, "Build", TabLocation.Bottom);

--- a/FRBDK/Glue/CompilerPlugin/Managers/ResourceDiagnosticsManager.cs
+++ b/FRBDK/Glue/CompilerPlugin/Managers/ResourceDiagnosticsManager.cs
@@ -1,0 +1,157 @@
+﻿using CompilerLibrary.Diagnostics;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CompilerPlugin.Managers
+{
+    /// <summary>
+    /// Watches the editor's USER/GDI/handle/thread counts and how long the UI thread has been quiet,
+    /// writing every sample to a file and the notable ones to the Build tab.
+    /// </summary>
+    /// <remarks>
+    /// Sampling runs on a background thread on purpose. The failures this exists to catch either block
+    /// the UI thread or exhaust the resources it needs to run, so anything driven by a DispatcherTimer
+    /// stops producing data exactly when the data matters. The UI thread's only job here is to stamp a
+    /// heartbeat that the background loop reads.
+    /// </remarks>
+    public class ResourceDiagnosticsManager
+    {
+        #region Fields/Properties
+
+        static readonly TimeSpan SampleInterval = TimeSpan.FromSeconds(2);
+        static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(1);
+
+        readonly ResourceDiagnosticsReporter reporter = new ResourceDiagnosticsReporter();
+        readonly Action<string> printOutput;
+
+        System.Windows.Threading.DispatcherTimer heartbeatTimer;
+        CancellationTokenSource samplingCancellation;
+
+        /// <summary>
+        /// Last time the UI thread ran, as a monotonic tick count. Written by the UI thread, read by the
+        /// sampling thread; long reads and writes are atomic on 64-bit so no lock is needed.
+        /// </summary>
+        long lastUiHeartbeatTicks;
+
+        string logFilePath;
+
+        public bool IsEnabled { get; private set; }
+
+        #endregion
+
+        public ResourceDiagnosticsManager(Action<string> printOutput)
+        {
+            this.printOutput = printOutput;
+        }
+
+        /// <summary>
+        /// Starts or stops sampling. Off by default: this is opt-in diagnostics, not always-on overhead.
+        /// </summary>
+        public void SetEnabled(bool isEnabled)
+        {
+            if (isEnabled == IsEnabled)
+            {
+                return;
+            }
+            IsEnabled = isEnabled;
+
+            if (isEnabled)
+            {
+                Start();
+            }
+            else
+            {
+                Stop();
+            }
+        }
+
+        void Start()
+        {
+            logFilePath = BuildLogFilePath();
+            printOutput($"Resource diagnostics on. Every sample is being appended to:{Environment.NewLine}{logFilePath}");
+
+            lastUiHeartbeatTicks = Environment.TickCount64;
+
+            heartbeatTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = HeartbeatInterval
+            };
+            heartbeatTimer.Tick += (_, __) => lastUiHeartbeatTicks = Environment.TickCount64;
+            heartbeatTimer.Start();
+
+            samplingCancellation = new CancellationTokenSource();
+            _ = SampleLoop(samplingCancellation.Token);
+        }
+
+        void Stop()
+        {
+            heartbeatTimer?.Stop();
+            heartbeatTimer = null;
+
+            try { samplingCancellation?.Cancel(); } catch { }
+            samplingCancellation = null;
+
+            printOutput("Resource diagnostics off.");
+        }
+
+        async Task SampleLoop(CancellationToken cancellation)
+        {
+            while (!cancellation.IsCancellationRequested)
+            {
+                try
+                {
+                    var sample = ResourceSampler.Take(Environment.TickCount64 - lastUiHeartbeatTicks);
+
+                    AppendToLogFile(ResourceDiagnosticsReporter.FormatForFile(DateTime.UtcNow, sample));
+
+                    foreach (var line in reporter.Observe(sample))
+                    {
+                        printOutput(line);
+                    }
+                }
+                catch (Exception e)
+                {
+                    // Diagnostics must never be the thing that breaks the editor.
+                    Debug.WriteLine($"Resource diagnostics sample failed: {e}");
+                }
+
+                try
+                {
+                    await Task.Delay(SampleInterval, cancellation).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
+
+        void AppendToLogFile(string line)
+        {
+            try
+            {
+                File.AppendAllText(logFilePath, line + Environment.NewLine);
+            }
+            catch
+            {
+                // A locked or unwritable log file is not worth interrupting the user over.
+            }
+        }
+
+        static string BuildLogFilePath()
+        {
+            var directory = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "FlatRedBall",
+                "Glue",
+                "Diagnostics");
+
+            Directory.CreateDirectory(directory);
+
+            return Path.Combine(directory, $"resources-{DateTime.Now:yyyyMMdd-HHmmss}.log");
+        }
+    }
+}

--- a/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml
+++ b/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml
@@ -33,6 +33,17 @@
                 <Button Click="HandleCancelBuildButtonClick" Content="Cancel Build"></Button>
             </StackPanel>
 
+            <CheckBox Content="Resource diagnostics" VerticalAlignment="Center" Margin="6,0,0,0"
+                      IsChecked="{Binding IsResourceDiagnosticsChecked}">
+                <CheckBox.ToolTip>
+                    <TextBlock>
+                        Samples this editor's USER/GDI object counts, handle and thread counts, and how long<LineBreak/>
+                        the UI thread has been unresponsive. Every sample is written to a log file, and new<LineBreak/>
+                        peaks and UI stalls are printed here. Use this when diagnosing a hang or a leak.
+                    </TextBlock>
+                </CheckBox.ToolTip>
+            </CheckBox>
+
         </WrapPanel>
 
         <RichTextBox Grid.Row="2" ScrollViewer.VerticalScrollBarVisibility="Auto" 

--- a/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml.cs
+++ b/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml.cs
@@ -26,6 +26,21 @@ namespace CompilerPlugin.Views
 
         OutputParser outputParser;
 
+        /// <summary>
+        /// Lines waiting to be shown. Filled from any thread, drained by <see cref="flushTimer"/>.
+        /// </summary>
+        readonly CompilerLibrary.OutputLineBuffer pendingLines = new();
+
+        readonly System.Windows.Threading.DispatcherTimer flushTimer;
+
+        /// <summary>
+        /// Cap on retained lines. Live edit can print continuously for hours, and an unbounded
+        /// FlowDocument grows without limit and gets progressively more expensive to lay out.
+        /// </summary>
+        public int MaxLinesOfText { get; set; } = 2000;
+
+        const int LinesToDropWhenOverCap = 200;
+
         #endregion
 
         #region Events
@@ -47,19 +62,24 @@ namespace CompilerPlugin.Views
 
             InitializeComponent();
 
-            TextBox.Document.Blocks.Add(new Paragraph());
-
             _foregroundBinding = new Binding("Foreground")
             {
                 Source = TextBox,
                 Mode = BindingMode.OneWay
             };
+
+            flushTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(100)
+            };
+            flushTimer.Tick += HandleFlushTimerTick;
+            flushTimer.Start();
         }
 
         private void HandleCompileClick()
         {
+            pendingLines.Clear();
             TextBox.Document.Blocks.Clear();
-            TextBox.Document.Blocks.Add(new Paragraph());
             BuildClicked?.Invoke(this, null);
         }
 
@@ -73,49 +93,53 @@ namespace CompilerPlugin.Views
             MSBuildSettingsClicked?.Invoke();
         }
 
-        public void PrintOutput(string text)
-        {
-            //////////////////////////////////// Early out ////////////////////////////////////////////
-            if (text == null) return;
-            //////////////////////////////////End Early Out////////////////////////////////////////////
+        /// <summary>
+        /// Queues output for display. Safe to call from any thread, and never blocks on the UI thread.
+        /// </summary>
+        public void PrintOutput(string text) => pendingLines.Add(text, isError: false);
 
-            // suppress warnings...
-            var split = text.Split('\n');
+        /// <inheritdoc cref="PrintOutput"/>
+        public void PrintError(string text) => pendingLines.Add(text, isError: true);
+
+        void HandleFlushTimerTick(object sender, EventArgs e)
+        {
+            if (pendingLines.Count == 0)
+            {
+                return;
+            }
+
+            var toAppend = pendingLines.TakeAll();
 
             try
             {
-                Glue.MainGlueWindow.Self.Invoke(() =>
+                foreach (var line in toAppend)
                 {
-                    var paragraph = TextBox.Document.Blocks.LastOrDefault() as Paragraph;
-                    if(paragraph == null)
+                    // Warnings are suppressed, same as before this was buffered.
+                    var outputType = line.IsError ? OutputType.Error : outputParser.GetOutputType(line.Text);
+                    if (outputType == OutputType.Warning)
                     {
-                        paragraph = new Paragraph();
-                        TextBox.Document.Blocks.Add(paragraph);
-                    }
-                    foreach (var line in split)
-                    {
-                        if(!string.IsNullOrWhiteSpace(line))
-                        {
-                            var outputType = outputParser.GetOutputType(line);
-                            if(outputType != OutputType.Warning)
-                            {
-                                Run run = new Run(line + "\r\n");
-                                paragraph.Inlines.Add(run);
-
-                                if (outputType == OutputType.Error)
-                                {
-                                    run.Foreground = Brushes.Red;
-                                } 
-                                else
-                                {
-                                    BindingOperations.SetBinding(run, ForegroundProperty, _foregroundBinding);
-                                }
-                            }
-                        }
+                        continue;
                     }
 
-                    TextBox.ScrollToEnd();
-                });
+                    var run = new Run(line.Text);
+                    if (outputType == OutputType.Error)
+                    {
+                        run.Foreground = Brushes.Red;
+                    }
+                    else
+                    {
+                        BindingOperations.SetBinding(run, ForegroundProperty, _foregroundBinding);
+                    }
+
+                    // One paragraph per line so the document can be trimmed by block. A single
+                    // ever-growing paragraph cannot be, and re-lays out in full on every append.
+                    var paragraph = new Paragraph(run) { Margin = new Thickness(0) };
+                    TextBox.Document.Blocks.Add(paragraph);
+                }
+
+                ShortenOutputIfNecessary();
+
+                TextBox.ScrollToEnd();
             }
             catch
             {
@@ -123,48 +147,22 @@ namespace CompilerPlugin.Views
             }
         }
 
-        public void PrintError(string text)
+        void ShortenOutputIfNecessary()
         {
-            //////////////////////////////////// Early out ////////////////////////////////////////////
-            if (string.IsNullOrEmpty(text)) return;
-            //////////////////////////////////End Early Out////////////////////////////////////////////
-
-            // suppress warnings...
-            var split = text.Split('\n');
-
-            try
+            if (TextBox.Document.Blocks.Count <= MaxLinesOfText)
             {
-                Glue.MainGlueWindow.Self.Invoke(() =>
-                {
-                    var paragraph = TextBox.Document.Blocks.LastOrDefault() as Paragraph;
-                    if (paragraph == null)
-                    {
-                        paragraph = new Paragraph();
-                        TextBox.Document.Blocks.Add(paragraph);
-                    }
-                    foreach (var line in split)
-                    {
-                        if (!string.IsNullOrWhiteSpace(line))
-                        {
-                            paragraph.Inlines.Add(new Run(line) { Foreground = Brushes.Red });
-                        }
-                    }
-                    if(split.Length > 0)
-                    {
-                        paragraph.Inlines.Add(new Run("\r\n") { Foreground = Brushes.Red });
-                    }
-
-                    TextBox.ScrollToEnd();
-                });
+                return;
             }
-            catch
+
+            for (int i = 0; i < LinesToDropWhenOverCap && TextBox.Document.Blocks.FirstBlock != null; i++)
             {
-                // could be exiting the app so tolerate the error, don't show a message to the user
+                TextBox.Document.Blocks.Remove(TextBox.Document.Blocks.FirstBlock);
             }
         }
 
         void Button_Click(object sender, RoutedEventArgs e)
         {
+            pendingLines.Clear();
             TextBox.Document.Blocks.Clear();
         }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/Common/GameConnectionManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/Common/GameConnectionManager.cs
@@ -30,33 +30,39 @@ namespace GameJsonCommunicationPlugin.Common
         private bool _isListening = false;
 
         private bool _isConnected = false;
-        public bool IsConnected
+        public bool IsConnected => _isConnected;
+
+        /// <summary>
+        /// Applies a connection state change, returning the notifications it produced (or null if the
+        /// state was already <paramref name="value"/>).
+        /// </summary>
+        /// <remarks>
+        /// The returned action must be invoked only AFTER <see cref="_lock"/> is released. Both the
+        /// diagnostic log and the plugin event reach the editor's UI thread and block until it services
+        /// them, while <see cref="StatusCheck"/> takes the same lock - so notifying while holding it
+        /// deadlocks the editor: the notifying thread waits on the UI thread, which waits on the lock.
+        /// </remarks>
+        private Action SetIsConnected(bool value)
         {
-            get
+            if (_isConnected == value)
             {
-                return _isConnected;
+                return null;
             }
+            _isConnected = value;
 
-            private set
-            {
-                if (_isConnected == value)
-                {
-                    return;
-                }
-                _isConnected = value;
-
-                if(_isConnected)
-                {
-                    LogDiagnostic("Connected (both sockets established)");
-                    _eventCaller("GameCommunication_Connected", "");
-                }
-                else
-                {
-                    LogDiagnostic("Disconnected");
-                    _eventCaller("GameCommunication_Disconnected", "");
-                }
-            }
+            return value
+                ? new Action(() =>
+                    {
+                        LogDiagnostic("Connected (both sockets established)");
+                        _eventCaller("GameCommunication_Connected", "");
+                    })
+                : new Action(() =>
+                    {
+                        LogDiagnostic("Disconnected");
+                        _eventCaller("GameCommunication_Disconnected", "");
+                    });
         }
+
         private CancellationTokenSource _periodicCheckTaskCancellationToken;
 
         #endregion
@@ -112,9 +118,20 @@ namespace GameJsonCommunicationPlugin.Common
         public static GameConnectionManager Self { get; set; }
 
         public GameConnectionManager(Action<string, string> eventCaller)
+            : this(eventCaller, 0)
+        {
+        }
+
+        /// <summary>
+        /// Preferred over setting <see cref="Port"/> after construction: the constructor starts
+        /// listening immediately, so assigning the port afterwards races the initial bind and can leave
+        /// the listener on the wrong port with nothing to re-listen it.
+        /// </summary>
+        public GameConnectionManager(Action<string, string> eventCaller, int port)
         {
             _eventCaller = eventCaller;
             _addr = IPAddress.Loopback;
+            _port = port;
             StartListening();
             _periodicCheckTaskCancellationToken = new CancellationTokenSource();
             Task task = StatusCheckTask(_periodicCheckTaskCancellationToken.Token);
@@ -156,9 +173,20 @@ namespace GameJsonCommunicationPlugin.Common
 
                                 HandleConnection(_listener.Accept());
                                 HandleConnection(_listener.Accept());
-                                IsConnected = true;
+
+                                Action notify;
+                                lock (_lock)
+                                {
+                                    notify = SetIsConnected(true);
+                                }
+                                notify?.Invoke();
                                 // Vic asks - do we still need this?
                                 _eventCaller("GameCommunication_Connected", "");
+
+                                // Only now that the connection is marked live - the loop guards on
+                                // IsConnected, so starting it any earlier races with the line above and
+                                // can exit immediately, leaving nothing draining the game's messages.
+                                StartGameToGlueReceiveLoop();
 
                                 _listener.Dispose();
                                 _listener = null;
@@ -213,6 +241,12 @@ namespace GameJsonCommunicationPlugin.Common
             Debug.WriteLine("Connected Game->Glue");
 
             gameToGlueSocket = socket;
+        }
+
+        private void StartGameToGlueReceiveLoop()
+        {
+            // Captured once: ResetConnection nulls the field, so reading it mid-loop can NRE.
+            var socket = gameToGlueSocket;
 
             Task.Run(async () =>
             {
@@ -220,7 +254,15 @@ namespace GameJsonCommunicationPlugin.Common
                 {
                     while (IsConnected)
                     {
-                        string stringFromGame = await ReceiveString(gameToGlueSocket);
+                        string stringFromGame = await ReceiveUnsolicitedString(socket);
+
+                        if (stringFromGame == null)
+                        {
+                            // Socket closed or shut down by the other end. Tear down so StatusCheck
+                            // re-handshakes rather than spinning on a dead socket.
+                            ResetConnection("game->glue socket closed");
+                            break;
+                        }
 
                         string toReturn = null;
 
@@ -256,7 +298,7 @@ namespace GameJsonCommunicationPlugin.Common
 
 
                         // todo - need to send the string...
-                        //gameToGlueSocket.Send(new byte[] { 0 });
+                        //socket.Send(new byte[] { 0 });
                         if (toReturn != null)
                         {
                             // This is a little noisy, but can be uncommented for more diagnostic info:
@@ -266,12 +308,12 @@ namespace GameJsonCommunicationPlugin.Common
 
                             //Send size
                             var bytesForSize = BitConverter.GetBytes(size);
-                            gameToGlueSocket.Send(bytesForSize);
+                            socket.Send(bytesForSize);
 
                             System.Diagnostics.Debug.WriteLine($"{DateTime.Now}-Sent long for {size} size ({bytesForSize.Length})");
 
                             //Send payload
-                            gameToGlueSocket.Send(sendBytes);
+                            socket.Send(sendBytes);
 
                             System.Diagnostics.Debug.WriteLine($"{DateTime.Now}-Sent body with {sendBytes.Length} bytes");
                         }
@@ -279,7 +321,7 @@ namespace GameJsonCommunicationPlugin.Common
                         {
 
                             var bytesForSize = BitConverter.GetBytes((long)0);
-                            var sentBytes = gameToGlueSocket.Send(bytesForSize);
+                            var sentBytes = socket.Send(bytesForSize);
 
                             System.Diagnostics.Debug.WriteLine($"{DateTime.Now}-Sent long(0) with {sentBytes} bytes");
 
@@ -292,7 +334,15 @@ namespace GameJsonCommunicationPlugin.Common
                 {
                     Debug.WriteLine($"Client Connection Failed: {ex}");
                 }
-                finally { IsConnected = false; }
+                finally
+                {
+                    Action notify;
+                    lock (_lock)
+                    {
+                        notify = SetIsConnected(false);
+                    }
+                    notify?.Invoke();
+                }
             });
         }
 
@@ -311,7 +361,7 @@ namespace GameJsonCommunicationPlugin.Common
                 //Send payload
                 socket.Send(sendBytes);
 
-                string responseString = await ReceiveString(socket);
+                string responseString = await ReceiveResponseString(socket);
                 return responseString;
             }
             catch (Exception ex) when (ex is SocketException || ex is ObjectDisposedException || ex is NullReferenceException)
@@ -333,6 +383,9 @@ namespace GameJsonCommunicationPlugin.Common
         /// </summary>
         private void ResetConnection(string reason)
         {
+            Action notify = null;
+            var didReset = false;
+
             lock (_lock)
             {
                 if (!_isConnected && glueToGameSocket == null && gameToGlueSocket == null)
@@ -341,36 +394,55 @@ namespace GameJsonCommunicationPlugin.Common
                     return;
                 }
 
-                LogDiagnostic($"Resetting connection: {reason}");
-
                 try { glueToGameSocket?.Dispose(); } catch { }
                 try { gameToGlueSocket?.Dispose(); } catch { }
                 glueToGameSocket = null;
                 gameToGlueSocket = null;
 
-                // Fires GameCommunication_Disconnected; StatusCheck then re-listens.
-                IsConnected = false;
+                // Produces GameCommunication_Disconnected; StatusCheck then re-listens.
+                notify = SetIsConnected(false);
+                didReset = true;
             }
+
+            // Outside the lock on purpose - see SetIsConnected. Logging blocks on the editor's UI
+            // thread, and StatusCheck runs on that thread taking this same lock.
+            if (didReset)
+            {
+                LogDiagnostic($"Resetting connection: {reason}");
+            }
+            notify?.Invoke();
+        }
+
+        /// <summary>
+        /// Where diagnostics go. Injectable so tests can observe connect/reset transitions without a
+        /// plugin host, and so the "never notify while holding the lock" guarantee above is testable.
+        /// </summary>
+        internal Action<string> LogAction { get; set; } = DefaultLogAction;
+
+        private static void DefaultLogAction(string message)
+        {
+            System.Diagnostics.Debug.WriteLine(message);
+            try { PluginManager.CallPluginMethod("Compiler Plugin", "HandleOutput", message); } catch { }
         }
 
         private void LogDiagnostic(string message)
         {
-            var full = $"[GameConnection] {message}";
-            System.Diagnostics.Debug.WriteLine(full);
-            try { PluginManager.CallPluginMethod("Compiler Plugin", "HandleOutput", full); } catch { }
+            try { LogAction($"[GameConnection] {message}"); } catch { }
         }
 
-        private async Task<string> ReceiveString(Socket socket)
+        /// <summary>
+        /// Reads a reply we are actively waiting for. A game that never answers (crashed mid-request,
+        /// deadlocked in its own CommandReceiver) must not leave this awaiting forever, so the read is
+        /// raced against <see cref="TimeoutInSeconds"/> and a timeout tears the connection down.
+        /// </summary>
+        private async Task<string> ReceiveResponseString(Socket socket)
         {
             try
             {
                 byte[] bufferSize = new byte[sizeof(long)];
-                //socket.Receive(bufferSize);
 
-                // The synchronous Receive calls below (the payload loop) honor ReceiveTimeout, but this
-                // header ReceiveAsync does not - without racing it against a timeout task, a game that
-                // never replies (crashed mid-request, deadlocked in its own CommandReceiver, etc.) leaves
-                // this awaiting forever with no thread blocked and no CPU used.
+                // The synchronous Receive calls in ReadPayload honor ReceiveTimeout, but ReceiveAsync
+                // does not - hence the explicit race below.
                 socket.ReceiveTimeout = (int)(TimeoutInSeconds * 1000);
 
                 ArraySegment<byte> buffer = new ArraySegment<byte>(bufferSize);
@@ -383,32 +455,66 @@ namespace GameJsonCommunicationPlugin.Common
                 }
                 await receiveTask;
 
-                var packetSize = BitConverter.ToInt64(bufferSize, 0);
-
-                string responseString = null;
-
-                using (MemoryStream stream = new MemoryStream())
-                {
-                    var remainingBytes = packetSize;
-                    while (remainingBytes > 0)
-                    {
-                        var pullSize = remainingBytes > 1024 ? 1024 : remainingBytes;
-                        byte[] bufferData = new byte[pullSize];
-                        socket.Receive(bufferData);
-                        stream.Write(bufferData, 0, bufferData.Length);
-                        remainingBytes -= pullSize;
-                    }
-
-                    responseString = Encoding.ASCII.GetString(stream.ToArray());
-                }
-
-                return responseString;
-
+                return ReadPayload(socket, BitConverter.ToInt64(bufferSize, 0));
             }
-            catch(SocketException)
+            catch (SocketException)
             {
                 // This can mean the socket was closed, so return null
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// Reads the next unsolicited message from the game, waiting as long as it takes.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately has no timeout. This socket is idle whenever the user is not interacting with
+        /// the game, which is most of the time, so applying the request/response timeout here would tear
+        /// down a perfectly healthy connection every <see cref="TimeoutInSeconds"/> and leave the editor
+        /// in a permanent reset/re-handshake loop. A genuinely dead socket still surfaces here promptly,
+        /// as a SocketException or ObjectDisposedException rather than as silence.
+        /// </remarks>
+        private async Task<string> ReceiveUnsolicitedString(Socket socket)
+        {
+            try
+            {
+                byte[] bufferSize = new byte[sizeof(long)];
+
+                // 0 means "no timeout" - the payload reads below should wait as long as the header did.
+                socket.ReceiveTimeout = 0;
+
+                var received = await socket.ReceiveAsync(new ArraySegment<byte>(bufferSize), SocketFlags.None);
+
+                if (received == 0)
+                {
+                    // Orderly shutdown by the other end.
+                    return null;
+                }
+
+                return ReadPayload(socket, BitConverter.ToInt64(bufferSize, 0));
+            }
+            catch (Exception ex) when (ex is SocketException || ex is ObjectDisposedException)
+            {
+                // The socket was closed, so return null and let the caller tear the connection down.
+                return null;
+            }
+        }
+
+        private static string ReadPayload(Socket socket, long packetSize)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                var remainingBytes = packetSize;
+                while (remainingBytes > 0)
+                {
+                    var pullSize = remainingBytes > 1024 ? 1024 : remainingBytes;
+                    byte[] bufferData = new byte[pullSize];
+                    socket.Receive(bufferData);
+                    stream.Write(bufferData, 0, bufferData.Length);
+                    remainingBytes -= pullSize;
+                }
+
+                return Encoding.ASCII.GetString(stream.ToArray());
             }
         }
 
@@ -417,11 +523,18 @@ namespace GameJsonCommunicationPlugin.Common
             while (!cancellation.IsCancellationRequested)
             {
                 StatusCheck();
-                await Task.Delay(100, cancellation);
+                // ConfigureAwait(false) keeps this loop off the editor's UI thread. Without it the
+                // continuation resumes on the captured WinForms context, so StatusCheck takes _lock on
+                // the UI thread ten times a second - one half of the deadlock SetIsConnected describes.
+                await Task.Delay(100, cancellation).ConfigureAwait(false);
             }
         }
 
-        private void StatusCheck()
+        /// <summary>
+        /// Re-listens if the connection is dead. Runs every 100ms; internal so tests can drive the
+        /// lock contention it creates against <see cref="ResetConnection"/>.
+        /// </summary>
+        internal void StatusCheck()
         {
             lock (_lock)
             {
@@ -467,6 +580,7 @@ namespace GameJsonCommunicationPlugin.Common
             try { _periodicCheckTaskCancellationToken.Cancel(); } catch { }
             try { _listener?.Dispose(); } catch { }
             try { glueToGameSocket?.Dispose(); } catch { }
+            try { gameToGlueSocket?.Dispose(); } catch { }
         }
 
         #endregion

--- a/FRBDK/Glue/GameCommunicationPlugin/MainGameCommunicationPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/MainGameCommunicationPlugin.cs
@@ -50,8 +50,7 @@ namespace GameCommunicationPlugin
         public override void StartUp()
         {
             Self = this;
-            _gameCommunicationManager = new GameConnectionManager(ReactToPluginEvent);
-            _gameCommunicationManager.Port = 8888;
+            _gameCommunicationManager = new GameConnectionManager(ReactToPluginEvent, 8888);
             _gameCommunicationManager.OnPacketReceived += HandleOnPacketReceived;
             GameConnectionManager.Self = _gameCommunicationManager;
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Controls/OutputLineBufferTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Controls/OutputLineBufferTests.cs
@@ -1,0 +1,92 @@
+using CompilerLibrary;
+using Shouldly;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.Controls
+{
+    public class OutputLineBufferTests
+    {
+        [Fact]
+        public void Add_SplitsOnNewlinesAndDropsBlankLines()
+        {
+            var buffer = new OutputLineBuffer();
+
+            buffer.Add("first\n\nsecond\n   \nthird", isError: false);
+
+            var lines = buffer.TakeAll();
+            lines.Select(x => x.Text).ShouldBe(new[] { "first", "second", "third" });
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Add_IgnoresEmptyText(string text)
+        {
+            var buffer = new OutputLineBuffer();
+
+            buffer.Add(text, isError: false);
+
+            buffer.Count.ShouldBe(0);
+        }
+
+        [Fact]
+        public void Add_RecordsWhetherTheLineWasErrorOutput()
+        {
+            var buffer = new OutputLineBuffer();
+
+            buffer.Add("normal", isError: false);
+            buffer.Add("bad", isError: true);
+
+            var lines = buffer.TakeAll();
+            lines.Single(x => x.Text == "normal").IsError.ShouldBeFalse();
+            lines.Single(x => x.Text == "bad").IsError.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TakeAll_EmptiesTheBuffer()
+        {
+            var buffer = new OutputLineBuffer();
+            buffer.Add("something", isError: false);
+
+            buffer.TakeAll().Length.ShouldBe(1);
+
+            buffer.Count.ShouldBe(0);
+            buffer.TakeAll().ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void Clear_DiscardsQueuedLines()
+        {
+            var buffer = new OutputLineBuffer();
+            buffer.Add("a\nb\nc", isError: false);
+
+            buffer.Clear();
+
+            buffer.Count.ShouldBe(0);
+        }
+
+        /// <summary>
+        /// The whole point of the buffer is that any thread can print without touching the UI thread, so
+        /// concurrent adds must not lose lines or corrupt the list.
+        /// </summary>
+        [Fact]
+        public void Add_IsSafeFromManyThreadsAtOnce()
+        {
+            var buffer = new OutputLineBuffer();
+            const int threadCount = 8;
+            const int linesPerThread = 500;
+
+            Parallel.For(0, threadCount, threadIndex =>
+            {
+                for (int i = 0; i < linesPerThread; i++)
+                {
+                    buffer.Add($"thread {threadIndex} line {i}", isError: false);
+                }
+            });
+
+            buffer.TakeAll().Length.ShouldBe(threadCount * linesPerThread);
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GameConnectionManagerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GameConnectionManagerTests.cs
@@ -1,0 +1,223 @@
+using GameJsonCommunicationPlugin.Common;
+using Shouldly;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin
+{
+    /// <summary>
+    /// Drives the real <see cref="GameConnectionManager"/> over loopback sockets, standing in for the
+    /// game side of live edit. No game process is launched - the handshake is just two sockets, each
+    /// identifying its direction with a single byte (1 = glue->game, 2 = game->glue).
+    /// </summary>
+    public class GameConnectionManagerTests
+    {
+        const double ShortTimeoutInSeconds = 0.3;
+
+        #region Harness
+
+        static int GetFreePort()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        /// <summary>
+        /// Performs the game side of the handshake and waits until the manager reports connected.
+        /// </summary>
+        static async Task<(Socket glueToGame, Socket gameToGlue)> ConnectAsGameAsync(GameConnectionManager manager, int port)
+        {
+            var glueToGame = await ConnectWithRetryAsync(port);
+            glueToGame.Send(new byte[] { 1 });
+
+            var gameToGlue = await ConnectWithRetryAsync(port);
+            gameToGlue.Send(new byte[] { 2 });
+
+            await WaitUntilAsync(() => manager.IsConnected, TimeSpan.FromSeconds(10));
+            manager.IsConnected.ShouldBeTrue("the handshake should have completed");
+
+            return (glueToGame, gameToGlue);
+        }
+
+        static async Task<Socket> ConnectWithRetryAsync(int port)
+        {
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+
+            while (true)
+            {
+                var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                try
+                {
+                    await socket.ConnectAsync(IPAddress.Loopback, port);
+                    return socket;
+                }
+                catch (SocketException)
+                {
+                    socket.Dispose();
+                    if (DateTime.UtcNow > deadline)
+                    {
+                        throw;
+                    }
+                    // The manager listens from a Task.Run started in its constructor, so the first
+                    // attempts can beat the bind.
+                    await Task.Delay(25);
+                }
+            }
+        }
+
+        static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (!condition() && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(25);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// An editor sitting in edit mode with nobody touching it sends and receives nothing. The
+        /// game->glue socket is idle by design, so the request/response timeout must not apply to it -
+        /// otherwise the connection is torn down and re-handshaked every TimeoutInSeconds forever.
+        /// </summary>
+        [Fact]
+        public async Task IdleConnection_IsNotTornDownByTheResponseTimeout()
+        {
+            var port = GetFreePort();
+            var logMessages = new ConcurrentQueue<string>();
+
+            using var manager = new GameConnectionManager((_, __) => { }, port)
+            {
+                TimeoutInSeconds = ShortTimeoutInSeconds,
+                LogAction = logMessages.Enqueue
+            };
+
+            var (glueToGame, gameToGlue) = await ConnectAsGameAsync(manager, port);
+
+            try
+            {
+                // Well over the timeout, with no traffic in either direction.
+                await Task.Delay(TimeSpan.FromSeconds(ShortTimeoutInSeconds * 8));
+
+                manager.IsConnected.ShouldBeTrue("an idle connection is healthy and must stay connected");
+                logMessages.Any(x => x?.Contains("Resetting connection") == true)
+                    .ShouldBeFalse("idle time is not a failure: " + string.Join(" | ", logMessages));
+            }
+            finally
+            {
+                glueToGame.Dispose();
+                gameToGlue.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// The other half of the above: a reply we are actively waiting for still has to time out, or a
+        /// game that died mid-request leaves the editor awaiting forever.
+        /// </summary>
+        [Fact]
+        public async Task UnansweredRequest_TimesOutAndResetsTheConnection()
+        {
+            var port = GetFreePort();
+            var logMessages = new ConcurrentQueue<string>();
+
+            using var manager = new GameConnectionManager((_, __) => { }, port)
+            {
+                TimeoutInSeconds = ShortTimeoutInSeconds,
+                LogAction = logMessages.Enqueue
+            };
+
+            var (glueToGame, gameToGlue) = await ConnectAsGameAsync(manager, port);
+
+            try
+            {
+                // Nothing on the far end reads this or replies to it.
+                await manager.SendItemWithResponse(new GameConnectionManager.Packet
+                {
+                    PacketType = "Test",
+                    Payload = "no one is going to answer this"
+                });
+
+                manager.IsConnected.ShouldBeFalse("an unanswered request should tear the connection down");
+                logMessages.Any(x => x?.Contains("No response received within") == true)
+                    .ShouldBeTrue("the reset reason should name the timeout: " + string.Join(" | ", logMessages));
+            }
+            finally
+            {
+                glueToGame.Dispose();
+                gameToGlue.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Reproduces the editor freeze: diagnostics reach the UI thread and block until it services
+        /// them, and StatusCheck takes the connection lock on that same UI thread ten times a second. If
+        /// a reset logs while holding the lock, the logging thread waits on the UI thread and the UI
+        /// thread waits on the lock - Glue hangs with no CPU use and nothing written to the output.
+        /// </summary>
+        [Fact]
+        public async Task ResetConnection_DoesNotLogWhileHoldingTheConnectionLock()
+        {
+            var port = GetFreePort();
+            var statusCheckFinished = new ManualResetEventSlim(false);
+            GameConnectionManager manager = null;
+
+            using (manager = new GameConnectionManager((_, __) => { }, port) { TimeoutInSeconds = ShortTimeoutInSeconds })
+            {
+                manager.LogAction = message =>
+                {
+                    if (message?.Contains("Resetting connection") != true)
+                    {
+                        return;
+                    }
+
+                    // Stands in for the UI thread this log call would be blocking on.
+                    var contender = new Thread(() =>
+                    {
+                        try
+                        {
+                            manager.StatusCheck();
+                        }
+                        finally
+                        {
+                            statusCheckFinished.Set();
+                        }
+                    })
+                    { IsBackground = true };
+
+                    contender.Start();
+                    statusCheckFinished.Wait(TimeSpan.FromSeconds(5));
+                };
+
+                var (glueToGame, gameToGlue) = await ConnectAsGameAsync(manager, port);
+
+                try
+                {
+                    // Times out with no reply, which triggers the reset and therefore the log above.
+                    await manager.SendItemWithResponse(new GameConnectionManager.Packet
+                    {
+                        PacketType = "Test",
+                        Payload = "no one is going to answer this"
+                    });
+
+                    statusCheckFinished.IsSet.ShouldBeTrue(
+                        "the reset logged while holding the connection lock, so a thread needing that lock could not proceed - this is the editor deadlock");
+                }
+                finally
+                {
+                    glueToGame.Dispose();
+                    gameToGlue.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Managers/ResourceDiagnosticsReporterTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Managers/ResourceDiagnosticsReporterTests.cs
@@ -1,0 +1,159 @@
+using CompilerLibrary.Diagnostics;
+using Shouldly;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace GlueUnitTests.Managers
+{
+    public class ResourceDiagnosticsReporterTests
+    {
+        static ResourceSample Sample(
+            int userObjects = 100,
+            int gdiObjects = 100,
+            int handles = 100,
+            int threads = 10,
+            long uiStallMilliseconds = 0) => new ResourceSample
+            {
+                UserObjectCount = userObjects,
+                GdiObjectCount = gdiObjects,
+                HandleCount = handles,
+                ThreadCount = threads,
+                UiThreadStallMilliseconds = uiStallMilliseconds
+            };
+
+        [Fact]
+        public void FirstSample_ReportsABaseline()
+        {
+            var reporter = new ResourceDiagnosticsReporter();
+
+            var lines = reporter.Observe(Sample(userObjects: 250, gdiObjects: 300, handles: 900, threads: 42));
+
+            lines.ShouldHaveSingleItem();
+            lines[0].ShouldContain("250");
+            lines[0].ShouldContain("300");
+            lines[0].ShouldContain("900");
+            lines[0].ShouldContain("42");
+        }
+
+        /// <summary>
+        /// The point of reporting only new peaks: a healthy editor settles at a ceiling and stops
+        /// producing output, so continuous output means something is actually growing.
+        /// </summary>
+        [Fact]
+        public void SamplesAtOrBelowThePeak_ReportNothing()
+        {
+            var reporter = new ResourceDiagnosticsReporter();
+            reporter.Observe(Sample(userObjects: 500));
+
+            reporter.Observe(Sample(userObjects: 500)).ShouldBeEmpty();
+            reporter.Observe(Sample(userObjects: 499)).ShouldBeEmpty();
+            reporter.Observe(Sample(userObjects: 200)).ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void NewPeak_ReportsTheValueAndTheIncrease()
+        {
+            var reporter = new ResourceDiagnosticsReporter();
+            reporter.Observe(Sample(userObjects: 500));
+
+            var lines = reporter.Observe(Sample(userObjects: 530));
+
+            lines.ShouldHaveSingleItem();
+            lines[0].ShouldContain("USER objects");
+            lines[0].ShouldContain("530");
+            lines[0].ShouldContain("30");
+        }
+
+        [Fact]
+        public void EachCounter_IsTrackedSeparately()
+        {
+            var reporter = new ResourceDiagnosticsReporter();
+            reporter.Observe(Sample());
+
+            var lines = reporter.Observe(Sample(userObjects: 101, gdiObjects: 101, handles: 101, threads: 11));
+
+            lines.Count.ShouldBe(4);
+            lines.ShouldContain(x => x.Contains("USER objects"));
+            lines.ShouldContain(x => x.Contains("GDI objects"));
+            lines.ShouldContain(x => x.Contains("handles"));
+            lines.ShouldContain(x => x.Contains("threads"));
+        }
+
+        [Fact]
+        public void ApproachingTheUserObjectLimit_WarnsOncePerThreshold()
+        {
+            var reporter = new ResourceDiagnosticsReporter();
+            reporter.Observe(Sample(userObjects: 100));
+
+            var atHalf = reporter.Observe(Sample(userObjects: ResourceDiagnosticsReporter.UserObjectLimit / 2));
+            atHalf.ShouldContain(x => x.Contains("50%"));
+
+            // Still over half, but the 50% warning has already been given.
+            var stillOverHalf = reporter.Observe(Sample(userObjects: ResourceDiagnosticsReporter.UserObjectLimit / 2 + 1));
+            stillOverHalf.ShouldNotContain(x => x.Contains("50%"));
+        }
+
+        [Fact]
+        public void UiThreadStall_IsWarnedAboutOnceItPassesTheThreshold()
+        {
+            var reporter = new ResourceDiagnosticsReporter { StallWarningMilliseconds = 2000 };
+            reporter.Observe(Sample());
+
+            reporter.Observe(Sample(uiStallMilliseconds: 1500)).ShouldBeEmpty();
+
+            var lines = reporter.Observe(Sample(uiStallMilliseconds: 2500));
+            lines.ShouldContain(x => x.Contains("UI thread has not run for 2500ms"));
+        }
+
+        /// <summary>
+        /// A freeze lasting minutes must not produce a warning per sample.
+        /// </summary>
+        [Fact]
+        public void OngoingStall_IsReportedOnlyOnEachDoubling()
+        {
+            var reporter = new ResourceDiagnosticsReporter { StallWarningMilliseconds = 2000 };
+            reporter.Observe(Sample());
+
+            reporter.Observe(Sample(uiStallMilliseconds: 2000)).ShouldNotBeEmpty();
+            reporter.Observe(Sample(uiStallMilliseconds: 2500)).ShouldBeEmpty();
+            reporter.Observe(Sample(uiStallMilliseconds: 3900)).ShouldBeEmpty();
+            reporter.Observe(Sample(uiStallMilliseconds: 4000)).ShouldNotBeEmpty();
+            reporter.Observe(Sample(uiStallMilliseconds: 7000)).ShouldBeEmpty();
+            reporter.Observe(Sample(uiStallMilliseconds: 8000)).ShouldNotBeEmpty();
+        }
+
+        [Fact]
+        public void RecoveringFromAStall_IsReported()
+        {
+            var reporter = new ResourceDiagnosticsReporter { StallWarningMilliseconds = 2000 };
+            reporter.Observe(Sample());
+            reporter.Observe(Sample(uiStallMilliseconds: 5000));
+
+            var lines = reporter.Observe(Sample(uiStallMilliseconds: 10));
+
+            lines.ShouldContain(x => x.Contains("responded again after 5000ms"));
+        }
+
+        [Fact]
+        public void RecoveryIsReportedOnlyOnce()
+        {
+            var reporter = new ResourceDiagnosticsReporter { StallWarningMilliseconds = 2000 };
+            reporter.Observe(Sample());
+            reporter.Observe(Sample(uiStallMilliseconds: 5000));
+            reporter.Observe(Sample(uiStallMilliseconds: 10));
+
+            reporter.Observe(Sample(uiStallMilliseconds: 10)).ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void FormatForFile_WritesEverySampleAsOneParseableLine()
+        {
+            var line = ResourceDiagnosticsReporter.FormatForFile(
+                new DateTime(2026, 8, 8, 13, 5, 6, 700, DateTimeKind.Utc),
+                Sample(userObjects: 1, gdiObjects: 2, handles: 3, threads: 4, uiStallMilliseconds: 5));
+
+            line.ShouldBe("2026-08-08 13:05:06.700\tuser=1\tgdi=2\thandles=3\tthreads=4\tuiStallMs=5");
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Managers/ResourceSamplerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Managers/ResourceSamplerTests.cs
@@ -1,0 +1,47 @@
+using CompilerLibrary.Diagnostics;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Managers
+{
+    /// <summary>
+    /// The reporting rules are covered by <see cref="ResourceDiagnosticsReporterTests"/>. This only
+    /// checks that the actual GetGuiResources P/Invoke and process counters return usable numbers, since
+    /// a wrong signature or flag would silently report zeros forever and look like "nothing is leaking".
+    /// </summary>
+    public class ResourceSamplerTests
+    {
+        [Fact]
+        public void Take_ReturnsRealCountersForThisProcess()
+        {
+            var sample = ResourceSampler.Take(uiThreadStallMilliseconds: 1234);
+
+            sample.HandleCount.ShouldBeGreaterThan(0);
+            sample.ThreadCount.ShouldBeGreaterThan(0);
+
+            // A test host is not a windowed app, so these can legitimately be low, but a negative value
+            // means the P/Invoke failed rather than the process being frugal.
+            sample.UserObjectCount.ShouldBeGreaterThanOrEqualTo(0);
+            sample.GdiObjectCount.ShouldBeGreaterThanOrEqualTo(0);
+
+            sample.UiThreadStallMilliseconds.ShouldBe(1234);
+        }
+
+        [Fact]
+        public void Take_DoesNotLeakHandlesEachTimeItIsCalled()
+        {
+            var first = ResourceSampler.Take(0);
+
+            for (int i = 0; i < 200; i++)
+            {
+                ResourceSampler.Take(0);
+            }
+
+            var last = ResourceSampler.Take(0);
+
+            // Sampling opens a Process object every call. If it were not disposed, 200 calls would show
+            // up plainly here - which would make the leak detector itself a leak.
+            (last.HandleCount - first.HandleCount).ShouldBeLessThan(100);
+        }
+    }
+}


### PR DESCRIPTION
Adds a "Resource diagnostics" checkbox to the Build tab. Part of #2022.

**Stacked on #2024** (it needs that PR's buffered, capped output pane, since chatty diagnostics into the old uncapped one would make things worse). Review that first; GitHub will retarget this to `NetStandard` when it merges.

## Why

The reported failure was `Win32Exception (1816)`, `ERROR_NOT_ENOUGH_QUOTA`, from `PostMessage`. That means the process exhausted a per-process window-system resource, not that it deadlocked. Nothing in Glue measured any of those counters, and none of them appear as CPU or memory, which is exactly why the report was "unresponsive, no CPU spike, no memory growth, no error".

#2024 fixes a deadlock that explains the *other* report. It does not explain 1816: a deadlock freezes without throwing. This is for the half that still has no identified mechanism.

## What it does

When checked, samples every 2 seconds:

- USER objects and GDI objects (both capped per process at 10000, which is what 1816 means)
- kernel handle count and thread count
- how long since the UI thread last ran

The tab gets new peaks, warnings at 50/75/90% of the USER object limit, and UI stall warnings. The log file under `%LOCALAPPDATA%\FlatRedBall\Glue\Diagnostics` gets **every** sample.

The file is the part that matters. When this fires the UI is frozen, so anything printed on screen cannot be read or copied.

## Two design points worth reviewing

**Sampling is on a background thread, not a `DispatcherTimer`.** Both failure modes either block the UI thread or exhaust what it needs to run, so UI-driven sampling stops producing data at exactly the moment the data matters. The UI thread's only job is to stamp a heartbeat the sampler reads, which is also what makes the stall measurement possible.

**Reporting is on new high-water marks, not on every change.** A healthy editor reaches its working ceiling and then goes quiet, so continuous output is itself the leak signal rather than noise to tune away. Ongoing stalls report on first breach and each doubling, so a five-minute freeze produces a handful of lines instead of 150.

## Testing

14 new tests. Reporting rules and sampling live in `CompilerLibrary.Diagnostics` with no timers, file access or UI, so both are directly tested; `ResourceDiagnosticsManager` is only wiring.

Includes a smoke test that `GetGuiResources` returns real numbers, because a wrong flag or signature would report zeros forever and read as "nothing is leaking", and one that repeated sampling does not itself leak handles.

Full suite: 363 passed, 2 failed. Those 2 are the pre-existing `GoldProjectCompileTests` order dependence in #2025, which fails the same way on clean `NetStandard`.

Manual test: needed.

1. Open a project, go to the Build tab, check "Resource diagnostics". A baseline line and the log file path should print.
2. Confirm the file exists at that path and gains a line every 2 seconds.
3. Work normally for a few minutes. Expect a handful of "New peak" lines early, then it should go quiet. Continuous output means a real leak, which is the thing we are looking for.
4. Leave it running in edit mode for an hour or two and check whether USER objects climb steadily. That is the measurement this exists for.
5. Uncheck it and confirm output stops.
