### PR TITLE
Blame the plugin an exception actually came from, not one that merely references the thrower

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -2301,7 +2301,11 @@ public class PluginManager : PluginManagerBase
     {
         bool wasHandled = false;
 
-        string source = exception.Source;
+        // The unhandled-exception handler passes `thrownObject as Exception`, which can be null.
+        if (exception == null)
+        {
+            return false;
+        }
 
         foreach (var instance in mInstances)
         {
@@ -2334,22 +2338,83 @@ public class PluginManager : PluginManagerBase
         return wasHandled;
     }
 
-    private static bool WasExceptionCausedByPlugin(Exception exception, PluginContainer plugin)
+    private static bool WasExceptionCausedByPlugin(Exception exception, PluginContainer plugin) =>
+        WasExceptionThrownByAssembly(exception, plugin.Plugin.GetType().Assembly);
+
+    /// <summary>
+    /// Whether <paramref name="exception"/> actually came from code in <paramref name="assembly"/>,
+    /// determined from the stack trace.
+    /// </summary>
+    /// <remarks>
+    /// This used to also blame an assembly whose *referenced* assemblies included Exception.Source. That
+    /// matches far too much: Source is usually the framework assembly that threw, so a WPF exception with
+    /// Source "PresentationCore" matched every plugin referencing WPF, and the first one enumerated was
+    /// shut down for someone else's error. A real user report was blamed on a plugin with no frames in
+    /// the stack at all. Blaming nobody is fine - the caller then reports the exception normally.
+    /// </remarks>
+    internal static bool WasExceptionThrownByAssembly(Exception exception, Assembly assembly)
     {
-        if(plugin.Plugin.GetType().Assembly.GetName().Name == exception.Source)
+        if (exception == null || assembly == null)
         {
-            return true;
+            return false;
         }
 
-        foreach (var name in plugin.Plugin.GetType().Assembly.GetReferencedAssemblies())
+        foreach (var toCheck in EnumerateExceptionAndInnerExceptions(exception))
         {
-            if (name.Name == exception.Source)
+            // Source is set to the throwing method's assembly, so an exact match is the plugin itself.
+            if (assembly.GetName().Name == toCheck.Source)
             {
                 return true;
+            }
+
+            var frames = new System.Diagnostics.StackTrace(toCheck, fNeedFileInfo: false).GetFrames();
+            if (frames == null)
+            {
+                continue;
+            }
+
+            foreach (var frame in frames)
+            {
+                if (frame?.GetMethod()?.DeclaringType?.Assembly == assembly)
+                {
+                    return true;
+                }
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Flattens an exception chain, since a plugin's own frames are commonly buried under a
+    /// TargetInvocationException or an AggregateException rather than being on the outermost one.
+    /// </summary>
+    static IEnumerable<Exception> EnumerateExceptionAndInnerExceptions(Exception exception)
+    {
+        if (exception == null)
+        {
+            yield break;
+        }
+
+        yield return exception;
+
+        if (exception is AggregateException aggregate)
+        {
+            foreach (var inner in aggregate.InnerExceptions)
+            {
+                foreach (var nested in EnumerateExceptionAndInnerExceptions(inner))
+                {
+                    yield return nested;
+                }
+            }
+        }
+        else
+        {
+            foreach (var nested in EnumerateExceptionAndInnerExceptions(exception.InnerException))
+            {
+                yield return nested;
+            }
+        }
     }
 
     /// <summary>

--- a/FRBDK/Glue/Tests/GlueUnitTests/Managers/PluginExceptionAttributionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Managers/PluginExceptionAttributionTests.cs
@@ -1,0 +1,113 @@
+using FlatRedBall.Glue.Plugins;
+using Newtonsoft.Json;
+using Shouldly;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.Managers
+{
+    /// <summary>
+    /// Covers which assembly gets blamed for an unhandled exception. Blaming the wrong one is not
+    /// cosmetic: Glue shuts the blamed plugin down and shows the user its name and file path, so a
+    /// misattributed error both disables working functionality and sends bug reports to the wrong place.
+    /// </summary>
+    public class PluginExceptionAttributionTests
+    {
+        static Assembly ThisAssembly => typeof(PluginExceptionAttributionTests).Assembly;
+
+        static Exception Thrown(Action action)
+        {
+            try
+            {
+                action();
+                throw new InvalidOperationException("the action was supposed to throw");
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
+        }
+
+        [Fact]
+        public void ExceptionThrownFromTheAssembly_IsAttributedToIt()
+        {
+            var exception = Thrown(() => throw new InvalidOperationException("from this test assembly"));
+
+            PluginManager.WasExceptionThrownByAssembly(exception, ThisAssembly).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ExceptionThrownFromElsewhere_IsNotAttributedToThisAssembly()
+        {
+            // Thrown entirely inside Newtonsoft, so no frame here belongs to the test assembly.
+            var exception = Thrown(() => JsonConvert.DeserializeObject<int>("not json at all"));
+
+            PluginManager.WasExceptionThrownByAssembly(exception, typeof(JsonConvert).Assembly).ShouldBeTrue();
+        }
+
+        /// <summary>
+        /// The actual reported bug. A WPF exception has Source "PresentationCore", and attribution used to
+        /// match any assembly that merely *referenced* Source. Every WPF plugin references PresentationCore,
+        /// so an arbitrary innocent plugin was blamed and shut down.
+        /// </summary>
+        [Fact]
+        public void AssemblyThatMerelyReferencesTheThrowingAssembly_IsNotBlamed()
+        {
+            var exception = Thrown(() => JsonConvert.DeserializeObject<int>("not json at all"));
+
+            var throwingAssemblyName = typeof(JsonConvert).Assembly.GetName().Name;
+
+            exception.Source.ShouldBe(throwingAssemblyName,
+                "this test relies on Source being the throwing framework assembly");
+
+            // Glue's own assembly references the throwing assembly but has no frames in this stack, which
+            // is exactly the shape that got an innocent plugin blamed and shut down.
+            var referencesButDidNotThrow = typeof(PluginManager).Assembly;
+            referencesButDidNotThrow.GetReferencedAssemblies()
+                .ShouldContain(x => x.Name == throwingAssemblyName,
+                    "this test relies on the candidate assembly referencing the throwing assembly");
+
+            PluginManager.WasExceptionThrownByAssembly(exception, referencesButDidNotThrow).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ExceptionBuriedInAnInnerException_IsStillAttributed()
+        {
+            var inner = Thrown(() => throw new InvalidOperationException("from this test assembly"));
+            var wrapped = new Exception("wrapped by something else", inner);
+
+            PluginManager.WasExceptionThrownByAssembly(wrapped, ThisAssembly).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ExceptionBuriedInAnAggregateException_IsStillAttributed()
+        {
+            var inner = Thrown(() => throw new InvalidOperationException("from this test assembly"));
+            var aggregate = new AggregateException(new Exception("unrelated"), inner);
+
+            PluginManager.WasExceptionThrownByAssembly(aggregate, ThisAssembly).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ExceptionWithNoStackTrace_BlamesNobody()
+        {
+            // Never thrown, so it has no frames and no Source.
+            var exception = new InvalidOperationException("constructed but not thrown");
+
+            PluginManager.WasExceptionThrownByAssembly(exception, ThisAssembly).ShouldBeFalse();
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public void NullArguments_BlameNobody(bool nullException, bool nullAssembly)
+        {
+            var exception = nullException ? null : new Exception("some error");
+            var assembly = nullAssembly ? null : ThisAssembly;
+
+            PluginManager.WasExceptionThrownByAssembly(exception, assembly).ShouldBeFalse();
+        }
+    }
+}


### PR DESCRIPTION
`PluginManager.WasExceptionCausedByPlugin` blamed a plugin if `Exception.Source` matched its assembly name **or the name of any assembly it referenced**. Part of #2022. Independent of #2024 and #2026, branches off `NetStandard`.

`Source` is normally the framework assembly that threw. So a WPF exception with `Source` = `PresentationCore` matched every plugin that references WPF, and whichever came first in enumeration order got blamed. Glue then showed the user that plugin's name and file path and called `plugin.Fail` on it, disabling working functionality over an unrelated error.

Not hypothetical: a user's hang report came with a dialog naming "FRB Sync Plugin", which does nothing after `StartUp` and had no frames anywhere in the reported stack trace. The report pointed at entirely the wrong component, and the plugin was shut down for it.

## Fix

Attribution now walks the exception's stack frames and matches on the declaring type's assembly. Inner and aggregate exceptions are flattened, since a plugin's own frames are usually under a `TargetInvocationException`. The exact `Source` match is kept, because that genuinely does identify the throwing assembly.

Blaming nobody is a fine outcome. `TryHandleException` returns false and `Program.HandleExceptionsUnified` reports the exception through `PrintError`, which is strictly better than shutting down an innocent plugin.

Also fixes `TryHandleException` dereferencing a null exception, reachable because the caller passes `thrownObject as Exception` and the unhandled object need not be an `Exception`.

## Testing

8 new tests. Verified red first: restoring the old matching logic fails 5 of them, including the reported case.

Full suite: 348 passed, 3 failed. Those 3 are the pre-existing `GoldProjectCompileTests` order dependence in #2025, which fails identically on clean `NetStandard`.

Manual test: not needed. The change is a pure predicate over an exception's stack trace, covered by unit tests including the exact reported shape, and the only behavioral difference is which branch of an existing error path runs.
