### PR TITLE
FRB2: fix editing bugs, recognise and create dotnet-new projects, and fix the flaky gold tests

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/IO/FileManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/IO/FileManager.cs
@@ -70,7 +70,16 @@ namespace FlatRedBall.IO
 
 #endif
 
-        static Dictionary<int, string> mRelativeDirectoryDictionary = new Dictionary<int, string>();
+        /// <summary>
+        /// The relative directory is per-thread. This used to be a Dictionary keyed on managed thread
+        /// id whose setter took a lock but whose getter did not, so a read racing a write that resized
+        /// it could throw - and the getter swallowed that and silently answered
+        /// <see cref="DefaultRelativeDirectory"/> instead. Glue reads and writes this from Parallel.For
+        /// workers while updating file memberships, so that race was live and intermittent. ThreadStatic
+        /// gives the same semantics with no sharing to get wrong, and no lock on the read path.
+        /// </summary>
+        [ThreadStatic]
+        static string mRelativeDirectoryForThread;
 
 
 
@@ -112,29 +121,7 @@ namespace FlatRedBall.IO
         /// </summary>
         static public string RelativeDirectory
         {
-            get
-            {
-                int threadID = System.Threading.Thread.CurrentThread.ManagedThreadId;
-
-                if (mRelativeDirectoryDictionary.ContainsKey(threadID))
-                {
-                    // VERY rare, but possible:
-                    try
-                    {
-                        // the thread ID could go away inbetween the if.
-                        return mRelativeDirectoryDictionary[threadID];
-                    }
-                    catch
-                    {
-                        return DefaultRelativeDirectory;
-                    }
-                }
-                else
-                {
-                    return DefaultRelativeDirectory;
-                }
-
-            }
+            get => mRelativeDirectoryForThread ?? DefaultRelativeDirectory;
             set
             {
 
@@ -172,29 +159,10 @@ namespace FlatRedBall.IO
 
 
 
-                int threadID = System.Threading.Thread.CurrentThread.ManagedThreadId;
-
-                lock (mRelativeDirectoryDictionary)
-                {
-                    if (valueToSet == DefaultRelativeDirectory)
-                    {
-                        if (mRelativeDirectoryDictionary.ContainsKey(threadID))
-                        {
-                            mRelativeDirectoryDictionary.Remove(threadID);
-                        }
-                    }
-                    else
-                    {
-                        if (mRelativeDirectoryDictionary.ContainsKey(threadID))
-                        {
-                            mRelativeDirectoryDictionary[threadID] = valueToSet;
-                        }
-                        else
-                        {
-                            mRelativeDirectoryDictionary.Add(threadID, valueToSet);
-                        }
-                    }
-                }
+                // Null rather than storing the default, so the getter falls back to whatever
+                // DefaultRelativeDirectory is at read time - the dictionary version removed the entry
+                // for exactly this reason.
+                mRelativeDirectoryForThread = valueToSet == DefaultRelativeDirectory ? null : valueToSet;
             }
         }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/CodeGeneration/EmbeddedCodeManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/CodeGeneration/EmbeddedCodeManager.cs
@@ -34,8 +34,11 @@ namespace GameCommunicationPlugin.CodeGeneration
             var prefix = "GameCommunicationPlugin.Embedded.";
             string glueControlManagerCode = GetEmbeddedStringContents(prefix + resourcePath);
             FilePath destinationFilePath = glueControlFolder + relativeDestinationFilePath;
-            GlueCommands.Self.ProjectCommands.CreateAndAddCodeFile(destinationFilePath);
-            GlueCommands.Self.TryMultipleTimes(() => System.IO.File.WriteAllText(destinationFilePath.FullPath, glueControlManagerCode));
+            GlueCommands.Self.TryMultipleTimes(() =>
+            {
+                GlueCommands.Self.ProjectCommands.CreateAndAddCodeFile(destinationFilePath);
+                GlueCommands.Self.FileCommands.SaveIfDiffers(destinationFilePath, glueControlManagerCode);
+            });
         }
 
         private static string GetEmbeddedStringContents(string embeddedLocation)

--- a/FRBDK/Glue/Glue/CodeGeneration/CodeWriter.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/CodeWriter.cs
@@ -2433,10 +2433,15 @@ namespace FlatRedBallAddOns.Entities
         {
             string strippedName = FileManager.RemovePath(element.Name);
 
-            // This also has a factory, so check for that.
+            // This also has a factory, so check for that. Everything else here comes from enumerating
+            // the disk, so this has to check too - the factory has not been generated yet for a newly
+            // pooled entity, and never is for a project Glue does not generate code for.
             string fullName = GlueState.Self.CurrentGlueProjectDirectory + "Factories/" + strippedName + "Factory.Generated.cs";
 
-            foundCsFiles.Add(fullName);
+            if (System.IO.File.Exists(fullName))
+            {
+                foundCsFiles.Add(fullName);
+            }
         }
 
         return foundCsFiles;

--- a/FRBDK/Glue/Glue/IO/ProjectLoader.cs
+++ b/FRBDK/Glue/Glue/IO/ProjectLoader.cs
@@ -83,6 +83,24 @@ namespace FlatRedBall.Glue.IO
             }
             //////////////////// End EARLY OUT////////////////////////////////
 
+            // A FlatRedBall 2 game created by `dotnet new frb2-desktop` is two projects: MyGame.Common
+            // holds Game1, the content and the engine reference, while MyGame.Desktop is a launcher that
+            // reaches the engine through Common. Common is the one Glue edits, but Desktop is the
+            // runnable one and just as natural a thing to pick, and picking it used to end at "could not
+            // determine the project type" with nothing loaded. Resolving here rather than deeper in the
+            // load keeps every later step - Load, RelativeDirectory, the solution lookup - agreeing on
+            // one path.
+            var frb2GameProject = Frb2ProjectDetector.FindFrb2GameProjectFor(projectFileName);
+            if (frb2GameProject != null &&
+                !string.Equals(FileManager.Standardize(frb2GameProject),
+                    FileManager.Standardize(projectFileName), StringComparison.OrdinalIgnoreCase))
+            {
+                GlueCommands.Self.PrintOutput(
+                    $"Opening {FileManager.RemovePath(frb2GameProject)} instead of " +
+                    $"{FileManager.RemovePath(projectFileName)} - it is the FlatRedBall project of the two.");
+                projectFileName = frb2GameProject;
+            }
+
             TaskManager.Self.RecordTaskHistory($"--Received Load project Command {projectFileName}--");
 
             FileWatchManager.PerformFlushing = false;

--- a/FRBDK/Glue/Glue/Plugins/CodeGenerators/FullFileCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/Plugins/CodeGenerators/FullFileCodeGenerator.cs
@@ -17,13 +17,19 @@ namespace FlatRedBall.Glue.Plugins.CodeGenerators
     {
         public abstract string RelativeFile { get; }
 
+        /// <summary>
+        /// Where <see cref="GenerateAndSave"/> writes, for callers that need to remove the file from
+        /// the project when the feature it belongs to is turned off.
+        /// </summary>
+        public FilePath FileLocation => GlueState.Self.CurrentGlueProjectDirectory + RelativeFile;
+
         public void GenerateAndSave()
         {
             TaskManager.Self.Add(() =>
             {
                 var contents = GenerateFileContents();
 
-                FilePath fullPath = GlueState.Self.CurrentGlueProjectDirectory + RelativeFile;
+                FilePath fullPath = FileLocation;
 
                 GlueCommands.Self.TryMultipleTimes(() =>
                 {
@@ -32,9 +38,17 @@ namespace FlatRedBall.Glue.Plugins.CodeGenerators
 
                 });
 
+                AfterSave();
+
             }, $"Adding {RelativeFile}");
         }
 
         protected abstract string GenerateFileContents();
+
+        /// <summary>
+        /// Runs after the file has been written, for cleanup a generator needs to do alongside it -
+        /// typically removing an earlier file this one replaced.
+        /// </summary>
+        protected virtual void AfterSave() { }
     }
 }

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
@@ -119,10 +119,19 @@ public class GluxCommands : IGluxCommands
 
                 GlueState.Self.CurrentGlueProject.StartUpScreen = value;
                 GluxCommands.Self.SaveGlujFile();
