### PR TITLE
Fix KeyNotFoundException selecting a named object with missing source file

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/NamedObjectVariableShowingLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/NamedObjectVariableShowingLogic.cs
@@ -116,10 +116,17 @@ namespace OfficialPlugins.VariableDisplay
                         {
                             var nameOnInstance = (newMember as NamedObjectSaveVariableDataGridItem).NameOnInstance;
 
-                            var variableDefinition = variableDefinitions[nameOnInstance];
-                            memberAsNamedObjectSaveVariableDataGridItem.RefreshFrom(instance, variableDefinition: variableDefinition, container: container, categories: grid.Categories, customTypeName: null,
-                                nameOnInstance: nameOnInstance);
-                            memberAsNamedObjectSaveVariableDataGridItem.DetailText = newMember.DetailText;
+                            // The variable definitions are re-derived from the instance's current
+                            // AssetTypeInfo, which can lose entries that the grid's existing members
+                            // were built from - for example if the instance's source file has gone
+                            // missing since the grid was last populated. Skip refreshing this member
+                            // rather than crashing; a full refresh will replace it once one is triggered.
+                            if (variableDefinitions.TryGetValue(nameOnInstance, out var variableDefinition))
+                            {
+                                memberAsNamedObjectSaveVariableDataGridItem.RefreshFrom(instance, variableDefinition: variableDefinition, container: container, categories: grid.Categories, customTypeName: null,
+                                    nameOnInstance: nameOnInstance);
+                                memberAsNamedObjectSaveVariableDataGridItem.DetailText = newMember.DetailText;
+                            }
                         }
                         else
                         {

--- a/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/NamedObjectVariableShowingLogicTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/NamedObjectVariableShowingLogicTests.cs
@@ -1,0 +1,68 @@
+using System;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using OfficialPlugins.VariableDisplay;
+using Shouldly;
+using WpfDataUi;
+
+namespace GlueUnitTests.PropertyGrid;
+
+// GitHub issue #2034: selecting a named object whose source file went missing threw a
+// KeyNotFoundException in the property grid. UpdateShownVariables builds the grid's categories
+// from the AssetTypeInfo the caller passes in, but on a non-full-refresh update it re-derives a
+// *fresh* AssetTypeInfo via NamedObjectSave.GetAssetTypeInfo() to look up each member's
+// VariableDefinition. If that fresh lookup no longer contains a variable the caller-supplied ATI
+// produced a grid member for - exactly what happens once the source file backing the instance's
+// own ATI resolution disappears - the direct dictionary indexer threw instead of degrading
+// gracefully.
+public class NamedObjectVariableShowingLogicTests : IDisposable
+{
+    private readonly GlueProjectSave _originalGlueProject;
+
+    public NamedObjectVariableShowingLogicTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+    }
+
+    public void Dispose()
+    {
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+    }
+
+    [StaFact]
+    public void UpdateShownVariables_ShouldNotThrow_WhenInstanceAssetTypeInfoNoLongerHasAMemberTheGridWasBuiltFrom()
+    {
+        var screen = new ScreenSave { Name = "Screens/GameScreen/GameScreen" };
+        ObjectFinder.Self.GlueProject.Screens.Add(screen);
+
+        // A caller-supplied ATI (mirrors MainPropertyGridPlugin.HandleNamedObjectSelect passing an
+        // already-resolved ATI into UpdateShownVariables) with a variable that instance.ClassType
+        // being unset means NamedObjectSave.GetAssetTypeInfo() will never independently resolve.
+        var ati = new AssetTypeInfo { FriendlyName = "TestType" };
+        ati.VariableDefinitions.Add(new VariableDefinition { Name = "ExtraVariable", Type = "float" });
+
+        var instance = new NamedObjectSave
+        {
+            InstanceName = "TestInstance",
+            SourceType = SourceType.FlatRedBallType,
+        };
+        screen.NamedObjects.Add(instance);
+
+        var grid = new DataUiGrid();
+
+        // First selection: grid is empty, so this always takes the full-refresh path and populates
+        // grid.Categories directly from the categories built off the passed-in `ati`.
+        NamedObjectVariableShowingLogic.UpdateShownVariables(grid, instance, screen, ati);
+        grid.Categories.ShouldNotBeEmpty();
+
+        // Second update with the exact same inputs: the newly-built categories match the grid's
+        // existing shape, so this takes the non-full-refresh path, which looks up each member via
+        // instance.GetAssetTypeInfo() instead of the `ati` that was passed in. That call returns
+        // null (instance.ClassType is unset), so "ExtraVariable" is missing from the freshly
+        // derived dictionary even though the grid has a member for it.
+        Should.NotThrow(() => NamedObjectVariableShowingLogic.UpdateShownVariables(grid, instance, screen, ati));
+    }
+}


### PR DESCRIPTION
Fixes #2034.

`UpdateShownVariables` builds the grid's categories from the `AssetTypeInfo` the caller passes in (e.g. `MainPropertyGridPlugin.HandleNamedObjectSelect`), but on an incremental (non-full-refresh) update it re-derives a *fresh* `AssetTypeInfo` via `NamedObjectSave.GetAssetTypeInfo()` for the per-member variable-definition lookup, and indexes the resulting dictionary directly. If that fresh lookup no longer has an entry the grid was built from, the indexer throws.

This is exactly what happens once the source file backing the instance's own ATI resolution goes missing: the caller's ATI (already resolved before the update) still has the variable, but the fresh, independent `GetAssetTypeInfo()` call inside `UpdateShownVariables` no longer resolves to an ATI containing it.

Fix: use `TryGetValue` and skip refreshing that one member instead of crashing - a subsequent full refresh (triggered elsewhere) replaces it once one occurs.

Added `NamedObjectVariableShowingLogicTests` pinning this against the real `UpdateShownVariables` entry point, reproducing the same `KeyNotFoundException` from the original report through two consecutive calls where the caller-supplied ATI and the instance's independently-resolved ATI diverge.

Manual test: not needed - covered by the new unit test plus compilation; full non-BuildSmoke suite (439/439) passes from a clean rebuild.
