### PR TITLE
Ask everything a Screen/Entity delete needs in one dialog

### DIFF
--- a/FRBDK/Glue/EntityInputMovementPlugin/MainEntityInputMovementPlugin.cs
+++ b/FRBDK/Glue/EntityInputMovementPlugin/MainEntityInputMovementPlugin.cs
@@ -57,7 +57,7 @@ namespace EntityInputMovementPlugin
         {
             this.ReactToLoadedGlux += HandleGluxLoaded;
             this.ReactToItemsSelected += HandleItemsSelected;
-            this.ReactToEntityRemoved += HandleElementRemoved;
+            this.ReactToElementRemoved += HandleElementRemoved;
             this.ReactToElementRenamed += HandleElementRenamed;
             this.ModifyAddEntityWindow += TopDownPlugin.Logic.ModifyAddEntityWindowLogic.HandleModifyAddEntityWindow;
             this.NewEntityCreatedWithUi += HandleNewEntityCreatedWithUi;
@@ -255,8 +255,13 @@ namespace EntityInputMovementPlugin
             }
         }
 
-        private void HandleElementRemoved(EntitySave removedElement, List<string> additionalFiles)
+        private void HandleElementRemoved(GlueElement removedElement, GlueFormsCore.ViewModels.DeleteOptionsViewModel deleteOptions)
         {
+            if (!(removedElement is EntitySave))
+            {
+                return;
+            }
+
             // This could be the very last entity that was a top-down or platformer. If so, we should
             // check and remove unused files.
             TopDownPlugin.Controllers.MainController.Self.CheckForNoTopDownEntities();

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -168,7 +168,7 @@ namespace GameCommunicationPlugin.GlueControl
                 _refreshManager.HandleNewScreenCreated();
                 return Task.CompletedTask;
             };
-            this.ReactToScreenRemoved += ToolbarController.Self.HandleScreenRemoved;
+            this.ReactToElementRemoved += ToolbarController.Self.HandleElementRemoved;
             // todo - handle startup changed...
 
             this.ReactToNewObjectListAsync += _refreshManager.HandleNewObjectList;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/ToolbarController.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/ToolbarController.cs
@@ -60,7 +60,7 @@ class ToolbarController : Singleton<ToolbarController>
     }
 
     internal void HandleNewScreenCreated(ScreenSave screen) => RefreshToolbarScreens();
-    internal void HandleScreenRemoved(ScreenSave screen, List<string> arg2) => RefreshToolbarScreens();
+    internal void HandleElementRemoved(GlueElement element, GlueFormsCore.ViewModels.DeleteOptionsViewModel deleteOptions) => RefreshToolbarScreens();
     internal void HandleGluxLoaded() => RefreshToolbarScreens();
     internal void HandleScreenRenamed(IElement element, string newName) => RefreshToolbarScreens();
 

--- a/FRBDK/Glue/Glue/Controls/DeleteOptionsWindow.xaml
+++ b/FRBDK/Glue/Glue/Controls/DeleteOptionsWindow.xaml
@@ -1,0 +1,65 @@
+﻿<Window x:Class="GlueFormsCore.Controls.DeleteOptionsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:localization="clr-namespace:Localization;assembly=Localization"
+        mc:Ignorable="d"
+        Title="Delete?" SizeToContent="Height" Width="560" MaxHeight="700" ResizeMode="CanResizeWithGrip"
+        WindowStartupLocation="CenterOwner">
+    <Grid Margin="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="{Binding Message}" TextWrapping="Wrap" FontWeight="Bold" Margin="0,0,0,8" />
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+
+                <!-- Things which come along with the delete whether the user likes it or not -->
+                <StackPanel Visibility="{Binding ObjectsToRemoveVisibility}" Margin="0,0,0,8">
+                    <TextBlock Text="{x:Static localization:Texts.DeleteAlsoFollowing}" TextWrapping="Wrap" />
+                    <ListBox ItemsSource="{Binding ObjectsToRemove}" MaxHeight="120" Margin="0,2,0,0" />
+                </StackPanel>
+
+                <!-- One checkbox per optional part of the delete. Plugins add to this list through
+                     PluginManager.FillDeleteOptions rather than showing their own dialog. -->
+                <StackPanel Visibility="{Binding OptionsVisibility}" Margin="0,0,0,8">
+                    <ItemsControl ItemsSource="{Binding Options}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding IsChecked}" Margin="0,2,0,2">
+                                    <TextBlock Text="{Binding Display}" TextWrapping="Wrap" />
+                                </CheckBox>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- The leftover-files question, which used to be a separate dialog shown after the delete -->
+                <StackPanel Visibility="{Binding FilesToRemoveVisibility}">
+                    <TextBlock Text="What would you like to do with the following files:" TextWrapping="Wrap" />
+                    <ListBox ItemsSource="{Binding FilesToRemove}" MaxHeight="160" Margin="0,2,0,4" />
+                    <RadioButton GroupName="FileAction" Margin="0,2,0,2"
+                                 IsChecked="{Binding IsRemoveAndDeleteFilesChecked}"
+                                 Content="Remove them from the project and delete the files" />
+                    <RadioButton GroupName="FileAction" Margin="0,2,0,2"
+                                 IsChecked="{Binding IsRemoveFilesFromProjectChecked}"
+                                 Content="Remove them from the project but keep the files" />
+                    <RadioButton GroupName="FileAction" Margin="0,2,0,2"
+                                 IsChecked="{Binding IsDoNothingWithFilesChecked}"
+                                 Content="Nothing - leave them as part of the game project" />
+                </StackPanel>
+
+            </StackPanel>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button Click="DeleteButton_Click" IsDefault="True" Content="Delete" MinWidth="80" Padding="6,2" />
+            <Button Click="CancelButton_Click" IsCancel="True" Content="Cancel" MinWidth="80" Padding="6,2" Margin="6,0,0,0" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/FRBDK/Glue/Glue/Controls/DeleteOptionsWindow.xaml
+++ b/FRBDK/Glue/Glue/Controls/DeleteOptionsWindow.xaml
@@ -42,7 +42,7 @@
                 <!-- The leftover-files question, which used to be a separate dialog shown after the delete -->
                 <StackPanel Visibility="{Binding FilesToRemoveVisibility}">
                     <TextBlock Text="What would you like to do with the following files:" TextWrapping="Wrap" />
-                    <ListBox ItemsSource="{Binding FilesToRemove}" MaxHeight="160" Margin="0,2,0,4" />
+                    <ListBox ItemsSource="{Binding FilesToRemoveDisplay}" MaxHeight="160" Margin="0,2,0,4" />
                     <RadioButton GroupName="FileAction" Margin="0,2,0,2"
                                  IsChecked="{Binding IsRemoveAndDeleteFilesChecked}"
                                  Content="Remove them from the project and delete the files" />