-                if (string.IsNullOrEmpty(ProjectManager.GameClassFileName))
+
+                if (!CodeWritePolicy.WritesCodeForCurrentProject)
                 {
+                    // A project Glue does not own the code of reads StartUpScreen straight out of the
+                    // .gluj at runtime, which the save above just wrote. There is no Game class for
+                    // Glue to find and none it should be editing, so there is nothing missing.
+                }
+                else if (string.IsNullOrEmpty(ProjectManager.GameClassFileName))
+                {
+                    // The startup screen itself was saved above - only the code that acts on it wasn't.
                     GlueCommands.Self.DialogCommands.ShowMessageBox(
-                        "Could not set the startup screen because Glue could not find the Game class.");
+                        "The startup screen was saved, but Glue could not find the Game class to update, " +
+                        "so the game will not start on it until that is fixed.");
                 }
                 else
                 {
@@ -3161,6 +3170,9 @@ public class GluxCommands : IGluxCommands
 
     public async Task RemoveEntityAsync(EntitySave entityToRemove, List<string> filesThatCouldBeRemoved = null)
     {
+        // The parameter is an output accumulator, so the documented default overload used to fail at
+        // the first Add. RemoveScreen already does this.
+        filesThatCouldBeRemoved = filesThatCouldBeRemoved ?? new List<string>();
         List<NamedObjectSave> namedObjectsToRemove = ObjectFinder.Self.GetAllNamedObjectsThatUseEntity(entityToRemove.Name);
         List<EntitySave> inheritingEntities = ObjectFinder.Self.GetAllEntitiesThatInheritFrom(entityToRemove);
 

--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -875,6 +875,8 @@ public class PluginManager : PluginManagerBase
 
     internal static void HandleFileReadError(FilePath filePath, GeneralResponse response)
     {
+        SaveRelativeDirectory();
+
         CallMethodOnPluginNotUiThread(
             plugin =>
             {
@@ -2580,57 +2582,49 @@ public class PluginManager : PluginManagerBase
     }
 
 
-    static System.Collections.Concurrent.ConcurrentStack<string> mOldRelativeDirectories = new System.Collections.Concurrent.ConcurrentStack<string>();
+    /// <summary>
+    /// Per-thread, because <see cref="FileManager.RelativeDirectory"/> is per-thread - it reads and
+    /// writes a dictionary keyed on the managed thread id. Glue makes these plugin calls from
+    /// Parallel.For workers (see ProjectCommands.CallUpdateFileMembershipsOnAllFiles), so one shared
+    /// stack had workers popping each other's entries: a resume would restore another thread's
+    /// directory over its own and report "the relativeDirectory wasn't set properly" against a caller
+    /// that did nothing wrong, and the orphaned entries outlived the project load that pushed them.
+    /// </summary>
+    [ThreadStatic]
+    static Stack<string> mOldRelativeDirectories;
+
+    static Stack<string> OldRelativeDirectories => mOldRelativeDirectories ??= new Stack<string>();
 
     static void SaveRelativeDirectory()
     {
-        mOldRelativeDirectories.Push(FileManager.RelativeDirectory);
+        OldRelativeDirectories.Push(FileManager.RelativeDirectory);
     }
 
     static void ResumeRelativeDirectory(string function)
     {
-        if (mOldRelativeDirectories.Count == 0)
+        var stack = OldRelativeDirectories;
+
+        if (stack.Count == 0)
         {
-            FileManager.RelativeDirectory = FileManager.GetDirectory(
-                FlatRedBall.Glue.Plugins.ExportedImplementations.GlueState.Self.CurrentCodeProjectFileName.FullPath);
+            // Nothing to resume - every push on this thread has already been consumed, which means a
+            // resume is unbalanced. Falling back to the loaded project's directory is a guess, and
+            // with no project loaded there isn't even one to make, so leave the directory alone
+            // rather than dereferencing null.
+            var codeProject = FlatRedBall.Glue.Plugins.ExportedImplementations.GlueState.Self.CurrentCodeProjectFileName;
+            if (codeProject != null)
+            {
+                FileManager.RelativeDirectory = FileManager.GetDirectory(codeProject.FullPath);
+            }
+            return;
         }
-        else
+
+        var saved = stack.Pop();
+
+        if (FileManager.RelativeDirectory != saved)
         {
-            bool differs = true;
-
-            try
-            {
-                string top = null;
-                if(mOldRelativeDirectories.TryPeek(out top))
-                {
-                    differs = FileManager.RelativeDirectory != top;
-                }
-            }
-            catch
-            {
-                // no big deal we'll just act as if it differs
-            }
-            if (differs)
-            {
-                ReceiveError("The relativeDirectory wasn't set properly in " + function);
-
-                string top = null;
-                if (mOldRelativeDirectories.TryPeek(out top))
-                {
-                    FileManager.RelativeDirectory = top;
-                }
-
-            }
-
-            try
-            {
-                string throwaway;
-                mOldRelativeDirectories.TryPop(out throwaway);
-            }
-            catch(ArgumentOutOfRangeException)
-            {
-                // no big deal
-            }
+            // A plugin changed the relative directory and did not put it back.
+            ReceiveError("The relativeDirectory wasn't set properly in " + function);
+            FileManager.RelativeDirectory = saved;
         }
     }
 

--- a/FRBDK/Glue/Glue/Projects/NewProjectHelper.cs
+++ b/FRBDK/Glue/Glue/Projects/NewProjectHelper.cs
@@ -89,7 +89,10 @@ public class NewProjectHelper
 
         if(viewModel != null)
         {
-            createdProject = $@"{viewModel.FinalDirectory}\{viewModel.ProjectName}\{viewModel.ProjectName}.csproj";
+            // Not every template puts the project Glue should open at the same place - a dotnet
+            // template can produce several projects, only one of which is the game.
+            createdProject = Npc.ProjectCreationHelper.GetProjectToOpen(
+                viewModel.SelectedProject, viewModel.ProjectName, viewModel.FinalDirectory);
         }
 
         GlueCommands.Self.DialogCommands.ShowSpinner("Preparing Project...");

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2ProjectDetector.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2ProjectDetector.cs
@@ -15,19 +15,36 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
     /// This runs before <see cref="ProjectCreator"/>'s DefineConstants cascade, because an FRB2
     /// .csproj sets none of the preprocessor constants that cascade keys off of.
     ///
-    /// Rules are a list rather than a single check so more ways of referencing FRB2 can be added
-    /// without restructuring. Today the only shipping FRB2 games reference the engine by source; a
-    /// PackageReference rule gets added once FRB2 publishes a nuget package.
+    /// Rules are a list rather than a single check because there is more than one way to reference
+    /// FRB2: games inside the FRB2 repo reference the engine by source, and games created by
+    /// <c>dotnet new frb2-desktop</c> reference the published nuget packages.
     /// </remarks>
     public static class Frb2ProjectDetector
     {
         const string Frb2SourceProjectFileName = "FlatRedBall2.csproj";
+        const string Frb2PackagePrefix = "FlatRedBall2";
 
         static readonly Func<ProjectItemInfo, bool>[] Rules = new Func<ProjectItemInfo, bool>[]
         {
             item => item.ItemType == "ProjectReference" &&
                 string.Equals(GetFileName(item.Include), Frb2SourceProjectFileName, StringComparison.OrdinalIgnoreCase),
+
+            item => item.ItemType == "PackageReference" && IsFrb2Package(item.Include),
         };
+
+        /// <summary>
+        /// Matches the engine packages a template-created game takes - FlatRedBall2.MonoGame,
+        /// FlatRedBall2.Kni, and anything else published under that prefix.
+        /// </summary>
+        /// <remarks>
+        /// The trailing dot matters: FRB1's packages are FlatRedBall.*, and treating one of those as
+        /// FRB2 would silently stop Glue generating that project's code. "FlatRedBall2" cannot be a
+        /// prefix of "FlatRedBall." so the two families cannot be confused.
+        /// </remarks>
+        static bool IsFrb2Package(string include) =>
+            !string.IsNullOrEmpty(include) &&
+            (string.Equals(include, Frb2PackagePrefix, StringComparison.OrdinalIgnoreCase) ||
+             include.StartsWith(Frb2PackagePrefix + ".", StringComparison.OrdinalIgnoreCase));
 
         /// <summary>
         /// The one thing every rule needs from a project item, so callers can test this without an
@@ -53,6 +70,82 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             }
 
             return projectItems.Any(item => Rules.Any(rule => rule(item)));
+        }
+
+        /// <summary>
+        /// The FRB2 game project the user means by picking <paramref name="csprojPath"/>: the file
+        /// itself when it is one, otherwise a project it directly references that is. Null when neither
+        /// applies, which must leave the caller's original choice alone.
+        /// </summary>
+        /// <remarks>
+        /// `dotnet new frb2-desktop` splits a game into MyGame.Common - Game1, content, and the engine
+        /// reference - and MyGame.Desktop, a launcher holding only Program.cs and the content pipeline.
+        /// Common is what Glue edits, but Desktop is the runnable one and just as likely to be picked.
+        ///
+        /// The .csproj files are read as XML rather than evaluated by MSBuild: this runs on a file the
+        /// user may have picked by mistake, and an SDK or import that fails to resolve should produce
+        /// "no redirect", not an exception on the load path.
+        ///
+        /// One hop only. Following the whole reference graph would eventually reach the engine from
+        /// almost anywhere and start redirecting people to projects they never meant to open.
+        /// </remarks>
+        public static string FindFrb2GameProjectFor(string csprojPath)
+        {
+            if (string.IsNullOrEmpty(csprojPath) || !File.Exists(csprojPath))
+            {
+                return null;
+            }
+
+            if (IsFrb2Project(ReadProjectItems(csprojPath)))
+            {
+                return csprojPath;
+            }
+
+            var directory = Path.GetDirectoryName(csprojPath);
+
+            foreach (var item in ReadProjectItems(csprojPath))
+            {
+                if (item.ItemType != "ProjectReference" || string.IsNullOrEmpty(item.Include))
+                {
+                    continue;
+                }
+
+                string referencedPath;
+                try
+                {
+                    referencedPath = Path.GetFullPath(
+                        Path.Combine(directory, item.Include.Replace('\\', Path.DirectorySeparatorChar)));
+                }
+                catch (ArgumentException)
+                {
+                    continue;
+                }
+
+                if (File.Exists(referencedPath) && IsFrb2Project(ReadProjectItems(referencedPath)))
+                {
+                    return referencedPath;
+                }
+            }
+
+            return null;
+        }
+
+        static IEnumerable<ProjectItemInfo> ReadProjectItems(string csprojPath)
+        {
+            try
+            {
+                return System.Xml.Linq.XDocument.Load(csprojPath)
+                    .Descendants()
+                    .Where(element => element.Attribute("Include") != null)
+                    .Select(element => new ProjectItemInfo(
+                        element.Name.LocalName, element.Attribute("Include").Value))
+                    .ToArray();
+            }
+            catch (Exception)
+            {
+                // Unreadable or malformed - no redirect, and let whatever opens it report the problem.
+                return Array.Empty<ProjectItemInfo>();
+            }
         }
 
         public static bool IsFrb2Project(Project coreVisualStudioProject) =>

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Managers/CodeGeneratorManager.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Managers/CodeGeneratorManager.cs
@@ -406,13 +406,10 @@ public class CodeGeneratorManager : Singleton<CodeGeneratorManager>
             shouldCustomGumBeInProject = true;
             var customCode = CustomCodeGenerator.Self.GetCustomGumRuntimeCustomCode(element);
 
-            var directory = FileManager.GetDirectory(customGumRuntimeSaveLocation);
-            System.IO.Directory.CreateDirectory(directory);
-
             PrintIfVerbose($"Saving custom runtime code: {customGumRuntimeSaveLocation}");
 
             GlueCommands.Self.TryMultipleTimes(() =>
-                FlatRedBall.IO.FileManager.SaveText(customCode, customGumRuntimeSaveLocation));
+                GlueCommands.Self.FileCommands.SaveIfDiffers(customGumRuntimeSaveLocation, customCode));
         }
 
         if (shouldCustomGumBeInProject)
@@ -451,14 +448,11 @@ public class CodeGeneratorManager : Singleton<CodeGeneratorManager>
             if (resultToReturn.DidSaveCustomForms)
             {
 
-                var directory = FileManager.GetDirectory(customFormsSaveLocation);
-                System.IO.Directory.CreateDirectory(directory);
-
                 PrintIfVerbose($"Saved custom forms code: {customFormsSaveLocation}");
 
 
                 GlueCommands.Self.TryMultipleTimes(() =>
-                    FlatRedBall.IO.FileManager.SaveText(customFormsCode, customFormsSaveLocation));
+                    GlueCommands.Self.FileCommands.SaveIfDiffers(customFormsSaveLocation, customFormsCode));
 
                 bool wasAnythingAdded =
                     FlatRedBall.Glue.ProjectManager.CodeProjectHelper.AddFileToCodeProjectIfNotAlreadyAdded(
@@ -516,14 +510,11 @@ public class CodeGeneratorManager : Singleton<CodeGeneratorManager>
         }
         if (resultToReturn.DidSaveGeneratedGumRuntime)
         {
-            // in case directory doesn't exist
-            System.IO.Directory.CreateDirectory(generatedSaveLocation.GetDirectoryContainingThis().FullPath);
-
             PrintIfVerbose($"Saved generated runtime code: {generatedSaveLocation.FullPath}");
 
 
             GlueCommands.Self.TryMultipleTimes(() =>
-                FlatRedBall.IO.FileManager.SaveText(generatedGumRuntimeCode, generatedSaveLocation.FullPath));
+                GlueCommands.Self.FileCommands.SaveIfDiffers(generatedSaveLocation, generatedGumRuntimeCode));
         }
 
         if (shouldGeneratedGumBeInProject)
@@ -573,13 +564,10 @@ public class CodeGeneratorManager : Singleton<CodeGeneratorManager>
 
         if (resultToReturn.DidSaveGeneratedForms)
         {
-            // in case it doesn't exist
-            System.IO.Directory.CreateDirectory(generatedFormsSaveLocation.GetDirectoryContainingThis().FullPath);
-
             PrintIfVerbose($"Saved generated forms code: {generatedFormsSaveLocation.FullPath}");
 
             GlueCommands.Self.TryMultipleTimes(() =>
-                FlatRedBall.IO.FileManager.SaveText(generatedFormsCode, generatedFormsSaveLocation.FullPath));
+                GlueCommands.Self.FileCommands.SaveIfDiffers(generatedFormsSaveLocation, generatedFormsCode));
         }
 
         if (shouldGeneratedFormsBeInProject)
@@ -818,15 +806,16 @@ public class CodeGeneratorManager : Singleton<CodeGeneratorManager>
     {
         bool wasSaved = false;
 
-        var directory = FileManager.GetDirectory(fileName);
-        Directory.CreateDirectory(directory);
         const int timesToTry = 4;
         int timesTried = 0;
         while (true)
         {
             try
             {
-                FlatRedBall.IO.FileManager.SaveText(fileContents, fileName);
+                // SaveIfDiffers, not FileManager.SaveText: it is where CodeWritePolicy is consulted, so
+                // nothing is written into a project Glue does not own the code of. It creates the
+                // directory too.
+                GlueCommands.Self.FileCommands.SaveIfDiffers(fileName, fileContents);
                 wasSaved = true;
                 break;
             }

--- a/FRBDK/Glue/GumPlugin/GumPlugin/ViewModels/GumViewModel.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/ViewModels/GumViewModel.cs
@@ -155,7 +155,12 @@ namespace GumPlugin.ViewModels
             ShowMouse = backingRfs.Properties.GetValue<bool>(nameof(ShowMouse));
             UpdateFromGlueObject();
 
-            GumProjectInfo = $"{gumProjectSave.Screens.Count} Screens\n{gumProjectSave.Components.Count} Components\n{gumProjectSave.Behaviors.Count} Behaviors";
+            // Null until the Gum project itself has loaded, and the .gumx can be selected before then.
+            // Throwing here costs more than the missing summary: PluginManager turns any exception out
+            // of a plugin into PluginContainer.Fail, which disables the Gum plugin for the session.
+            GumProjectInfo = gumProjectSave == null
+                ? string.Empty
+                : $"{gumProjectSave.Screens.Count} Screens\n{gumProjectSave.Components.Count} Components\n{gumProjectSave.Behaviors.Count} Behaviors";
         }
 
 

--- a/FRBDK/Glue/NpcWpfLib/Data/EmptyTemplates.cs
+++ b/FRBDK/Glue/NpcWpfLib/Data/EmptyTemplates.cs
@@ -31,6 +31,20 @@ namespace Npc.Data
             Add("FNA .NET 7 (Windows, Mac, Linux)", "FlatRedBallDesktopFnaTemplate",
                 "http://files.flatredball.com/content/FrbXnaTemplates/DailyBuild/ZippedTemplates/FlatRedBallDesktopFnaTemplate.zip");
 
+            // FlatRedBall 2 ships its templates as a nuget package rather than a zip this repo builds,
+            // so this entry is created by the dotnet CLI and is exempt from the zip-pipeline checks in
+            // NewProjectTemplateListTests. Glue opens the .Common project of the pair - it holds Game1,
+            // the content and the engine reference, while .Desktop is only a launcher.
+            Projects.Add(new DotnetNewProjectInfo
+            {
+                FriendlyName = "FlatRedBall 2 Desktop (Windows, Mac, Linux) - MonoGame",
+                Namespace = "FlatRedBall2DesktopTemplate",
+                TemplatePackageId = "FlatRedBall2.Templates",
+                TemplateShortName = "frb2-desktop",
+                ProjectToOpenPattern = "{ProjectName}.Common/{ProjectName}.Common.csproj",
+                SupportedInGlue = true,
+            });
+
             Projects.Add(new AddNewLocalProjectOption());
         }
 

