### PR TITLE
Add Recenter Camera button next to fixed-size preview toggle

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -250,6 +250,14 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
         public float ResolutionHeight { get; set; }
     }
 
+    /// <summary>
+    /// Snaps the camera's position back to the origin (0,0) and zoom back to the game's default - issue #2044.
+    /// </summary>
+    public class RecenterCameraDto
+    {
+        // no members
+    }
+
     #endregion
 
     #region AddObjectDto

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -921,6 +921,9 @@ namespace GlueControl
         private static void HandleDto(SetFixedSizePreviewLockDto dto) =>
             CameraLogic.SetFixedSizePreviewLock(dto.IsLocked, dto.ResolutionHeight);
 
+        private static void HandleDto(RecenterCameraDto dto) =>
+            CameraLogic.RecenterCamera();
+
         #endregion
 
         #region Rename

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -251,6 +251,14 @@ namespace GlueControl.Dtos
         public float ResolutionHeight { get; set; }
     }
 
+    /// <summary>
+    /// Snaps the camera's position back to the origin (0,0) and zoom back to the game's default - issue #2044.
+    /// </summary>
+    public class RecenterCameraDto
+    {
+        // no members
+    }
+
     #endregion
 
     #region AddObjectDto

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/CameraLogic.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/CameraLogic.cs
@@ -296,7 +296,7 @@ namespace GlueControl.Editing
                 camera.Y += yMovementRatio * MaxVelocity * TimeManager.SecondDifference;
             }
         }
-        public static void UpdateCameraToZoomLevel(bool zoomAroundCursorPosition = true, bool forceTo100 = false)
+        public static void UpdateCameraToZoomLevel(bool zoomAroundCursorPosition = true, bool forceTo100 = false, bool forceToGameDefault = false)
         {
             var mouse = InputManager.Mouse;
             var worldXBefore = mouse.WorldXAt(0);
@@ -317,9 +317,18 @@ namespace GlueControl.Editing
             }
             else
             {
-                var divisor = forceTo100
-                    ? 1
-                    : zoomLevels[(int)currentZoomLevelIndex] / 100.0f;
+                // Divisor here is "screen pixels per world unit" (PixelsPerUnitAt), which is what
+                // the zoom percentage actually represents - it stays constant as the window/panel
+                // resizes since it's derived from the *current* DestinationRectangle.Height, not an
+                // absolute value. forceToGameDefault reproduces a real launch's pixel density
+                // (Data.Scale / 100) using that same window-relative formula, rather than pinning
+                // OrthogonalHeight to an absolute Data.ResolutionHeight (which would make the ratio
+                // panel-size-dependent instead of matching Data.Scale) - issue #2044.
+                var divisor = forceToGameDefault
+                    ? CameraSetup.Data.Scale / 100.0f
+                    : forceTo100
+                        ? 1
+                        : zoomLevels[(int)currentZoomLevelIndex] / 100.0f;
 
                 if (Camera.Main.Orthogonal == true)
                 {
@@ -447,6 +456,26 @@ namespace GlueControl.Editing
             lockedOrthogonalHeight = resolutionHeight;
             UpdateCameraToZoomLevel(zoomAroundCursorPosition: false);
             PushZoomLevelToEditor();
+        }
+
+        // Matches the position reset in the generated ResetCamera method (CameraSetupCodeGenerator).
+        public static void RecenterCamera()
+        {
+            Camera.Main.X = 0;
+            Camera.Main.Y = 0;
+            Camera.Main.XVelocity = 0;
+            Camera.Main.YVelocity = 0;
+
+            // Zoom is already locked/fixed while fixed-size preview is on, so leave it alone -
+            // same guard DoZoomPlus/DoZoomMinus use.
+            if (!isFixedSizePreviewLocked)
+            {
+                // Reset to the real game's default zoom (pixel density = Data.Scale / 100), not an
+                // arbitrary editor zoom level. See forceToGameDefault's comment above.
+                UpdateCameraToZoomLevel(zoomAroundCursorPosition: false, forceToGameDefault: true);
+                UpdateZoomIndexToCamera();
+                PushZoomLevelToEditor();
+            }
         }
 
         public static void PushZoomLevelToEditor()

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/BottomStatusBar.xaml
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/BottomStatusBar.xaml
@@ -37,5 +37,12 @@
                 </ToolTip>
             </ToggleButton.ToolTip>
         </ToggleButton>
+        <Button
+            Height="20"
+            Margin="4,0,0,0"
+            Click="RecenterCameraClicked"
+            Content="{materialDesign:PackIcon ImageFilterCenterFocus}"
+            Style="{DynamicResource IconButton}"
+            ToolTip="Recenter Camera - resets position and zoom to the game's default" />
     </StackPanel>
 </UserControl>

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/BottomStatusBar.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/BottomStatusBar.xaml.cs
@@ -20,6 +20,7 @@ namespace GameCommunicationPlugin.GlueControl.Views
     {
         public event Action ZoomMinusClick;
         public event Action ZoomPlusClick;
+        public event Action RecenterCameraClick;
         public BottomStatusBar()
         {
             InitializeComponent();
@@ -33,6 +34,11 @@ namespace GameCommunicationPlugin.GlueControl.Views
         private void ZoomPlusClicked()
         {
             ZoomPlusClick?.Invoke();
+        }
+
+        private void RecenterCameraClicked(object sender, RoutedEventArgs e)
+        {
+            RecenterCameraClick?.Invoke();
         }
     }
 }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml
@@ -220,6 +220,7 @@
                 Grid.Row="1"
                 Grid.Column="1"
                 Visibility="{Binding WhileRunningViewVisibility}"
+                RecenterCameraClick="BottomStatusBar_RecenterCameraClick"
                 ZoomMinusClick="BottomStatusBar_ZoomMinusClick"
                 ZoomPlusClick="BottomStatusBar_ZoomPlusClick" />
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
@@ -457,6 +457,12 @@ namespace OfficialPlugins.GameHost.Views
             await CommandSender.Self.Send(dto);
         }
 
