### PR TITLE
Reword the stale WpfDataUi OldValue comments now that Gum populates it

### DIFF
--- a/FRBDK/Glue/Glue/SetProperty/ReferencedFileSaveSetPropertyManager.cs
+++ b/FRBDK/Glue/Glue/SetProperty/ReferencedFileSaveSetPropertyManager.cs
@@ -160,10 +160,10 @@ namespace FlatRedBall.Glue.SetVariable
             {
                 updateTreeView = false;
                 bool newValue = rfs.IsDatabaseForLocalizing;
-                // oldValue is null when this change comes from the WPF "Settings (Preview)" grid -
-                // WpfDataUi's DataUiGrid.PropertyChange never populates PropertyChangedArgs.OldValue
-                // (only NewValue), unlike the WinForms PropertyGrid path. A checkbox can only have
-                // flipped from the opposite of its new value, so that's a safe, correct fallback.
+                // Don't unbox oldValue blindly - this method is reachable from both property grids and
+                // from internal callers, and not every one of them has an old value to hand over. A
+                // checkbox can only have flipped from the opposite of its new value, so that's a safe
+                // fallback when it's missing.
                 bool oldValueAsBool = oldValue is bool oldValueUnboxed ? oldValueUnboxed : !newValue;
 
                 if(newValue)

--- a/FRBDK/Glue/Tests/GlueUnitTests/SetProperty/ReferencedFileSaveSetPropertyManagerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/SetProperty/ReferencedFileSaveSetPropertyManagerTests.cs
@@ -12,13 +12,10 @@ using Shouldly;
 namespace GlueUnitTests.SetProperty;
 
 // GitHub issue #2016: toggling "Is Database For Localizing" in the ReferencedFileSave "Settings
-// (Preview)" tab crashed Glue with a NullReferenceException. Root cause: that tab is backed by
-// WpfDataUi's DataUiGrid, whose PropertyChange event never populates PropertyChangedArgs.OldValue
-// (only NewValue) - see DataUiGrid.HandleInstanceMemberSetByUi in the sibling Gum repo. So
-// MainPropertyGridPlugin.HandlePropertyChanged always forwards oldValue: null for any property changed
-// through this grid, unlike the WinForms PropertyGrid path (SetPropertyManager.PropertyValueChanged),
-// which gets a real old value from System.ComponentModel. This test reproduces that always-null
-// oldValue directly against the real production method.
+// (Preview)" tab crashed Glue with a NullReferenceException, because the handler unboxed oldValue as
+// bool unconditionally. ReactToChangedReferencedFile is internal and has several callers that pass no
+// old value, so a null oldValue is a legitimate input, not a bug in one caller - this test pins the
+// null-safe handling against the real production method.
 public class ReferencedFileSaveSetPropertyManagerTests : IDisposable
 {
     private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
@@ -77,9 +74,8 @@ public class ReferencedFileSaveSetPropertyManagerTests : IDisposable
         ObjectFinder.Self.GlueProject.GlobalFiles.Add(rfs);
         GlueState.Self.CurrentReferencedFileSave = rfs;
 
-        // Mirrors what the real WPF "Settings (Preview)" grid does before it raises PropertyChange:
-        // WpfDataUi's InstanceMember already wrote the new value through to the instance, and then
-        // fires PropertyChange with OldValue left at its default (null) - see the class comment above.
+        // Matches the contract every caller honors: the new value is already written through to the
+        // ReferencedFileSave before ReactToChangedReferencedFile is notified about the change.
         rfs.IsDatabaseForLocalizing = true;
 
         var sut = new ReferencedFileSaveSetPropertyManager();


### PR DESCRIPTION
Gum's fix landed (vchelaru/Gum#4389, commit `277c7c750`): `DataUiGrid.HandleInstanceMemberSetByUi` now sets `args.OldValue` from `InstanceMember.OldValue`. Glue consumes WpfDataUi via `ProjectReference` into the sibling Gum checkout, so it's already live here.

That makes the comments in `ReferencedFileSaveSetPropertyManager` and `ReferencedFileSaveSetPropertyManagerTests` — which say the WPF "Settings (Preview)" grid *never* populates `OldValue` — false. Reworded both to plain null-safety framing.

The fallback (`oldValue is bool ... : !newValue`) and its test stay. `ReactToChangedReferencedFile` is `internal` and has callers that legitimately pass no old value (e.g. the two-arg overload, `ReactToChangedRuntimeType`), so the unconditional `(bool)` unbox was a real bug independent of Gum's.

Comment-only, no behavior change. 426/426 non-BuildSmoke tests green.

Closes #2019

🤖 Generated with [Claude Code](https://claude.com/claude-code)