--- a/FRBDK/Glue/NpcWpfLib/Managers/DotnetNewService.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/DotnetNewService.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using ToolsUtilities;
+
+namespace Npc.Managers;
+
+/// <summary>
+/// Runs the dotnet CLI's template engine. Separated behind an interface so project creation can be
+/// tested without the SDK, the network, or a real template package installed.
+/// </summary>
+public interface IDotnetNewService
+{
+    /// <summary>
+    /// Installs <paramref name="templatePackageId"/> if the CLI does not already have it, then runs the
+    /// template into <paramref name="outputDirectory"/>.
+    /// </summary>
+    Task<GeneralResponse> CreateProjectAsync(
+        string templatePackageId, string templateShortName, string projectName, string outputDirectory);
+}
+
+public class DotnetNewService : IDotnetNewService
+{
+    static readonly TimeSpan Timeout = TimeSpan.FromMinutes(5);
+
+    public async Task<GeneralResponse> CreateProjectAsync(
+        string templatePackageId, string templateShortName, string projectName, string outputDirectory)
+    {
+        var probe = await RunAsync($"new {templateShortName} --help");
+
+        if (probe.ExitCode != 0)
+        {
+            // Not installed, or no SDK at all - the install attempt below distinguishes them.
+            var install = await RunAsync($"new install {templatePackageId}");
+
+            if (install.ExitCode != 0)
+            {
+                return GeneralResponse.UnsuccessfulWith(
+                    $"Could not install the {templatePackageId} template package. FlatRedBall 2 projects " +
+                    $"are created by the dotnet CLI, so the .NET SDK has to be installed and on the PATH, " +
+                    $"and this first install needs internet access.\n\n{install.Output}");
+            }
+        }
+
+        var create = await RunAsync(
+            $"new {templateShortName} -n \"{projectName}\" -o \"{outputDirectory}\"");
+
+        return create.ExitCode == 0
+            ? GeneralResponse.SuccessfulResponse
+            : GeneralResponse.UnsuccessfulWith(
+                $"`dotnet new {templateShortName}` failed:\n\n{create.Output}");
+    }
+
+    /// <summary>
+    /// Both streams are drained concurrently and the whole process tree is killed on timeout. The
+    /// obvious version - redirect, StandardOutput.ReadToEnd(), WaitForExit() - deadlocks: a dotnet
+    /// command can leave build worker nodes holding the inherited stdout handle open long after it
+    /// exits, so ReadToEnd never sees EOF and blocks for the nodes' idle timeout instead. Node reuse is
+    /// disabled here for the same reason. See GlueUnitTests' NestedDotnetCli and GitHub issue #1969.
+    /// </summary>
+    static async Task<(int ExitCode, string Output)> RunAsync(string arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", arguments)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        startInfo.EnvironmentVariables["MSBUILDDISABLENODEREUSE"] = "1";
+        startInfo.EnvironmentVariables["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+
+        var output = new StringBuilder();
+
+        try
+        {
+            using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+
+            void Collect(string line)
+            {
+                if (line != null)
+                {
+                    lock (output) { output.AppendLine(line); }
+                }
+            }
+
+            process.OutputDataReceived += (_, e) => Collect(e.Data);
+            process.ErrorDataReceived += (_, e) => Collect(e.Data);
+
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            using var cancellation = new System.Threading.CancellationTokenSource(Timeout);
+
+            try
+            {
+                await process.WaitForExitAsync(cancellation.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                return (-1, $"`dotnet {arguments}` did not finish within {Timeout.TotalMinutes} minutes.");
+            }
+
+            lock (output) { return (process.ExitCode, output.ToString()); }
+        }
+        catch (Exception exception)
+        {
+            // Most commonly the SDK simply is not installed, so "dotnet" does not resolve.
+            return (-1, $"Could not run `dotnet {arguments}`: {exception.Message}");
+        }
+    }
+}

--- a/FRBDK/Glue/NpcWpfLib/Managers/ProjectCreationHelper.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/ProjectCreationHelper.cs
@@ -82,8 +82,19 @@ public static class ProjectCreationHelper
         Notifier.ShowMessage(message);
     }
 
+    /// <summary>
+    /// Creates projects from dotnet CLI templates. Defaults to shelling out to the real CLI; tests can
+    /// swap in a fake so creation can run headless. See <see cref="IDotnetNewService"/>.
+    /// </summary>
+    public static IDotnetNewService DotnetNew { get; set; } = new DotnetNewService();
+
     public static async Task<bool> MakeNewProject(NewProjectViewModel viewModel)
     {
+        if (viewModel.SelectedProject is DotnetNewProjectInfo dotnetNewProject)
+        {
+            return await MakeNewDotnetTemplateProject(viewModel, dotnetNewProject);
+        }
+
         string stringToReplace = GetDefaultProjectNamespace(viewModel.SelectedProject);
 
         string projectZipUrl = GetFileToDownload(viewModel);
@@ -188,6 +199,63 @@ public static class ProjectCreationHelper
         return generalResponse.Succeeded;
     }
 
+
+    /// <summary>
+    /// The dotnet CLI path. Deliberately short: `dotnet new` already names the project, rewrites the
+    /// namespaces and generates fresh guids, so none of RenameEverything, ReplaceGuids or the zip
+    /// download/unzip steps apply.
+    /// </summary>
+    static async Task<bool> MakeNewDotnetTemplateProject(
+        NewProjectViewModel viewModel, DotnetNewProjectInfo templateInfo)
+    {
+        var unpackDirectory = viewModel.FinalDirectory;
+
+        if (!GetIfFileNameIsValid(viewModel, unpackDirectory))
+        {
+            return false;
+        }
+
+        unpackDirectory = viewModel.FinalDirectory;
+
+        var response = await DotnetNew.CreateProjectAsync(
+            templateInfo.TemplatePackageId,
+            templateInfo.TemplateShortName,
+            viewModel.ProjectName,
+            unpackDirectory);
+
+        if (!response.Succeeded)
+        {
+            ShowMessageBox(response.Message);
+            return false;
+        }
+
+        if (viewModel.OpenSlnFolderAfterCreation)
+        {
+            System.Diagnostics.Process.Start(
+                Environment.GetEnvironmentVariable("WINDIR") + @"\explorer.exe", unpackDirectory);
+        }
+
+        System.Console.Out.WriteLine(unpackDirectory);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Which .csproj Glue should open once a project has been created. A zip template unpacks a single
+    /// project into a folder named after it; a dotnet template can produce several - `dotnet new
+    /// frb2-desktop` makes a .Common and a .Desktop - and only one of them is the game.
+    /// </summary>
+    public static string GetProjectToOpen(PlatformProjectInfo projectInfo, string projectName, string createdDirectory)
+    {
+        if (projectInfo is DotnetNewProjectInfo { ProjectToOpenPattern: not null } dotnetNew)
+        {
+            return Path.Combine(createdDirectory,
+                dotnetNew.ProjectToOpenPattern.Replace("{ProjectName}", projectName)
+                    .Replace('/', Path.DirectorySeparatorChar));
+        }
+
+        return Path.Combine(createdDirectory, projectName, projectName + ".csproj");
+    }
 
     private static void RenameEverything(NewProjectViewModel viewModel, string stringToReplace, string unpackDirectory)
     {

--- a/FRBDK/Glue/NpcWpfLib/Models/PlatformProjectInfo.cs
+++ b/FRBDK/Glue/NpcWpfLib/Models/PlatformProjectInfo.cs
@@ -33,4 +33,26 @@ namespace Npc
         public override string ToString() => "Select Local Project...";
     }
 
+    /// <summary>
+    /// A template the dotnet CLI owns rather than one this repo zips and uploads. FlatRedBall 2 ships
+    /// its templates as a nuget package, so creating one of these is `dotnet new`, not download and
+    /// unzip - and none of the renaming, guid rewriting or zip-pipeline bookkeeping applies, because
+    /// the CLI does that itself.
+    /// </summary>
+    public class DotnetNewProjectInfo : PlatformProjectInfo
+    {
+        /// <summary>The nuget package holding the template, e.g. FlatRedBall2.Templates.</summary>
+        public string TemplatePackageId;
+
+        /// <summary>The template's short name, e.g. frb2-desktop.</summary>
+        public string TemplateShortName;
+
+        /// <summary>
+        /// The project the created game should be opened by, relative to the created folder, using
+        /// {ProjectName} for the name the user chose. `dotnet new frb2-desktop` produces a .Common and
+        /// a .Desktop, and .Common is the one Glue edits.
+        /// </summary>
+        public string ProjectToOpenPattern;
+    }
+
 }

--- a/FRBDK/Glue/OfficialPlugins/EffectPlugin/CodeGenerators/PostProcessCodeGenerator.cs
+++ b/FRBDK/Glue/OfficialPlugins/EffectPlugin/CodeGenerators/PostProcessCodeGenerator.cs
@@ -71,13 +71,10 @@ internal class PostProcessCodeGenerator
 
                 }
 
-                var directory = destinationFile.GetDirectoryContainingThis();
-                if (!System.IO.Directory.Exists(directory.FullPath))
-                {
-                    System.IO.Directory.CreateDirectory(directory.FullPath);
-                }
-
-                System.IO.File.WriteAllText(destinationFile.FullPath, fileContents);
+                // SaveIfDiffers rather than File.WriteAllText: it is where CodeWritePolicy is consulted,
+                // so a project Glue does not own the code of (FRB2) gets nothing written into it. It
+                // creates the directory too.
+                GlueCommands.Self.FileCommands.SaveIfDiffers(destinationFile, fileContents);
 
                 GlueCommands.Self.ProjectCommands.TryAddCodeFileToProjectAsync(destinationFile.FullPath);
             });

--- a/FRBDK/Glue/OfficialPlugins/EffectPlugin/MainEffectPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/EffectPlugin/MainEffectPlugin.cs
@@ -167,13 +167,9 @@ namespace OfficialPlugins.EffectPlugin
 
                 fileContent = fileContent.Replace("ReplaceNamespace", $"{GlueState.Self.ProjectNamespace}.EffectWrappers");
                 
-                var directory = destinationFile.GetDirectoryContainingThis();
-                if(!System.IO.Directory.Exists(directory.FullPath))
-                {
-                    System.IO.Directory.CreateDirectory(directory.FullPath);
-                }
-
-                System.IO.File.WriteAllText(destinationFile.FullPath, fileContent);
+                // See PostProcessCodeGenerator: SaveIfDiffers is the seam that consults CodeWritePolicy,
+                // and it creates the directory itself.
+                GlueCommands.Self.FileCommands.SaveIfDiffers(destinationFile, fileContent);
 
                 GlueCommands.Self.ProjectCommands.TryAddCodeFileToProjectAsync(destinationFile.FullPath);
             }

--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/GlueElementNodeViewModel.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/GlueElementNodeViewModel.cs
@@ -44,11 +44,19 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
                 StatesNode = new StatesRootNodeViewModel(this, glueElement) { Text = "States" };
                 Children.Add(StatesNode);
 
-                EventsNode = new EventsRootViewModel(this, glueElement) { Text = "Events" };
-                Children.Add(EventsNode);
+                // Both of these describe generated source, so neither means anything for a project Glue
+                // does not own the code of: Code lists the element's .cs files, and Events exist to
+                // generate its .Event.cs. An FRB2 game reads the .gluj at runtime and writes all of its
+                // own source. The nodes above stay - Files, Objects, Variables and States are .gluj
+                // data, which is exactly what Glue is still there to author.
+                if (CodeWritePolicy.WritesCodeForCurrentProject)
+                {
+                    EventsNode = new EventsRootViewModel(this, glueElement) { Text = "Events" };
+                    Children.Add(EventsNode);
 
-                CodeNode = new CodeRootViewModel(this, glueElement) { Text = "Code" };
-                Children.Add(CodeNode);
+                    CodeNode = new CodeRootViewModel(this, glueElement) { Text = "Code" };
+                    Children.Add(CodeNode);
+                }
             }
 
             if (glueElement is ScreenSave)

