### PR TITLE
Fix right/left panel collapsing to zero width on first launch

### DIFF
--- a/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
+++ b/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
@@ -160,7 +160,13 @@ namespace GlueFormsCore.ViewModels
                     _ => null
                 };
 
-                gridLength = new GridLength(length ?? 220, GridUnitType.Pixel);
+                // A saved width of 0 (or less) is not a deliberate preference - it can only get persisted
+                // by closing the app while a panel is transiently empty (see AdjustGrid's `count == 0`
+                // branch below, and GitHub issue #2043: plugins like the Properties panel add a tab then
+                // immediately hide it again during their own StartUp, before anything is selected). Treat
+                // it the same as a missing value so the panel recovers to a usable width instead of
+                // staying collapsed to the MinPanelConverter floor forever.
+                gridLength = new GridLength(length is > 0 ? length.Value : 220, GridUnitType.Pixel);
             }
             else if (tab.Count == 0)
             {

--- a/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/TabControlViewModelPanelWidthTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/TabControlViewModelPanelWidthTests.cs
@@ -1,0 +1,66 @@
+using FlatRedBall.Glue.Plugins;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueFormsCore.ViewModels;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.ViewModels;
+
+/// <summary>
+/// GitHub issue #2043: MainCodePreviewPlugin and MainPropertiesTabOldPlugin each add a tab to the right
+/// panel and immediately hide it again during their own StartUp, before anything is selected. That
+/// transient churn drives TabControlViewModel.RightPanelWidth to exactly 0 via AdjustGrid's "no tabs"
+/// branch. If the app is closed while that 0 is still in effect, GlueCommands.UpdateGlueSettingsFromCurrentGlueStateImmediately
+/// persists it into GlueSettingsSave.RightTabWidthPixels. On every later launch, AdjustGrid's fallback to
+/// a default width only kicks in for a *missing* (null) saved width - a persisted 0 is a valid double, so
+/// it is treated as a deliberate preference forever, collapsing the panel to the MinPanelConverter floor
+/// until the user manually drags the splitter to a positive width.
+/// </summary>
+public class TabControlViewModelPanelWidthTests
+{
+    [Fact]
+    public void RightPanelWidth_ShouldFallBackToDefault_WhenSavedWidthIsZero()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        var originalSettings = GlueState.Self.GlueSettingsSave;
+        try
+        {
+            GlueState.Self.GlueSettingsSave = new GlueSettingsSave { RightTabWidthPixels = 0 };
+
+            var tabControlViewModel = new TabControlViewModel();
+            tabControlViewModel.RightTabItems.Add(new PluginTab());
+
+            tabControlViewModel.RightPanelWidth.Value.ShouldBeGreaterThan(0);
+        }
+        finally
+        {
+            GlueState.Self.GlueSettingsSave = originalSettings;
+        }
+    }
+
+    [Fact]
+    public void RightPanelWidth_ShouldStillCollapseToZero_WhenAllTabsAreRemoved()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        var originalSettings = GlueState.Self.GlueSettingsSave;
+        try
+        {
+            GlueState.Self.GlueSettingsSave = new GlueSettingsSave { RightTabWidthPixels = 386 };
+
+            var tabControlViewModel = new TabControlViewModel();
+            var tab = new PluginTab();
+            tabControlViewModel.RightTabItems.Add(tab);
+            tabControlViewModel.RightTabItems.Remove(tab);
+
+            tabControlViewModel.RightPanelWidth.Value.ShouldBe(0);
+        }
+        finally
+        {
+            GlueState.Self.GlueSettingsSave = originalSettings;
+        }
+    }
+}


### PR DESCRIPTION
Closes #2043.

## Root cause
`MainPropertiesTabOldPlugin` and `MainCodePreviewPlugin` each add a tab to a side panel and immediately hide it during their own `StartUp()`, before anything is selected. That transient churn hits `TabControlViewModel.AdjustGrid`'s "no tabs" branch, which forces the panel width to exactly `0`.

If the app is closed while that `0` is still in effect (i.e. the user never manually resized the panel), it gets persisted as `GlueSettingsSave.RightTabWidthPixels`/`LeftTabWidthPixels` - a valid `double`, not `null`. The existing `?? 220` fallback only substitutes a default for a *missing* saved width, so a persisted `0` is treated as a deliberate preference forever - collapsing the panel to the `MinPanelConverter` floor (32px) on every future launch, until the user manually drags the splitter to a positive width (which is exactly what "fixes" it and why the issue only shows on the very first launch).

Confirmed by instrumenting `AdjustGrid` and reproducing against a clean profile - the panel collapses to 0 during startup regardless of launch, and previously only "looked fine" because a later tab re-add happened to land after the saved width had already gone bad in the other direction (non-zero). Screenshots of the collapsed and fixed states available on request.

## Fix
In `AdjustGrid`, treat a saved width of `0` or less the same as a missing one, falling back to the 220px default instead of perpetuating the collapse.

## Testing
Added `TabControlViewModelPanelWidthTests`:
- `RightPanelWidth_ShouldFallBackToDefault_WhenSavedWidthIsZero` - pins the bug (fails without the fix, passes with it).
- `RightPanelWidth_ShouldStillCollapseToZero_WhenAllTabsAreRemoved` - confirms the legitimate "no tabs" collapse behavior is unchanged.

Full non-BuildSmoke suite (450 tests) passes.

Manual test: also verified live in the running editor - reproduced the exact stuck-at-zero state via a `settings.xml` with `RightTabWidthPixels`/`LeftTabWidthPixels` set to `0`, confirmed both panels rendered collapsed before the fix and at a normal width after.