+        private async void BottomStatusBar_RecenterCameraClick()
+        {
+            var dto = new RecenterCameraDto();
+            await CommandSender.Self.Send(dto);
+        }
+
         private void ToolsSidePanel_Drop(object sender, DragEventArgs e)
         {
             var draggedNode = GlueState.Self.DraggedTreeNode;


### PR DESCRIPTION
Closes #2044.

Adds a "Recenter Camera" button next to the fixed-size preview toggle in the Game tab's bottom status bar. Clicking it snaps the embedded preview's camera back to (0,0), and its zoom back to the real game's default pixel density (`Data.Scale/100` screen pixels per world unit) - matching what a real launch shows.

Zoom is derived, not absolute: `UpdateCameraToZoomLevel` gets a new `forceToGameDefault` flag that reuses the existing window-relative divisor formula (`OrthogonalHeight = DestinationRectangle.Height / divisor`) with `divisor = Data.Scale/100`, the same shape every other zoom level already uses (`zoomLevels[i]/100`) - this is what makes the resulting pixel-density ratio (`DestinationRectangle.Height / OrthogonalHeight`) equal `Data.Scale/100` for *any* panel size, matching a real launch. An earlier version of this PR instead pinned `OrthogonalHeight` to an absolute `Data.ResolutionHeight`, which broke that panel-size independence and made the displayed zoom % track the Game tab's current pixel size instead of `Data.Scale` (confirmed via manual testing - reported as 175%/125% instead of the project's actual 200% Scale). Zoom reset is skipped while fixed-size preview is on, since zoom is already locked there.

Follows the existing `ChangeZoomDto`/`SetFixedSizePreviewLockDto` round-trip: `BottomStatusBar` button click -> `GameHostView` sends `RecenterCameraDto` -> `CommandReceiver.HandleDto` in the running game process calls `CameraLogic.RecenterCamera()`.

No new unit test: like the two DTOs above (untested precedent), this is a trivial DTO round-trip plus direct field assignment on `FlatRedBall.Camera.Main` / a new flag threaded through the already-untested `UpdateCameraToZoomLevel` - no new branching logic to pin beyond what's already covered by manual verification.

Manual test: needed.
1. Open a project with Camera Settings' Scale != 100% (to actually exercise the Scale-aware path), run the game from the Game tab (edit mode).
2. Pan the camera away from origin (middle-mouse drag) and zoom in/out.
3. Click the new "Recenter Camera" icon (crosshair-style icon) next to the fixed-size preview toggle in the bottom status bar.
4. Camera should snap back to (0,0), and the zoom % label should read the project's Scale value (e.g. 200% for a 200%-Scale project), regardless of the Game tab panel's current size.
5. Toggle fixed-size preview on, then click Recenter Camera again - position should still reset but zoom should stay locked (not error/flicker).
