### PR TITLE
Widen the embedded-game borderless retry budget from 90ms to 1s (#2048)

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
+++ b/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
@@ -146,6 +146,7 @@
     <Compile Include="GlueControl\ViewModels\RunnerToolbarViewModel.cs" />
     <Compile Include="GlueControl\ViewModels\TestViewModel.cs" />
     <Compile Include="GlueControl\Views\AirspacePopup.cs" />
+    <Compile Include="GlueControl\Views\BorderlessRetryPolicy.cs" />
     <Compile Include="GlueControl\Views\BottomStatusBar.xaml.cs" />
     <Compile Include="GlueControl\Views\EditingToolsView.xaml.cs" />
     <Compile Include="GlueControl\Views\FixedSizePreviewCalculator.cs" />

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/BorderlessRetryPolicy.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/BorderlessRetryPolicy.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading.Tasks;
+
+namespace GameCommunicationPlugin.GlueControl.Views
+{
+    /// <summary>
+    /// Retry budget for the SetBorderlessDto that strips the game window's frame when it's embedded
+    /// in the Game tab (issue #2048). Runner_GameStarted fires as soon as the game process has a
+    /// window handle, but the DTO is only actually handled once the game's Initialize has gotten as
+    /// far as constructing GlueControlManager - until then the socket is connected yet
+    /// GlueControlManager.Self is null, so the receive loop answers with an empty payload and the
+    /// command is silently dropped. Retrying past that gap is the whole point of this type.
+    /// </summary>
+    public static class BorderlessRetryPolicy
+    {
+        public const int MaxAttempts = 40;
+
+        public const int MillisecondsBetweenAttempts = 25;
+
+        /// <summary>
+        /// Total wall-clock time spent before giving up. Has to comfortably outlast the game's
+        /// graphics-device setup (CameraSetup.SetupCamera runs between the connection being made and
+        /// GlueControlManager being constructed), which is the step whose duration swings most
+        /// between a warm machine and a cold GPU driver load.
+        /// </summary>
+        public static int TotalBudgetMilliseconds => MaxAttempts * MillisecondsBetweenAttempts;
+
+        /// <summary>
+        /// Runs <paramref name="attemptAsync"/> until it reports success or the budget is exhausted.
+        /// Returns whether it ever succeeded. Delays only *between* attempts, never after the last
+        /// one, so an exhausted budget doesn't cost an extra wait for nothing.
+        /// </summary>
+        /// <param name="attemptAsync">One attempt; true means it took effect.</param>
+        /// <param name="delayAsync">How to wait between attempts. Injected so tests don't sleep.</param>
+        public static async Task<bool> TryRepeatedlyAsync(
+            Func<Task<bool>> attemptAsync,
+            Func<int, Task> delayAsync = null,
+            int maxAttempts = MaxAttempts,
+            int millisecondsBetweenAttempts = MillisecondsBetweenAttempts)
+        {
+            if (attemptAsync == null)
+            {
+                throw new ArgumentNullException(nameof(attemptAsync));
+            }
+
+            delayAsync = delayAsync ?? (milliseconds => Task.Delay(milliseconds));
+
+            for (int i = 0; i < maxAttempts; i++)
+            {
+                if (await attemptAsync())
+                {
+                    return true;
+                }
+
+                var isLastAttempt = i == maxAttempts - 1;
+
+                if (!isLastAttempt)
+                {
+                    await delayAsync(millisecondsBetweenAttempts);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
@@ -179,24 +179,27 @@ namespace OfficialPlugins.GameHost.Views
 
         private async Task<bool> MakeGameBorderless()
         {
-            var attemptsToConnect = 0;
-            int maxAttempts = 6;
-            bool succeeded = false;
             var dto = new GameCommunicationPlugin.GlueControl.Dtos.SetBorderlessDto { IsBorderless = true };
 
-            do
+            var succeeded = await BorderlessRetryPolicy.TryRepeatedlyAsync(async () =>
             {
                 var sendResponse = await CommandSender.Self.Send(dto);
                 var response = sendResponse.Succeeded ? sendResponse.Data : string.Empty;
 
-                succeeded = !string.IsNullOrWhiteSpace(response);
+                // An empty response means the game got the command but had nothing to handle it
+                // with yet (GlueControlManager.Self still null), so this is a "try again", not a
+                // "the game refused".
+                return !string.IsNullOrWhiteSpace(response);
+            });
 
-                if (!succeeded)
-                {
-                    await Task.Delay(15);
-                    attemptsToConnect++;
-                }
-            } while (succeeded == false && attemptsToConnect < maxAttempts);
+            if (!succeeded)
+            {
+                GlueCommands.Self.PrintOutput(
+                    $"Failed to make the game window borderless after {BorderlessRetryPolicy.TotalBudgetMilliseconds}ms, " +
+                    "so it will stay embedded with its own title bar and won't be resized to fit the Game tab. " +
+                    "Restarting the game usually fixes this - please report it (with this message) at " +
+                    "https://github.com/vchelaru/FlatRedBall/issues/2048 if it keeps happening.");
+            }
 
             return succeeded;
         }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/BorderlessRetryPolicyTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/BorderlessRetryPolicyTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GameCommunicationPlugin.GlueControl.Views;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin;
+
+/// <summary>
+/// The retry budget for the SetBorderlessDto sent when the game is embedded in the Game tab
+/// (issue #2048). The game answers with an empty payload - which reads as failure - for the window
+/// between its socket connecting and GlueControlManager being constructed, so the budget has to
+/// outlast that gap or the game keeps its window frame for the rest of the session.
+/// </summary>
+public class BorderlessRetryPolicyTests
+{
+    [Fact]
+    public async Task TryRepeatedlyAsync_ShouldStopAtFirstSuccess()
+    {
+        var attempts = 0;
+
+        var succeeded = await BorderlessRetryPolicy.TryRepeatedlyAsync(
+            attemptAsync: () => { attempts++; return Task.FromResult(true); },
+            delayAsync: _ => Task.CompletedTask);
+
+        succeeded.ShouldBeTrue();
+        attempts.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task TryRepeatedlyAsync_ShouldKeepRetrying_UntilAttemptSucceeds()
+    {
+        var attempts = 0;
+
+        var succeeded = await BorderlessRetryPolicy.TryRepeatedlyAsync(
+            attemptAsync: () => { attempts++; return Task.FromResult(attempts == 4); },
+            delayAsync: _ => Task.CompletedTask);
+
+        succeeded.ShouldBeTrue();
+        attempts.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task TryRepeatedlyAsync_ShouldReportFailure_AfterExhaustingAttempts()
+    {
+        var attempts = 0;
+
+        var succeeded = await BorderlessRetryPolicy.TryRepeatedlyAsync(
+            attemptAsync: () => { attempts++; return Task.FromResult(false); },
+            delayAsync: _ => Task.CompletedTask,
+            maxAttempts: 5);
+
+        succeeded.ShouldBeFalse();
+        attempts.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task TryRepeatedlyAsync_ShouldNotDelayAfterTheFinalAttempt()
+    {
+        var delays = new List<int>();
+
+        await BorderlessRetryPolicy.TryRepeatedlyAsync(
+            attemptAsync: () => Task.FromResult(false),
+            delayAsync: milliseconds => { delays.Add(milliseconds); return Task.CompletedTask; },
+            maxAttempts: 3,
+            millisecondsBetweenAttempts: 25);
+
+        // 3 attempts, but only 2 gaps between them - an exhausted budget shouldn't pay for a
+        // wait that nothing follows.
+        delays.ShouldBe(new[] { 25, 25 });
+    }
+
+    [Fact]
+    public void TotalBudget_ShouldOutlastTheGameSideStartupGap()
+    {
+        // The gap being waited on is the game's Initialize between GameConnectionManager (which
+        // connects immediately) and GlueControlManager (which is what actually handles the DTO) -
+        // CameraSetup.SetupCamera sits between them, and graphics-device setup is what swings on a
+        // cold GPU driver load. The original 90ms budget lost that race often enough to be reported.
+        BorderlessRetryPolicy.TotalBudgetMilliseconds.ShouldBeGreaterThanOrEqualTo(1000);
+    }
+}


### PR DESCRIPTION
Fixes #2048.

The game embeds into the Game tab but keeps its own title bar and isn't resized to fit, and the Output pane fills with "Failed to set game/edit mode to Edit". Goes away on restart.

## Cause

`Runner_GameStarted` fires as soon as the game process has a `MainWindowHandle`. `SetParent` is a Win32 call so it always works, but the `SetBorderlessDto` that strips the frame travels over the DTO socket, and it's only *handled* once the game's `Initialize` has gotten as far as constructing `GlueControlManager`:

```
gameConnectionManager = new GameConnectionManager(port);        // connects immediately
CameraSetup.SetupCamera(...);                                   // graphics device setup
glueControlManager = new GlueControl.GlueControlManager(port);  // assigns GlueControlManager.Self
```

In that gap the socket is connected but `GlueControlManager.Self` is null, so the game's receive loop hits `GlueControlManager.Self?.ProcessMessage(...)`, gets null back, and replies with a zero-length payload. Glue reads the empty response as failure. The command is dropped with no error on either side.

The retry budget for that was 6 attempts x 15ms = 90ms, which is enough most of the time. `SetupCamera` is graphics-device setup though, and that's the step that swings on a cold GPU driver load, so it loses often enough to get reported. Nothing retried afterwards, so a single loss meant a framed window for the rest of the session, and `EmbedHwnd` skips its `Runner_MoveWindow` sizing loop on failure, which is the second half of the screenshot.

## Change

Extracted the retry loop into `BorderlessRetryPolicy` (next to `FixedSizePreviewCalculator`, same reason: the budget is the thing worth pinning and `GameHostView` isn't unit-testable) and widened it to 40 x 25ms = 1s. Retries stop at first success, so the happy path costs nothing extra.

Also prints an output message when the budget does run out. Previously it failed completely silently, which is why this surfaced as a screenshot of a window frame instead of a report of what actually failed.

Hooking `GameCommunication_Connected` to retry looked like the tidier fix and isn't one: connected is exactly the state where this still fails.

## Tests

`BorderlessRetryPolicyTests`, 5 tests. The budget one was watched failing at 90ms before the widening. Full non-BuildSmoke suite green from a clean build, 456/456.

Manual verification is still worth doing since the tests don't cover the real embed path.
