### PR TITLE
Distinguish a dropped DTO from a handled one

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/Common/GameConnectionManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/Common/GameConnectionManager.cs
@@ -115,6 +115,20 @@ namespace GameJsonCommunicationPlugin.Common
         public double TimeoutInSeconds { get; set; } = 10;
         #endregion
 
+        /// <summary>
+        /// What the game replies with when its socket is up but it cannot dispatch the command yet -
+        /// GlueControlManager is constructed in Game1.Initialize, well after GameConnectionManager
+        /// connects. Without an explicit marker the game replies with an empty body, which is also what a
+        /// successfully handled void command returns, so a dropped command reads as success.
+        /// </summary>
+        /// <remarks>
+        /// The game-side copy of this class is an embedded resource (see
+        /// <c>GlueControl\Embedded\GameConnectionManager.cs</c>), compiled only inside a game project, so
+        /// it repeats this literal rather than sharing the constant. GameConnectionResponseTests pins that
+        /// the two agree.
+        /// </remarks>
+        public const string NotReadyPayload = "__GlueControlNotReady__";
+
         public static GameConnectionManager Self { get; set; }
 
         public GameConnectionManager(Action<string, string> eventCaller)
@@ -556,22 +570,43 @@ namespace GameJsonCommunicationPlugin.Common
             }
         }
 
+        /// <summary>
+        /// Sends a packet and classifies what comes back. The classification is the whole point: an empty
+        /// reply is the game's normal "handled it, nothing to send back" answer, so it can only be told
+        /// apart from a dropped command if the drop says so explicitly.
+        /// </summary>
         public async Task<GeneralResponse<string>> SendItemWithResponse(Packet item)
         {
             var responseToReturn = new GeneralResponse<string>();
 
-            if (IsConnected)
-            {
-                var responseString = await SendItemImmediately(item);
-
-                responseToReturn.Succeeded = true;
-                responseToReturn.Data = responseString;
-            }
-            else
+            if (!IsConnected)
             {
                 responseToReturn.Succeeded = false;
                 responseToReturn.Message = "Not connected";
+                return responseToReturn;
             }
+
+            var responseString = await SendItemImmediately(item);
+
+            if (responseString == null)
+            {
+                // The game never answered - it died mid-request, or the read timed out and tore the
+                // connection down. Either way the command was not carried out.
+                responseToReturn.Succeeded = false;
+                responseToReturn.Message = $"No response received from the game for '{item?.PacketType}'";
+            }
+            else if (responseString == NotReadyPayload)
+            {
+                responseToReturn.Succeeded = false;
+                responseToReturn.Message =
+                    $"The game is not ready to handle commands yet, so '{item?.PacketType}' was dropped";
+            }
+            else
+            {
+                responseToReturn.Succeeded = true;
+                responseToReturn.Data = responseString;
+            }
+
             return responseToReturn;
         }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
+++ b/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
@@ -147,6 +147,7 @@
     <Compile Include="GlueControl\ViewModels\TestViewModel.cs" />
     <Compile Include="GlueControl\Views\AirspacePopup.cs" />
     <Compile Include="GlueControl\Views\BorderlessRetryPolicy.cs" />
+    <Compile Include="GlueControl\Views\EmbedSettlePolicy.cs" />
     <Compile Include="GlueControl\Views\BottomStatusBar.xaml.cs" />
     <Compile Include="GlueControl\Views\EditingToolsView.xaml.cs" />
     <Compile Include="GlueControl\Views\FixedSizePreviewCalculator.cs" />

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandSending/CommandSender.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandSending/CommandSender.cs
@@ -51,6 +51,18 @@ namespace GameCommunicationPlugin.GlueControl.CommandSending
 
         public static CommandSender Self { get; private set; }
 
+        GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager;
+        /// <summary>
+        /// The transport this sender writes to. Defaults to the process-wide instance the plugin creates;
+        /// assignable so a test can point one sender at its own loopback connection instead of racing the
+        /// singleton.
+        /// </summary>
+        internal GameJsonCommunicationPlugin.Common.GameConnectionManager ConnectionManager
+        {
+            get => connectionManager ?? GameJsonCommunicationPlugin.Common.GameConnectionManager.Self;
+            set => connectionManager = value;
+        }
+
 
         #endregion
 
@@ -58,7 +70,7 @@ namespace GameCommunicationPlugin.GlueControl.CommandSending
         {
             Self = new CommandSender();
         }
-        private CommandSender() { }
+        internal CommandSender() { }
 
         #region General Send
 