--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/MainTreeViewViewModel.Refresh.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/MainTreeViewViewModel.Refresh.cs
@@ -328,11 +328,23 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
 
                         if (treeNode == null)
                         {
+                            var directoryName = FileManager.RemovePath(directory);
+
+                            if (IsNameOwnedByElementNode(parentTreeNode, directoryName))
+                            {
+                                // This directory holds a Screen's or Entity's content, and the element
+                                // already has a node here - so the folder is the element's, not a peer of
+                                // it, and its contents belong under the element's Files node. The lookup
+                                // above cannot tell: it only matches nodes where IsDirectoryNode() is
+                                // true, and that is false for any node carrying a Tag.
+                                continue;
+                            }
+
                             treeNode = new NodeViewModel(TreeNodeType.GeneralDirectoryNode, parentTreeNode);
 
                             treeNode.IsEditable = true;
 
-                            treeNode.Text = FileManager.RemovePath(directory);
+                            treeNode.Text = directoryName;
                             parentTreeNode.Children.Add(treeNode);
                         }
 
@@ -373,6 +385,37 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
                             parentTreeNode.Children.RemoveAt(i);
                         }
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Whether a Screen or Entity node under <paramref name="parentTreeNode"/> already goes by
+        /// <paramref name="name"/>, which makes a directory of that name the element's own content
+        /// folder rather than a folder sitting beside it.
+        /// </summary>
+        internal static bool IsNameOwnedByElementNode(NodeViewModel parentTreeNode, string name) =>
+            parentTreeNode.Children.Any(node =>
+                node.Tag is GlueElement &&
+                string.Equals(node.Text, name, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// Drops a plain folder node that an element is about to take the name of. Needed because the
+        /// directory pass and the element pass run in either order: when directories are enumerated
+        /// first there is no element node yet for them to defer to, so the folder node has to go when
+        /// the element arrives.
+        /// </summary>
+        internal static void RemoveFolderNodeNamed(NodeViewModel parentTreeNode, string name)
+        {
+            for (int i = parentTreeNode.Children.Count - 1; i > -1; i--)
+            {
+                var child = parentTreeNode.Children[i];
+
+                if (child.Tag == null &&
+                    child.TreeNodeType == TreeNodeType.GeneralDirectoryNode &&
+                    string.Equals(child.Text, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    parentTreeNode.Children.RemoveAt(i);
                 }
             }
         }
@@ -441,6 +484,8 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
                 throw new NullReferenceException("treeNode is null.  This is bad");
             }
 
+            RemoveFolderNodeNamed(treeNodeToAddTo, treeNode.Text);
+
             treeNodeToAddTo.Children.Add(treeNode);
             treeNodeToAddTo.SortByTextConsideringDirectories();
 
@@ -453,7 +498,7 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
             return treeNode;
         }
 
-        private NodeViewModel AddScreenTreeNode(ScreenSave screenSave)
+        internal NodeViewModel AddScreenTreeNode(ScreenSave screenSave)
         {
             string containingDirectory = FileManager.MakeRelative(FileManager.GetDirectory(screenSave.Name));
 
@@ -491,6 +536,8 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
 
             if (treeNodeToAddTo != null)
             {
+                RemoveFolderNodeNamed(treeNodeToAddTo, treeNode.Text);
+
                 treeNodeToAddTo.Children.Add(treeNode);
                 treeNodeToAddTo.SortByTextConsideringDirectories();
             }

--- a/FRBDK/Glue/PlatformerPlugin/CodeGenerators/EnumFileGenerator.cs
+++ b/FRBDK/Glue/PlatformerPlugin/CodeGenerators/EnumFileGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
 using FlatRedBall.Glue.IO;
-using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.CodeGenerators;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.IO;
 using System;
@@ -11,50 +11,21 @@ using System.Threading.Tasks;
 
 namespace FlatRedBall.PlatformerPlugin.Generators
 {
-    public class EnumFileGenerator : Singleton<EnumFileGenerator>
+    public class EnumFileGenerator : FullFileCodeGenerator
     {
-        public string RelativeFileLocation => "Platformer/Enums.Generated.cs";
-        public FilePath FileLocation => (GlueState.Self.CurrentGlueProjectDirectory + RelativeFileLocation);
+        public override string RelativeFile => "Platformer/Enums.Generated.cs";
 
-        public void GenerateAndSave()
+        static EnumFileGenerator mSelf;
+        public static EnumFileGenerator Self => mSelf ??= new EnumFileGenerator();
+
+        protected override void AfterSave()
         {
-
-            TaskManager.Self.Add(() =>
-            {
-                var contents = GenerateFileContents();
-
-                var relativeDirectory = RelativeFileLocation;
-
-                GlueCommands.Self.ProjectCommands.CreateAndAddCodeFile(relativeDirectory);
-
-                var glueProjectDirectory = GlueState.Self.CurrentGlueProjectDirectory;
-
-                if(!string.IsNullOrEmpty(glueProjectDirectory))
-                {
-                    var fullFile = GlueState.Self.CurrentGlueProjectDirectory + relativeDirectory;
-
-                    try
-                    {
-                        GlueCommands.Self.TryMultipleTimes(() =>
-                            System.IO.File.WriteAllText(fullFile, contents));
-                    }
-                    catch(Exception e)
-                    {
-                        GlueCommands.Self.PrintError(e.ToString());
-                    }
-
-                    FilePath oldFile = GlueState.Self.CurrentGlueProjectDirectory +
-                        "Platformer/Enums.cs";
-                    GlueCommands.Self.ProjectCommands.RemoveFromProjects(
-                        oldFile, saveAfterRemoving: true);
-                }
-
-            }, "Adding platformer enum files to the project");
-
-            
+            // What this generator used to be called, before it was suffixed .Generated.
+            FilePath oldFile = GlueState.Self.CurrentGlueProjectDirectory + "Platformer/Enums.cs";
+            GlueCommands.Self.ProjectCommands.RemoveFromProjects(oldFile, saveAfterRemoving: true);
         }
 
-        private string GenerateFileContents()
+        protected override string GenerateFileContents()
         {
             var toReturn =
 $@"

--- a/FRBDK/Glue/PlatformerPlugin/CodeGenerators/IPlatformerCodeGenerator.cs
+++ b/FRBDK/Glue/PlatformerPlugin/CodeGenerators/IPlatformerCodeGenerator.cs
@@ -1,48 +1,19 @@
-﻿using FlatRedBall.Glue.Managers;
+﻿using FlatRedBall.Glue.Plugins.CodeGenerators;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
-using FlatRedBall.IO;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace FlatRedBall.PlatformerPlugin.Generators
 {
-    public class IPlatformerCodeGenerator : Singleton<IPlatformerCodeGenerator>
+    public class IPlatformerCodeGenerator : FullFileCodeGenerator
     {
-        string RelativeFileLocation => "Platformer/IPlatformer.Generated.cs";
-        public FilePath FileLocation => GlueState.Self.CurrentGlueProjectDirectory + RelativeFileLocation;
+        public override string RelativeFile => "Platformer/IPlatformer.Generated.cs";
 
-        public void GenerateAndSave()
-        {
-            TaskManager.Self.Add(() =>
-            {
-                var contents = GenerateFileContents();
+        static IPlatformerCodeGenerator mSelf;
+        public static IPlatformerCodeGenerator Self => mSelf ??= new IPlatformerCodeGenerator();
 
-                var relativeDirectory = RelativeFileLocation;
-
-                GlueCommands.Self.ProjectCommands.CreateAndAddCodeFile(relativeDirectory);
-
-                var glueProjectDirectory = GlueState.Self.CurrentGlueProjectDirectory;
-
-                if (!string.IsNullOrEmpty(glueProjectDirectory))
-                {
-                    var fullFile = GlueState.Self.CurrentGlueProjectDirectory + relativeDirectory;
-
-                    try
-                    {
-                        GlueCommands.Self.TryMultipleTimes(() =>
-                            System.IO.File.WriteAllText(fullFile, contents));
-                    }
-                    catch (Exception e)
-                    {
-                        GlueCommands.Self.PrintError(e.ToString());
-                    }
-                }
-
-            }, "Adding IPlatformer.Generated.cs to the project");
-        }
-
-        private string GenerateFileContents()
+        protected override string GenerateFileContents()
         {
             var toReturn =
 $@"

--- a/FRBDK/Glue/PlatformerPlugin/CodeGenerators/PlatformerAnimationControllerGenerator.cs
+++ b/FRBDK/Glue/PlatformerPlugin/CodeGenerators/PlatformerAnimationControllerGenerator.cs
@@ -1,53 +1,21 @@
-﻿using FlatRedBall.Glue.Managers;
+﻿using FlatRedBall.Glue.Plugins.CodeGenerators;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.SaveClasses;
-using FlatRedBall.IO;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace FlatRedBall.PlatformerPlugin.Generators;
 
-public class PlatformerAnimationControllerGenerator : Singleton<PlatformerAnimationControllerGenerator>
+public class PlatformerAnimationControllerGenerator : FullFileCodeGenerator
 {
-    string RelativeFileLocation => "Platformer/PlatformerAnimationController.Generated.cs";
-    public FilePath FileLocation => GlueState.Self.CurrentGlueProjectDirectory + RelativeFileLocation;
+    public override string RelativeFile => "Platformer/PlatformerAnimationController.Generated.cs";
 
+    static PlatformerAnimationControllerGenerator mSelf;
+    public static PlatformerAnimationControllerGenerator Self =>
+        mSelf ??= new PlatformerAnimationControllerGenerator();
 
-    public void GenerateAndSave()
-    {
-
-        TaskManager.Self.Add(() =>
-        {
-            var contents = GenerateFileContents();
-
-            var relativeDirectory = RelativeFileLocation;
-
-            GlueCommands.Self.ProjectCommands.CreateAndAddCodeFile(relativeDirectory);
-
-            var glueProjectDirectory = GlueState.Self.CurrentGlueProjectDirectory;
-
-            if (!string.IsNullOrEmpty(glueProjectDirectory))
-            {
-                var fullFile = GlueState.Self.CurrentGlueProjectDirectory + relativeDirectory;
-
-                try
-                {
-                    GlueCommands.Self.TryMultipleTimes(() =>
-                        System.IO.File.WriteAllText(fullFile, contents));
-                }
-                catch (Exception e)
-                {
-                    GlueCommands.Self.PrintError(e.ToString());
-                }
-            }
-
-        }, "Adding PlatformerAnimationConfiguration.Generated.cs to the project");
-
-
-    }
-
-    private string GenerateFileContents()
+    protected override string GenerateFileContents()
     {
         var toReturn =
 @"

--- a/FRBDK/Glue/RacingPlugin/CodeGenerators/CollisionHistoryCodeGenerator.cs
+++ b/FRBDK/Glue/RacingPlugin/CodeGenerators/CollisionHistoryCodeGenerator.cs
@@ -1,5 +1,5 @@
 ﻿using FlatRedBall.Glue.IO;
-using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.CodeGenerators;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.IO;
 using System;
@@ -10,9 +10,14 @@ using System.Threading.Tasks;
 
 namespace RacingPlugin.CodeGenerators
 {
-    public class CollisionHistoryCodeGenerator : Singleton<CollisionHistoryCodeGenerator>
+    public class CollisionHistoryCodeGenerator : FullFileCodeGenerator
     {
-        public string GetFileContents()
+        public override string RelativeFile => "DataTypes/CollisionHistory.Generated.cs";
+
+        static CollisionHistoryCodeGenerator mSelf;
+        public static CollisionHistoryCodeGenerator Self => mSelf ??= new CollisionHistoryCodeGenerator();
+
+        protected override string GenerateFileContents()
         {
             string projectNamespace = GlueState.Self.ProjectNamespace + ".DataTypes";
 
@@ -49,11 +54,6 @@ namespace " + projectNamespace + @"
 }
 ";
             return toReturn;
-        }
-
-        internal FilePath GetFilePath()
-        {
-            return GlueState.Self.CurrentGlueProjectDirectory + "/DataTypes/CollisionHistory.Generated.cs";
         }
     }
 }

--- a/FRBDK/Glue/RacingPlugin/CodeGenerators/EnumFileGenerator.cs
+++ b/FRBDK/Glue/RacingPlugin/CodeGenerators/EnumFileGenerator.cs
@@ -1,4 +1,4 @@
-﻿using FlatRedBall.Glue.Managers;
+﻿using FlatRedBall.Glue.Plugins.CodeGenerators;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using System;
 using System.Collections.Generic;
@@ -8,27 +8,14 @@ using System.Threading.Tasks;
 
 namespace RacingPlugin.CodeGenerators
 {
-    class EnumFileGenerator : Singleton<EnumFileGenerator>
+    class EnumFileGenerator : FullFileCodeGenerator
     {
-        public void GenerateAndSaveEnumFile()
-        {
-            TaskManager.Self.Add(() =>
-            {
-                var contents = GenerateFileContents();
+        public override string RelativeFile => "RacingEntity/Enums.cs";
 
-                var relativeDirectory = "RacingEntity/Enums.cs";
+        static EnumFileGenerator mSelf;
+        public static EnumFileGenerator Self => mSelf ??= new EnumFileGenerator();
 
-                GlueCommands.Self.ProjectCommands.CreateAndAddCodeFile(relativeDirectory);
-
-                var fullFile = GlueState.Self.CurrentGlueProjectDirectory + relativeDirectory;
-
-                GlueCommands.Self.TryMultipleTimes(() =>
-                    System.IO.File.WriteAllText(fullFile, contents));
-
-            }, "Adding racing entity enum files to the project");
-        }
-
-        private string GenerateFileContents()
+        protected override string GenerateFileContents()
         {
             var toReturn =
 $@"

--- a/FRBDK/Glue/RacingPlugin/Controllers/MainController.cs
+++ b/FRBDK/Glue/RacingPlugin/Controllers/MainController.cs
@@ -114,7 +114,7 @@ namespace RacingPlugin.Controllers
                 TaskManager.Self.Add(
                     () =>
                     {
-                        EnumFileGenerator.Self.GenerateAndSaveEnumFile();
+                        EnumFileGenerator.Self.GenerateAndSave();
 
                         // not sure if this needs any interfaces
                         //InterfacesFileGenerator.Self.GenerateAndSave();
@@ -128,16 +128,7 @@ namespace RacingPlugin.Controllers
 
         public void AddCollisionHistoryFile()
         {
-            var filePath = CollisionHistoryCodeGenerator.Self.GetFilePath();
-            GlueCommands.Self.ProjectCommands.CreateAndAddCodeFile(filePath, save:false);
-
-            var contents = CollisionHistoryCodeGenerator.Self.GetFileContents();
-            GlueCommands.Self.TryMultipleTimes(() =>
-            {
-                System.IO.File.WriteAllText(filePath.FullPath, contents);
-            });
-
-
+            CollisionHistoryCodeGenerator.Self.GenerateAndSave();
         }
 
         private void DetermineWhatToGenerate(string propertyName, RacingEntityViewModel viewModel, out bool shouldGenerateCsv, out bool shouldGenerateEntity, out bool shouldAddTopDownVariables)

--- a/FRBDK/Glue/RacingPlugin/MainPlugin.cs
+++ b/FRBDK/Glue/RacingPlugin/MainPlugin.cs
@@ -64,7 +64,7 @@ namespace RacingPlugin
             if (anyTopDownEntities)
             {
                 MainController.Self.AddCollisionHistoryFile();
-                EnumFileGenerator.Self.GenerateAndSaveEnumFile();
+                EnumFileGenerator.Self.GenerateAndSave();
                 // just in case it's not there:
                 //InterfacesFileGenerator.Self.GenerateAndSave();
                 //AiCodeGenerator.Self.GenerateAndSave();

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumViewModelSetFromTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumViewModelSetFromTests.cs
@@ -1,0 +1,25 @@
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using GumPlugin.ViewModels;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GumPluginTests;
+
+public class GumViewModelSetFromTests
+{
+    public GumViewModelSetFromTests() => GlueTestBootstrap.EnsureInitialized();
+
+    [StaFact]
+    public void SetFrom_ToleratesNoLoadedGumProject()
+    {
+        // MainGumPlugin.HandleItemSelected passes AppState.Self.GumProjectSave straight through when a
+        // .gumx is selected, and that is null until the Gum project has actually loaded. The resulting
+        // NullReferenceException does not just fail the selection: PluginManager catches it and calls
+        // PluginContainer.Fail, which disables the Gum plugin for the rest of the session.
+        var viewModel = new GumViewModel();
+        var rfs = new ReferencedFileSave { Name = "GlobalContent/GumProject.gumx" };
+
+        Should.NotThrow(() => viewModel.SetFrom(null, rfs));
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Plugins/PluginManagerRelativeDirectoryTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Plugins/PluginManagerRelativeDirectoryTests.cs
@@ -1,0 +1,91 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Plugins;
+using FlatRedBall.IO;
+using GlueUnitTests.TestSupport;
+using Xunit;
+using FileManager = FlatRedBall.IO.FileManager;
+using FilePath = FlatRedBall.IO.FilePath;
+using GeneralResponse = ToolsUtilities.GeneralResponse;
+
+namespace GlueUnitTests.Plugins;
+
+/// <summary>
+/// <c>PluginManager</c> brackets each plugin dispatch with a push/pop of
+/// <c>FileManager.RelativeDirectory</c> onto one process-wide stack, so a plugin that changes the
+/// relative directory and does not put it back is caught and corrected. The stack outlives any one
+/// project load, so an unbalanced push or pop does not fail where it happens - it leaves a previous
+/// project's directory on the stack for the next load to restore, and reports
+/// "The relativeDirectory wasn't set properly" against a caller that did nothing wrong.
+/// </summary>
+public class PluginManagerRelativeDirectoryTests
+{
+    public PluginManagerRelativeDirectoryTests() => GlueTestBootstrap.EnsureInitialized();
+
+    [Fact]
+    public void HandleFileReadError_LeavesTheRelativeDirectoryAlone()
+    {
+        // It resumed a relative directory it never saved, so it consumed whichever entry the call it
+        // was nested inside had pushed. That outer call then restored the entry below - a directory
+        // belonging to whatever loaded before it.
+        var original = FileManager.RelativeDirectory;
+        try
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "PluginManagerRelDirTest") +
+                Path.DirectorySeparatorChar;
+            FileManager.RelativeDirectory = directory;
+            // Read back rather than comparing to what was assigned - the setter normalizes separators.
+            var expected = FileManager.RelativeDirectory;
+            ErrorRecordingPlugin.Errors.Clear();
+
+            PluginManager.HandleFileReadError(
+                new FilePath(directory + "missing.png"),
+                GeneralResponse.UnsuccessfulWith("could not read"));
+
+            Assert.Equal(expected, FileManager.RelativeDirectory);
+            Assert.Empty(ErrorRecordingPlugin.Errors);
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = original;
+        }
+    }
+
+    [Fact]
+    public void ConcurrentPluginCalls_DoNotConsumeEachOthersSavedRelativeDirectory()
+    {
+        // FileManager.RelativeDirectory is per-thread (it reads and writes a dictionary keyed on the
+        // managed thread id), but the stack it was saved onto was shared by every thread. Glue calls
+        // these through Parallel.For while updating file memberships, so one worker's resume popped
+        // another's entry and then assigned that other worker's directory over its own - and the
+        // orphaned entries outlived the load that made them.
+        var original = FileManager.RelativeDirectory;
+        try
+        {
+            var directories = Enumerable.Range(0, 8)
+                .Select(i => Path.Combine(Path.GetTempPath(), "RelDirConcurrency" + i) +
+                    Path.DirectorySeparatorChar)
+                .ToArray();
+            ErrorRecordingPlugin.Errors.Clear();
+
+            Parallel.ForEach(directories, directory =>
+            {
+                FileManager.RelativeDirectory = directory;
+                var expected = FileManager.RelativeDirectory;
+
+                for (var i = 0; i < 50; i++)
+                {
+                    PluginManager.CanFileReferenceContent(directory + "content.png");
+                    Assert.Equal(expected, FileManager.RelativeDirectory);
+                }
+            });
+
+            Assert.Empty(ErrorRecordingPlugin.Errors);
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = original;
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/DotnetNewProjectCreationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/DotnetNewProjectCreationTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GlueUnitTests.TestSupport;
+using Npc;
+using Npc.Data;
+using Npc.Managers;
+using Npc.ViewModels;
+using Shouldly;
+using ToolsUtilities;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// FlatRedBall 2 ships its templates as a nuget package, so creating one is `dotnet new` rather than
+/// the download-zip / unzip / rename / rewrite-guids pipeline every other entry in the New Project
+/// window uses. The CLI does the naming and guid work itself, so the point of these is as much what
+/// does *not* happen as what does.
+/// </summary>
+public class DotnetNewProjectCreationTests : IDisposable
+{
+    readonly string _root;
+    readonly IDotnetNewService _originalService;
+    readonly IProjectCreationNotifier _originalNotifier;
+    readonly RecordingDotnetNewService _service = new();
+    readonly RecordingNotifier _notifier = new();
+
+    public DotnetNewProjectCreationTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "DotnetNew_" + Guid.NewGuid());
+        Directory.CreateDirectory(_root);
+
+        _originalService = ProjectCreationHelper.DotnetNew;
+        _originalNotifier = ProjectCreationHelper.Notifier;
+        ProjectCreationHelper.DotnetNew = _service;
+        ProjectCreationHelper.Notifier = _notifier;
+    }
+
+    public void Dispose()
+    {
+        ProjectCreationHelper.DotnetNew = _originalService;
+        ProjectCreationHelper.Notifier = _originalNotifier;
+
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    static DotnetNewProjectInfo Frb2Template() =>
+        (DotnetNewProjectInfo)EmptyTemplates.Projects.First(item => item is DotnetNewProjectInfo);
+
+    NewProjectViewModel MakeViewModel(string projectName) => new()
+    {
+        ProjectName = projectName,
+        SelectedProject = Frb2Template(),
+        ProjectDestinationLocation = _root + Path.DirectorySeparatorChar,
+        IsCreateProjectDirectoryChecked = true,
+        OpenSlnFolderAfterCreation = false,
+    };
+
+    [Fact]
+    public void TheWindowOffersAnFrb2Entry()
+    {
+        // The whole point: it has to be selectable alongside the zip templates.
+        var template = Frb2Template();
+
+        template.TemplatePackageId.ShouldBe("FlatRedBall2.Templates");
+        template.TemplateShortName.ShouldBe("frb2-desktop");
+        template.SupportedInGlue.ShouldBeTrue();
+        template.Url.ShouldBeNullOrEmpty("A dotnet template has no zip to download.");
+    }
+
+    [Fact]
+    public async Task CreatingAnFrb2Project_InvokesTheTemplateWithTheChosenName()
+    {
+        var succeeded = await ProjectCreationHelper.MakeNewProject(MakeViewModel("MyFrb2Game"));
+
+        succeeded.ShouldBeTrue(string.Join("\n", _notifier.Messages));
+        _service.Calls.Count.ShouldBe(1);
+        _service.Calls[0].TemplateShortName.ShouldBe("frb2-desktop");
+        _service.Calls[0].ProjectName.ShouldBe("MyFrb2Game");
+        _service.Calls[0].OutputDirectory.ShouldContain("MyFrb2Game");
+    }
+
+    [Fact]
+    public async Task CreatingAnFrb2Project_ReportsTheFailureInsteadOfClaimingSuccess()
+    {
+        _service.Response = GeneralResponse.UnsuccessfulWith("the SDK is not installed");
+
+        var succeeded = await ProjectCreationHelper.MakeNewProject(MakeViewModel("Doomed"));
+
+        succeeded.ShouldBeFalse();
+        _notifier.Messages.ShouldContain(message => message.Contains("the SDK is not installed"));
+    }
+
+    [Fact]
+    public async Task CreatingAnFrb2Project_DoesNotRenameOrRewriteAnything()
+    {
+        // The zip path replaces a placeholder name across every file and regenerates guids. Doing that
+        // to a dotnet-new project would corrupt a tree the CLI has already named correctly, so nothing
+        // may be written beyond what the template produced.
+        _service.OnCreate = (name, directory) =>
+        {
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, name + ".Common.csproj"), "<Project />");
+        };
+
+        await ProjectCreationHelper.MakeNewProject(MakeViewModel("Untouched"));
+
+        var created = Directory.GetFiles(_service.Calls[0].OutputDirectory, "*", SearchOption.AllDirectories)
+            .Select(Path.GetFileName)
+            .ToList();
+
+        created.ShouldBe(new[] { "Untouched.Common.csproj" });
+    }
+
+    [Fact]
+    public void GlueIsToldToOpenTheCommonProject_NotTheLauncher()
+    {
+        // `dotnet new frb2-desktop` produces two projects and only .Common is the game.
+        var toOpen = ProjectCreationHelper.GetProjectToOpen(Frb2Template(), "MyFrb2Game", @"C:\Games\MyFrb2Game");
+
+        Path.GetFileName(toOpen).ShouldBe("MyFrb2Game.Common.csproj");
+    }
+
+    [Fact]
+    public void AZipTemplate_StillOpensTheProjectInsideItsOwnFolder()
+    {
+        // Unchanged behaviour for every existing entry: a zip unpacks one project into a folder named
+        // after it. This used to be hardcoded at the call site in NewProjectHelper.
+        var zipTemplate = EmptyTemplates.Projects.First(item => !string.IsNullOrEmpty(item.Url));
+
+        var toOpen = ProjectCreationHelper.GetProjectToOpen(zipTemplate, "Whatever", @"C:\Games");
+
+        toOpen.ShouldBe(Path.Combine(@"C:\Games", "Whatever", "Whatever.csproj"));
+    }
+
+    class RecordingDotnetNewService : IDotnetNewService
+    {
+        public record Call(string TemplatePackageId, string TemplateShortName, string ProjectName, string OutputDirectory);
+
+        public List<Call> Calls { get; } = new();
+        public GeneralResponse Response { get; set; } = GeneralResponse.SuccessfulResponse;
+        public Action<string, string> OnCreate { get; set; }
+
+        public Task<GeneralResponse> CreateProjectAsync(
+            string templatePackageId, string templateShortName, string projectName, string outputDirectory)
+        {
+            Calls.Add(new Call(templatePackageId, templateShortName, projectName, outputDirectory));
+            OnCreate?.Invoke(projectName, outputDirectory);
+            return Task.FromResult(Response);
+        }
+    }
+
+    class RecordingNotifier : IProjectCreationNotifier
+    {
+        public List<string> Messages { get; } = new();
+
+        public void ShowMessage(string message) => Messages.Add(message);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2GameProjectResolutionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2GameProjectResolutionTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// `dotnet new frb2-desktop` produces two projects: MyGame.Common, which holds Game1, the content and
+/// the engine reference, and MyGame.Desktop, a launcher that reaches the engine only through Common.
+/// Common is the one Glue edits, but Desktop is the runnable one and an equally natural thing to pick
+/// from a file dialog - and picking it used to end at "could not determine the project type", with the
+/// project not loading at all.
+/// </summary>
+public class Frb2GameProjectResolutionTests : IDisposable
+{
+    readonly string _root;
+
+    public Frb2GameProjectResolutionTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "Frb2Resolve_" + Guid.NewGuid());
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    string WriteProject(string name, string itemGroupXml)
+    {
+        var directory = Path.Combine(_root, name);
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, name + ".csproj");
+        File.WriteAllText(path, $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+{itemGroupXml}
+  </ItemGroup>
+</Project>");
+        return path;
+    }
+
+    string WriteFrb2Common() =>
+        WriteProject("MyGame.Common", @"    <PackageReference Include=""FlatRedBall2.MonoGame"" Version=""*-*"" />");
+
+    string WriteDesktopLauncher() =>
+        WriteProject("MyGame.Desktop",
+            @"    <PackageReference Include=""MonoGame.Framework.DesktopGL"" Version=""3.8.4.1"" />
+    <ProjectReference Include=""..\MyGame.Common\MyGame.Common.csproj"" />");
+
+    [Fact]
+    public void PickingTheDesktopLauncher_ResolvesToTheCommonProject()
+    {
+        var common = WriteFrb2Common();
+        var desktop = WriteDesktopLauncher();
+
+        var resolved = Frb2ProjectDetector.FindFrb2GameProjectFor(desktop);
+
+        Assert.Equal(Path.GetFullPath(common), Path.GetFullPath(resolved));
+    }
+
+    [Fact]
+    public void PickingTheCommonProject_ResolvesToItself()
+    {
+        var common = WriteFrb2Common();
+
+        Assert.Equal(Path.GetFullPath(common), Path.GetFullPath(Frb2ProjectDetector.FindFrb2GameProjectFor(common)));
+    }
+
+    [Fact]
+    public void AnFrb1Project_ResolvesToNothing()
+    {
+        // Nothing here may redirect: silently opening a different project than the user picked would be
+        // far worse than the message they get today.
+        var frb1 = WriteProject("Frb1Game",
+            @"    <PackageReference Include=""FlatRedBall.Forms"" Version=""1.0.0"" />");
+
+        Assert.Null(Frb2ProjectDetector.FindFrb2GameProjectFor(frb1));
+    }
+
+    [Fact]
+    public void AProjectReferencingSomethingMissing_ResolvesToNothingRatherThanThrowing()
+    {
+        var dangling = WriteProject("Dangling",
+            @"    <ProjectReference Include=""..\NotThere\NotThere.csproj"" />");
+
+        Assert.Null(Frb2ProjectDetector.FindFrb2GameProjectFor(dangling));
+    }
+
+    [Fact]
+    public void AMissingOrUnreadableProject_ResolvesToNothingRatherThanThrowing()
+    {
+        Assert.Null(Frb2ProjectDetector.FindFrb2GameProjectFor(Path.Combine(_root, "Nope", "Nope.csproj")));
+        Assert.Null(Frb2ProjectDetector.FindFrb2GameProjectFor(null));
+    }
+
+    [Fact]
+    public void ResolutionIsOneHopOnly()
+    {
+        // A launcher pointing at a launcher pointing at Common is not a shape the template produces, and
+        // chasing an arbitrary graph risks picking something the user never intended.
+        WriteFrb2Common();
+        WriteDesktopLauncher();
+        var outer = WriteProject("MyGame.Outer",
+            @"    <ProjectReference Include=""..\MyGame.Desktop\MyGame.Desktop.csproj"" />");
+
+        Assert.Null(Frb2ProjectDetector.FindFrb2GameProjectFor(outer));
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectLoadTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectLoadTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FlatRedBall.Glue.Controls;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.Glue.VSHelpers.Projects;
 using FlatRedBall.IO;
 using GlueFormsCore.ViewModels;
@@ -55,6 +56,106 @@ public class Frb2ProjectLoadTests
         File.WriteAllText(Path.Combine(root, ProjectName + ".slnx"),
             $"<Solution>\n  <Project Path=\"{ProjectName}.csproj\" />\n</Solution>\n");
         return csprojPath;
+    }
+
+    /// <summary>
+    /// The layout `dotnet new frb2-desktop` produces: a MyGame.Common holding Game1, Content and the
+    /// engine PackageReference, a MyGame.Desktop launcher that only reaches the engine through Common,
+    /// and a .slnx one level up.
+    ///
+    /// The version is kept out of the Include here deliberately - the shipped template writes it inline
+    /// (Version="*-*") while central package management puts it in Directory.Packages.props, and the
+    /// detector has to match on the package id either way.
+    /// </summary>
+    static string WriteTemplateShapedFrb2Project(string root)
+    {
+        var commonDirectory = Path.Combine(root, ProjectName + ".Common");
+        var desktopDirectory = Path.Combine(root, ProjectName + ".Desktop");
+        Directory.CreateDirectory(Path.Combine(commonDirectory, "Content"));
+        Directory.CreateDirectory(desktopDirectory);
+
+        File.WriteAllText(Path.Combine(root, "Directory.Packages.props"),
+            "<Project>\n  <PropertyGroup>\n    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>\n" +
+            "  </PropertyGroup>\n  <ItemGroup>\n    <PackageVersion Include=\"FlatRedBall2.MonoGame\" Version=\"1.0.0\" />\n" +
+            "  </ItemGroup>\n</Project>\n");
+
+        var commonCsproj = Path.Combine(commonDirectory, ProjectName + ".Common.csproj");
+        File.WriteAllText(commonCsproj, $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>{ProjectName}</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""FlatRedBall2.MonoGame"" />
+    <PackageReference Include=""MonoGame.Framework.DesktopGL"" />
+  </ItemGroup>
+</Project>");
+
+        File.WriteAllText(Path.Combine(commonDirectory, "Game1.cs"),
+            "namespace " + ProjectName + ";\npublic class Game1\n{\n}\n");
+
+        File.WriteAllText(Path.Combine(desktopDirectory, ProjectName + ".Desktop.csproj"), $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""MonoGame.Framework.DesktopGL"" />
+    <ProjectReference Include=""..\{ProjectName}.Common\{ProjectName}.Common.csproj"" />
+  </ItemGroup>
+</Project>");
+
+        File.WriteAllText(Path.Combine(root, ProjectName + ".slnx"),
+            $"<Solution>\n  <Project Path=\"{ProjectName}.Common/{ProjectName}.Common.csproj\" />\n" +
+            $"  <Project Path=\"{ProjectName}.Desktop/{ProjectName}.Desktop.csproj\" />\n</Solution>\n");
+
+        return commonCsproj;
+    }
+
+    [StaFact]
+    public async Task LoadingATemplateCreatedFrb2Project_IsRecognisedAndWritesNoCode()
+    {
+        // `dotnet new frb2-desktop` takes the engine from nuget rather than by source, which the
+        // detector's original single rule did not match - so a template-created game fell through to
+        // the DefineConstants cascade and could not be opened at all.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2Template_");
+        var commonCsproj = WriteTemplateShapedFrb2Project(temp.Root);
+
+        await GoldProject.LoadInGlueAsync(commonCsproj);
+
+        Assert.IsType<Frb2Project>(GlueState.Self.CurrentMainProject);
+        Assert.True(File.Exists(Path.Combine(
+                Path.GetDirectoryName(commonCsproj)!, "Content", "FrbEditor", ProjectName + ".Common.gluj")),
+            "The .gluj should land under the Common project's Content/FrbEditor/.");
+
+        // Same contract as a source-referencing FRB2 game: no generated code anywhere.
+        Assert.Empty(Directory.GetFiles(temp.Root, "*.cs", SearchOption.AllDirectories)
+            .Select(f => Path.GetRelativePath(temp.Root, f).Replace('\\', '/'))
+            .Where(f => f != ProjectName + ".Common/Game1.cs"));
+    }
+
+    [StaFact]
+    public async Task OpeningTheDesktopLauncher_LoadsTheCommonProjectInstead()
+    {
+        // Measured before the redirect existed: ProjectCreator returned null for the launcher and asked
+        // "FlatRedBall could not determine the project type", after which ProjectLoader skipped loading
+        // entirely. Picking the runnable project of the two is not a user error worth failing on.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2Launcher_");
+        WriteTemplateShapedFrb2Project(temp.Root);
+        var desktopCsproj = Path.Combine(
+            temp.Root, ProjectName + ".Desktop", ProjectName + ".Desktop.csproj");
+
+        await GoldProject.LoadInGlueAsync(desktopCsproj);
+
+        Assert.IsType<Frb2Project>(GlueState.Self.CurrentMainProject);
+        Assert.Equal(
+            ProjectName + ".Common.csproj",
+            Path.GetFileName(GlueState.Self.CurrentMainProject.FullFileName.FullPath));
+        Assert.Empty(GlueTestBootstrap.RecordedDialogMessages);
     }
 
     [StaFact]
@@ -245,6 +346,100 @@ public class Frb2ProjectLoadTests
         }
 
         Assert.Empty(choicesOffered);
+        Assert.Empty(GlueTestBootstrap.RecordedDialogMessages);
+    }
+
+    [StaFact]
+    public async Task LoadingAnFrb2Project_WithATopDownEntity_WritesNoTopDownCode()
+    {
+        // Opening a project with a top-down entity threw DirectoryNotFoundException on
+        // Content/FrbEditor/TopDown/TopDownAnimationControllerGenerator.Generated.cs: the generator
+        // asked CreateAndAddCodeFile for the file (suppressed for FRB2, so its Directory.CreateDirectory
+        // never ran) and then wrote with System.IO.File.WriteAllText, which consults nothing.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2TopDown_");
+        var csprojPath = WriteFrb2Project(temp.Root);
+        await GoldProject.LoadInGlueAsync(csprojPath);
+
+        var entity = await GlueCommands.Self.GluxCommands.EntityCommands.AddEntityAsync(
+            new AddEntityViewModel { Name = "PlayerEntity" });
+        entity.Properties.SetValue("IsTopDown", true);
+        GlueCommands.Self.GluxCommands.SaveProjectAndElements();
+
+        // Loaded again rather than asserting on the first load: the top-down generators run from
+        // EntityInputMovementPlugin's ReactToLoadedGlux, which only fires them for a project that
+        // already has a top-down entity in it - which is the state the user's project opens in.
+        await GoldProject.LoadInGlueAsync(csprojPath);
+
+        Assert.Empty(ErrorRecordingPlugin.Errors);
+        Assert.Empty(Directory.GetFiles(temp.Root, "*.cs", SearchOption.AllDirectories)
+            .Select(f => Path.GetRelativePath(temp.Root, f).Replace('\\', '/'))
+            .Where(f => f != "Game1.cs"));
+    }
+
+    [StaFact]
+    public async Task SettingTheStartupScreen_OnAnFrb2Project_SavesItWithoutWarningAboutTheGameClass()
+    {
+        // The setter writes StartUpScreen to the .gluj and saves it, and only then looks for the Game
+        // class to regenerate. An FRB2 project has no Game class for Glue to find and does not want one
+        // touched - it reads StartUpScreen out of the .gluj at runtime - so the "could not set the
+        // startup screen" popup fired on a change that had in fact already been made.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2Startup_");
+        await GoldProject.LoadInGlueAsync(WriteFrb2Project(temp.Root));
+        await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen("NewScreen");
+
+        GlueTestBootstrap.RecordedDialogMessages.Clear();
+
+        GlueCommands.Self.GluxCommands.StartUpScreenName = "Screens\\NewScreen";
+
+        Assert.Empty(GlueTestBootstrap.RecordedDialogMessages);
+        Assert.Equal("Screens\\NewScreen", GlueState.Self.CurrentGlueProject.StartUpScreen);
+    }
+
+    [StaFact]
+    public async Task RenamingAScreen_OnAnFrb2Project_RenamesTheGlsj_WithoutWarningAboutCode()
+    {
+        // Rename moves the element's .cs and .Generated.cs alongside its JSON. An FRB2 project has
+        // neither, so this is the same shape as the startup-screen popup: a code-shaped step failing on
+        // a project that legitimately has no code.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2Rename_");
+        await GoldProject.LoadInGlueAsync(WriteFrb2Project(temp.Root));
+        var screen = await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen("NewScreen");
+
+        GlueTestBootstrap.RecordedDialogMessages.Clear();
+
+        await GlueCommands.Self.GluxCommands.ElementCommands.RenameElement(
+            screen, "Screens\\RenamedScreen", showRenameWindow: false);
+
+        Assert.True(File.Exists(Path.Combine(temp.Root, "Content", "FrbEditor", "Screens", "RenamedScreen.glsj")),
+            "The renamed screen's .glsj should exist under its new name.");
+        Assert.Empty(GlueTestBootstrap.RecordedDialogMessages);
+    }
+
+    [StaFact]
+    public async Task RemoveEntityAsync_WithNoFileList_RemovesTheEntityInsteadOfThrowing()
+    {
+        // filesThatCouldBeRemoved is an output accumulator that the caller shows the user - the method
+        // does not delete anything itself. It defaults to null and was then added to unconditionally, so
+        // the documented no-list overload threw at the first Add for any project type. RemoveScreen has
+        // always coalesced it; this one did not.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2Remove_");
+        await GoldProject.LoadInGlueAsync(WriteFrb2Project(temp.Root));
+        var entity = await GlueCommands.Self.GluxCommands.EntityCommands.AddEntityAsync(
+            new AddEntityViewModel { Name = "DoomedEntity" });
+
+        GlueTestBootstrap.RecordedDialogMessages.Clear();
+
+        await GlueCommands.Self.GluxCommands.RemoveEntityAsync(entity);
+
+        Assert.DoesNotContain(GlueState.Self.CurrentGlueProject.Entities, item => item.Name == entity.Name);
         Assert.Empty(GlueTestBootstrap.RecordedDialogMessages);
     }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectTests.cs
@@ -43,6 +43,54 @@ public class Frb2ProjectDetectorTests
     }
 
     [Fact]
+    public void IsFrb2Project_IsTrue_ForTheDotnetNewTemplatesPackageReference()
+    {
+        // What `dotnet new frb2-desktop` actually produces in MyGame.Common: the engine comes from
+        // nuget, not from a ProjectReference into the FRB2 repo. Versions live in
+        // Directory.Packages.props, so the Include carries no version.
+        Assert.True(Frb2ProjectDetector.IsFrb2Project(new[]
+        {
+            Item("PackageReference", "FlatRedBall2.MonoGame"),
+            Item("PackageReference", "MonoGame.Framework.DesktopGL"),
+        }));
+    }
+
+    [Fact]
+    public void IsFrb2Project_IsTrue_ForTheKniPackageReference()
+    {
+        // The multiplatform template's Common project takes both backends.
+        Assert.True(Frb2ProjectDetector.IsFrb2Project(new[]
+        {
+            Item("PackageReference", "FlatRedBall2.Kni"),
+        }));
+    }
+
+    [Fact]
+    public void IsFrb2Project_IsFalse_ForAnFrb1PackageReference()
+    {
+        // The dangerous false positive: mistaking an FRB1 project for FRB2 silently stops Glue
+        // generating its code. FRB1's packages are FlatRedBall.*, which must not match FlatRedBall2.*.
+        Assert.False(Frb2ProjectDetector.IsFrb2Project(new[]
+        {
+            Item("PackageReference", "FlatRedBall.Forms"),
+            Item("PackageReference", "FlatRedBall"),
+        }));
+    }
+
+    [Fact]
+    public void IsFrb2Project_IsFalse_ForTheDesktopLauncherProject()
+    {
+        // MyGame.Desktop only holds Program.cs and the content pipeline - it reaches the engine through
+        // MyGame.Common, so it is not itself the project Glue edits.
+        Assert.False(Frb2ProjectDetector.IsFrb2Project(new[]
+        {
+            Item("PackageReference", "MonoGame.Framework.DesktopGL"),
+            Item("PackageReference", "MonoGame.Content.Builder.Task"),
+            Item("ProjectReference", @"..\MyGame.Common\MyGame.Common.csproj"),
+        }));
+    }
+
+    [Fact]
     public void IsFrb2Project_IsFalse_ForFrb1SourceLinkedProject()
     {
         // "Link Game to FRB Source" on an FRB1 project produces this. It must not be mistaken for FRB2,

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/NewProjectTemplateListTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/NewProjectTemplateListTests.cs
@@ -66,9 +66,16 @@ public class NewProjectTemplateListTests
     // Namespace is the template folder name; it is also the token ProjectCreationHelper replaces with
     // the new project's name. AddNewLocalProjectOption is the "Select Local Project..." row, which
     // points at a folder the user picks rather than at a template in this repo.
+    //
+    // Both invariants above are about the zip pipeline - a template this repo builds, the release
+    // uploads, and the window downloads - so they apply to entries that actually have a zip. A
+    // DotnetNewProjectInfo has no Url because the dotnet CLI owns its template, so it has no zip to
+    // build and no engine to register. Keyed on the entry having a Url rather than on its type, so a
+    // future non-zip template is exempt automatically and every new zip template is still guarded.
     private static HashSet<string> WizardTemplateNames() =>
         EmptyTemplates.Projects
             .Where(project => project is not AddNewLocalProjectOption)
+            .Where(project => !string.IsNullOrEmpty(project.Url))
             .Select(project => project.Namespace)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/SetProperty/ReferencedFileSaveSetPropertyManagerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/SetProperty/ReferencedFileSaveSetPropertyManagerTests.cs
@@ -67,7 +67,13 @@ public class ReferencedFileSaveSetPropertyManagerTests : IDisposable
     [Fact]
     public void ReactToChangedReferencedFile_ShouldNotThrow_WhenIsDatabaseForLocalizingChangesWithNullOldValue()
     {
-        var rfs = new ReferencedFileSave { Name = "GlobalContent/GumProject.gumx" };
+        // A .csv, because that is what IsDatabaseForLocalizing applies to - the path under test runs
+        // RemoveCodeForCsv/CsvCodeGenerator and never looks at the extension. It also has to not be a
+        // .gumx: assigning CurrentReferencedFileSave round-trips through Find.TreeNodeByTag and raises
+        // ReactToItemsSelected for real, and MainGumPlugin answers a .gumx selection by building its WPF
+        // GumControl - which throws in a test host and leaves PluginManager disabling the Gum plugin for
+        // every test that runs after this one.
+        var rfs = new ReferencedFileSave { Name = "GlobalContent/Localization.csv" };
         ObjectFinder.Self.GlueProject.GlobalFiles.Add(rfs);
         GlueState.Self.CurrentReferencedFileSave = rfs;
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/CodeNodeTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/CodeNodeTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.IO;
+using System.Linq;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Parsing;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Microsoft.Build.Evaluation;
+using OfficialPlugins.TreeViewPlugin.ViewModels;
+using Shouldly;
+
+namespace GlueUnitTests.TreeViewPlugin;
+
+/// <summary>
+/// The Code node under a Screen or Entity lists that element's .cs files. Everything in it is found by
+/// enumerating the disk except the factory, which <see cref="CodeWriter.GetAllCodeFilesFor"/> appends
+/// by name whether or not it was ever generated - so the tree offered a file that does not exist.
+/// </summary>
+public class CodeNodeTests : IDisposable
+{
+    readonly string _directory;
+    readonly VisualStudioProject _originalMainProject;
+    readonly GlueProjectSave _originalGlueProject;
+    readonly string _originalRelativeDirectory;
+
+    public CodeNodeTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+
+        _directory = Path.Combine(Path.GetTempPath(), "CodeNode_" + Guid.NewGuid());
+        Directory.CreateDirectory(_directory);
+
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    T UseProject<T>(Func<Project, T> construct, string projectName) where T : VisualStudioProject
+    {
+        var csprojPath = Path.Combine(_directory, projectName + ".csproj");
+        File.WriteAllText(csprojPath, $@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <RootNamespace>{projectName}</RootNamespace>
+  </PropertyGroup>
+</Project>");
+        GlueTestBootstrap.EnsureMsBuildEnvironmentVariable();
+
+        var project = construct(new Project(csprojPath, null, null, new ProjectCollection()));
+        GlueState.Self.CurrentMainProject = project;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _directory + Path.DirectorySeparatorChar;
+        return project;
+    }
+
+    static EntitySave PooledEntity() =>
+        new() { Name = @"Entities\Bear", CreatedByOtherEntities = true };
+
+    [Fact]
+    public void GetAllCodeFilesFor_OmitsAFactoryThatWasNeverGenerated()
+    {
+        UseProject(p => new ClassLibraryProject(p), "Frb1Game");
+
+        var files = CodeWriter.GetAllCodeFilesFor(PooledEntity());
+
+        files.Select(file => file.NoPath)
+            .ShouldNotContain("BearFactory.Generated.cs",
+                "The factory file is not on disk, so the Code node must not offer it.");
+    }
+
+    [Fact]
+    public void GetAllCodeFilesFor_StillListsAFactoryThatExists()
+    {
+        // The guard against over-fixing: a real factory still has to show up.
+        UseProject(p => new ClassLibraryProject(p), "Frb1Game");
+        var factoriesDirectory = Path.Combine(_directory, "Factories");
+        Directory.CreateDirectory(factoriesDirectory);
+        File.WriteAllText(Path.Combine(factoriesDirectory, "BearFactory.Generated.cs"), "// generated");
+
+        var files = CodeWriter.GetAllCodeFilesFor(PooledEntity());
+
+        files.Select(file => file.NoPath).ShouldContain("BearFactory.Generated.cs");
+    }
+
+    [StaFact]
+    public void AnEntityInAnFrb2Project_HasNoCodeNode()
+    {
+        // FRB2 owns all of its own source and Glue writes none of it, so a node listing "this element's
+        // generated code" describes nothing that exists.
+        UseProject(p => new Frb2Project(p), "Frb2Game");
+
+        var node = new GlueElementNodeViewModel(null, PooledEntity(), createChildrenNodes: true);
+
+        node.Children.Select(child => child.Text).ShouldNotContain("Code");
+    }
+
+    [StaFact]
+    public void AnEntityInANormalProject_StillHasACodeNode()
+    {
+        UseProject(p => new ClassLibraryProject(p), "Frb1Game");
+
+        var node = new GlueElementNodeViewModel(null, PooledEntity(), createChildrenNodes: true);
+
+        node.Children.Select(child => child.Text).ShouldContain("Code");
+    }
+
+    [StaFact]
+    public void AnEntityInAnFrb2Project_HasNoEventsNode()
+    {
+        // Events exist to generate the element's .Event.cs and .Generated.Event.cs, so they produce
+        // nothing at all in a project Glue writes no code for.
+        UseProject(p => new Frb2Project(p), "Frb2Game");
+
+        var node = new GlueElementNodeViewModel(null, PooledEntity(), createChildrenNodes: true);
+
+        node.Children.Select(child => child.Text).ShouldNotContain("Events");
+    }
+
+    [StaFact]
+    public void AnEntityInANormalProject_StillHasAnEventsNode()
+    {
+        UseProject(p => new ClassLibraryProject(p), "Frb1Game");
+
+        var node = new GlueElementNodeViewModel(null, PooledEntity(), createChildrenNodes: true);
+
+        node.Children.Select(child => child.Text).ShouldContain("Events");
+    }
+
+    [StaFact]
+    public void AnEntityInAnFrb2Project_KeepsTheNodesThatHoldData()
+    {
+        // Objects, Variables and States are .gluj data that an FRB2 game reads at runtime, so hiding
+        // the code-shaped nodes must not take these with them.
+        UseProject(p => new Frb2Project(p), "Frb2Game");
+
+        var node = new GlueElementNodeViewModel(null, PooledEntity(), createChildrenNodes: true);
+        var texts = node.Children.Select(child => child.Text).ToList();
+
+        texts.ShouldContain("Files");
+        texts.ShouldContain("Objects");
+        texts.ShouldContain("Variables");
+        texts.ShouldContain("States");
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/DirectoryNodeCollisionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/DirectoryNodeCollisionTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Linq;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using Moq;
+using OfficialPlugins.TreeViewPlugin.Models;
+using OfficialPlugins.TreeViewPlugin.ViewModels;
+using Shouldly;
+
+namespace GlueUnitTests.TreeViewPlugin;
+
+/// <summary>
+/// Folder nodes under Screens/Entities come from Directory.GetDirectories, and elements come from the
+/// .gluj - two passes that never see each other. In FRB1 they cannot collide, because a screen's
+/// definition and its content folder hang off different roots (CurrentGlueProjectDirectory vs
+/// ContentDirectory). An FRB2 project puts everything Glue authors under one folder, so
+/// Screens/NewScreen.glsj and the content folder Screens/NewScreen/ become siblings and the screen
+/// gets a second, duplicate node.
+/// </summary>
+public class DirectoryNodeCollisionTests : IDisposable
+{
+    readonly string _root;
+    readonly string _originalRelativeDirectory;
+    readonly GlueProjectSave _originalGlueProject;
+    readonly MainTreeViewViewModel _viewModel;
+
+    public DirectoryNodeCollisionTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _root = Path.Combine(Path.GetTempPath(), "TreeViewCollision_" + Guid.NewGuid()) +
+            Path.DirectorySeparatorChar;
+        Directory.CreateDirectory(Path.Combine(_root, "Screens"));
+
+        // AddScreenTreeNode finishes by refreshing the new node, which reads
+        // GlueState.Self.CurrentGlueProject.StartUpScreen off the static singleton - not the injected
+        // mock. Without one this test passes mid-suite (some earlier test left a project behind) and
+        // NREs on its own.
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+
+        // AddScreenTreeNode resolves the element's containing folder with FileManager.MakeRelative,
+        // which reads the process-wide RelativeDirectory. Left to whatever ran before, this test
+        // passes mid-suite and fails on its own.
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _root;
+
+        var glueCommands = new Mock<IGlueCommands>();
+        // Only reached by the orphan-cleanup pass, which asks where a directory node points so it can
+        // drop nodes whose directory is gone. Answering with the real path keeps live nodes alive.
+        glueCommands
+            .Setup(item => item.GetAbsoluteFileName(It.IsAny<string>(), It.IsAny<bool>()))
+            .Returns((string relative, bool _) => Path.Combine(_root, relative ?? string.Empty));
+
+        _viewModel = new MainTreeViewViewModel(new Mock<IGlueState>().Object, glueCommands.Object);
+    }
+
+    public void Dispose()
+    {
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [StaFact]
+    public void AddDirectoryNodes_DoesNotAddASecondNode_WhenAScreenAlreadyOwnsThatName()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "Screens", "NewScreen"));
+        AddScreenNode("Screens\\NewScreen");
+
+        _viewModel.AddDirectoryNodes(_root + "Screens/", _viewModel.ScreenRootNode, ScreenOrEntity.Screen);
+
+        _viewModel.ScreenRootNode.Children
+            .Count(node => node.Text == "NewScreen")
+            .ShouldBe(1, "The screen's own content folder should not appear beside the screen.");
+    }
+
+    [StaFact]
+    public void AddDirectoryNodes_StillAddsAFolderNode_WhenNoElementOwnsThatName()
+    {
+        // A folder the user made to organize screens is not owned by any element, so it still shows.
+        Directory.CreateDirectory(Path.Combine(_root, "Screens", "Levels"));
+
+        _viewModel.AddDirectoryNodes(_root + "Screens/", _viewModel.ScreenRootNode, ScreenOrEntity.Screen);
+
+        _viewModel.ScreenRootNode.Children
+            .Count(node => node.Text == "Levels")
+            .ShouldBe(1);
+    }
+
+    [StaFact]
+    public void AddDirectoryNodes_ThenTheElement_LeavesOnlyTheElementNode()
+    {
+        // The other order, and the one the screenshot showed: directories are enumerated on glux load
+        // before any element node exists, so the skip-check has nothing to defer to and the folder node
+        // is created. The element pass has to clear it when the element arrives.
+        Directory.CreateDirectory(Path.Combine(_root, "Screens", "NewScreen"));
+
+        _viewModel.AddDirectoryNodes(_root + "Screens/", _viewModel.ScreenRootNode, ScreenOrEntity.Screen);
+        _viewModel.AddScreenTreeNode(new ScreenSave { Name = "Screens\\NewScreen" });
+
+        _viewModel.ScreenRootNode.Children
+            .Count(node => node.Text == "NewScreen")
+            .ShouldBe(1, "The folder node should have been replaced by the screen, not kept beside it.");
+    }
+
+    void AddScreenNode(string screenName)
+    {
+        var screen = new ScreenSave { Name = screenName };
+        var node = new GlueElementNodeViewModel(_viewModel.ScreenRootNode, screen, createChildrenNodes: false);
+        _viewModel.ScreenRootNode.Children.Add(node);
+    }
+}

--- a/FRBDK/Glue/TopDownPlugin/CodeGenerators/TopDownAnimationControllerGenerator.cs
+++ b/FRBDK/Glue/TopDownPlugin/CodeGenerators/TopDownAnimationControllerGenerator.cs
@@ -1,7 +1,6 @@
-﻿using FlatRedBall.Glue.Managers;
+﻿using FlatRedBall.Glue.Plugins.CodeGenerators;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.SaveClasses;
-using FlatRedBall.IO;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,44 +9,15 @@ using System.Threading.Tasks;
 
 namespace TopDownPlugin.CodeGenerators;
 
-public class TopDownAnimationControllerGenerator : Singleton<TopDownAnimationControllerGenerator>
+public class TopDownAnimationControllerGenerator : FullFileCodeGenerator
 {
-    string RelativeFileLocation = "TopDown/TopDownAnimationControllerGenerator.Generated.cs";
-    public FilePath FileLocation => GlueState.Self.CurrentGlueProjectDirectory + RelativeFileLocation;
+    public override string RelativeFile => "TopDown/TopDownAnimationControllerGenerator.Generated.cs";
 
-    public void GenerateAndSave()
-    {
+    static TopDownAnimationControllerGenerator mSelf;
+    public static TopDownAnimationControllerGenerator Self =>
+        mSelf ??= new TopDownAnimationControllerGenerator();
 
-        TaskManager.Self.Add(() =>
-        {
-            var contents = GenerateFileContents();
-
-            var relativeDirectory = RelativeFileLocation;
-
-            GlueCommands.Self.ProjectCommands.CreateAndAddCodeFile(relativeDirectory);
-
-            var glueProjectDirectory = GlueState.Self.CurrentGlueProjectDirectory;
-
-            if (!string.IsNullOrEmpty(glueProjectDirectory))
-            {
-                var fullFile = GlueState.Self.CurrentGlueProjectDirectory + relativeDirectory;
-
-                try
-                {
-                    GlueCommands.Self.TryMultipleTimes(() =>
-                        System.IO.File.WriteAllText(fullFile, contents));
-                }
-                catch (Exception e)
-                {
-                    GlueCommands.Self.PrintError(e.ToString());
-                }
-            }
-
-        }, "Adding TopDownAnimationControllerGenerator.Generated.cs to the project");
-
-    }
-
-    private string GenerateFileContents()
+    protected override string GenerateFileContents()
     {
         var toReturn =
 @"


### PR DESCRIPTION
Follows #2021. Fixes found while actually opening and editing an FRB2 project in Glue, plus the test-suite problems that surfaced along the way.

## FRB2 editing

- **Opening a project with a top-down entity threw `DirectoryNotFoundException`.** Five plugin generators were hand-rolled copies of `FullFileCodeGenerator` that wrote with `File.WriteAllText` instead of pairing `CreateAndAddCodeFile` with `SaveIfDiffers` — the two seams that consult `CodeWritePolicy`. Deriving from the base fixes them by construction and removes the duplication. EffectPlugin, GumPlugin, GameCommunicationPlugin and Racing's `CollisionHistoryCodeGenerator` created their own directories so they didn't crash, but still wrote `.cs` into a project Glue doesn't own the code of.
- **Setting the startup screen popped "could not set the startup screen because Glue could not find the Game class"** — on a change that had already been written to the `.gluj` and saved. FRB2 reads it at runtime and has no Game class for Glue to edit. Deleting the startup screen goes through the same setter, so that route is fixed too. The FRB1 wording was also wrong and now says the screen was saved but the code wasn't updated.
- **A screen or entity appeared twice in the tree** — once as the element, once as its own content folder. FRB1 can't hit this because a screen's definition and its content hang off different roots; FRB2 puts everything Glue authors under one folder, making them siblings.
- **The Code node offered `<Entity>Factory.Generated.cs` that wasn't on disk.** Everything else in that list is found by enumerating the disk; the factory was appended by name. That also affected FRB1 entities before their first codegen.
- **Code and Events nodes are hidden for FRB2** — both describe generated source. Files, Objects, Variables and States stay: that's `.gluj` data, which is what Glue is still there to author.
- **`RemoveEntityAsync`'s `filesThatCouldBeRemoved`** defaulted to `null` and was then added to unconditionally, so the no-list overload threw for any project type. `RemoveScreen` has always coalesced it.

## FRB2 project detection and creation

- **Glue couldn't open a `dotnet new frb2-desktop` project at all.** The detector matched only a `ProjectReference` to `FlatRedBall2.csproj` — how games inside the FRB2 repo reference the engine. A template-created game takes it from nuget. The trailing dot in the new package rule matters: FRB1 ships `FlatRedBall.*` packages, and treating one as FRB2 would silently stop Glue generating its code.
- **Picking the launcher project now works.** The template splits a game into `MyGame.Common` (Game1, content, engine reference) and `MyGame.Desktop` (a launcher). Common is what Glue edits, but Desktop is the runnable one and just as natural to pick; it previously ended at "could not determine the project type" with nothing loaded. `ProjectLoader` resolves one hop and prints which project it opened. The `.csproj` is read as XML rather than evaluated — this runs on a file the user may have picked by mistake, so an unresolvable SDK should mean "no redirect", not an exception on the load path.
- **The New Project window offers an FRB2 entry.** `dotnet new` does the naming and guid work the zip pipeline hand-rolls, so that path skips download/unzip/rename/rewrite entirely. `NpcWpfLib` needs its own process runner because `NestedDotnetCli` is test-only; it drains both streams concurrently and disables node reuse, per #1969.
- `NewProjectTemplateListTests`' two guards are about the zip pipeline, so they now iterate entries that *have* a zip — keyed on that rather than on a type, so a future non-zip template is exempt automatically and every new zip template stays guarded. Verified by removing the filter and watching both guards fire.

## Test suite: 3–4 gold-project failures per run, shuffling every time

Three independent causes, two of which are live product bugs rather than test problems:

- **`FileManager.RelativeDirectory` is per-thread, but `PluginManager` saved and restored it on one shared stack.** Glue makes those calls from `Parallel.For` workers, so a worker's resume popped another's entry and restored the wrong directory over its own. Orphaned entries outlived the load that pushed them. `HandleFileReadError` also resumed without ever saving.
- **`FileManager` itself had the same bug one layer down** — the backing dictionary's setter locked and its getter didn't, so a read racing a resize threw and was silently answered with `DefaultRelativeDirectory`. Now `[ThreadStatic]`. This is the only engine-side file in the PR.
- **A null `GumProjectSave` permanently disabled the Gum plugin.** `PluginManager` turns any plugin exception into `PluginContainer.Fail`, which sets `IsEnabled = false` for the session — so one `.gumx` selected before its project loaded cost Gum for every later operation, failing somewhere unrelated.

Full suite goes from 3–4 intermittent failures to **446/446, verified over three consecutive clean runs**.

## Testing

Every fix was written test-first, with the fix disabled to confirm the test failed for the right reason — one initially "red" test turned out to be failing on an NRE rather than its assertion, and was corrected. FRB2 detection and project creation were additionally verified end to end against a real `dotnet new frb2-desktop` run driven through the production `DotnetNewService` and loaded by the real `ProjectLoader`.

**Not covered, worth knowing:**
- The New Project window flow itself is WPF and unverified by hand — the created-project logic underneath it is tested, the dialog is not.
- A created FRB2 project needs `dotnet tool restore` before it will run; Glue doesn't do that.
- `dotnet new install` doesn't pin a template version, so the editor could get a template newer than its `.gluj` expectations.
- The tree view's real delete path (`RemoveFromProjectToolStripMenuItem`) is dialog-driven and unprobed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
