### PR TITLE
Glue: make FRB2 code generation an opt-in per-project setting

### DIFF
--- a/FRBDK/Glue/Glue/IO/ProjectLoader.cs
+++ b/FRBDK/Glue/Glue/IO/ProjectLoader.cs
@@ -279,6 +279,10 @@ namespace FlatRedBall.Glue.IO
 
             if (succeeded)
             {
+                // Must happen before anything below generates code - it's what lets an FRB2 project
+                // that opted in via GlueProjectSave.GenerateCode actually generate.
+                Frb2CodeGenerationSync.ApplyGenerateCodeSetting(GlueState.Self.CurrentMainProject, ProjectManager.GlueProjectSave);
+
                 // This seems to take some time (like 1 second). Can we possibly
                 // make it faster by having it chek Game1.cs first? Why is this so slow?
                 ProjectManager.FindGameClass();

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2CodeGenerationSync.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2CodeGenerationSync.cs
@@ -1,0 +1,21 @@
+using FlatRedBall.Glue.SaveClasses;
+
+namespace FlatRedBall.Glue.VSHelpers.Projects
+{
+    /// <summary>
+    /// Applies a loaded project's <see cref="GlueProjectSave.GenerateCode"/> setting to
+    /// <see cref="ProjectBase.IsMaintainedByGlue"/>, which is what <c>GlueCommands.GenerateCodeCommands</c>
+    /// and <c>CodeWritePolicy</c> actually key off. Only FRB2 projects are affected - FRB1 code
+    /// generation is mandatory and this setting has no meaning for it.
+    /// </summary>
+    public static class Frb2CodeGenerationSync
+    {
+        public static void ApplyGenerateCodeSetting(ProjectBase project, GlueProjectSave glueProjectSave)
+        {
+            if (project is Frb2Project)
+            {
+                project.IsMaintainedByGlue = glueProjectSave?.GenerateCode == true;
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2Project.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2Project.cs
@@ -40,8 +40,6 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         /// </remarks>
         public override string ContentDirectory => GlueProjectSubdirectory;
 
-        public override bool IsMaintainedByGlue => false;
-
         /// <summary>
         /// Self-contained, so the game copies it to output with one rule and no exclusions, and so it
         /// parallels the Gum project's own Content/GumProject/ folder.
@@ -56,6 +54,9 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         {
             ContentProject = this;
             CodeProject = this;
+            // Off until the loaded .gluj's GenerateCode setting says otherwise - see
+            // Frb2CodeGenerationSync, which applies that setting once the project JSON is loaded.
+            IsMaintainedByGlue = false;
         }
     }
 }

--- a/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
+++ b/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
@@ -275,6 +275,18 @@ namespace FlatRedBall.Glue.SaveClasses
 
         #endregion
 
+        #region FlatRedBall 2
+
+        /// <summary>
+        /// Whether Glue generates code for this project. Only meaningful for FlatRedBall 2 projects -
+        /// FRB1 code generation is mandatory and always ignores this. Off by default: an FRB2 game runs
+        /// entirely from this JSON via runtime reflection, so a project only needs this once it wants
+        /// typed accessors instead of string-based lookups.
+        /// </summary>
+        public bool GenerateCode { get; set; }
+
+        #endregion
+
         #region Fields / Properties
 
         public GluxPluginData PluginData

--- a/FRBDK/Glue/GlueCommon/VSHelper/Projects/ProjectBase.cs
+++ b/FRBDK/Glue/GlueCommon/VSHelper/Projects/ProjectBase.cs
@@ -120,11 +120,12 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         }
 
         /// <summary>
-        /// Whether Glue owns this project's .csproj and generated code. False for FlatRedBall 2
-        /// projects, which read Glue's .gluj/.glsj/.glej JSON directly at runtime: Glue authors that
-        /// JSON and nothing else, so it neither generates code nor writes the .csproj back to disk.
+        /// Whether Glue owns this project's .csproj and generated code. Always true for FRB1 projects -
+        /// code generation there is mandatory. False by default for FlatRedBall 2 projects, which read
+        /// Glue's .gluj/.glsj/.glej JSON directly at runtime and so do not need generated code, but
+        /// settable per-project via <c>GlueProjectSave.GenerateCode</c> for a project that opts in.
         /// </summary>
-        public virtual bool IsMaintainedByGlue => true;
+        public bool IsMaintainedByGlue { get; set; } = true;
 
         /// <summary>
         /// Where the .gluj and the Screens/Entities JSON beside it live, relative to the project

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectTests.cs
@@ -451,4 +451,123 @@ public class Frb2CodeGenerationSuppressionTests : IDisposable
         Assert.Equal("Frb2Game.Screens", commands.GetNamespaceForElementName("Screens\\Level1"));
         Assert.Equal("no versions here", commands.ReplaceGlueVersionString("no versions here"));
     }
+
+    [Fact]
+    public void GenerateCodeCommands_IsTheRealOne_WhenFrb2ProjectOptsIntoCodeGeneration()
+    {
+        var frb2 = CreateProject(p => new Frb2Project(p), "Frb2Game");
+        frb2.IsMaintainedByGlue = true;
+        GlueState.Self.CurrentMainProject = frb2;
+
+        Assert.IsNotType<NoCodeGenerationCommands>(GlueCommands.Self.GenerateCodeCommands);
+    }
+
+    [Fact]
+    public void SaveIfDiffers_WritesCodeFiles_WhenFrb2ProjectOptsIntoCodeGeneration()
+    {
+        var frb2 = CreateProject(p => new Frb2Project(p), "Frb2Game");
+        frb2.IsMaintainedByGlue = true;
+        GlueState.Self.CurrentMainProject = frb2;
+        var codeFile = Path.Combine(_directory, "Setup", "CameraSetup.Generated.cs");
+        Directory.CreateDirectory(Path.GetDirectoryName(codeFile));
+
+        var didWrite = GlueCommands.Self.FileCommands.SaveIfDiffers(codeFile, "// generated");
+
+        Assert.True(didWrite);
+        Assert.True(File.Exists(codeFile));
+    }
+}
+
+/// <summary>
+/// <see cref="Frb2CodeGenerationSync"/> applies GlueProjectSave.GenerateCode to
+/// ProjectBase.IsMaintainedByGlue - the one place project load turns an FRB2 project's opt-in setting
+/// into the flag GenerateCodeCommands/CodeWritePolicy actually key off.
+/// </summary>
+public class Frb2CodeGenerationSyncTests : IDisposable
+{
+    readonly string _directory;
+
+    public Frb2CodeGenerationSyncTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        _directory = Path.Combine(Path.GetTempPath(), "GlueUnitTests_Frb2Sync_" + Guid.NewGuid());
+        Directory.CreateDirectory(_directory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    Frb2Project CreateFrb2Project()
+    {
+        var csprojPath = Path.Combine(_directory, "Frb2Game.csproj");
+        File.WriteAllText(csprojPath, @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <RootNamespace>Frb2Game</RootNamespace>
+  </PropertyGroup>
+</Project>");
+        GlueTestBootstrap.EnsureMsBuildEnvironmentVariable();
+        return new Frb2Project(new Project(csprojPath, null, null, new ProjectCollection()));
+    }
+
+    [Fact]
+    public void ApplyGenerateCodeSetting_TurnsOnCodeGeneration_WhenTheProjectOptsIn()
+    {
+        var project = CreateFrb2Project();
+        var glueProjectSave = new GlueProjectSave { GenerateCode = true };
+
+        Frb2CodeGenerationSync.ApplyGenerateCodeSetting(project, glueProjectSave);
+
+        Assert.True(project.IsMaintainedByGlue);
+    }
+
+    [Fact]
+    public void ApplyGenerateCodeSetting_LeavesCodeGenerationOff_WhenTheProjectDoesNotOptIn()
+    {
+        var project = CreateFrb2Project();
+        var glueProjectSave = new GlueProjectSave { GenerateCode = false };
+
+        Frb2CodeGenerationSync.ApplyGenerateCodeSetting(project, glueProjectSave);
+
+        Assert.False(project.IsMaintainedByGlue);
+    }
+
+    [Fact]
+    public void ApplyGenerateCodeSetting_LeavesCodeGenerationOff_WhenNoGlueProjectSaveIsLoadedYet()
+    {
+        // The pre-existing-project path in ProjectLoader can reach this before a GlueProjectSave is
+        // assigned - must not throw, and must not turn generation on with nothing to read a setting from.
+        var project = CreateFrb2Project();
+
+        Frb2CodeGenerationSync.ApplyGenerateCodeSetting(project, null);
+
+        Assert.False(project.IsMaintainedByGlue);
+    }
+
+    [Fact]
+    public void ApplyGenerateCodeSetting_DoesNothing_ForANonFrb2Project()
+    {
+        // FRB1 projects are mandatory-codegen and never read this setting, so opting a non-FRB2
+        // project's GlueProjectSave into GenerateCode must never flip its IsMaintainedByGlue.
+        var csprojPath = Path.Combine(_directory, "Frb1Game.csproj");
+        File.WriteAllText(csprojPath, @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <RootNamespace>Frb1Game</RootNamespace>
+  </PropertyGroup>
+</Project>");
+        GlueTestBootstrap.EnsureMsBuildEnvironmentVariable();
+        var project = new ClassLibraryProject(new Project(csprojPath, null, null, new ProjectCollection()));
+        var glueProjectSave = new GlueProjectSave { GenerateCode = true };
+
+        Frb2CodeGenerationSync.ApplyGenerateCodeSetting(project, glueProjectSave);
+
+        Assert.True(project.IsMaintainedByGlue);
+    }
 }


### PR DESCRIPTION
Part of #2037.

Toggle plumbing only, no FRB2 code generator yet. Adds `GlueProjectSave.GenerateCode` (off by default), turns `ProjectBase.IsMaintainedByGlue` from a hardcoded per-subtype override into a settable property, and adds `Frb2CodeGenerationSync.ApplyGenerateCodeSetting`, called once on project load, to translate the JSON setting into that flag.

Both existing write-gates (`GlueCommands.GenerateCodeCommands`, `CodeWritePolicy`) already key off `IsMaintainedByGlue`, so an FRB2 project that opts in gets real codegen through both with no new branching at call sites. FRB1 is unaffected: `IsMaintainedByGlue` still defaults `true` and nothing there reads `GenerateCode`.

No `GluxVersions` bump. `GenerateCode` is a new optional bool defaulting to `false`, which matches current behavior for every existing FRB2 project - nothing to migrate.

No UI toggle in this PR. There's nowhere in the property grid yet for an FRB2 project to flip this, so for now it's settable only by hand-editing the `.gluj`. Follow-up.

Left for follow-up PRs on #2037:
- The actual FRB2 code generator (FindByName-style only, per the design note on #2037 - FRB2's runtime already builds the tree from JSON via reflection, so generated code should just look up and type named instances, never instantiate)
- UI toggle for `GenerateCode`
- Two-file partial-class wiring for FRB2 elements (Glue already has this machinery for FRB1 via `CodeProjectHelper.CreateAndAddPartialGeneratedCodeFile`, reuse it)
- Rename/delete file reconciliation for FRB2 generated files once they exist

441 unit tests pass, including 6 new ones covering `Frb2CodeGenerationSync` directly and the two write-gates end to end.