@@ -83,6 +95,16 @@ namespace GameCommunicationPlugin.GlueControl.CommandSending
             if(sendResponse.Succeeded == false)
             {
                 toReturn.SetFrom(sendResponse);
+            }
+            // An empty reply is the game's "handled it, nothing to send back", which is a fine answer for a
+            // fire-and-forget command but not for a caller that asked for typed data. Deserializing it
+            // yields null without throwing, so without this the caller gets Succeeded = true, Data = null
+            // and has to invent its own meaning for that.
+            else if(string.IsNullOrWhiteSpace(responseString))
+            {
+                toReturn.Succeeded = false;
+                toReturn.Message = $"The game did not send back a {typeof(T).Name}, so the command was not carried out";
+                toReturn.Data = default(T);
             }
             else
             {
@@ -212,7 +234,7 @@ namespace GameCommunicationPlugin.GlueControl.CommandSending
                 var toReturn = new global::ToolsUtilities.GeneralResponse<string>();
                 try
                 {
-                    var gameConnectionManager = GameJsonCommunicationPlugin.Common.GameConnectionManager.Self;
+                    var gameConnectionManager = ConnectionManager;
                     if(gameConnectionManager != null)
                     {
                         var response = await gameConnectionManager.SendItemWithResponse(whatToSend);
@@ -231,7 +253,7 @@ namespace GameCommunicationPlugin.GlueControl.CommandSending
             }
             else
             {
-                await GameJsonCommunicationPlugin.Common.GameConnectionManager.Self.SendItem(whatToSend);
+                await ConnectionManager.SendItem(whatToSend);
                 // I guess we return success?
                 return new global::ToolsUtilities.GeneralResponse<string>() { Succeeded = true };
             }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GameConnectionManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GameConnectionManager.cs
@@ -18,6 +18,15 @@ namespace GlueCommunication
     {
         public static bool CanUseJsonManager = false;
 
+        /// <summary>
+        /// Replied when a command arrives before GlueControlManager exists, so Glue can tell a dropped
+        /// command apart from a handled one. Must stay identical to
+        /// GameJsonCommunicationPlugin.Common.GameConnectionManager.NotReadyPayload on the Glue side -
+        /// this file is an embedded resource that only compiles inside a game project, so the two cannot
+        /// share a constant. GameConnectionResponseTests pins that they agree.
+        /// </summary>
+        public const string NotReadyPayload = "__GlueControlNotReady__";
+
         #region private
         private Object _lock = new Object();
         private IPAddress _addr;
@@ -134,8 +143,15 @@ namespace GlueCommunication
 
                         if(packet != null)
                         {
+                            var glueControlManager = GlueControl.GlueControlManager.Self;
 
-                            var returnValue = await GlueControl.GlueControlManager.Self?.ProcessMessage(packet.Payload);
+                            // Sockets connect before Game1.Initialize constructs GlueControlManager, so
+                            // there is a window where a command arrives with nothing able to dispatch it.
+                            // Saying so explicitly is the only way Glue can tell that apart from the empty
+                            // reply a successfully handled void command sends back.
+                            var returnValue = glueControlManager != null
+                                ? await glueControlManager.ProcessMessage(packet.Payload)
+                                : NotReadyPayload;
 
                             var sendBytes = returnValue != null
                                 ? Encoding.ASCII.GetBytes(returnValue)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -809,24 +809,14 @@ namespace GameCommunicationPlugin.GlueControl
 
             var response = await CommandSender.Self.Send<Dtos.GeneralCommandResponse>(dto, SendImportance.RetryOnFailure);
 
-            if (response?.Succeeded != true)
+            var failureMessage = GetSetEditModeFailureMessage(
+                response, CompilerViewModel.PlayOrEdit, CommandSender.Self.IsConnected);
+
+            if (failureMessage != null)
             {
-                var message = string.Format($"Failed to set game/edit mode to {CompilerViewModel.PlayOrEdit}\n");
-                if (response == null)
-                {
-                    message += "Game sent back no response";
-                }
-                else
-                {
-                    message += $"Game sent back the following message: {response.Message}";
-                }
-                PluginManager.CallPluginMethod("Compiler Plugin", "HandleOutput", message);
-                
-                GlueCommands.Self.PrintOutput(message);
-            }
-            else if (CommandSender.Self.IsConnected == false)
-            {
-                var message = $"Failed to set game/edit mode to {CompilerViewModel.PlayOrEdit} because the game is not connected.";
+                PluginManager.CallPluginMethod("Compiler Plugin", "HandleOutput", failureMessage);
+
+                GlueCommands.Self.PrintOutput(failureMessage);
             }
             else if (isInEditMode)
             {
@@ -901,6 +891,35 @@ namespace GameCommunicationPlugin.GlueControl
             }
                     
             await CommandSender.Self.Send(setCameraAspectRatioDto);
+        }
+
+        /// <summary>
+        /// What to print when switching the game between play and edit mode did not take effect, or null
+        /// if it did. Pulled out of ReactToPlayOrEditSet so the rule can be pinned by tests - the method
+        /// itself needs a running game, a loaded project and a live plugin host.
+        /// </summary>
+        internal static string GetSetEditModeFailureMessage(
+            ToolsUtilities.GeneralResponse<Dtos.GeneralCommandResponse> response,
+            PlayOrEdit playOrEdit,
+            bool isConnected)
+        {
+            if (response?.Succeeded != true)
+            {
+                var message = $"Failed to set game/edit mode to {playOrEdit}\n";
+
+                message += response == null
+                    ? "Game sent back no response"
+                    : $"Game sent back the following message: {response.Message}";
+
+                return message;
+            }
+
+            if (!isConnected)
+            {
+                return $"Failed to set game/edit mode to {playOrEdit} because the game is not connected.";
+            }
+
+            return null;
         }
 
         private async Task HandlePortOrGenerateCheckedChanged(string propertyName)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -1140,13 +1140,13 @@ namespace GameCommunicationPlugin.GlueControl
                     CompilerViewModel.IsWindowEmbedded = true;
                 });
 
-                // sometimes the game doesn't embed itself properly. To fix this, we can resize the window:
-                await Task.Delay(50);
-
-                await GlueCommands.Self.DoOnUiThread(async () =>
-                {
-                    await gameHostView.ForceRefreshGameArea(force: true);
-                });
+                // Sometimes the game doesn't embed itself properly - see EmbedSettlePolicy for what
+                // "properly" means here and why one pass isn't always enough.
+                await Views.EmbedSettlePolicy.SettleAsync(() =>
+                    GlueCommands.Self.DoOnUiThread(async () =>
+                    {
+                        await gameHostView.ForceRefreshGameArea(force: true);
+                    }));
             }
             else
             {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/ProfilingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/ProfilingManager.cs
@@ -14,8 +14,24 @@ namespace GameCommunicationPlugin.GlueControl.Managers
 {
     public class ProfilingManager : Singleton<ProfilingManager>
     {
-        ProfilingControlViewModel ProfilingViewModel;
+        /// <summary>
+        /// Assignable rather than set only by <see cref="Initialize"/>, which also starts the polling
+        /// timer - a test wants the refresh logic without a WPF dispatcher running.
+        /// </summary>
+        internal ProfilingControlViewModel ProfilingViewModel { get; set; }
         CompilerViewModel CompilerViewModel;
+
+        CommandSending.CommandSender commandSender;
+        /// <summary>
+        /// Defaults to the process-wide sender; assignable so a test can point this manager at its own
+        /// fake game instead of mutating the singleton.
+        /// </summary>
+        internal CommandSending.CommandSender CommandSender
+        {
+            get => commandSender ?? CommandSending.CommandSender.Self;
+            set => commandSender = value;
+        }
+
         public void Initialize(ProfilingControlViewModel profilingViewModel, CompilerViewModel compilerViewModel)
         {
             ProfilingViewModel = profilingViewModel;
@@ -42,20 +58,20 @@ namespace GameCommunicationPlugin.GlueControl.Managers
             dto.IsTimestepDisabled = ProfilingViewModel.IsDisableFixedTimestepChecked;
 
             GeneralResponse<ProfilingDataDto> response;
-            if(CommandSending.CommandSender.Self.GlueViewSettingsViewModel.EnableLiveEdit == false)
+            if(CommandSender.GlueViewSettingsViewModel.EnableLiveEdit == false)
             {
                 response = GeneralResponse<ProfilingDataDto>.UnsuccessfulWith("Live edit is disabled - enable it from the Editor Settings tab to receive profiling information from the game");
             }
 
             else
             {
-                response = await CommandSending.CommandSender.Self.Send<Dtos.ProfilingDataDto>(dto, CommandSending.SendImportance.IfNotBusy );
+                response = await CommandSender.Send<Dtos.ProfilingDataDto>(dto, CommandSending.SendImportance.IfNotBusy );
             }
 
             if (response.Succeeded)
             {
-                // for some reason the data can be null here. We don't want to treat this as a failure, so let's
-                // handle a null:
+                // Succeeded no longer implies data - a command the game dropped is reported as a failure
+                // now - but a handler can still legitimately answer with a JSON null.
                 if(response.Data != null)
                 {
                     ProfilingViewModel.SummaryText = response.Data.SummaryData;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
@@ -505,11 +505,11 @@ namespace GameCommunicationPlugin.GlueControl.Managers
 
                 var response = await CommandSender.Self.Send<AddObjectDtoListResponse>(list);
 
-                if (response.Succeeded == false ||
-                    response.Data?.Data == null ||
-                    response.Data.Data.Any(item => item.CreationResponse.Succeeded == false))
+                var restartReason = GetAddObjectRestartReason(response);
+
+                if (restartReason != null)
                 {
-                    CreateStopAndRestartTask("Restarting because the add object group failed");
+                    CreateStopAndRestartTask(restartReason);
                 }
                 else
                 {
@@ -524,6 +524,33 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Why adding this group of objects live has to fall back to a full stop/rebuild/relaunch, or null
+        /// if it does not. A restart is the most expensive thing this class can do, so the reason it
+        /// happened has to reach the user - "the game never answered" and "the game refused one of the
+        /// objects" are very different problems.
+        /// </summary>
+        internal static string GetAddObjectRestartReason(ToolsUtilities.GeneralResponse<AddObjectDtoListResponse> response)
+        {
+            if (response?.Succeeded != true)
+            {
+                return "Restarting because the game did not carry out the add object group: " +
+                    (string.IsNullOrEmpty(response?.Message) ? "no response" : response.Message);
+            }
+
+            if (response.Data?.Data == null)
+            {
+                return "Restarting because the add object group failed";
+            }
+
+            if (response.Data.Data.Any(item => item.CreationResponse.Succeeded == false))
+            {
+                return "Restarting because the add object group failed";
+            }
+
+            return null;
         }
 
         private AddObjectDto CreateAddObjectDtoFor(NamedObjectSave newNamedObject)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/BorderlessRetryPolicy.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/BorderlessRetryPolicy.cs
@@ -8,8 +8,8 @@ namespace GameCommunicationPlugin.GlueControl.Views
     /// in the Game tab (issue #2048). Runner_GameStarted fires as soon as the game process has a
     /// window handle, but the DTO is only actually handled once the game's Initialize has gotten as
     /// far as constructing GlueControlManager - until then the socket is connected yet
-    /// GlueControlManager.Self is null, so the receive loop answers with an empty payload and the
-    /// command is silently dropped. Retrying past that gap is the whole point of this type.
+    /// GlueControlManager.Self is null, so the receive loop reports itself as not ready and the
+    /// command is dropped. Retrying past that gap is the whole point of this type.
     /// </summary>
     public static class BorderlessRetryPolicy
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/EmbedSettlePolicy.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/EmbedSettlePolicy.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GameCommunicationPlugin.GlueControl.Views
+{
+    /// <summary>
+    /// When the game's window is reparented into the Game tab, MonoGame/SDL keeps using the position it
+    /// cached while the window was still top-level to turn the cursor's screen position into client
+    /// coordinates. Until something moves the window relative to its new parent, clicks and drag
+    /// rectangles land offset by exactly the reparent distance. `GameHostView.ForceRefreshGameArea` is
+    /// what forces that move (see its "Victor Chelaru Oct 4" comment); this decides when to run it.
+    /// </summary>
+    public static class EmbedSettlePolicy
+    {
+        /// <summary>
+        /// How long to wait before each refresh pass.
+        /// </summary>
+        /// <remarks>
+        /// More than one pass because nothing can detect whether a pass worked: the window is drawn
+        /// correctly either way, and the stale coordinates only show up when the user clicks. A pass that
+        /// lands before the window has settled after the borderless style change is simply lost, so the
+        /// later ones are there to cover a slow window - each costs a brief flicker of the left panel,
+        /// which is why they are spread out rather than repeated tightly.
+        /// </remarks>
+        public static readonly IReadOnlyList<int> DelaysBeforeEachRefreshMilliseconds = new[] { 50, 250, 750 };
+
+        /// <summary>
+        /// Waits and refreshes once per entry in <paramref name="delaysBeforeEachRefresh"/>.
+        /// </summary>
+        /// <param name="refreshAsync">One refresh pass.</param>
+        /// <param name="delayAsync">How to wait. Injected so tests don't sleep.</param>
+        public static async Task SettleAsync(
+            Func<Task> refreshAsync,
+            Func<int, Task> delayAsync = null,
+            IReadOnlyList<int> delaysBeforeEachRefresh = null)
+        {
+            if (refreshAsync == null)
+            {
+                throw new ArgumentNullException(nameof(refreshAsync));
+            }
+
+            delayAsync = delayAsync ?? (milliseconds => Task.Delay(milliseconds));
+            delaysBeforeEachRefresh = delaysBeforeEachRefresh ?? DelaysBeforeEachRefreshMilliseconds;
+
+            foreach (var delay in delaysBeforeEachRefresh)
+            {
+                await delayAsync(delay);
+                await refreshAsync();
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
@@ -184,12 +184,12 @@ namespace OfficialPlugins.GameHost.Views
             var succeeded = await BorderlessRetryPolicy.TryRepeatedlyAsync(async () =>
             {
                 var sendResponse = await CommandSender.Self.Send(dto);
-                var response = sendResponse.Succeeded ? sendResponse.Data : string.Empty;
 
-                // An empty response means the game got the command but had nothing to handle it
-                // with yet (GlueControlManager.Self still null), so this is a "try again", not a
-                // "the game refused".
-                return !string.IsNullOrWhiteSpace(response);
+                // A game that isn't ready to dispatch the command yet (GlueControlManager.Self still
+                // null during Game1.Initialize) reports as unsuccessful, so this is a "try again". It
+                // used to test the response string for content instead, which happened to retry for the
+                // right reason but reads as a success check for a command whose handler returns nothing.
+                return sendResponse.Succeeded;
             });
 
             if (!succeeded)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
@@ -146,35 +146,14 @@ namespace OfficialPlugins.GameHost.Views
             });
 
             gameHandle = handle;
-            var succeededMakingGameBorderless = await MakeGameBorderless();
 
-            if(succeededMakingGameBorderless)
-            {
-                JObject windowInfo = JObject.Parse(await _eventCallerWithResult("Runner_GetWindowInfo", ""));
-
-                // I used to have this code check if the window was at 0,0,
-                // but that doesn't seem to actually work - the loop would run 
-                // indefinitely, continually changing the position of the cursor.
-                // Now I just do it 5 times and it seems to work
-                for (int i = 0; i < 5; i++)
-                {
-                    var delay = 180;
-                    await Task.Delay(delay);
-
-                    var width = windowInfo.ContainsKey("ActualWidth") ? windowInfo.Value<int>("ActualWidth") : 0;
-                    var height = windowInfo.ContainsKey("ActualHeight") ? windowInfo.Value<int>("ActualHeight") : 0;
-
-                    _eventCaller("Runner_MoveWindow", JsonConvert.SerializeObject(new
-                    {
-                        X = 0,
-                        Y = 0,
-                        Width = width,
-                        Height = height,
-                        Repaint = true
-                    }));
-                }
-
-            }
+            // Sizing and positioning the embedded window is SetGameToEmbeddedGameWindow's job -
+            // MoveGameToHost calls ForceRefreshGameArea right after this returns. This used to follow up
+            // with its own Runner_MoveWindow loop driven by a "Runner_GetWindowInfo" request, but no
+            // plugin has ever handled that event name, and the awaiting flavor of the plugin event bus
+            // waits forever rather than failing (see PluginBase.ReactToPluginEventWithReturn), so
+            // reaching it hangs EmbedHwnd and IsWindowEmbedded is never set.
+            await MakeGameBorderless();
         }
 
         private async Task<bool> MakeGameBorderless()

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/BorderlessRetryPolicyTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/BorderlessRetryPolicyTests.cs
@@ -9,9 +9,9 @@ namespace GlueUnitTests.GameCommunicationPlugin;
 
 /// <summary>
 /// The retry budget for the SetBorderlessDto sent when the game is embedded in the Game tab
-/// (issue #2048). The game answers with an empty payload - which reads as failure - for the window
-/// between its socket connecting and GlueControlManager being constructed, so the budget has to
-/// outlast that gap or the game keeps its window frame for the rest of the session.
+/// (issue #2048). The game reports itself as not ready for the window between its socket connecting
+/// and GlueControlManager being constructed, so the budget has to outlast that gap or the game keeps
+/// its window frame for the rest of the session.
 /// </summary>
 public class BorderlessRetryPolicyTests
 {

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/CommandSenderResponseTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/CommandSenderResponseTests.cs
@@ -1,0 +1,267 @@
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GameCommunicationPlugin.GlueControl.CommandSending;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GameJsonCommunicationPlugin.Common;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin
+{
+    /// <summary>
+    /// Drives the real <see cref="CommandSender"/> against a fake game over real loopback sockets, so the
+    /// whole Glue-side stack (serialize -> packet -> socket -> classify -> deserialize) is exercised. What
+    /// is being pinned is a single rule: a caller can tell whether the game carried out its command.
+    /// </summary>
+    public class CommandSenderResponseTests : IDisposable
+    {
+        const double ShortTimeoutInSeconds = 0.3;
+
+        readonly GlueProjectSave? previousGlueProject;
+
+        public CommandSenderResponseTests()
+        {
+            GlueTestBootstrap.EnsureInitialized();
+
+            // SendCommand early-outs with "No project loaded" without one.
+            previousGlueProject = ObjectFinder.Self.GlueProject;
+            ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        }
+
+        public void Dispose() => ObjectFinder.Self.GlueProject = previousGlueProject;
+
+        #region Harness
+
+        sealed class Fixture : IDisposable
+        {
+            public required GameConnectionManager Manager { get; init; }
+            public required FakeGameSide Game { get; init; }
+            public required CommandSender Sender { get; init; }
+
+            public void Dispose()
+            {
+                Game.Dispose();
+                Manager.Dispose();
+            }
+        }
+
+        static async Task<Fixture> ConnectAsync(Func<string, string?> respond)
+        {
+            var port = FakeGameSide.GetFreePort();
+            var manager = new GameConnectionManager((_, __) => { }, port)
+            {
+                TimeoutInSeconds = ShortTimeoutInSeconds,
+                LogAction = _ => { }
+            };
+
+            var game = await FakeGameSide.ConnectAsync(manager, port);
+            game.StartResponder(respond);
+
+            // CompilerViewModel is a private-constructor singleton; the flag only gates printing every
+            // sent command to the Build tab, which a test has no use for.
+            CompilerLibrary.ViewModels.CompilerViewModel.Self.IsPrintEditorToGameCheckboxChecked = false;
+
+            var sender = new CommandSender
+            {
+                ConnectionManager = manager,
+                PrintOutput = _ => { },
+                CompilerViewModel = CompilerLibrary.ViewModels.CompilerViewModel.Self
+            };
+
+            return new Fixture { Manager = manager, Game = game, Sender = sender };
+        }
+
+        #endregion
+
+        #region Send<T> - callers that need data back
+
+        /// <summary>
+        /// A caller asking for a typed response and getting nothing did not get its command carried out -
+        /// the game either dropped it or its handler failed. This used to report Succeeded = true with
+        /// null Data, which is what left MainCompilerPlugin, RefreshManager and ProfilingManager each
+        /// guessing differently about what null meant.
+        /// </summary>
+        [Fact]
+        public async Task TypedSend_WhenTheGameSendsNothingBack_ReportsFailure()
+        {
+            using var fixture = await ConnectAsync(_ => null);
+
+            var response = await fixture.Sender.Send<GeneralCommandResponse>(new SetEditMode());
+
+            response.Succeeded.ShouldBeFalse();
+            response.Message.ShouldNotBeNullOrEmpty("the caller has to be able to print why it failed");
+        }
+
+        [Fact]
+        public async Task TypedSend_WhenTheGameIsNotReady_ReportsFailure()
+        {
+            using var fixture = await ConnectAsync(_ => GameConnectionManager.NotReadyPayload);
+
+            var response = await fixture.Sender.Send<GeneralCommandResponse>(new SetEditMode());
+
+            response.Succeeded.ShouldBeFalse();
+            response.Message.ShouldContain("not ready");
+        }
+
+        [Fact]
+        public async Task TypedSend_WhenTheGameNeverAnswers_ReportsFailure()
+        {
+            using var fixture = await ConnectAsync(_ => throw new NotSupportedException("unreachable"));
+            fixture.Game.Dispose();
+
+            var response = await fixture.Sender.Send<GeneralCommandResponse>(new SetEditMode());
+
+            response.Succeeded.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task TypedSend_WithARealPayload_SucceedsAndDeserializes()
+        {
+            using var fixture = await ConnectAsync(_ =>
+                "{\"Succeeded\":true,\"Message\":\"all good\"}");
+
+            var response = await fixture.Sender.Send<GeneralCommandResponse>(new SetEditMode());
+
+            response.Succeeded.ShouldBeTrue();
+            response.Data.ShouldNotBeNull();
+            response.Data.Message.ShouldBe("all good");
+        }
+
+        [Fact]
+        public async Task TypedSend_WithUnparseablePayload_ReportsFailure()
+        {
+            using var fixture = await ConnectAsync(_ => "this is not json");
+
+            var response = await fixture.Sender.Send<GeneralCommandResponse>(new SetEditMode());
+
+            response.Succeeded.ShouldBeFalse();
+        }
+
+        #endregion
+
+        #region Send - fire-and-forget callers
+
+        /// <summary>
+        /// Most DTOs have a void handler, so an empty reply is the game saying "done". Turning that into a
+        /// failure would make every fire-and-forget command in live edit look broken - and RefreshManager
+        /// answers a failure by restarting the game.
+        /// </summary>
+        [Fact]
+        public async Task UntypedSend_WhenTheGameHandlesItWithNothingToReturn_Succeeds()
+        {
+            using var fixture = await ConnectAsync(_ => null);
+
+            var response = await fixture.Sender.Send(new RestartScreenDto());
+
+            response.Succeeded.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UntypedSend_WhenTheGameIsNotReady_ReportsFailure()
+        {
+            using var fixture = await ConnectAsync(_ => GameConnectionManager.NotReadyPayload);
+
+            var response = await fixture.Sender.Send(new RestartScreenDto());
+
+            response.Succeeded.ShouldBeFalse();
+            response.Data.ShouldBeNull("the marker must never reach a caller as if it were a payload");
+        }
+
+        #endregion
+
+        #region Every command the game accepts
+
+        /// <summary>
+        /// The set of commands the game can dispatch, read out of the game-side CommandReceiver's HandleDto
+        /// overloads. Derived rather than hand-listed so a DTO added later is covered without anyone
+        /// remembering to add it here.
+        /// </summary>
+        public static IEnumerable<object[]> EveryCommandDtoTypeName()
+        {
+            foreach (var name in GameSideCommandDtoNames())
+            {
+                yield return new object[] { name };
+            }
+        }
+
+        static IReadOnlyList<string> GameSideCommandDtoNames()
+        {
+            using var stream = typeof(CommandSender).Assembly
+                .GetManifestResourceStream("GameCommunicationPlugin.GlueControl.Embedded.CommandReceiver.cs")
+                ?? throw new InvalidOperationException("The game-side CommandReceiver source is not embedded.");
+
+            var source = new System.IO.StreamReader(stream).ReadToEnd();
+
+            return Regex.Matches(source, @"HandleDto\(\s*(?:Dtos\.)?(\w+)\s+\w+\s*\)")
+                .Select(match => match.Groups[1].Value)
+                // Resolvable on the Glue side, and constructible - a couple of game-side handlers take
+                // types that only exist inside a game project.
+                .Where(name => ResolveGlueSideDto(name) != null)
+                .Distinct()
+                .OrderBy(name => name)
+                .ToList();
+        }
+
+        static Type? ResolveGlueSideDto(string name)
+        {
+            var type = typeof(CommandSender).Assembly
+                .GetType($"GameCommunicationPlugin.GlueControl.Dtos.{name}");
+
+            return type?.GetConstructor(Type.EmptyTypes) == null ? null : type;
+        }
+
+        /// <summary>
+        /// Guards the theory below against quietly covering nothing if the source shape or the resource
+        /// name ever changes.
+        /// </summary>
+        [Fact]
+        public void TheCommandListIsDerivedFromTheGameAndIsNotEmpty()
+        {
+            GameSideCommandDtoNames().Count.ShouldBeGreaterThan(20);
+        }
+
+        /// <summary>
+        /// The issue's actual claim, applied to every command rather than the three that happened to be
+        /// noticed: if the game could not handle it, the caller must not be told it worked.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(EveryCommandDtoTypeName))]
+        public async Task EveryCommand_DroppedByANotReadyGame_ReportsFailure(string dtoTypeName)
+        {
+            var dtoType = ResolveGlueSideDto(dtoTypeName).ShouldNotBeNull();
+            var dto = Activator.CreateInstance(dtoType)!;
+
+            using var fixture = await ConnectAsync(_ => GameConnectionManager.NotReadyPayload);
+
+            var response = await fixture.Sender.Send(dto);
+
+            response.Succeeded.ShouldBeFalse($"{dtoTypeName} was dropped, so the caller must not read it as success");
+        }
+
+        /// <summary>
+        /// The other half: the same command, handled with nothing to send back, still has to read as
+        /// success. Without this the theory above would pass just as well if everything failed.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(EveryCommandDtoTypeName))]
+        public async Task EveryCommand_HandledWithNoDataToReturn_ReportsSuccess(string dtoTypeName)
+        {
+            var dtoType = ResolveGlueSideDto(dtoTypeName).ShouldNotBeNull();
+            var dto = Activator.CreateInstance(dtoType)!;
+
+            using var fixture = await ConnectAsync(_ => null);
+
+            var response = await fixture.Sender.Send(dto);
+
+            response.Succeeded.ShouldBeTrue($"{dtoTypeName} was handled, so the caller must not read it as a failure");
+        }
+
+        #endregion
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/DroppedCommandCallerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/DroppedCommandCallerTests.cs
@@ -1,0 +1,140 @@
+using CompilerLibrary.ViewModels;
+using GameCommunicationPlugin.GlueControl;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GameCommunicationPlugin.GlueControl.Managers;
+using Shouldly;
+using System.Collections.Generic;
+using ToolsUtilities;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin
+{
+    /// <summary>
+    /// The three callers that read a game response used to each invent their own meaning for "succeeded
+    /// but empty". These pin what each does now that the transport reports a dropped command as a failure.
+    /// </summary>
+    public class DroppedCommandCallerTests
+    {
+        #region Play/edit mode switch
+
+        [Fact]
+        public void SetEditMode_WhenTheGameCarriedItOut_ReportsNothing()
+        {
+            var response = new GeneralResponse<GeneralCommandResponse>
+            {
+                Succeeded = true,
+                Data = new GeneralCommandResponse { Succeeded = true }
+            };
+
+            MainCompilerPlugin.GetSetEditModeFailureMessage(response, PlayOrEdit.Edit, isConnected: true)
+                .ShouldBeNull();
+        }
+
+        /// <summary>
+        /// The symptom from the issue: a dropped command answered with an empty payload read as success,
+        /// so edit mode silently did not get set and nothing was printed.
+        /// </summary>
+        [Fact]
+        public void SetEditMode_WhenTheCommandWasDropped_SaysSoAndRepeatsTheReason()
+        {
+            var response = GeneralResponse<GeneralCommandResponse>.UnsuccessfulWith(
+                "The game is not ready to handle commands yet");
+
+            var message = MainCompilerPlugin.GetSetEditModeFailureMessage(response, PlayOrEdit.Edit, isConnected: true);
+
+            message.ShouldNotBeNull();
+            message.ShouldContain("Edit");
+            message.ShouldContain("not ready to handle commands");
+        }
+
+        [Fact]
+        public void SetEditMode_WhenThereIsNoResponseObjectAtAll_SaysSo()
+        {
+            var message = MainCompilerPlugin.GetSetEditModeFailureMessage(null, PlayOrEdit.Play, isConnected: true);
+
+            message.ShouldNotBeNull();
+            message.ShouldContain("no response");
+        }
+
+        /// <summary>
+        /// This branch built a message and then threw it away, so a play/edit switch against a
+        /// disconnected game produced no output at all.
+        /// </summary>
+        [Fact]
+        public void SetEditMode_WhenTheGameIsNotConnected_SaysSo()
+        {
+            var response = new GeneralResponse<GeneralCommandResponse> { Succeeded = true };
+
+            var message = MainCompilerPlugin.GetSetEditModeFailureMessage(response, PlayOrEdit.Edit, isConnected: false);
+
+            message.ShouldNotBeNull("a switch that could not reach the game must not be silent");
+            message.ShouldContain("not connected");
+        }
+
+        #endregion
+
+        #region Adding objects live
+
+        [Fact]
+        public void AddObject_WhenEveryObjectWasCreated_DoesNotRestart()
+        {
+            var response = new GeneralResponse<AddObjectDtoListResponse>
+            {
+                Succeeded = true,
+                Data = new AddObjectDtoListResponse
+                {
+                    Data = new List<AddObjectDtoResponse>
+                    {
+                        new AddObjectDtoResponse { CreationResponse = OptionallyAttemptedGeneralResponse.SuccessfulAttempt }
+                    }
+                }
+            };
+
+            RefreshManager.GetAddObjectRestartReason(response).ShouldBeNull();
+        }
+
+        [Fact]
+        public void AddObject_WhenTheGameRefusedAnObject_Restarts()
+        {
+            var response = new GeneralResponse<AddObjectDtoListResponse>
+            {
+                Succeeded = true,
+                Data = new AddObjectDtoListResponse
+                {
+                    Data = new List<AddObjectDtoResponse>
+                    {
+                        new AddObjectDtoResponse { CreationResponse = OptionallyAttemptedGeneralResponse.UnsuccessfulWith("no such type") }
+                    }
+                }
+            };
+
+            RefreshManager.GetAddObjectRestartReason(response).ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void AddObject_WhenTheGameSentNoData_Restarts()
+        {
+            var response = new GeneralResponse<AddObjectDtoListResponse> { Succeeded = true, Data = null };
+
+            RefreshManager.GetAddObjectRestartReason(response).ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// A restart costs the user a full rebuild and relaunch, so when it happens because the game never
+        /// took the command, the reason has to say that rather than blaming the objects.
+        /// </summary>
+        [Fact]
+        public void AddObject_WhenTheCommandWasDropped_RestartReasonNamesTheDrop()
+        {
+            var response = GeneralResponse<AddObjectDtoListResponse>.UnsuccessfulWith(
+                "The game is not ready to handle commands yet");
+
+            var reason = RefreshManager.GetAddObjectRestartReason(response);
+
+            reason.ShouldNotBeNull();
+            reason.ShouldContain("not ready to handle commands");
+        }
+
+        #endregion
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbedSettlePolicyTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbedSettlePolicyTests.cs
@@ -1,0 +1,82 @@
+using GameCommunicationPlugin.GlueControl.Views;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin;
+
+/// <summary>
+/// How many times the embedded game window gets nudged after being reparented into the Game tab, and
+/// how long it is given to settle first. Getting this wrong is not a crash: the game embeds and draws
+/// correctly, but every click and drag-rectangle lands offset from the cursor, because MonoGame/SDL is
+/// still translating screen coordinates with the position it cached before the reparent.
+/// </summary>
+public class EmbedSettlePolicyTests
+{
+    static (List<int> delays, int refreshes) Record(IReadOnlyList<int> schedule = null)
+    {
+        var delays = new List<int>();
+        var refreshes = 0;
+
+        EmbedSettlePolicy.SettleAsync(
+            refreshAsync: () => { refreshes++; return Task.CompletedTask; },
+            delayAsync: milliseconds => { delays.Add(milliseconds); return Task.CompletedTask; },
+            delaysBeforeEachRefresh: schedule).Wait();
+
+        return (delays, refreshes);
+    }
+
+    [Fact]
+    public async Task SettleAsync_WaitsBeforeEachRefresh()
+    {
+        var order = new List<string>();
+
+        await EmbedSettlePolicy.SettleAsync(
+            refreshAsync: () => { order.Add("refresh"); return Task.CompletedTask; },
+            delayAsync: _ => { order.Add("delay"); return Task.CompletedTask; },
+            delaysBeforeEachRefresh: new[] { 10, 20 });
+
+        order.ShouldBe(new[] { "delay", "refresh", "delay", "refresh" });
+    }
+
+    [Fact]
+    public async Task SettleAsync_RefreshesOncePerScheduledDelay()
+    {
+        var refreshes = 0;
+
+        await EmbedSettlePolicy.SettleAsync(
+            refreshAsync: () => { refreshes++; return Task.CompletedTask; },
+            delayAsync: _ => Task.CompletedTask,
+            delaysBeforeEachRefresh: new[] { 1, 2, 3 });
+
+        refreshes.ShouldBe(3);
+    }
+
+    /// <summary>
+    /// A single pass is a race: it can land before the window has finished settling after the borderless
+    /// style change, and a nudge SDL never latches leaves the stale position in place for the rest of the
+    /// session. Nothing detects that, so the only fix available is to nudge again later.
+    /// </summary>
+    [Fact]
+    public void TheRealSchedule_NudgesMoreThanOnce()
+    {
+        var (_, refreshes) = Record();
+
+        refreshes.ShouldBeGreaterThan(1, "one pass that lands too early is never retried");
+    }
+
+    /// <summary>
+    /// Each pass costs a brief visible flicker of the left panel, so the extra ones have to be spread far
+    /// enough apart to actually cover a slow window rather than all landing inside the same bad moment.
+    /// </summary>
+    [Fact]
+    public void TheRealSchedule_KeepsNudgingWellPastTheFirstPass()
+    {
+        var (delays, _) = Record();
+
+        delays.First().ShouldBeLessThanOrEqualTo(50, "the first pass should stay as prompt as it is today");
+        delays.Sum().ShouldBeGreaterThanOrEqualTo(1000, "the last pass has to outlast a slow window setup");
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/FakeGameSide.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/FakeGameSide.cs
@@ -1,0 +1,190 @@
+using GameJsonCommunicationPlugin.Common;
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GlueUnitTests.GameCommunicationPlugin
+{
+    /// <summary>
+    /// Stands in for the game process on the other end of live edit's two loopback sockets. No game is
+    /// launched - the handshake is just two connections, each identifying its direction with a single
+    /// byte (1 = glue->game, 2 = game->glue).
+    /// </summary>
+    /// <remarks>
+    /// Deliberately speaks the wire format by hand (8-byte little-endian length, then an ASCII body)
+    /// rather than reusing any production helper, so a change to how Glue frames a message shows up here
+    /// as a failing test instead of being mirrored into the test and hidden.
+    /// </remarks>
+    internal sealed class FakeGameSide : IDisposable
+    {
+        private readonly Socket glueToGame;
+        private readonly Socket gameToGlue;
+        private CancellationTokenSource? responderCancellation;
+
+        private FakeGameSide(Socket glueToGame, Socket gameToGlue)
+        {
+            this.glueToGame = glueToGame;
+            this.gameToGlue = gameToGlue;
+        }
+
+        public static int GetFreePort()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        /// <summary>
+        /// Performs the game side of the handshake and waits until the manager reports connected.
+        /// </summary>
+        public static async Task<FakeGameSide> ConnectAsync(GameConnectionManager manager, int port)
+        {
+            var glueToGame = await ConnectWithRetryAsync(port);
+            glueToGame.Send(new byte[] { 1 });
+
+            var gameToGlue = await ConnectWithRetryAsync(port);
+            gameToGlue.Send(new byte[] { 2 });
+
+            await WaitUntilAsync(() => manager.IsConnected, TimeSpan.FromSeconds(10));
+
+            if (!manager.IsConnected)
+            {
+                glueToGame.Dispose();
+                gameToGlue.Dispose();
+                throw new TimeoutException("The handshake never completed.");
+            }
+
+            return new FakeGameSide(glueToGame, gameToGlue);
+        }
+
+        /// <summary>
+        /// Answers every incoming request on a background thread, the way the real game's receive loop
+        /// does. <paramref name="respond"/> receives the raw request body (the serialized
+        /// <see cref="GameConnectionManager.Packet"/>) and returns the reply payload; returning null
+        /// replies with a zero-length body, which is what the game sends when it has nothing to say.
+        /// </summary>
+        public void StartResponder(Func<string, string?> respond)
+        {
+            responderCancellation = new CancellationTokenSource();
+            var cancellation = responderCancellation.Token;
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    while (!cancellation.IsCancellationRequested)
+                    {
+                        var request = ReadFramedString(glueToGame);
+                        if (request == null)
+                        {
+                            return;
+                        }
+
+                        WriteFramedString(glueToGame, respond(request));
+                    }
+                }
+                catch (Exception ex) when (ex is SocketException || ex is ObjectDisposedException)
+                {
+                    // The test finished and disposed the sockets.
+                }
+            });
+        }
+
+        /// <summary>
+        /// Sends an unsolicited game-&gt;Glue message, the shape live edit uses for drag/resize results.
+        /// </summary>
+        public void SendUnsolicited(string body) => WriteFramedString(gameToGlue, body);
+
+        private static string? ReadFramedString(Socket socket)
+        {
+            var sizeBuffer = new byte[sizeof(long)];
+            if (!ReadExactly(socket, sizeBuffer))
+            {
+                return null;
+            }
+
+            var size = BitConverter.ToInt64(sizeBuffer, 0);
+            if (size == 0)
+            {
+                return string.Empty;
+            }
+
+            var body = new byte[size];
+            return ReadExactly(socket, body)
+                ? Encoding.ASCII.GetString(body)
+                : null;
+        }
+
+        private static bool ReadExactly(Socket socket, byte[] buffer)
+        {
+            var read = 0;
+            while (read < buffer.Length)
+            {
+                var amount = socket.Receive(buffer, read, buffer.Length - read, SocketFlags.None);
+                if (amount == 0)
+                {
+                    return false;
+                }
+                read += amount;
+            }
+            return true;
+        }
+
+        private static void WriteFramedString(Socket socket, string? body)
+        {
+            var bytes = body == null ? Array.Empty<byte>() : Encoding.ASCII.GetBytes(body);
+            socket.Send(BitConverter.GetBytes(bytes.LongLength));
+            if (bytes.Length > 0)
+            {
+                socket.Send(bytes);
+            }
+        }
+
+        private static async Task<Socket> ConnectWithRetryAsync(int port)
+        {
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+
+            while (true)
+            {
+                var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                try
+                {
+                    await socket.ConnectAsync(IPAddress.Loopback, port);
+                    return socket;
+                }
+                catch (SocketException)
+                {
+                    socket.Dispose();
+                    if (DateTime.UtcNow > deadline)
+                    {
+                        throw;
+                    }
+                    // The manager listens from a Task.Run started in its constructor, so the first
+                    // attempts can beat the bind.
+                    await Task.Delay(25);
+                }
+            }
+        }
+
+        public static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (!condition() && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(25);
+            }
+        }
+
+        public void Dispose()
+        {
+            try { responderCancellation?.Cancel(); } catch { }
+            try { glueToGame.Dispose(); } catch { }
+            try { gameToGlue.Dispose(); } catch { }
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GameConnectionResponseTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GameConnectionResponseTests.cs
@@ -1,0 +1,154 @@
+using GameJsonCommunicationPlugin.Common;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin
+{
+    /// <summary>
+    /// "The game dropped this command" and "the game handled this command" have to be distinguishable at
+    /// the call site. These pin the classification <see cref="GameConnectionManager.SendItemWithResponse"/>
+    /// applies to whatever comes back over the socket.
+    /// </summary>
+    public class GameConnectionResponseTests
+    {
+        const double ShortTimeoutInSeconds = 0.3;
+
+        static GameConnectionManager CreateManager(int port) =>
+            new GameConnectionManager((_, __) => { }, port)
+            {
+                TimeoutInSeconds = ShortTimeoutInSeconds,
+                LogAction = _ => { }
+            };
+
+        static GameConnectionManager.Packet AnyPacket() => new GameConnectionManager.Packet
+        {
+            PacketType = "OldDTO",
+            Payload = "RestartScreenDto:{}"
+        };
+
+        /// <summary>
+        /// The game answering with nothing is its normal "handled it, no data to send back" reply - most
+        /// DTOs have a void handler. That has to stay a success or every fire-and-forget command in live
+        /// edit starts reporting failure.
+        /// </summary>
+        [Fact]
+        public async Task EmptyReply_IsSuccessBecauseMostHandlersHaveNothingToSendBack()
+        {
+            var port = FakeGameSide.GetFreePort();
+            using var manager = CreateManager(port);
+            using var game = await FakeGameSide.ConnectAsync(manager, port);
+
+            game.StartResponder(_ => null);
+
+            var response = await manager.SendItemWithResponse(AnyPacket());
+
+            response.Succeeded.ShouldBeTrue("a handler with nothing to return is not a failure");
+        }
+
+        [Fact]
+        public async Task PayloadReply_IsSuccessAndCarriesThePayload()
+        {
+            var port = FakeGameSide.GetFreePort();
+            using var manager = CreateManager(port);
+            using var game = await FakeGameSide.ConnectAsync(manager, port);
+
+            game.StartResponder(_ => "{\"Succeeded\":true}");
+
+            var response = await manager.SendItemWithResponse(AnyPacket());
+
+            response.Succeeded.ShouldBeTrue();
+            response.Data.ShouldBe("{\"Succeeded\":true}");
+        }
+
+        /// <summary>
+        /// The game never answering is a dropped command, not a successful one. Before this was pinned,
+        /// the timeout tore the connection down (correctly) but still handed the caller
+        /// Succeeded = true with null data.
+        /// </summary>
+        [Fact]
+        public async Task NoReplyAtAll_IsReportedAsFailure()
+        {
+            var port = FakeGameSide.GetFreePort();
+            using var manager = CreateManager(port);
+            using var game = await FakeGameSide.ConnectAsync(manager, port);
+
+            // No responder started - nothing on the far end reads the request or answers it.
+            var response = await manager.SendItemWithResponse(AnyPacket());
+
+            response.Succeeded.ShouldBeFalse("a command the game never answered was not carried out");
+            response.Message.ShouldNotBeNullOrEmpty("the caller needs to be able to say why it failed");
+        }
+
+        /// <summary>
+        /// The window this issue is about: the game's socket is up but GlueControlManager has not been
+        /// constructed yet, so nothing can dispatch the DTO. The game says so explicitly instead of
+        /// replying with an empty body, which is indistinguishable from the success above.
+        /// </summary>
+        [Fact]
+        public async Task NotReadyReply_IsReportedAsFailure()
+        {
+            var port = FakeGameSide.GetFreePort();
+            using var manager = CreateManager(port);
+            using var game = await FakeGameSide.ConnectAsync(manager, port);
+
+            game.StartResponder(_ => GameConnectionManager.NotReadyPayload);
+
+            var response = await manager.SendItemWithResponse(AnyPacket());
+
+            response.Succeeded.ShouldBeFalse("the game said it could not handle the command");
+            response.Data.ShouldBeNull("the marker is not a payload the caller should try to read");
+        }
+
+        [Fact]
+        public async Task NotReadyReply_ExplainsThatTheGameIsNotReady()
+        {
+            var port = FakeGameSide.GetFreePort();
+            using var manager = CreateManager(port);
+            using var game = await FakeGameSide.ConnectAsync(manager, port);
+
+            game.StartResponder(_ => GameConnectionManager.NotReadyPayload);
+
+            var response = await manager.SendItemWithResponse(AnyPacket());
+
+            response.Message.ShouldContain("not ready");
+        }
+
+        [Fact]
+        public async Task WhenNotConnected_IsReportedAsFailure()
+        {
+            var port = FakeGameSide.GetFreePort();
+            using var manager = CreateManager(port);
+
+            var response = await manager.SendItemWithResponse(AnyPacket());
+
+            response.Succeeded.ShouldBeFalse();
+            response.Message.ShouldContain("Not connected");
+        }
+
+        /// <summary>
+        /// The game-side copy of GameConnectionManager is an embedded resource, not compiled into this
+        /// assembly - it only compiles inside a game project. The two halves of the marker therefore
+        /// cannot share a constant, so pin that they still agree.
+        /// </summary>
+        [Fact]
+        public void TheGameSideSourceUsesTheSameNotReadyMarker()
+        {
+            // Read straight out of the manifest rather than through GlueControlCodeGenerator, which also
+            // stamps in project namespace and #defines and so needs a loaded project.
+            using var stream = typeof(global::GameCommunicationPlugin.GlueControl.CodeGeneration.GlueControlCodeGenerator)
+                .Assembly
+                .GetManifestResourceStream("GameCommunicationPlugin.GlueControl.Embedded.GameConnectionManager.cs");
+
+            stream.ShouldNotBeNull("the game-side source should ship as an embedded resource");
+
+            var gameSideSource = new System.IO.StreamReader(stream).ReadToEnd();
+
+            gameSideSource.ShouldContain(
+                GameConnectionManager.NotReadyPayload,
+                customMessage: "the game replies with this literal and Glue recognizes it - if they drift, " +
+                    "a dropped command silently reads as success again");
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/ProfilingManagerResponseTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/ProfilingManagerResponseTests.cs
@@ -1,0 +1,119 @@
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GameCommunicationPlugin.GlueControl.CommandSending;
+using GameCommunicationPlugin.GlueControl.Managers;
+using GameCommunicationPlugin.GlueControl.ViewModels;
+using GameJsonCommunicationPlugin.Common;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin
+{
+    /// <summary>
+    /// The profiling tab polls the game once a second. It used to carry a
+    /// "for some reason the data can be null here" workaround, which was this issue seen from the far end:
+    /// a dropped command arrived as Succeeded with no data, so the tab silently kept showing whatever it
+    /// last managed to read.
+    /// </summary>
+    public class ProfilingManagerResponseTests : IDisposable
+    {
+        const double ShortTimeoutInSeconds = 0.3;
+
+        readonly GlueProjectSave? previousGlueProject;
+
+        public ProfilingManagerResponseTests()
+        {
+            GlueTestBootstrap.EnsureInitialized();
+
+            previousGlueProject = ObjectFinder.Self.GlueProject;
+            ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        }
+
+        public void Dispose() => ObjectFinder.Self.GlueProject = previousGlueProject;
+
+        sealed class Fixture : IDisposable
+        {
+            public required GameConnectionManager Manager { get; init; }
+            public required FakeGameSide Game { get; init; }
+            public required ProfilingManager Profiling { get; init; }
+            public required ProfilingControlViewModel ViewModel { get; init; }
+
+            public void Dispose()
+            {
+                Game.Dispose();
+                Manager.Dispose();
+            }
+        }
+
+        static async Task<Fixture> ConnectAsync(Func<string, string?> respond)
+        {
+            var port = FakeGameSide.GetFreePort();
+            var manager = new GameConnectionManager((_, __) => { }, port)
+            {
+                TimeoutInSeconds = ShortTimeoutInSeconds,
+                LogAction = _ => { }
+            };
+
+            var game = await FakeGameSide.ConnectAsync(manager, port);
+            game.StartResponder(respond);
+
+            CompilerLibrary.ViewModels.CompilerViewModel.Self.IsPrintEditorToGameCheckboxChecked = false;
+
+            var sender = new CommandSender
+            {
+                ConnectionManager = manager,
+                PrintOutput = _ => { },
+                CompilerViewModel = CompilerLibrary.ViewModels.CompilerViewModel.Self,
+                GlueViewSettingsViewModel = new GlueViewSettingsViewModel { EnableLiveEdit = true }
+            };
+
+            var viewModel = new ProfilingControlViewModel
+            {
+                SummaryText = "stale numbers from the last successful poll"
+            };
+
+            return new Fixture
+            {
+                Manager = manager,
+                Game = game,
+                ViewModel = viewModel,
+                Profiling = new ProfilingManager { ProfilingViewModel = viewModel, CommandSender = sender }
+            };
+        }
+
+        [Fact]
+        public async Task WhenTheGameIsNotReady_TheTabExplainsInsteadOfShowingStaleNumbers()
+        {
+            using var fixture = await ConnectAsync(_ => GameConnectionManager.NotReadyPayload);
+
+            await fixture.Profiling.RefreshProfilingData();
+
+            fixture.ViewModel.SummaryText.ShouldContain("not ready");
+        }
+
+        [Fact]
+        public async Task WhenTheGameSendsNothingBack_TheTabExplainsInsteadOfShowingStaleNumbers()
+        {
+            using var fixture = await ConnectAsync(_ => null);
+
+            await fixture.Profiling.RefreshProfilingData();
+
+            fixture.ViewModel.SummaryText.ShouldNotContain("stale numbers");
+            fixture.ViewModel.SummaryText.ShouldNotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task WhenTheGameAnswers_TheTabShowsTheProfilingData()
+        {
+            using var fixture = await ConnectAsync(_ =>
+                "{\"SummaryData\":\"1 Sprite\",\"CollisionData\":[]}");
+
+            await fixture.Profiling.RefreshProfilingData();
+
+            fixture.ViewModel.SummaryText.ShouldBe("1 Sprite");
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Plugins/PluginEventContractTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Plugins/PluginEventContractTests.cs
@@ -1,0 +1,73 @@
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace GlueUnitTests.Plugins
+{
+    /// <summary>
+    /// Plugins talk to each other by raising named events. The fire-and-forget flavor
+    /// (<c>ReactToPluginEvent</c>) is harmless when nobody handles it, but the awaiting flavor
+    /// (<c>ReactToPluginEventWithReturn</c>) polls <c>_pendingRequests</c> until an answer arrives and
+    /// there is no timeout - see <c>PluginBase.ReactToPluginEventWithReturn</c>. An event name with no
+    /// handler therefore does not fail, it hangs the awaiting code forever.
+    /// </summary>
+    public class PluginEventContractTests
+    {
+        static readonly Regex RaisedWaitingForReply = new Regex(
+            @"(ReactToPluginEventWithReturn|_eventCallerWith(Result|Action|Return))\(\s*""(?<name>[A-Za-z0-9_]+)""");
+
+        static readonly Regex Handled = new Regex(@"case\s+""(?<name>[A-Za-z0-9_]+)""\s*:");
+
+        [Fact]
+        public void EveryEventRaisedWaitingForAReply_HasAHandler()
+        {
+            var glueRoot = Path.Combine(RepoPaths.FrbRoot, "FRBDK", "Glue");
+
+            var raised = new SortedDictionary<string, string>();
+            var handled = new HashSet<string>();
+
+            foreach (var file in EnumerateSourceFiles(glueRoot))
+            {
+                var text = File.ReadAllText(file);
+                var isHandler = text.Contains("HandleEvent");
+
+                foreach (var line in text.Split('\n'))
+                {
+                    if (line.TrimStart().StartsWith("//"))
+                    {
+                        continue;
+                    }
+
+                    foreach (Match match in RaisedWaitingForReply.Matches(line))
+                    {
+                        raised[match.Groups["name"].Value] = Path.GetFileName(file);
+                    }
+
+                    if (isHandler)
+                    {
+                        foreach (Match match in Handled.Matches(line))
+                        {
+                            handled.Add(match.Groups["name"].Value);
+                        }
+                    }
+                }
+            }
+
+            raised.ShouldNotBeEmpty("the scan found nothing, so it is no longer matching how events are raised");
+
+            var unhandled = raised.Where(pair => !handled.Contains(pair.Key)).ToList();
+
+            unhandled.ShouldBeEmpty(
+                "these events are awaited but nothing answers them, so whatever raises them hangs forever: " +
+                string.Join(", ", unhandled.Select(pair => $"{pair.Key} ({pair.Value})")));
+        }
+
+        static IEnumerable<string> EnumerateSourceFiles(string root) =>
+            Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+                .Where(file => !file.Contains(@"\bin\") && !file.Contains(@"\obj\"));
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameCommandResponseTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameCommandResponseTests.cs
@@ -1,0 +1,77 @@
+using System.Threading.Tasks;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// The socket-level tests use a fake game, so they can only prove Glue reads a reply correctly - not that
+/// a real game sends the reply they assume. These drive an actual running game process to pin what it
+/// really answers, which is the half of issue #2051 that no unit test can reach (the game-side
+/// GameConnectionManager is an embedded resource that only compiles inside a game project).
+///
+/// Tagged "LiveGame" like <see cref="LiveGameProcessTests"/> - launches a real MonoGame window, so it is
+/// developer-machine-only: `dotnet test ... --filter "Category=LiveGame"`.
+/// </summary>
+[Trait("Category", "LiveGame")]
+public class LiveGameCommandResponseTests
+{
+    static Task<LiveGameProcess> StartAsync() => LiveGameProcess.StartAsync(
+        "Samples/EditorTest1",
+        csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+        exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe");
+
+    /// <summary>
+    /// SetBorderlessDto's handler returns void, so the game answers with an empty body. That has to read as
+    /// success: it is how the editor decides the game is ready to be embedded, and the same shape covers
+    /// most of live edit's commands.
+    /// </summary>
+    [StaFact]
+    public async Task VoidHandlerCommand_AgainstARunningGame_ReportsSuccess()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await StartAsync();
+
+        var response = await game.Send(new SetBorderlessDto { IsBorderless = true });
+
+        response.Succeeded.ShouldBeTrue(
+            "the game handled the command; a void handler having nothing to return is not a failure");
+    }
+
+    /// <summary>
+    /// The other side of the same reply, and the reason the old "did the game send a non-empty string?"
+    /// check could not tell a handled command from a dropped one: a real game handling a void command sends
+    /// back nothing at all.
+    /// </summary>
+    [StaFact]
+    public async Task VoidHandlerCommand_AgainstARunningGame_SendsBackNoPayload()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await StartAsync();
+
+        var response = await game.Send(new SetBorderlessDto { IsBorderless = true });
+
+        response.Data.ShouldBeNullOrEmpty();
+    }
+
+    /// <summary>
+    /// A command whose handler does return data still comes back as data, so the classification above did
+    /// not swallow real payloads.
+    /// </summary>
+    [StaFact]
+    public async Task CommandWithAResponse_AgainstARunningGame_CarriesThePayload()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await StartAsync();
+
+        var response = await game.Send(new GetCameraPosition());
+
+        response.Succeeded.ShouldBeTrue();
+        response.Data.ShouldNotBeNullOrEmpty();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
@@ -163,6 +163,12 @@ internal sealed class LiveGameProcess : IDisposable
     }
 
     /// <summary>
+    /// Sends any DTO over the real CommandSender, for tests that care about what the running game answers
+    /// rather than about a particular editor gesture.
+    /// </summary>
+    public Task<GeneralResponse<string>> Send(object dto) => CommandSender.Self.Send(dto);
+
+    /// <summary>
     /// Sends the same SelectObjectDto Glue sends when the user clicks an entity in the tree, over the real
     /// CommandSender/wire protocol - see RefreshManager.PushGlueSelectionToGame for the production version
     /// of this DTO shape.


### PR DESCRIPTION
Closes #2051.

The game answered commands it couldn't dispatch yet with a zero-length payload — the same thing it sends for a command it handled fine — so Glue reported a dropped command as `Succeeded = true`. Three callers each guessed differently at what that meant.

## Change

One rule: `Succeeded` means the game carried the command out.

- **Game side** (`Embedded/GameConnectionManager.cs`): when `GlueControlManager.Self` is still null, reply with an explicit not-ready marker instead of nothing.
- **`GameConnectionManager.SendItemWithResponse`**: not-ready marker → failure; no reply at all (timeout, dead socket) → failure, which it also used to report as success. An empty payload stays a success — most handlers are `void` and that is their normal answer.
- **`CommandSender.Send<T>`**: an empty reply is now a failure, since a caller that asked for typed data and got none did not get its command carried out.

Callers updated to use it, and their decisions pulled into pinnable functions:

- `MainCompilerPlugin.GetSetEditModeFailureMessage` — also fixes the "not connected" branch that built a message and threw it away.
- `RefreshManager.GetAddObjectRestartReason` — a restart now names the dropped command instead of blaming the objects.
- `ProfilingManager` — the profiling tab shows why it's blank instead of leaving stale numbers up. Its `// for some reason the data can be null here` workaround was this bug.

## Also fixes: the borderless retry could never succeed, and the embed path behind it hangs

`GameHostView.MakeGameBorderless` decided "the game is ready" by testing the response for content, but `HandleDto(SetBorderlessDto)` returns `void`, so a healthy game always answers with nothing — verified against a real running game in `LiveGameCommandResponseTests`. The retry always exhausted its budget and printed the "Failed to make the game window borderless" warning, which is very likely what #2048 was actually reporting; widening the budget could not have helped.

Switching it to `Succeeded` then exposed a second bug behind it. `EmbedHwnd`'s follow-up `Runner_MoveWindow` loop asks for window dimensions with a `Runner_GetWindowInfo` plugin event that **no plugin has ever handled**, and `PluginBase.ReactToPluginEventWithReturn` polls for an answer with no timeout — so awaiting it never returns, `IsWindowEmbedded` is never set, and the game ends up reparented into a hidden panel ("The game is running in an external window"). That block is superseded by `SetGameToEmbeddedGameWindow`, which `MoveGameToHost` already drives via `ForceRefreshGameArea`, so it is removed. `PluginEventContractTests` now fails the build if any awaited plugin event has no handler.

## Also: the embedded window's cursor offset

MonoGame/SDL keeps translating screen coordinates with the position it cached before `SetParent` reparented the game into the Game tab, so clicks and drag rectangles land offset until something moves the window relative to its new parent — that is what `ForceRefreshGameArea`'s panel nudge exists to force. A single nudge is a race: one that lands before the window has settled is lost, and nothing detects it, since the game still draws correctly either way. `MakeGameBorderless` used to burn its full 1s budget on every launch, which accidentally gave the window that long to settle; now that it returns promptly, `EmbedSettlePolicy` spreads three nudges over ~1s deliberately. Costs two extra brief flickers of the left panel at launch.

## Tests

- `GameConnectionResponseTests` — classification over real loopback sockets, plus a check that the Glue-side constant and the embedded game-side literal still agree (they can't share one; the game file is an embedded resource).
- `CommandSenderResponseTests` — the whole Glue-side stack against a fake game, including a per-DTO theory over **every** command the game declares a handler for, derived from the embedded `CommandReceiver` source rather than hand-listed. Each is asserted both ways: dropped → failure, handled-with-no-data → success.
- `DroppedCommandCallerTests`, `ProfilingManagerResponseTests` — the three callers.
- `PluginEventContractTests` — no awaited plugin event without a handler.
- `EmbedSettlePolicyTests` — the nudge schedule stays prompt on its first pass and keeps going past it.
- `LiveGameCommandResponseTests` (`Category=LiveGame`, developer-machine-only) — a real game process, which is the only way to cover the game-side half.

Seams added to make the above possible, all the transitional-injection pattern from `REFACTORING.md`: `CommandSender.ConnectionManager`, `ProfilingManager.ProfilingViewModel`/`CommandSender`.

560/560 non-BuildSmoke green; `Beefball_WithLiveEditCode_LoadInGlue_ThenBuild_ShouldSucceed` and the `LiveGame` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