--- a/FRBDK/Glue/Glue/Controls/DeleteOptionsWindow.xaml.cs
+++ b/FRBDK/Glue/Glue/Controls/DeleteOptionsWindow.xaml.cs
@@ -1,0 +1,35 @@
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using System.Windows;
+
+namespace GlueFormsCore.Controls
+{
+    /// <summary>
+    /// The single dialog every element delete asks its questions through. Its content is entirely driven by
+    /// the DeleteOptionsViewModel it is given, so plugins extend it by adding options to that view model
+    /// rather than by showing a dialog of their own. See GitHub issue #429.
+    /// </summary>
+    public partial class DeleteOptionsWindow : Window
+    {
+        public DeleteOptionsWindow()
+        {
+            InitializeComponent();
+
+            Loaded += HandleLoaded;
+        }
+
+        private void HandleLoaded(object sender, RoutedEventArgs e)
+        {
+            GlueCommands.Self.DialogCommands.MoveToCursor(this);
+        }
+
+        private void DeleteButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/Controls/DialogService.cs
+++ b/FRBDK/Glue/Glue/Controls/DialogService.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Linq;
+using FlatRedBall.Glue.AutomatedGlue;
 using FlatRedBall.Glue.Managers;
+using GlueFormsCore.Controls;
+using GlueFormsCore.ViewModels;
 
 namespace FlatRedBall.Glue.Controls
 {
@@ -35,6 +38,7 @@ namespace FlatRedBall.Glue.Controls
         public static Action<string> ShowMessageImpl { get; set; } = DefaultShowMessage;
         public static Func<string, DialogButton, DialogButton, DialogButton?> ShowConfirmImpl { get; set; } = DefaultShowConfirm;
         public static Func<string, (string label, object value)[], object> ShowChoiceImpl { get; set; } = DefaultShowChoice;
+        public static Func<DeleteOptionsViewModel, bool> ShowDeleteImpl { get; set; } = DefaultShowDelete;
 
         /// <summary>
         /// Shows a simple single-button ("OK") informational message.
@@ -71,13 +75,45 @@ namespace FlatRedBall.Glue.Controls
             return result is TResult typed ? typed : default;
         }
 
+        /// <summary>
+        /// Shows the one dialog a delete asks everything through - what is being deleted, which optional
+        /// parts to include, and what to do with the files left behind. Returns true if the user confirmed.
+        /// See GitHub issue #429 for why this replaced a chain of separate prompts.
+        /// </summary>
+        public static bool ShowDelete(DeleteOptionsViewModel viewModel)
+        {
+            return TaskManager.Self.OnUiThread(() => ShowDeleteImpl(viewModel));
+        }
+
         private static void DefaultShowMessage(string text)
         {
             System.Windows.MessageBox.Show(text);
         }
 
+        private static bool DefaultShowDelete(DeleteOptionsViewModel viewModel)
+        {
+            if (!GlueGui.ShowGui)
+            {
+                return false;
+            }
+
+            var window = new DeleteOptionsWindow
+            {
+                DataContext = viewModel
+            };
+
+            return window.ShowDialog() == true;
+        }
+
         private static DialogButton? DefaultShowConfirm(string text, DialogButton primary, DialogButton secondary)
         {
+            // Headless (unit tests, automated Glue) has no desktop to put a modal on. Returning null is the
+            // same answer the caller gets when the user closes the window without clicking a button.
+            if (!GlueGui.ShowGui)
+            {
+                return null;
+            }
+
             var mbmb = new MultiButtonMessageBoxWpf
             {
                 MessageText = text
@@ -96,6 +132,11 @@ namespace FlatRedBall.Glue.Controls
 
         private static object DefaultShowChoice(string text, (string label, object value)[] options)
         {
+            if (!GlueGui.ShowGui)
+            {
+                return null;
+            }
+
             var mbmb = new MultiButtonMessageBoxWpf
             {
                 MessageText = text

--- a/FRBDK/Glue/Glue/Elements/DeletionPlanner.cs
+++ b/FRBDK/Glue/Glue/Elements/DeletionPlanner.cs
@@ -1,0 +1,188 @@
+using FlatRedBall.Glue.Plugins;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.IO;
+using GlueFormsCore.ViewModels;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FlatRedBall.Glue.Elements
+{
+    /// <summary>
+    /// Works out everything a delete will do <b>before</b> any of it happens, and expresses it as a
+    /// <see cref="DeleteOptionsViewModel"/> the user answers in one dialog.
+    ///
+    /// Nothing here touches UI or mutates the project, which is the whole reason it is a separate class:
+    /// deleting a Screen used to ask its questions from four different places part-way through the delete
+    /// (the "are you sure", the per-derived-screen inheritance reset inside <c>RemoveScreen</c>, the Gum
+    /// plugin's own prompt inside <c>ReactToScreenRemoved</c>, and the leftover-files dialog at the end).
+    /// See GitHub issue #429.
+    /// </summary>
+    public static class DeletionPlanner
+    {
+        /// <summary>
+        /// Tag used for the "reset the inheritance for X" options, so the code performing the delete can
+        /// find them again without matching on display text.
+        /// </summary>
+        public class ResetInheritanceTag
+        {
+            public GlueElement DerivedElement { get; set; }
+
+            public override bool Equals(object obj) =>
+                obj is ResetInheritanceTag other && other.DerivedElement == DerivedElement;
+
+            public override int GetHashCode() => DerivedElement?.GetHashCode() ?? 0;
+        }
+
+        public static DeleteOptionsViewModel CreateForScreen(ScreenSave screen)
+        {
+            var viewModel = CreateForElement(screen);
+
+            foreach (var inheriting in ObjectFinder.Self.GetAllScreensThatInheritFrom(screen))
+            {
+                AddResetInheritanceOption(viewModel, inheriting);
+            }
+
+            FinishPlan(viewModel);
+
+            return viewModel;
+        }
+
+        public static DeleteOptionsViewModel CreateForEntity(EntitySave entity)
+        {
+            var viewModel = CreateForElement(entity);
+
+            foreach (var nos in ObjectFinder.Self.GetAllNamedObjectsThatUseEntity(entity.Name))
+            {
+                viewModel.ObjectsToRemove.Add(nos.ToString());
+            }
+
+            foreach (var inheriting in ObjectFinder.Self.GetAllEntitiesThatInheritFrom(entity))
+            {
+                AddResetInheritanceOption(viewModel, inheriting);
+            }
+
+            FinishPlan(viewModel);
+
+            return viewModel;
+        }
+
+        static DeleteOptionsViewModel CreateForElement(GlueElement element)
+        {
+            var viewModel = new DeleteOptionsViewModel
+            {
+                Element = element,
+                Message = $"Are you sure you want to delete {element}?"
+            };
+
+            viewModel.AlwaysRemovedFiles.AddRange(GetFilesThatWouldBeRemoved(element));
+
+            return viewModel;
+        }
+
+        static void AddResetInheritanceOption(DeleteOptionsViewModel viewModel, GlueElement derivedElement)
+        {
+            viewModel.AddOption(
+                $"Reset the inheritance for {derivedElement.Name}",
+                new ResetInheritanceTag { DerivedElement = derivedElement });
+        }
+
+        /// <summary>
+        /// Lets plugins add their own options (and the files those options bring with them) before the
+        /// dialog is shown, then brings the file list in line with what is checked.
+        /// </summary>
+        static void FinishPlan(DeleteOptionsViewModel viewModel)
+        {
+            PluginManager.FillDeleteOptions(viewModel.Element, viewModel);
+            viewModel.RefreshFilesToRemove();
+        }
+
+        /// <summary>
+        /// The files deleting <paramref name="element"/> would orphan: its own code and JSON files, plus
+        /// any file it references that nothing else in the project references.
+        ///
+        /// <c>GluxCommands.RemoveScreen</c>/<c>RemoveEntityAsync</c> call <see cref="FillWithOwnedFiles"/>
+        /// from here rather than keeping their own copy, so the list the dialog shows up front cannot
+        /// drift from the list the delete actually produces.
+        /// </summary>
+        public static List<string> GetFilesThatWouldBeRemoved(GlueElement element)
+        {
+            var toReturn = new List<string>();
+
+            if (element == null)
+            {
+                return toReturn;
+            }
+
+            var referencedElsewhere = ObjectFinder.Self.GlueProject == null
+                ? new HashSet<string>()
+                : GetFilePathsReferencedOutsideOf(element);
+
+            foreach (var rfs in element.ReferencedFiles)
+            {
+                var relativePath = rfs.GetRelativePath();
+                if (!referencedElsewhere.Contains(relativePath))
+                {
+                    toReturn.Add(relativePath);
+                }
+            }
+
+            FillWithOwnedFiles(toReturn, element);
+
+            return toReturn.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// Adds the code and JSON files an element owns outright - its custom and generated .cs, its event
+        /// files and factory if they exist on disk, and its .glsj/.glej. Shared by the planner (to show the
+        /// user) and by the delete itself (to act on).
+        /// </summary>
+        public static void FillWithOwnedFiles(List<string> filesThatCouldBeRemoved, GlueElement element)
+        {
+            var elementName = element.Name;
+
+            filesThatCouldBeRemoved.Add(elementName + ".cs");
+            filesThatCouldBeRemoved.Add(elementName + ".Generated.cs");
+
+            AddIfExists(elementName + ".Event.cs");
+            AddIfExists(elementName + ".Generated.Event.cs");
+
+            var factoryName = "Factories/" + FileManager.RemovePath(elementName) + "Factory.Generated.cs";
+            var absoluteFactoryName = GlueCommands.Self.GetAbsoluteFileName(factoryName, false);
+            if (System.IO.File.Exists(absoluteFactoryName))
+            {
+                filesThatCouldBeRemoved.Add(absoluteFactoryName);
+            }
+
+            var extension = element is ScreenSave
+                ? GlueProjectSave.ScreenExtension
+                : GlueProjectSave.EntityExtension;
+            filesThatCouldBeRemoved.Add(elementName + "." + extension);
+
+            void AddIfExists(string relativeFile)
+            {
+                if (System.IO.File.Exists(GlueCommands.Self.GetAbsoluteFileName(relativeFile, false)))
+                {
+                    filesThatCouldBeRemoved.Add(relativeFile);
+                }
+            }
+        }
+
+        static HashSet<string> GetFilePathsReferencedOutsideOf(GlueElement element)
+        {
+            var glueProject = ObjectFinder.Self.GlueProject;
+
+            var otherElements = glueProject.Screens.Cast<GlueElement>()
+                .Concat(glueProject.Entities)
+                .Where(item => item != element);
+
+            var toReturn = otherElements
+                .SelectMany(item => item.ReferencedFiles)
+                .Concat(glueProject.GlobalFiles)
+                .Select(item => item.GetRelativePath())
+                .ToHashSet();
+
+            return toReturn;
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/Elements/DeletionPlanner.cs
+++ b/FRBDK/Glue/Glue/Elements/DeletionPlanner.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using FlatRedBall.Glue.Plugins;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.SaveClasses;
@@ -72,12 +73,33 @@ namespace FlatRedBall.Glue.Elements
             var viewModel = new DeleteOptionsViewModel
             {
                 Element = element,
-                Message = $"Are you sure you want to delete {element}?"
+                Message = $"Are you sure you want to delete {element}?",
+                ProjectRootForDisplay = ToCanonicalPath(GlueState.Self.CurrentGlueProjectDirectory)
             };
 
             viewModel.AlwaysRemovedFiles.AddRange(GetFilesThatWouldBeRemoved(element));
 
             return viewModel;
+        }
+
+        /// <summary>
+        /// One spelling for every file in a delete: absolute, with forward slashes. The lists feeding the
+        /// dialog come from several places - a ReferencedFileSave's content-relative path, an element's
+        /// code path, a plugin's <c>FilePath.FullPath</c> - and used to reach the user exactly as each
+        /// source happened to spell it, so the same list mixed separators and mixed absolute with relative.
+        /// </summary>
+        public static string ToCanonicalPath(string file)
+        {
+            if (string.IsNullOrWhiteSpace(file))
+            {
+                return file;
+            }
+
+            var absolute = FileManager.IsRelative(file)
+                ? GlueCommands.Self.GetAbsoluteFileName(file, false)
+                : file;
+
+            return absolute.Replace('\\', '/');
         }
 
         static void AddResetInheritanceOption(DeleteOptionsViewModel viewModel, GlueElement derivedElement)
@@ -123,47 +145,43 @@ namespace FlatRedBall.Glue.Elements
                 var relativePath = rfs.GetRelativePath();
                 if (!referencedElsewhere.Contains(relativePath))
                 {
-                    toReturn.Add(relativePath);
+                    toReturn.Add(ToCanonicalPath(relativePath));
                 }
             }
 
             FillWithOwnedFiles(toReturn, element);
 
-            return toReturn.Distinct().ToList();
+            return toReturn.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         }
 
         /// <summary>
         /// Adds the code and JSON files an element owns outright - its custom and generated .cs, its event
         /// files and factory if they exist on disk, and its .glsj/.glej. Shared by the planner (to show the
-        /// user) and by the delete itself (to act on).
+        /// user) and by the delete itself (to act on), all as canonical paths.
         /// </summary>
         public static void FillWithOwnedFiles(List<string> filesThatCouldBeRemoved, GlueElement element)
         {
             var elementName = element.Name;
 
-            filesThatCouldBeRemoved.Add(elementName + ".cs");
-            filesThatCouldBeRemoved.Add(elementName + ".Generated.cs");
+            Add(elementName + ".cs");
+            Add(elementName + ".Generated.cs");
 
             AddIfExists(elementName + ".Event.cs");
             AddIfExists(elementName + ".Generated.Event.cs");
-
-            var factoryName = "Factories/" + FileManager.RemovePath(elementName) + "Factory.Generated.cs";
-            var absoluteFactoryName = GlueCommands.Self.GetAbsoluteFileName(factoryName, false);
-            if (System.IO.File.Exists(absoluteFactoryName))
-            {
-                filesThatCouldBeRemoved.Add(absoluteFactoryName);
-            }
+            AddIfExists("Factories/" + FileManager.RemovePath(elementName) + "Factory.Generated.cs");
 
             var extension = element is ScreenSave
                 ? GlueProjectSave.ScreenExtension
                 : GlueProjectSave.EntityExtension;
-            filesThatCouldBeRemoved.Add(elementName + "." + extension);
+            Add(elementName + "." + extension);
+
+            void Add(string relativeFile) => filesThatCouldBeRemoved.Add(ToCanonicalPath(relativeFile));
 
             void AddIfExists(string relativeFile)
             {
                 if (System.IO.File.Exists(GlueCommands.Self.GetAbsoluteFileName(relativeFile, false)))
                 {
-                    filesThatCouldBeRemoved.Add(relativeFile);
+                    Add(relativeFile);
                 }
             }
         }

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.Delete.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.Delete.cs
@@ -1,0 +1,178 @@
+using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.IO;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.IO;
+using FlatRedBall.Utilities;
+using GlueFormsCore.Controls;
+using GlueFormsCore.ViewModels;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
+{
+    /// <summary>
+    /// The plan-ask-execute flow every Screen and Entity delete goes through.
+    ///
+    /// Deleting a Screen used to ask up to four questions from four different places, each one a modal
+    /// that could end up behind the editor window: the confirm, one popup per derived Screen about
+    /// resetting its inheritance, the Gum plugin's own popup about its Screen, and finally the
+    /// leftover-files dialog. They were interleaved with the delete itself, which is also why none of it
+    /// could be tested. See GitHub issue #429.
+    /// </summary>
+    partial class DialogCommands
+    {
+        public async Task<bool> AskToRemoveScreenAsync(ScreenSave screenToRemove, bool askToDeleteFiles = true)
+        {
+            var viewModel = DeletionPlanner.CreateForScreen(screenToRemove);
+
+            if (!ConfirmDelete(viewModel, askToDeleteFiles))
+            {
+                return false;
+            }
+
+            var filesToRemove = new List<string>();
+
+            await TaskManager.Self.AddAsync(
+                async () => await GlueCommands.Self.GluxCommands.RemoveScreenAsync(screenToRemove, viewModel, filesToRemove),
+                $"Removing Screen {screenToRemove}");
+
+            await ApplyFileActionAsync(viewModel, filesToRemove, askToDeleteFiles);
+
+            return true;
+        }
+
+        public async Task<bool> AskToRemoveEntityAsync(EntitySave entityToRemove, bool askToDeleteFiles = true)
+        {
+            var viewModel = DeletionPlanner.CreateForEntity(entityToRemove);
+
+            if (!ConfirmDelete(viewModel, askToDeleteFiles))
+            {
+                return false;
+            }
+
+            var filesToRemove = new List<string>();
+
+            await TaskManager.Self.AddAsync(
+                async () => await GlueCommands.Self.GluxCommands.RemoveEntityAsync(entityToRemove, viewModel, filesToRemove),
+                $"Removing Entity {entityToRemove}");
+
+            await ApplyFileActionAsync(viewModel, filesToRemove, askToDeleteFiles);
+
+            return true;
+        }
+
+        static bool ConfirmDelete(DeleteOptionsViewModel viewModel, bool askToDeleteFiles)
+        {
+            if (!askToDeleteFiles)
+            {
+                // The caller is handling files itself, so the dialog shouldn't offer to.
+                viewModel.AlwaysRemovedFiles.Clear();
+                viewModel.RefreshFilesToRemove();
+                viewModel.FileAction = FileDeleteAction.Nothing;
+            }
+
+            return DialogService.ShowDelete(viewModel);
+        }
+
+        /// <summary>
+        /// Applies the file action the user picked in the delete dialog. <paramref name="actuallyRemoved"/>
+        /// is what the delete itself accumulated; anything in there the plan didn't predict is included so
+        /// a file is never left behind silently, and <c>DeletionPlannerTests</c> pins the two lists to each
+        /// other so the dialog doesn't quietly under-report.
+        /// </summary>
+        async Task ApplyFileActionAsync(DeleteOptionsViewModel viewModel, List<string> actuallyRemoved, bool askToDeleteFiles)
+        {
+            if (!askToDeleteFiles || viewModel.FileAction == FileDeleteAction.Nothing)
+            {
+                return;
+            }
+
+            var files = viewModel.FilesToRemove.Concat(actuallyRemoved).ToList();
+
+            await RemoveFilesAsync(files, deleteFromDisk: viewModel.FileAction == FileDeleteAction.RemoveAndDelete);
+        }
+
+        /// <summary>
+        /// Asks what to do with a list of leftover files and does it. Used by the delete paths that don't
+        /// have their own dialog yet (files, custom variables, states) - Screens and Entities fold this
+        /// question into <see cref="DeleteOptionsWindow"/> instead of showing it separately.
+        /// </summary>
+        public async Task AskWhatToDoWithFilesAsync(List<string> filesToRemove)
+        {
+            if (filesToRemove == null || filesToRemove.Count == 0)
+            {
+                return;
+            }
+
+            var normalized = NormalizeFilePaths(filesToRemove);
+
+            var listBoxWindow = new ListBoxWindowWpf
+            {
+                Message = "What would you like to do with the following files:\n"
+            };
+
+            foreach (var file in normalized)
+            {
+                listBoxWindow.AddItem(file);
+            }
+
+            listBoxWindow.ClearButtons();
+            listBoxWindow.AddButton("Nothing - leave them as part of the game project", FileDeleteAction.Nothing);
+            listBoxWindow.AddButton("Remove them from the project but keep the files", FileDeleteAction.RemoveFromProject);
+            listBoxWindow.AddButton("Remove and delete the files", FileDeleteAction.RemoveAndDelete);
+
+            listBoxWindow.ShowDialog();
+
+            if (listBoxWindow.ClickedOption is FileDeleteAction action && action != FileDeleteAction.Nothing)
+            {
+                await RemoveFilesAsync(normalized, deleteFromDisk: action == FileDeleteAction.RemoveAndDelete);
+            }
+        }
+
+        static async Task RemoveFilesAsync(List<string> files, bool deleteFromDisk)
+        {
+            var normalized = NormalizeFilePaths(files);
+
+            if (normalized.Count == 0)
+            {
+                return;
+            }
+
+            await TaskManager.Self.AddAsync(() =>
+            {
+                foreach (var file in normalized)
+                {
+                    FilePath filePath = GlueCommands.Self.GetAbsoluteFileName(file, false);
+
+                    // The file may have been removed in Windows Explorer and only now removed from Glue,
+                    // so nothing here assumes it still exists.
+                    GlueCommands.Self.ProjectCommands.RemoveFromProjects(filePath, false);
+
+                    if (deleteFromDisk && filePath.Exists())
+                    {
+                        FileHelper.MoveToRecycleBin(filePath.FullPath);
+                    }
+                }
+
+                GluxCommands.Self.ProjectCommands.SaveProjects();
+            }, "Removing files");
+        }
+
+        static List<string> NormalizeFilePaths(List<string> files)
+        {
+            var toReturn = files
+                .Where(item => !string.IsNullOrWhiteSpace(item))
+                .Select(item => (FileManager.IsRelative(item)
+                    ? GlueCommands.Self.GetAbsoluteFileName(item, false)
+                    : item).Replace("\\", "/"))
+                .ToList();
+
+            StringFunctions.RemoveDuplicates(toReturn, true);
+
+            return toReturn;
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.Delete.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.Delete.cs
@@ -108,6 +108,7 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
             }
 
             var normalized = NormalizeFilePaths(filesToRemove);
+            var root = DeletionPlanner.ToCanonicalPath(GlueState.Self.CurrentGlueProjectDirectory);
 
             var listBoxWindow = new ListBoxWindowWpf
             {
@@ -116,7 +117,7 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
 
             foreach (var file in normalized)
             {
-                listBoxWindow.AddItem(file);
+                listBoxWindow.AddItem(DeleteOptionsViewModel.ToDisplayPath(file, root));
             }
 
             listBoxWindow.ClearButtons();
@@ -165,9 +166,7 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
         {
             var toReturn = files
                 .Where(item => !string.IsNullOrWhiteSpace(item))
-                .Select(item => (FileManager.IsRelative(item)
-                    ? GlueCommands.Self.GetAbsoluteFileName(item, false)
-                    : item).Replace("\\", "/"))
+                .Select(DeletionPlanner.ToCanonicalPath)
                 .ToList();
 
             StringFunctions.RemoveDuplicates(toReturn, true);

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
@@ -34,7 +34,7 @@ using System.Reflection;
 
 namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces;
 
-class DialogCommands : IDialogCommands
+partial class DialogCommands : IDialogCommands
 {
     NameVerifier _nameVerifier;
 
@@ -386,58 +386,8 @@ class DialogCommands : IDialogCommands
             await GlueCommands.Self.GluxCommands
                 .RemoveNamedObjectListAsync(namedObjectsToRemove, true, true, filesToRemove);
 
-            if (filesToRemove.Count != 0)
-            {
-
-                for (int i = 0; i < filesToRemove.Count; i++)
-                {
-                    if (FileManager.IsRelative(filesToRemove[i]))
-                    {
-                        filesToRemove[i] = GlueCommands.Self.GetAbsoluteFileName(filesToRemove[i], false);
-                    }
-                    filesToRemove[i] = filesToRemove[i].Replace("\\", "/");
-                }
-
-                StringFunctions.RemoveDuplicates(filesToRemove, true);
-
-                var lbw = new ListBoxWindowWpf();
-
-                string messageString = "What would you like to do with the following files:\n";
-                lbw.Message = messageString;
-
-                foreach (var s in filesToRemove)
-                {
-                    lbw.AddItem(s);
-                }
-                lbw.ClearButtons();
-                lbw.AddButton("Nothing - leave them as part of the game project", DialogResult.No);
-                lbw.AddButton("Remove them from the project but keep the files", DialogResult.OK);
-                lbw.AddButton("Remove and delete the files", DialogResult.Yes);
-
-                lbw.ShowDialog();
-                var result = (DialogResult)lbw.ClickedOption;
-
-                if (result is DialogResult.OK or DialogResult.Yes)
-                {
-                    foreach (var file in filesToRemove)
-                    {
-                        FilePath fileName = GlueCommands.Self.GetAbsoluteFileName(file, false);
-                        // This file may have been removed
-                        // in windows explorer, and now removed
-                        // from Glue.  Check to prevent a crash.
-
-                        GlueCommands.Self.ProjectCommands.RemoveFromProjects(fileName, false);
-                    }
-                }
-
-                if (result == DialogResult.Yes)
-                {
-                    foreach (var fileName in filesToRemove.Select(file => GlueCommands.Self.GetAbsoluteFileName(file, false)).Where(System.IO.File.Exists))
-                    {
-                        FileHelper.MoveToRecycleBin(fileName);
-                    }
-                }
-            }
+            // Same question, same handling as every other delete path - see DialogCommands.Delete.cs.
+            await AskWhatToDoWithFilesAsync(filesToRemove);
 
             TaskManager.Self.AddOrRunIfTasked(() =>
             {
@@ -1153,30 +1103,31 @@ class DialogCommands : IDialogCommands
         caption ??= "Confirm";
         var result = System.Windows.MessageBoxResult.None;
 
-        if (GlueGui.ShowGui)
+        // The GlueGui.ShowGui check that used to live here now lives in DialogService's *default* (WPF)
+        // implementation, where "don't put a modal on a desktop that isn't there" belongs. Keeping it here
+        // meant a headless host never reached the seam at all, so a test could not see that a prompt was
+        // asked - which is how a delete could grow extra dialogs with the tests staying green.
+        //
+        // DialogService.ShowConfirm already marshals to the UI thread, but this stays wrapped in
+        // DoOnUiThread since `result` is captured by the caller synchronously below via DoOnUiThread's
+        // blocking behavior.
+        GlueCommands.Self.DoOnUiThread(() =>
         {
-            // DialogService.ShowConfirm already marshals to the UI thread, but this stays wrapped in
-            // DoOnUiThread since `result` is captured by the caller synchronously below via DoOnUiThread's
-            // blocking behavior.
-            GlueCommands.Self.DoOnUiThread(() =>
-           {
-               var confirmResult = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
+            var confirmResult = DialogService.ShowConfirm(message, DialogButton.Yes, DialogButton.No);
 
-               if (confirmResult == DialogButton.Yes)
-               {
-                   result = System.Windows.MessageBoxResult.Yes;
-                   yesAction?.Invoke();
-               }
-               else if (confirmResult == DialogButton.No)
-               {
-                   result = System.Windows.MessageBoxResult.No;
-                   noAction?.Invoke();
-               }
-               // Escape/close without a button click: confirmResult is null, result stays MessageBoxResult.None,
-               // matching the original WPF MessageBox.Show(...) escape behavior.
-           });
-
-        }
+            if (confirmResult == DialogButton.Yes)
+            {
+                result = System.Windows.MessageBoxResult.Yes;
+                yesAction?.Invoke();
+            }
+            else if (confirmResult == DialogButton.No)
+            {
+                result = System.Windows.MessageBoxResult.No;
+                noAction?.Invoke();
+            }
+            // Escape/close without a button click: confirmResult is null, result stays MessageBoxResult.None,
+            // matching the original WPF MessageBox.Show(...) escape behavior.
+        });
 
         return result;
     }

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
@@ -3168,7 +3168,14 @@ public class GluxCommands : IGluxCommands
         return succeeded;
     }
 
-    public async Task RemoveEntityAsync(EntitySave entityToRemove, List<string> filesThatCouldBeRemoved = null)
+    public Task RemoveEntityAsync(EntitySave entityToRemove, List<string> filesThatCouldBeRemoved = null) =>
+        RemoveEntityAsync(entityToRemove, null, filesThatCouldBeRemoved);
+
+    /// <summary>
+    /// Removes an Entity, applying the answers the user already gave in the single delete dialog. See
+    /// <see cref="RemoveScreenAsync"/> for what a null <paramref name="deleteOptions"/> means.
+    /// </summary>
+    public async Task RemoveEntityAsync(EntitySave entityToRemove, DeleteOptionsViewModel deleteOptions, List<string> filesThatCouldBeRemoved = null)
     {
         // The parameter is an output accumulator, so the documented default overload used to fail at
         // the first Add. RemoveScreen already does this.
@@ -3214,28 +3221,23 @@ public class GluxCommands : IGluxCommands
             GlueCommands.Self.GluxCommands
                 .RemoveNamedObject(nos, false, true, filesThatCouldBeRemoved);
         }
-        for (int i = 0; i < inheritingEntities.Count; i++)
+        // The user already answered this in the delete dialog rather than in one popup per derived entity.
+        foreach (var inheritingEntity in inheritingEntities)
         {
-            EntitySave inheritingEntity = inheritingEntities[i];
-
-            var result = GlueCommands.Self.DialogCommands.ShowYesNoMessageBox("Reset the inheritance for " + inheritingEntity.Name + "?",
-                caption: "Reset Inheritance?");
-
-            if (result == System.Windows.MessageBoxResult.Yes)
+            if (ShouldResetInheritance(deleteOptions, inheritingEntity))
             {
                 inheritingEntity.BaseEntity = "";
                 await CodeWriter.GenerateCode(inheritingEntity);
             }
         }
 
-        FillWithCodeFilesForElement(filesThatCouldBeRemoved, entityToRemove);
-        FillWithJsonFilesForElement(filesThatCouldBeRemoved, entityToRemove);
+        DeletionPlanner.FillWithOwnedFiles(filesThatCouldBeRemoved, entityToRemove);
 
         GlueCommands.Self.GenerateCodeCommands.GenerateAllCode();
 
         EditorObjects.IoC.Container.Get<GlueErrorManager>().ClearFixedErrors();
 
-        PluginManager.ReactToEntityRemoved(entityToRemove, filesThatCouldBeRemoved);
+        PluginManager.ReactToElementRemoved(entityToRemove, deleteOptions);
 
         GlueCommands.Self.ProjectCommands.SaveProjects();
 
@@ -3271,7 +3273,16 @@ public class GluxCommands : IGluxCommands
 
     #region Screen
 
-    public async void RemoveScreen(ScreenSave screenToRemove, List<string> filesThatCouldBeRemoved = null)
+    public async void RemoveScreen(ScreenSave screenToRemove, List<string> filesThatCouldBeRemoved = null) =>
+        await RemoveScreenAsync(screenToRemove, null, filesThatCouldBeRemoved);
+
+    /// <summary>
+    /// Removes a Screen, applying the answers the user already gave in the single delete dialog.
+    /// A null <paramref name="deleteOptions"/> means "no dialog was shown" - every optional part of the
+    /// delete (resetting derived screens' inheritance, anything a plugin contributed) is then skipped,
+    /// so a programmatic caller never silently changes elements it did not name.
+    /// </summary>
+    public async Task RemoveScreenAsync(ScreenSave screenToRemove, DeleteOptionsViewModel deleteOptions, List<string> filesThatCouldBeRemoved = null)
     {
         filesThatCouldBeRemoved = filesThatCouldBeRemoved ?? new List<string>();
         List<ScreenSave> inheritingScreens = ObjectFinder.Self.GetAllScreensThatInheritFrom(screenToRemove);
@@ -3325,14 +3336,10 @@ public class GluxCommands : IGluxCommands
 
         await RemoveUnreferencedFiles(screenToRemove, filesThatCouldBeRemoved);
 
-        for (int i = 0; i < inheritingScreens.Count; i++)
+        // The user already answered this in the delete dialog rather than in one popup per derived screen.
+        foreach (var inheritingScreen in inheritingScreens)
         {
-            ScreenSave inheritingScreen = inheritingScreens[i];
-
-            var result = GlueCommands.Self.DialogCommands.ShowYesNoMessageBox("Reset the inheritance for " + inheritingScreen.Name + "?",
-                caption: "Reset Inheritance?");
-
-            if (result == System.Windows.MessageBoxResult.Yes)
+            if (ShouldResetInheritance(deleteOptions, inheritingScreen))
             {
                 inheritingScreen.BaseScreen = "";
 
@@ -3347,15 +3354,17 @@ public class GluxCommands : IGluxCommands
             GlueCommands.Self.GenerateCodeCommands.GenerateElementCode(baseScreen, generateDerivedElements: false);
         }
 
-        PluginManager.ReactToScreenRemoved(screenToRemove, filesThatCouldBeRemoved);
+        PluginManager.ReactToElementRemoved(screenToRemove, deleteOptions);
 
-
-        FillWithCodeFilesForElement(filesThatCouldBeRemoved, screenToRemove);
-        FillWithJsonFilesForElement(filesThatCouldBeRemoved, screenToRemove);
+        DeletionPlanner.FillWithOwnedFiles(filesThatCouldBeRemoved, screenToRemove);
 
         GlueCommands.Self.ProjectCommands.SaveProjects();
         GluxCommands.Self.SaveProjectAndElements();
     }
+
+    static bool ShouldResetInheritance(DeleteOptionsViewModel deleteOptions, GlueElement derivedElement) =>
+        deleteOptions != null &&
+        deleteOptions.IsOptionChecked(new DeletionPlanner.ResetInheritanceTag { DerivedElement = derivedElement });
 
     private static async Task RemoveUnreferencedFiles(IElement element, List<string> filesThatCouldBeRemoved)
     {
@@ -3379,47 +3388,6 @@ public class GluxCommands : IGluxCommands
             {
                 await GluxCommands.Self.RemoveReferencedFileAsync(rfs, filesThatCouldBeRemoved);
             }
-        }
-    }
-
-    static void FillWithJsonFilesForElement(List<string> filesThatCouldBeRemoved, GlueElement element)
-    {
-        string extension = element is ScreenSave
-            ? GlueProjectSave.ScreenExtension
-            : GlueProjectSave.EntityExtension;
-        filesThatCouldBeRemoved.Add(element.Name + "." + extension);
-    }
-
-    static void FillWithCodeFilesForElement(List<string> filesThatCouldBeRemoved, GlueElement element)
-    {
-        string elementName = element.Name;
-
-
-
-        filesThatCouldBeRemoved.Add(elementName + ".cs");
-
-
-        filesThatCouldBeRemoved.Add(elementName + ".Generated.cs");
-
-        string eventFile = elementName + ".Event.cs";
-        string absoluteEvent = GlueCommands.Self.GetAbsoluteFileName(eventFile, false);
-        if (System.IO.File.Exists(absoluteEvent))
-        {
-            filesThatCouldBeRemoved.Add(eventFile);
-        }
-
-        string generatedEventFile = elementName + ".Generated.Event.cs";
-        string absoluteGeneratedEventFile = GlueCommands.Self.GetAbsoluteFileName(generatedEventFile, false);
-        if (System.IO.File.Exists(absoluteGeneratedEventFile))
-        {
-            filesThatCouldBeRemoved.Add(generatedEventFile);
-        }
-
-        string factoryName = "Factories/" + FileManager.RemovePath(elementName) + "Factory.Generated.cs";
-        string absoluteFactoryNameFile = GlueCommands.Self.GetAbsoluteFileName(factoryName, false);
-        if (System.IO.File.Exists(absoluteFactoryNameFile))
-        {
-            filesThatCouldBeRemoved.Add(absoluteFactoryNameFile);
         }
     }
 
@@ -3805,20 +3773,30 @@ public class GluxCommands : IGluxCommands
                 #region Find out if the user really wants to remove this - don't ask if askAreYouSure is false
                 var reallyRemoveResult = System.Windows.MessageBoxResult.Yes;
 
-                // Some objects may use a custom delete dialog. Those types should be checked here first:
+                // Screens and Entities ask everything - the confirm, the derived-element inheritance
+                // resets, whatever the plugins want, and what to do with the leftover files - in one
+                // dialog, so they take a different path from here down. See GitHub issue #429.
                 if (currentObject is ScreenSave screenToRemove)
                 {
-
-                    await TaskManager.Self.AddAsync(() =>
-                    {
-                        if (AskToRemoveScreen(screenToRemove, filesToRemove))
-                        {
-                            deletedElement = screenToRemove;
-                        }
-
-                    }, "Removing Screen");
+                    var wasRemoved = await GlueCommands.Self.DialogCommands.AskToRemoveScreenAsync(screenToRemove, askToDeleteFiles);
+                    deletedElement = wasRemoved ? screenToRemove : null;
 
                     askAreYouSure = false;
+                    // The dialog was the confirm, so the shared tail below (tree refresh, regenerate,
+                    // save) still runs - but only if the user actually went through with it.
+                    reallyRemoveResult = wasRemoved
+                        ? System.Windows.MessageBoxResult.Yes
+                        : System.Windows.MessageBoxResult.No;
+                }
+                else if (currentObject is EntitySave entityToRemove)
+                {
+                    var wasRemoved = await GlueCommands.Self.DialogCommands.AskToRemoveEntityAsync(entityToRemove, askToDeleteFiles);
+                    deletedElement = wasRemoved ? entityToRemove : null;
+
+                    askAreYouSure = false;
+                    reallyRemoveResult = wasRemoved
+                        ? System.Windows.MessageBoxResult.Yes
+                        : System.Windows.MessageBoxResult.No;
                 }
 
 
@@ -3910,81 +3888,11 @@ public class GluxCommands : IGluxCommands
                     }
                     #endregion
 
-                    #region Else if is EntitySave
-
-                    else if (GlueState.Self.CurrentEntitySave != null)
-                    {
-                        var entityToRemove = GlueState.Self.CurrentEntitySave;
-                        await TaskManager.Self.AddAsync(async () =>
-                        {
-                            await AskToRemoveEntity(GlueState.Self.CurrentEntitySave, filesToRemove);
-                            //ProjectManager.RemoveEntity(EditorLogic.CurrentEntitySave);
-                            deletedElement = entityToRemove;
-                        }, "Removing Entity");
-
-                    }
-
-                    #endregion
-
                     #region Files were deleted and the user wants to be asked to delete
 
-                    if (filesToRemove.Count != 0 && askToDeleteFiles)
+                    if (askToDeleteFiles)
                     {
-
-                        for (int i = 0; i < filesToRemove.Count; i++)
-                        {
-                            if (FileManager.IsRelative(filesToRemove[i]))
-                            {
-                                filesToRemove[i] = GlueCommands.Self.GetAbsoluteFileName(filesToRemove[i], false);
-                            }
-                            filesToRemove[i] = filesToRemove[i].Replace("\\", "/");
-                        }
-
-                        StringFunctions.RemoveDuplicates(filesToRemove, true);
-
-                        var lbw = new ListBoxWindowWpf();
-
-                        string messageString = "What would you like to do with the following files:\n";
-                        lbw.Message = messageString;
-
-                        foreach (string s in filesToRemove)
-                        {
-
-                            lbw.AddItem(s);
-                        }
-                        lbw.ClearButtons();
-                        lbw.AddButton("Nothing - leave them as part of the game project", DialogResult.No);
-                        lbw.AddButton("Remove them from the project but keep the files", DialogResult.OK);
-                        lbw.AddButton("Remove and delete the files", DialogResult.Yes);
-
-                        var dialogShowResult = lbw.ShowDialog();
-
-                        if (lbw.ClickedOption is DialogResult result)
-                        {
-                            if (result == DialogResult.OK || result == DialogResult.Yes)
-                            {
-                                await TaskManager.Self.AddAsync(() =>
-                                {
-                                    foreach (var file in filesToRemove)
-                                    {
-                                        FilePath filePath = GlueCommands.Self.GetAbsoluteFileName(file, false);
-                                        // This file may have been removed
-                                        // in windows explorer, and now removed
-                                        // from Glue.  Check to prevent a crash.
-
-                                        GlueCommands.Self.ProjectCommands.RemoveFromProjects(filePath, false);
-
-                                        if (result == DialogResult.Yes && filePath.Exists())
-                                        {
-                                            FileHelper.MoveToRecycleBin(filePath.FullPath);
-                                        }
-                                    }
-                                    GluxCommands.Self.ProjectCommands.SaveProjects();
-
-                                }, "Removing files");
-                            }
-
-                        }
+                        await GlueCommands.Self.DialogCommands.AskWhatToDoWithFilesAsync(filesToRemove);
                     }
 
                     #endregion
@@ -4039,77 +3947,6 @@ public class GluxCommands : IGluxCommands
 
         }
     }
-
-    private static bool AskToRemoveScreen(ScreenSave screenToRemove, List<string> filesThatCouldBeRemoved)
-    {
-        var message = String.Format("Are you sure you want to delete {0}?", screenToRemove);
-
-        List<ScreenSave> inheritingScreens = ObjectFinder.Self.GetAllScreensThatInheritFrom(screenToRemove);
-        if (inheritingScreens.Count != 0)
-        {
-            message += String.Format("\n\n" + "Warning: the Screen {0} is the base for the following Screens:", screenToRemove.GetStrippedName());
-            for (var i = 0; i < inheritingScreens.Count; i++)
-            {
-                message += "\n" + inheritingScreens[i];
-            }
-        }
-
-        var result = GlueCommands.Self.DialogCommands.ShowYesNoMessageBox(message, "Are you sure?");
-
-        var wasRemoved = false;
-        if (result == System.Windows.MessageBoxResult.Yes)
-        {
-            wasRemoved = true;
-
-            GlueCommands.Self.GluxCommands.RemoveScreen(screenToRemove, filesThatCouldBeRemoved);
-        }
-        return wasRemoved;
-    }
-
-    private static async Task AskToRemoveEntity(EntitySave entityToRemove, List<string> filesThatCouldBeRemoved)
-    {
-        var namedObjectsToRemove = ObjectFinder.Self.GetAllNamedObjectsThatUseEntity(entityToRemove.Name);
-
-        string message = null;
-
-        if (namedObjectsToRemove.Count != 0)
-        {
-            message = String.Format("The Entity {0} is referenced by the following objects:", entityToRemove);
-
-            for (var i = 0; i < namedObjectsToRemove.Count; i++)
-            {
-                message += "\n" + namedObjectsToRemove[i];
-            }
-        }
-
-        var inheritingEntities = ObjectFinder.Self.GetAllEntitiesThatInheritFrom(entityToRemove);
-
-        if (inheritingEntities.Count != 0)
-        {
-            message = String.Format("The Entity {0} is the base for the following Entities:", entityToRemove);
-            for (int i = 0; i < inheritingEntities.Count; i++)
-            {
-                message += "\n" + inheritingEntities[i];
-
-            }
-        }
-
-        if (message != null)
-        {
-            message += "\n\n" + "Are you sure you want to delete?";
-
-            var result = GlueCommands.Self.DialogCommands.ShowYesNoMessageBox(message);
-            if (result == System.Windows.MessageBoxResult.Yes)
-            {
-                await GlueCommands.Self.GluxCommands.RemoveEntityAsync(entityToRemove, filesThatCouldBeRemoved);
-            }
-        }
-        else
-        {
-            await GlueCommands.Self.GluxCommands.RemoveEntityAsync(entityToRemove, filesThatCouldBeRemoved);
-        }
-    }
-
 
     private static void AskToRemoveCustomVariablesWithoutState(IElement element)
     {

--- a/FRBDK/Glue/Glue/Plugins/ExportedInterfaces/CommandInterfaces/IDialogCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedInterfaces/CommandInterfaces/IDialogCommands.cs
@@ -24,6 +24,12 @@ public interface IDialogCommands
 
     AddEntityViewModel CreateAddNewEntityViewModel();
 
+    /// <summary>
+    /// Shows the single delete dialog for an Entity and, if confirmed, removes it. Returns whether it was
+    /// removed. See GitHub issue #429 - this replaced a chain of separate prompts.
+    /// </summary>
+    Task<bool> AskToRemoveEntityAsync(EntitySave entityToRemove, bool askToDeleteFiles = true);
+
     #endregion
 
     #region NamedObjectSave
@@ -40,6 +46,22 @@ public interface IDialogCommands
     #region Screen
 
     void ShowAddNewScreenDialog(AddScreenViewModel viewModel = null);
+
+    /// <summary>
+    /// Shows the single delete dialog for a Screen and, if confirmed, removes it. Returns whether it was
+    /// removed. See GitHub issue #429 - this replaced a chain of separate prompts.
+    /// </summary>
+    Task<bool> AskToRemoveScreenAsync(ScreenSave screenToRemove, bool askToDeleteFiles = true);
+
+    #endregion
+
+    #region Files
+
+    /// <summary>
+    /// Asks what should happen to a list of files a delete left behind, and does it. Screens and Entities
+    /// ask this inside their own delete dialog instead; this is for the paths that don't have one.
+    /// </summary>
+    Task AskWhatToDoWithFilesAsync(List<string> filesToRemove);
 
     #endregion
 

--- a/FRBDK/Glue/Glue/Plugins/ExportedInterfaces/CommandInterfaces/IGluxCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedInterfaces/CommandInterfaces/IGluxCommands.cs
@@ -156,11 +156,23 @@ namespace FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces
 
         Task RemoveEntityAsync(EntitySave entityToRemove, List<string> filesThatCouldBeRemoved = null);
 
+        /// <summary>
+        /// Removes an Entity, applying the answers the user gave in the delete dialog. Pass null for
+        /// <paramref name="deleteOptions"/> to skip every optional part of the delete.
+        /// </summary>
+        Task RemoveEntityAsync(EntitySave entityToRemove, DeleteOptionsViewModel deleteOptions, List<string> filesThatCouldBeRemoved = null);
+
         #endregion
 
         #region Screens
 
         void RemoveScreen(ScreenSave screenToRemove, List<string> filesThatCouldBeRemoved = null);
+
+        /// <summary>
+        /// Removes a Screen, applying the answers the user gave in the delete dialog. Pass null for
+        /// <paramref name="deleteOptions"/> to skip every optional part of the delete.
+        /// </summary>
+        Task RemoveScreenAsync(ScreenSave screenToRemove, DeleteOptionsViewModel deleteOptions, List<string> filesThatCouldBeRemoved = null);
 
         #endregion
 

--- a/FRBDK/Glue/Glue/Plugins/PluginBase.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginBase.cs
@@ -415,18 +415,21 @@ namespace FlatRedBall.Glue.Plugins
         public Action<GlueElement, ReferencedFileSave> ReactToFileRemoved { get; protected set; }
 
         /// <summary>
-        /// Delegate raised whenever an entity is going to be removed. The first argument
-        /// (EntitySave) is the entity to remove. The string list argument is 
-        /// a list of to-be-removed files. Entities can add addiitonal files.
+        /// Delegate raised before the delete dialog for a Screen or Entity is shown, so a plugin can add
+        /// its own checkboxes (and the files those checkboxes bring with them) to the same dialog.
+        /// <b>Do not show a dialog from here</b> - adding an option is how a plugin asks its question now.
+        /// Read the answer back in <see cref="ReactToElementRemoved"/> with
+        /// <c>DeleteOptionsViewModel.IsOptionChecked</c>.
         /// </summary>
-        public Action<EntitySave, List<string>> ReactToEntityRemoved { get; protected set; }
+        public Action<GlueElement, DeleteOptionsViewModel> FillDeleteOptions { get; protected set; }
 
         /// <summary>
-        /// Delegate raised whenever a Screen is removed. The first argument is the screen
-        /// which is being removed. The second argument is a list of files to remove. Plugins
-        /// can optionally add additional files to-be-removed when a Screen is removed.
+        /// Delegate raised when a Screen or Entity has been removed. The view model is the one the user
+        /// answered, so a plugin can act on the options it added in <see cref="FillDeleteOptions"/>. Files a
+        /// plugin wants deleted are declared on its option rather than added here - by this point the user
+        /// has already approved the file list.
         /// </summary>
-        public Action<ScreenSave, List<string>> ReactToScreenRemoved { get; protected set; }
+        public Action<GlueElement, DeleteOptionsViewModel> ReactToElementRemoved { get; protected set; }
 
         public Action<IElement, EventResponseSave> ReactToEventRemoved { get; protected set; }
 

--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -27,6 +27,7 @@ using System.ComponentModel;
 using System.Runtime.Loader;
 using FlatRedBall.Instructions.Reflection;
 using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
+using GlueFormsCore.ViewModels;
 using FlatRedBall.Content.Instructions;
 using FlatRedBall.Glue.Errors;
 using FlatRedBall.Glue.IO;
@@ -1070,16 +1071,22 @@ public class PluginManager : PluginManagerBase
             (plugin) => plugin.ReactToFileRemoved(element, file),
             (plugin) => plugin.ReactToFileRemoved != null);
 
-    internal static void ReactToEntityRemoved(EntitySave entity, List<string> filesToRemove) =>
+    /// <summary>
+    /// Lets every plugin add its own options to the one dialog a delete shows, before it is shown.
+    /// This is public because <c>DeletionPlanner</c> builds the view model outside this assembly's
+    /// plugin internals; see GitHub issue #429.
+    /// </summary>
+    public static void FillDeleteOptions(GlueElement element, DeleteOptionsViewModel viewModel) =>
         CallMethodOnPlugin(
-            plugin => plugin.ReactToEntityRemoved(entity, filesToRemove),
-            plugin => plugin.ReactToEntityRemoved != null,
-            nameof(ReactToEntityRemoved));
+            plugin => plugin.FillDeleteOptions(element, viewModel),
+            plugin => plugin.FillDeleteOptions != null,
+            nameof(FillDeleteOptions));
 
-    internal static void ReactToScreenRemoved(ScreenSave screenSave, List<string> filesToRemove) =>
+    internal static void ReactToElementRemoved(GlueElement element, DeleteOptionsViewModel viewModel) =>
         CallMethodOnPlugin(
-            plugin => plugin.ReactToScreenRemoved(screenSave, filesToRemove),
-            plugin => plugin.ReactToScreenRemoved != null);
+            plugin => plugin.ReactToElementRemoved(element, viewModel),
+            plugin => plugin.ReactToElementRemoved != null,
+            nameof(ReactToElementRemoved));
 
     internal static void ReactToElementVariableChange(GlueElement element, CustomVariable variable, object oldValue)
     {

--- a/FRBDK/Glue/Glue/ViewModels/DeleteOptionsViewModel.cs
+++ b/FRBDK/Glue/Glue/ViewModels/DeleteOptionsViewModel.cs
@@ -105,9 +105,22 @@ namespace GlueFormsCore.ViewModels
         /// <summary>
         /// The files this delete would leave orphaned, kept in sync with which <see cref="Options"/> are
         /// checked. Never assign to this - add to <see cref="AlwaysRemovedFiles"/> or to an option's
-        /// <see cref="DeleteOptionViewModel.AdditionalFilesToRemove"/>.
+        /// <see cref="DeleteOptionViewModel.AdditionalFilesToRemove"/>. These are the paths acted on;
+        /// <see cref="FilesToRemoveDisplay"/> is what the user sees.
         /// </summary>
         public ObservableCollection<string> FilesToRemove { get; } = new ObservableCollection<string>();
+
+        /// <summary>
+        /// <see cref="FilesToRemove"/> shortened to paths relative to <see cref="ProjectRootForDisplay"/>.
+        /// A delete's file list is assembled from several sources that each spell a path their own way, so
+        /// showing them raw mixed separators and mixed absolute with relative in the same list.
+        /// </summary>
+        public ObservableCollection<string> FilesToRemoveDisplay { get; } = new ObservableCollection<string>();
+
+        /// <summary>
+        /// Trimmed off the front of each file for display. Null leaves paths at full length.
+        /// </summary>
+        public string ProjectRootForDisplay { get; set; }
 
         [DependsOn(nameof(FilesToRemove))]
         public Visibility FilesToRemoveVisibility => (FilesToRemove.Count > 0).ToVisibility();
@@ -203,15 +216,46 @@ namespace GlueFormsCore.ViewModels
         {
             var desired = AlwaysRemovedFiles
                 .Concat(CheckedOptions.SelectMany(item => item.AdditionalFilesToRemove))
-                .Where(item => !string.IsNullOrEmpty(item))
-                .Distinct()
+                .Where(item => !string.IsNullOrWhiteSpace(item))
+                .Select(item => item.Replace('\\', '/'))
+                .Distinct(System.StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
             FilesToRemove.Clear();
+            FilesToRemoveDisplay.Clear();
             foreach (var file in desired)
             {
                 FilesToRemove.Add(file);
+                FilesToRemoveDisplay.Add(ToDisplayPath(file, ProjectRootForDisplay));
             }
+        }
+
+        /// <summary>
+        /// Shortens a path to one relative to <paramref name="root"/>, with forward slashes. A file
+        /// outside the project still comes back relative (a "../" chain) rather than as a full path, so
+        /// every row in the list reads the same way.
+        /// </summary>
+        public static string ToDisplayPath(string file, string root)
+        {
+            if (string.IsNullOrWhiteSpace(file) || string.IsNullOrWhiteSpace(root))
+            {
+                return file;
+            }
+
+            var normalizedRoot = root.Replace('\\', '/');
+            if (!normalizedRoot.EndsWith("/"))
+            {
+                normalizedRoot += "/";
+            }
+
+            if (file.StartsWith(normalizedRoot, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return file.Substring(normalizedRoot.Length);
+            }
+
+            // Different drive, no shared root - MakeRelative can't express it, so it hands the path back
+            // unchanged rather than producing something nonsensical.
+            return FlatRedBall.IO.FileManager.MakeRelative(file, normalizedRoot).Replace('\\', '/');
         }
 
         private void HandleOptionsChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/FRBDK/Glue/Glue/ViewModels/DeleteOptionsViewModel.cs
+++ b/FRBDK/Glue/Glue/ViewModels/DeleteOptionsViewModel.cs
@@ -1,0 +1,246 @@
+using FlatRedBall.Glue.MVVM;
+using FlatRedBall.Glue.SaveClasses;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+
+namespace GlueFormsCore.ViewModels
+{
+    /// <summary>
+    /// What should happen to the files that a delete leaves behind. Ordered so the least destructive
+    /// option is first; <see cref="RemoveAndDelete"/> sends files to the recycle bin rather than
+    /// erasing them.
+    /// </summary>
+    public enum FileDeleteAction
+    {
+        /// <summary>
+        /// Leave the files in the game project untouched.
+        /// </summary>
+        Nothing,
+        /// <summary>
+        /// Remove the files from the .csproj but leave them on disk.
+        /// </summary>
+        RemoveFromProject,
+        /// <summary>
+        /// Remove the files from the .csproj and move them to the recycle bin.
+        /// </summary>
+        RemoveAndDelete
+    }
+
+    /// <summary>
+    /// One optional, user-toggleable part of a delete - "reset the inheritance for DerivedScreen",
+    /// "delete the Gum screen GameScreenGum". Plugins add their own through
+    /// <c>PluginManager.FillDeleteOptions</c> so every question a delete needs to ask lands in the same
+    /// dialog instead of in a popup of its own.
+    /// </summary>
+    public class DeleteOptionViewModel : ViewModel
+    {
+        public string Display
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public bool IsChecked
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        /// <summary>
+        /// Identifies the option to whoever added it - the derived ScreenSave for an inheritance-reset
+        /// option, a plugin-defined key for a plugin option. Read back with
+        /// <see cref="DeleteOptionsViewModel.IsOptionChecked"/> after the dialog closes.
+        /// </summary>
+        public object Tag { get; set; }
+
+        /// <summary>
+        /// Files that only become deletable if this option is checked - the Gum screen's generated and
+        /// custom code files, for instance. They appear in <see cref="DeleteOptionsViewModel.FilesToRemove"/>
+        /// while the option is checked and disappear when it is unchecked, so the file list the user
+        /// approves always matches the options they picked.
+        /// </summary>
+        public List<string> AdditionalFilesToRemove { get; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Everything a single delete needs to ask the user, in one object: what is being deleted, what else
+    /// goes with it, which optional parts to include, and what to do with the leftover files.
+    ///
+    /// Built by <see cref="FlatRedBall.Glue.Elements.DeletionPlanner"/> without touching any UI, shown by
+    /// <c>DialogService.ShowDelete</c>, and then read back by the code that performs the delete. That split
+    /// is the point: deleting a Screen used to ask up to four separate questions from four different places
+    /// part-way through the delete itself (see GitHub issue #429).
+    /// </summary>
+    public class DeleteOptionsViewModel : ViewModel
+    {
+        /// <summary>
+        /// The element this delete is for. Null for deletes that aren't element deletes.
+        /// </summary>
+        public GlueElement Element { get; set; }
+
+        public string Message
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        /// <summary>
+        /// Things which are removed as an unavoidable consequence of this delete - objects referencing the
+        /// deleted entity, variables tied to a deleted state. Informational; the user cannot opt out.
+        /// </summary>
+        public ObservableCollection<string> ObjectsToRemove { get; } = new ObservableCollection<string>();
+
+        [DependsOn(nameof(ObjectsToRemove))]
+        public Visibility ObjectsToRemoveVisibility => (ObjectsToRemove.Count > 0).ToVisibility();
+
+        public ObservableCollection<DeleteOptionViewModel> Options { get; } = new ObservableCollection<DeleteOptionViewModel>();
+
+        [DependsOn(nameof(Options))]
+        public Visibility OptionsVisibility => (Options.Count > 0).ToVisibility();
+
+        /// <summary>
+        /// The files this delete would leave orphaned, kept in sync with which <see cref="Options"/> are
+        /// checked. Never assign to this - add to <see cref="AlwaysRemovedFiles"/> or to an option's
+        /// <see cref="DeleteOptionViewModel.AdditionalFilesToRemove"/>.
+        /// </summary>
+        public ObservableCollection<string> FilesToRemove { get; } = new ObservableCollection<string>();
+
+        [DependsOn(nameof(FilesToRemove))]
+        public Visibility FilesToRemoveVisibility => (FilesToRemove.Count > 0).ToVisibility();
+
+        /// <summary>
+        /// Files removed no matter which options the user picks - the deleted element's own code and
+        /// JSON files.
+        /// </summary>
+        public List<string> AlwaysRemovedFiles { get; } = new List<string>();
+
+        public FileDeleteAction FileAction
+        {
+            get => Get<FileDeleteAction>();
+            set => Set(value);
+        }
+
+        #region Radio button bindings for FileAction
+
+        public bool IsDoNothingWithFilesChecked
+        {
+            get => FileAction == FileDeleteAction.Nothing;
+            set { if (value) FileAction = FileDeleteAction.Nothing; }
+        }
+
+        public bool IsRemoveFilesFromProjectChecked
+        {
+            get => FileAction == FileDeleteAction.RemoveFromProject;
+            set { if (value) FileAction = FileDeleteAction.RemoveFromProject; }
+        }
+
+        public bool IsRemoveAndDeleteFilesChecked
+        {
+            get => FileAction == FileDeleteAction.RemoveAndDelete;
+            set { if (value) FileAction = FileDeleteAction.RemoveAndDelete; }
+        }
+
+        #endregion
+
+        public DeleteOptionsViewModel()
+        {
+            // Default to the action that leaves the project in the state the user asked for: the listed
+            // files are the deleted element's own code and content, which nothing references any more.
+            // They go to the recycle bin, not to nowhere.
+            FileAction = FileDeleteAction.RemoveAndDelete;
+
+            ObjectsToRemove.CollectionChanged += (_, __) => NotifyPropertyChanged(nameof(ObjectsToRemove));
+            FilesToRemove.CollectionChanged += (_, __) => NotifyPropertyChanged(nameof(FilesToRemove));
+            Options.CollectionChanged += HandleOptionsChanged;
+        }
+
+        protected override void NotifyPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
+        {
+            base.NotifyPropertyChanged(propertyName);
+
+            if (propertyName == nameof(FileAction))
+            {
+                base.NotifyPropertyChanged(nameof(IsDoNothingWithFilesChecked));
+                base.NotifyPropertyChanged(nameof(IsRemoveFilesFromProjectChecked));
+                base.NotifyPropertyChanged(nameof(IsRemoveAndDeleteFilesChecked));
+            }
+        }
+
+        /// <summary>
+        /// Adds a checkbox to the dialog. Checked by default, because every one of these replaced a
+        /// prompt whose default answer was the action itself.
+        /// </summary>
+        public DeleteOptionViewModel AddOption(string display, object tag = null, bool isChecked = true)
+        {
+            var option = new DeleteOptionViewModel
+            {
+                Display = display,
+                Tag = tag,
+                IsChecked = isChecked
+            };
+            Options.Add(option);
+            return option;
+        }
+
+        /// <summary>
+        /// Whether the user left the option with this tag checked. Returns false when no option has the
+        /// tag, so a plugin that didn't add an option never acts on one.
+        /// </summary>
+        public bool IsOptionChecked(object tag) =>
+            Options.Any(item => Equals(item.Tag, tag) && item.IsChecked);
+
+        public IEnumerable<DeleteOptionViewModel> CheckedOptions => Options.Where(item => item.IsChecked);
+
+        /// <summary>
+        /// Rebuilds <see cref="FilesToRemove"/> from <see cref="AlwaysRemovedFiles"/> plus the files of
+        /// every checked option, de-duplicated. Called automatically whenever an option is toggled.
+        /// </summary>
+        public void RefreshFilesToRemove()
+        {
+            var desired = AlwaysRemovedFiles
+                .Concat(CheckedOptions.SelectMany(item => item.AdditionalFilesToRemove))
+                .Where(item => !string.IsNullOrEmpty(item))
+                .Distinct()
+                .ToList();
+
+            FilesToRemove.Clear();
+            foreach (var file in desired)
+            {
+                FilesToRemove.Add(file);
+            }
+        }
+
+        private void HandleOptionsChanged(object sender, NotifyCollectionChangedEventArgs args)
+        {
+            if (args.OldItems != null)
+            {
+                foreach (DeleteOptionViewModel option in args.OldItems)
+                {
+                    option.PropertyChanged -= HandleOptionPropertyChanged;
+                }
+            }
+            if (args.NewItems != null)
+            {
+                foreach (DeleteOptionViewModel option in args.NewItems)
+                {
+                    option.PropertyChanged += HandleOptionPropertyChanged;
+                }
+            }
+
+            NotifyPropertyChanged(nameof(Options));
+            RefreshFilesToRemove();
+        }
+
+        private void HandleOptionPropertyChanged(object sender, PropertyChangedEventArgs args)
+        {
+            if (args.PropertyName == nameof(DeleteOptionViewModel.IsChecked))
+            {
+                RefreshFilesToRemove();
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
@@ -350,21 +350,24 @@ public class MainGumPlugin : PluginBase
             String.Format(Localization.Texts.GumConfirmDeleteScreen, gumScreen.Name, element),
             DeleteGumScreenOptionTag);
 
-        option.AdditionalFilesToRemove.Add(CodeGeneratorManager.Self.CustomRuntimeCodeLocationFor(gumScreen).FullPath);
-        option.AdditionalFilesToRemove.Add(CodeGeneratorManager.Self.GeneratedRuntimeCodeLocationFor(gumScreen).FullPath);
+        AddFile(CodeGeneratorManager.Self.CustomRuntimeCodeLocationFor(gumScreen));
+        AddFile(CodeGeneratorManager.Self.GeneratedRuntimeCodeLocationFor(gumScreen));
 
         // If there are forms screens, remove those too:
         var formsCustomFilePath = CodeGeneratorManager.Self.CustomFormsCodeLocationFor(gumScreen);
         if (formsCustomFilePath.Exists())
         {
-            option.AdditionalFilesToRemove.Add(formsCustomFilePath.FullPath);
+            AddFile(formsCustomFilePath);
         }
 
         var formsGeneratedFilePath = CodeGeneratorManager.Self.GeneratedFormsCodeLocationFor(gumScreen);
         if (formsGeneratedFilePath.Exists())
         {
-            option.AdditionalFilesToRemove.Add(formsGeneratedFilePath.FullPath);
+            AddFile(formsGeneratedFilePath);
         }
+
+        void AddFile(FilePath filePath) =>
+            option.AdditionalFilesToRemove.Add(DeletionPlanner.ToCanonicalPath(filePath.FullPath));
     }
 
     private void HandleElementRemoved(GlueElement element, DeleteOptionsViewModel viewModel)

--- a/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
@@ -23,6 +23,7 @@ using GumPlugin.CodeGeneration;
 using GumPlugin.Controls;
 using GumPlugin.Managers;
 using GumPlugin.ViewModels;
+using GlueFormsCore.ViewModels;
 using HQ.Util.Unmanaged;
 
 namespace GumPlugin;
@@ -160,7 +161,8 @@ public class MainGumPlugin : PluginBase
 
         this.NewScreenCreated += HandleNewScreen;
 
-        this.ReactToScreenRemoved += HandleScreenRemoved;
+        this.FillDeleteOptions += HandleFillDeleteOptions;
+        this.ReactToElementRemoved += HandleElementRemoved;
 
         #endregion
 
@@ -325,45 +327,72 @@ public class MainGumPlugin : PluginBase
     }
 
 
-    private void HandleScreenRemoved(FlatRedBall.Glue.SaveClasses.ScreenSave glueScreen, List<string> listToFillWithAdditionalFilesToRemove)
+    /// <summary>
+    /// Tag for the "also delete the Gum screen" option, so the answer can be read back in
+    /// <see cref="HandleElementRemoved"/> without matching on display text.
+    /// </summary>
+    const string DeleteGumScreenOptionTag = "GumPlugin.DeleteGumScreen";
+
+    /// <summary>
+    /// Adds the Gum screen question as a checkbox on Glue's delete dialog. This used to be a separate
+    /// MessageBox raised part-way through the delete, which is the second popup GitHub issue #429 is about.
+    /// </summary>
+    private void HandleFillDeleteOptions(GlueElement element, DeleteOptionsViewModel viewModel)
     {
-        if (AppState.Self.GumProjectSave != null)
+        var gumScreen = GetGumScreenFor(element);
+
+        if (gumScreen == null)
         {
-            var gumScreenName = GumPluginCommands.Self.GetExpectedGumScreenNameFor(glueScreen);
-
-            var gumScreen = AppState.Self.GumProjectSave.Screens.FirstOrDefault(item => item.Name == gumScreenName);
-
-            if (gumScreen != null)
-            {
-                var result = GlueCommands.Self.DialogCommands.ShowYesNoMessageBox(
-                    String.Format(Localization.Texts.GumConfirmDeleteScreen, gumScreen.Name, glueScreen));
-                if (result == System.Windows.MessageBoxResult.Yes)
-                {
-                    // don't await this, we want this method to immediately add to the lists
-                    _ = GumPluginCommands.Self.RemoveScreen(gumScreen);
-
-                    listToFillWithAdditionalFilesToRemove.Add(CodeGeneratorManager.Self.CustomRuntimeCodeLocationFor(gumScreen).FullPath);
-                    listToFillWithAdditionalFilesToRemove.Add(CodeGeneratorManager.Self.GeneratedRuntimeCodeLocationFor(gumScreen).FullPath);
-
-                    // If there are forms screens, remove those too:
-                    var formsCustomFilePath = CodeGeneratorManager.Self.CustomFormsCodeLocationFor(gumScreen);
-
-                    if (formsCustomFilePath.Exists())
-                    {
-                        listToFillWithAdditionalFilesToRemove.Add(formsCustomFilePath.FullPath);
-                    }
-
-                    var formsGeneratedFilePath = CodeGeneratorManager.Self.GeneratedFormsCodeLocationFor(gumScreen);
-                    if (formsGeneratedFilePath.Exists())
-                    {
-                        listToFillWithAdditionalFilesToRemove.Add(formsGeneratedFilePath.FullPath);
-                    }
-                }
-
-            }
-
-
+            return;
         }
+
+        var option = viewModel.AddOption(
+            String.Format(Localization.Texts.GumConfirmDeleteScreen, gumScreen.Name, element),
+            DeleteGumScreenOptionTag);
+
+        option.AdditionalFilesToRemove.Add(CodeGeneratorManager.Self.CustomRuntimeCodeLocationFor(gumScreen).FullPath);
+        option.AdditionalFilesToRemove.Add(CodeGeneratorManager.Self.GeneratedRuntimeCodeLocationFor(gumScreen).FullPath);
+
+        // If there are forms screens, remove those too:
+        var formsCustomFilePath = CodeGeneratorManager.Self.CustomFormsCodeLocationFor(gumScreen);
+        if (formsCustomFilePath.Exists())
+        {
+            option.AdditionalFilesToRemove.Add(formsCustomFilePath.FullPath);
+        }
+
+        var formsGeneratedFilePath = CodeGeneratorManager.Self.GeneratedFormsCodeLocationFor(gumScreen);
+        if (formsGeneratedFilePath.Exists())
+        {
+            option.AdditionalFilesToRemove.Add(formsGeneratedFilePath.FullPath);
+        }
+    }
+
+    private void HandleElementRemoved(GlueElement element, DeleteOptionsViewModel viewModel)
+    {
+        if (viewModel?.IsOptionChecked(DeleteGumScreenOptionTag) != true)
+        {
+            return;
+        }
+
+        var gumScreen = GetGumScreenFor(element);
+
+        if (gumScreen != null)
+        {
+            // don't await this, the delete has already been approved and the files are already listed
+            _ = GumPluginCommands.Self.RemoveScreen(gumScreen);
+        }
+    }
+
+    private static Gum.DataTypes.ScreenSave GetGumScreenFor(GlueElement element)
+    {
+        if (AppState.Self.GumProjectSave == null || !(element is FlatRedBall.Glue.SaveClasses.ScreenSave glueScreen))
+        {
+            return null;
+        }
+
+        var gumScreenName = GumPluginCommands.Self.GetExpectedGumScreenNameFor(glueScreen);
+
+        return AppState.Self.GumProjectSave.Screens.FirstOrDefault(item => item.Name == gumScreenName);
     }
 
     private void HandleItemSelected(ITreeNode selectedTreeNode)

--- a/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/DeleteElementTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/DeleteElementTests.cs
@@ -1,0 +1,259 @@
+﻿using FlatRedBall.Glue.Controls;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueFormsCore.ViewModels;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.CommandInterfaces;
+
+/// <summary>
+/// Deleting a Screen used to ask up to four separate questions - the confirm, one popup per derived Screen
+/// about resetting its inheritance, the Gum plugin's own popup about its Screen, and the leftover-files
+/// dialog - each of them a modal that could end up behind the editor window, and each raised part-way
+/// through the delete itself. These pin the single-dialog replacement: everything is asked once, up front,
+/// and the delete then applies the answers. See GitHub issue #429.
+/// </summary>
+[Trait("Category", "BuildSmoke")]
+public class DeleteElementTests : IDisposable
+{
+    private readonly Func<DeleteOptionsViewModel, bool> _originalShowDeleteImpl = DialogService.ShowDeleteImpl;
+    private readonly Func<string, DialogButton, DialogButton, DialogButton?> _originalShowConfirmImpl = DialogService.ShowConfirmImpl;
+    private readonly Func<string, (string label, object value)[], object> _originalShowChoiceImpl = DialogService.ShowChoiceImpl;
+
+    /// <summary>
+    /// Every view model handed to the one delete dialog, in order. Length is the assertion that matters:
+    /// the whole point of the issue is that a delete asks once.
+    /// </summary>
+    private readonly List<DeleteOptionsViewModel> _shownDeleteDialogs = new();
+
+    /// <summary>
+    /// Anything that reached one of the *other* dialog seams during a delete. A delete that populates this
+    /// is asking a question outside the single dialog, which is the regression being guarded against.
+    /// </summary>
+    private readonly List<string> _otherPrompts = new();
+
+    public DeleteElementTests()
+    {
+        DialogService.ShowConfirmImpl = (text, _, __) => { _otherPrompts.Add(text); return null; };
+        DialogService.ShowChoiceImpl = (text, _) => { _otherPrompts.Add(text); return null; };
+    }
+
+    public void Dispose()
+    {
+        DialogService.ShowDeleteImpl = _originalShowDeleteImpl;
+        DialogService.ShowConfirmImpl = _originalShowConfirmImpl;
+        DialogService.ShowChoiceImpl = _originalShowChoiceImpl;
+    }
+
+    /// <summary>
+    /// Answers the delete dialog the way a user would: records what it was asked, optionally adjusts the
+    /// options, and clicks Delete.
+    /// </summary>
+    private void AnswerDeleteDialog(Action<DeleteOptionsViewModel> adjust = null, bool confirm = true)
+    {
+        DialogService.ShowDeleteImpl = viewModel =>
+        {
+            _shownDeleteDialogs.Add(viewModel);
+            adjust?.Invoke(viewModel);
+            return confirm;
+        };
+    }
+
+    private static async Task<(ScreenSave baseScreen, ScreenSave derived)> AddScreenWithDerivedAsync(
+        string baseName, string derivedName)
+    {
+        var baseScreen = await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen(baseName);
+        var derived = await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen(derivedName);
+
+        derived.BaseScreen = baseScreen.Name;
+
+        return (baseScreen, derived);
+    }
+
+    private static async Task<TempDir> LoadFormsSampleAsync()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        var project = GoldProject.CopyOutOfRepo("Samples/FormsSampleProject");
+        await GoldProject.LoadInGlueAsync(
+            Path.Combine(project.Root, "FormsSampleProject", "FormsSampleProject.csproj"));
+
+        return project;
+    }
+
+    // The reported symptom, stated as a count. Before the fix this screen produced a confirm, then one
+    // "Reset the inheritance for..." popup per derived screen from inside RemoveScreen, then the Gum
+    // plugin's own popup from inside ReactToScreenRemoved.
+    [StaFact]
+    public async Task DeletingAScreenWithDerivedScreens_ShouldAskTheUserExactlyOnce()
+    {
+        using var project = await LoadFormsSampleAsync();
+
+        var (baseScreen, _) = await AddScreenWithDerivedAsync("DoomedBaseScreen", "DerivedOfDoomedScreen");
+        await AddScreenWithDerivedAsync("Unused", "SecondDerivedOfDoomedScreen");
+        ObjectFinder.Self.GlueProject.Screens
+            .First(item => item.Name.EndsWith("SecondDerivedOfDoomedScreen")).BaseScreen = baseScreen.Name;
+
+        AnswerDeleteDialog();
+
+        var wasRemoved = await GlueCommands.Self.DialogCommands.AskToRemoveScreenAsync(baseScreen);
+
+        wasRemoved.ShouldBeTrue();
+        _shownDeleteDialogs.Count.ShouldBe(1);
+        _otherPrompts.ShouldBeEmpty(
+            "every question a delete asks belongs in the one delete dialog: " + string.Join(" | ", _otherPrompts));
+    }
+
+    // The two derived screens are two separate opt-in choices in that one dialog, not two popups.
+    [StaFact]
+    public async Task TheDeleteDialog_ShouldOfferOneInheritanceResetOption_PerDerivedScreen()
+    {
+        using var project = await LoadFormsSampleAsync();
+
+        var (baseScreen, derived) = await AddScreenWithDerivedAsync("OptionBaseScreen", "OptionDerivedScreen");
+
+        AnswerDeleteDialog(confirm: false);
+
+        await GlueCommands.Self.DialogCommands.AskToRemoveScreenAsync(baseScreen);
+
+        var viewModel = _shownDeleteDialogs.Single();
+        viewModel.IsOptionChecked(new DeletionPlanner.ResetInheritanceTag { DerivedElement = derived })
+            .ShouldBeTrue();
+    }
+
+    [StaFact]
+    public async Task DeletingABaseScreen_ShouldResetTheDerivedScreensInheritance_WhenThatOptionIsChecked()
+    {
+        using var project = await LoadFormsSampleAsync();
+
+        var (baseScreen, derived) = await AddScreenWithDerivedAsync("CheckedBaseScreen", "CheckedDerivedScreen");
+
+        AnswerDeleteDialog(viewModel =>
+        {
+            foreach (var option in viewModel.Options)
+            {
+                option.IsChecked = true;
+            }
+        });
+
+        await GlueCommands.Self.DialogCommands.AskToRemoveScreenAsync(baseScreen);
+
+        derived.BaseScreen.ShouldBe("");
+    }
+
+    [StaFact]
+    public async Task DeletingABaseScreen_ShouldLeaveTheDerivedScreensInheritanceAlone_WhenThatOptionIsUnchecked()
+    {
+        using var project = await LoadFormsSampleAsync();
+
+        var (baseScreen, derived) = await AddScreenWithDerivedAsync("UncheckedBaseScreen", "UncheckedDerivedScreen");
+        var originalBaseName = derived.BaseScreen;
+
+        AnswerDeleteDialog(viewModel =>
+        {
+            foreach (var option in viewModel.Options)
+            {
+                option.IsChecked = false;
+            }
+        });
+
+        await GlueCommands.Self.DialogCommands.AskToRemoveScreenAsync(baseScreen);
+
+        derived.BaseScreen.ShouldBe(originalBaseName);
+    }
+
+    [StaFact]
+    public async Task CancellingTheDeleteDialog_ShouldLeaveTheScreenInTheProject()
+    {
+        using var project = await LoadFormsSampleAsync();
+
+        var screen = await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen("SurvivingScreen");
+
+        AnswerDeleteDialog(confirm: false);
+
+        var wasRemoved = await GlueCommands.Self.DialogCommands.AskToRemoveScreenAsync(screen);
+
+        wasRemoved.ShouldBeFalse();
+        ObjectFinder.Self.GlueProject.Screens.ShouldContain(screen);
+    }
+
+    // Entities take the same path, which is the point of unifying them - a fix or a regression on one is a
+    // fix or a regression on both.
+    [StaFact]
+    public async Task DeletingAnEntity_ShouldAskTheUserExactlyOnce_AndHonorTheInheritanceOption()
+    {
+        using var project = await LoadFormsSampleAsync();
+
+        var baseEntity = await GlueCommands.Self.GluxCommands.EntityCommands.AddEntityAsync(
+            new GlueFormsCore.ViewModels.AddEntityViewModel { Name = "DoomedBaseEntity" });
+        var derivedEntity = await GlueCommands.Self.GluxCommands.EntityCommands.AddEntityAsync(
+            new GlueFormsCore.ViewModels.AddEntityViewModel { Name = "DerivedOfDoomedEntity" });
+        derivedEntity.BaseEntity = baseEntity.Name;
+
+        AnswerDeleteDialog();
+
+        var wasRemoved = await GlueCommands.Self.DialogCommands.AskToRemoveEntityAsync(baseEntity);
+
+        wasRemoved.ShouldBeTrue();
+        _shownDeleteDialogs.Count.ShouldBe(1);
+        _otherPrompts.ShouldBeEmpty(
+            "every question a delete asks belongs in the one delete dialog: " + string.Join(" | ", _otherPrompts));
+        derivedEntity.BaseEntity.ShouldBe("");
+    }
+
+    // The dialog lists the files up front, before the delete has run, so the planner has to predict what
+    // the delete will produce. This is the guard against the two drifting apart and the dialog quietly
+    // under-reporting what it is about to delete.
+    [StaFact]
+    public async Task ThePlannedFileList_ShouldCoverEveryFileTheDeleteActuallyProduces()
+    {
+        using var project = await LoadFormsSampleAsync();
+
+        var screen = await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen("FileListScreen");
+
+        List<string> planned = null;
+        AnswerDeleteDialog(viewModel => planned = viewModel.FilesToRemove.ToList());
+
+        var actual = new List<string>();
+        var executionViewModel = DeletionPlanner.CreateForScreen(screen);
+        await GlueCommands.Self.GluxCommands.RemoveScreenAsync(screen, executionViewModel, actual);
+
+        planned = DeletionPlanner.GetFilesThatWouldBeRemoved(screen);
+
+        foreach (var file in actual)
+        {
+            planned.ShouldContain(file,
+                $"the delete produced {file}, which the dialog never showed the user");
+        }
+    }
+
+    // The Gum plugin used to raise its own MessageBox from inside ReactToScreenRemoved. It now contributes
+    // a checkbox to the same dialog, which is the plugin half of the fix.
+    [StaFact]
+    public async Task TheGumPlugin_ShouldContributeAnOptionToTheDeleteDialog_RatherThanShowingItsOwn()
+    {
+        using var project = await LoadFormsSampleAsync();
+
+        // MainMenu is the sample's Screen that has a matching Gum screen.
+        var screen = ObjectFinder.Self.GlueProject.Screens
+            .First(item => item.Name.EndsWith("MainMenu"));
+
+        AnswerDeleteDialog(confirm: false);
+
+        await GlueCommands.Self.DialogCommands.AskToRemoveScreenAsync(screen);
+
+        var viewModel = _shownDeleteDialogs.Single();
+        viewModel.Options.ShouldContain(
+            option => Equals(option.Tag, "GumPlugin.DeleteGumScreen"),
+            "the Gum plugin should ask about its screen as a checkbox in Glue's delete dialog");
+        _otherPrompts.ShouldBeEmpty();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/DeleteOptionsViewModelTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/DeleteOptionsViewModelTests.cs
@@ -65,6 +65,45 @@ public class DeleteOptionsViewModelTests
         viewModel.FilesToRemove.Count(item => item == "Screens/GameScreen.cs").ShouldBe(1);
     }
 
+    // The list is assembled from a ReferencedFileSave's content-relative path, an element's code path and
+    // a plugin's FilePath.FullPath, so left raw it showed backslashes next to forward slashes and full
+    // paths next to relative ones in the same list.
+    [Fact]
+    public void FilesToRemoveDisplay_ShouldBeProjectRelative_WithForwardSlashes()
+    {
+        var viewModel = new DeleteOptionsViewModel { ProjectRootForDisplay = "C:/Projects/MyGame" };
+        viewModel.AlwaysRemovedFiles.Add(@"C:\Projects\MyGame\Screens\NewScreen.cs");
+        viewModel.AlwaysRemovedFiles.Add("C:/Projects/MyGame/GumRuntimes/NewScreenRuntime.Generated.cs");
+        viewModel.RefreshFilesToRemove();
+
+        viewModel.FilesToRemoveDisplay.ShouldBe(new[]
+        {
+            "Screens/NewScreen.cs",
+            "GumRuntimes/NewScreenRuntime.Generated.cs"
+        });
+    }
+
+    [Fact]
+    public void FilesToRemoveDisplay_ShouldStayRelative_ForAFileOutsideTheProject()
+    {
+        var viewModel = new DeleteOptionsViewModel { ProjectRootForDisplay = "C:/Projects/MyGame" };
+        viewModel.AlwaysRemovedFiles.Add("C:/Projects/SharedArt/Tileset.png");
+        viewModel.RefreshFilesToRemove();
+
+        viewModel.FilesToRemoveDisplay.Single().ShouldBe("../SharedArt/Tileset.png");
+    }
+
+    [Fact]
+    public void FilesToRemove_ShouldNotTreatSeparatorDifferencesAsDifferentFiles()
+    {
+        var viewModel = new DeleteOptionsViewModel();
+        viewModel.AlwaysRemovedFiles.Add(@"C:\Projects\MyGame\Screens\NewScreen.cs");
+        viewModel.AlwaysRemovedFiles.Add("C:/Projects/MyGame/Screens/NewScreen.cs");
+        viewModel.RefreshFilesToRemove();
+
+        viewModel.FilesToRemove.Count.ShouldBe(1);
+    }
+
     [Fact]
     public void AddOption_ShouldCheckTheOptionByDefault()
     {

--- a/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/DeleteOptionsViewModelTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/DeleteOptionsViewModelTests.cs
@@ -1,0 +1,108 @@
+using GlueFormsCore.ViewModels;
+using Shouldly;
+using System.Linq;
+using Xunit;
+
+namespace GlueUnitTests.ViewModels;
+
+/// <summary>
+/// The delete dialog lists the files it is about to delete while the user is still toggling options, so
+/// the list has to track the options rather than being computed once. Unchecking "delete the Gum screen"
+/// has to take the Gum screen's code files back out of the list, or the user approves a list that no
+/// longer describes what happens. See GitHub issue #429.
+/// </summary>
+public class DeleteOptionsViewModelTests
+{
+    [Fact]
+    public void FilesToRemove_ShouldStartWithTheFilesThatGoRegardless()
+    {
+        var viewModel = new DeleteOptionsViewModel();
+        viewModel.AlwaysRemovedFiles.Add("Screens/GameScreen.cs");
+        viewModel.RefreshFilesToRemove();
+
+        viewModel.FilesToRemove.ShouldBe(new[] { "Screens/GameScreen.cs" });
+    }
+
+    [Fact]
+    public void CheckingAnOption_ShouldAddItsFilesToTheList()
+    {
+        var viewModel = new DeleteOptionsViewModel();
+        viewModel.AlwaysRemovedFiles.Add("Screens/GameScreen.cs");
+
+        var option = viewModel.AddOption("Delete the Gum screen", isChecked: false);
+        option.AdditionalFilesToRemove.Add("GumRuntimes/GameScreenRuntime.Generated.cs");
+
+        viewModel.FilesToRemove.ShouldNotContain("GumRuntimes/GameScreenRuntime.Generated.cs");
+
+        option.IsChecked = true;
+
+        viewModel.FilesToRemove.ShouldContain("GumRuntimes/GameScreenRuntime.Generated.cs");
+    }
+
+    [Fact]
+    public void UncheckingAnOption_ShouldTakeItsFilesBackOut()
+    {
+        var viewModel = new DeleteOptionsViewModel();
+        var option = viewModel.AddOption("Delete the Gum screen");
+        option.AdditionalFilesToRemove.Add("GumRuntimes/GameScreenRuntime.Generated.cs");
+        viewModel.RefreshFilesToRemove();
+
+        option.IsChecked = false;
+
+        viewModel.FilesToRemove.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FilesToRemove_ShouldNotListTheSameFileTwice()
+    {
+        var viewModel = new DeleteOptionsViewModel();
+        viewModel.AlwaysRemovedFiles.Add("Screens/GameScreen.cs");
+
+        var option = viewModel.AddOption("Something");
+        option.AdditionalFilesToRemove.Add("Screens/GameScreen.cs");
+        viewModel.RefreshFilesToRemove();
+
+        viewModel.FilesToRemove.Count(item => item == "Screens/GameScreen.cs").ShouldBe(1);
+    }
+
+    [Fact]
+    public void AddOption_ShouldCheckTheOptionByDefault()
+    {
+        // Every option replaced a prompt whose expected answer was Yes, so an unattended Delete does the
+        // same thing the old chain of popups did when the user clicked through it.
+        new DeleteOptionsViewModel().AddOption("Reset the inheritance for Derived").IsChecked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsOptionChecked_ShouldBeFalse_ForATagNoOptionUses()
+    {
+        // A plugin that added no option must never read back "true" and act on a delete it didn't ask about.
+        new DeleteOptionsViewModel().IsOptionChecked("SomeOtherPlugin.Option").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsOptionChecked_ShouldBeFalse_WhenTheUserUncheckedIt()
+    {
+        var viewModel = new DeleteOptionsViewModel();
+        viewModel.AddOption("Delete the Gum screen", "GumPlugin.DeleteGumScreen").IsChecked = false;
+
+        viewModel.IsOptionChecked("GumPlugin.DeleteGumScreen").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FileAction_ShouldDefaultToRemovingAndDeleting()
+    {
+        // The listed files are the deleted element's own code and content; they go to the recycle bin.
+        new DeleteOptionsViewModel().FileAction.ShouldBe(FileDeleteAction.RemoveAndDelete);
+    }
+
+    [Fact]
+    public void PickingAFileActionRadioButton_ShouldClearTheOthers()
+    {
+        var viewModel = new DeleteOptionsViewModel { IsDoNothingWithFilesChecked = true };
+
+        viewModel.FileAction.ShouldBe(FileDeleteAction.Nothing);
+        viewModel.IsRemoveAndDeleteFilesChecked.ShouldBeFalse();
+        viewModel.IsRemoveFilesFromProjectChecked.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Deleting a Screen asked up to four separate questions, each a modal that could end up behind the editor window, and each raised **part-way through the delete itself**:

1. "Are you sure?" — `GluxCommands.AskToRemoveScreen`
2. "Reset the inheritance for X?" — one per derived Screen, from inside `RemoveScreen`
3. "Delete the Gum Screen X?" — from inside GumPlugin's `ReactToScreenRemoved`
4. "What would you like to do with these files?" — at the end

Interleaving *ask* with *do* is also why none of it could be tested, and why the leftover-files block was copy-pasted in `GluxCommands` and `DialogCommands`.

## Now: plan → ask once → execute

- **`DeletionPlanner`** builds a `DeleteOptionsViewModel` without touching UI or mutating anything: the message, the cascading objects, one checkbox per derived element, and the file list.
- **`DeleteOptionsWindow`** shows it once. The file question is a radio group inside it, not a second dialog.
- **`GluxCommands.RemoveScreenAsync`/`RemoveEntityAsync`** take the answered view model and apply it. Passing `null` skips every optional part, so a programmatic caller never silently edits elements it didn't name.
- **`DialogService.ShowDelete`** is the seam, matching the existing `ShowMessage`/`ShowConfirm`/`ShowChoice` pattern, so tests drive the whole flow headlessly.

Screens and Entities now share one path, so a fix or regression on one is a fix or regression on both.

## Plugin API (breaking, all in-repo plugins converted)

`ReactToScreenRemoved` and `ReactToEntityRemoved` are replaced by:

- `FillDeleteOptions(GlueElement, DeleteOptionsViewModel)` — called before the dialog; add a checkbox instead of showing your own dialog. Files your option would delete go on the option, so they appear/disappear from the list as it's toggled.
- `ReactToElementRemoved(GlueElement, DeleteOptionsViewModel)` — read your answer back with `IsOptionChecked`.

Converted: GumPlugin (its popup is now a checkbox), GameCommunicationPlugin's toolbar refresh, EntityInputMovementPlugin.

## Other changes worth flagging

- `ShowYesNoMessageBox`'s `GlueGui.ShowGui` guard moved down into `DialogService`'s default WPF implementation. Same behavior, but a headless host now *reaches* the seam — without this a test cannot observe that a prompt was asked, which is exactly how a delete could grow extra dialogs with the suite staying green.
- File-list logic lives once, in `DeletionPlanner.FillWithOwnedFiles`, shared by the planner and the delete, so the list shown up front can't drift from what actually happens. A test asserts the executed list is covered by the plan.
- The duplicated leftover-files dialog is now `DialogCommands.AskWhatToDoWithFilesAsync`, used by the remaining non-element delete paths.
- Default file action is "remove from project and delete" (recycle bin) — the listed files are the deleted element's own code and content.

## Tests

Red was verified by restoring the old prompting in place: 4 tests failed, reporting the actual extra prompts (`Delete the Gum Screen DoomedBaseScreenGum`, `Reset the inheritance for Entities\DerivedOfDoomedEntity`).

435 unit + 28 BuildSmoke green from a clean build.

## Not in scope

`RemoveReferencedFileAsync` still prompts per NamedObject when a file is deleted directly — a different flow, noted on the issue.

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)
