### PR TITLE
Migrate the movement csv name instead of adding a second one

### DIFF
--- a/FRBDK/Glue/EntityInputMovementPlugin/MainEntityInputMovementPlugin.cs
+++ b/FRBDK/Glue/EntityInputMovementPlugin/MainEntityInputMovementPlugin.cs
@@ -78,9 +78,15 @@ namespace EntityInputMovementPlugin
 
         private async void HandleGluxLoaded()
         {
+            // Before anything reads a movement csv - the name changed at CsvInheritanceSupport, and reading
+            // under the new name in a project that still has the old one silently resets tuned values.
+            bool didMigrateCsvNames = MigrateLegacyMovementCsvNames();
+
             bool didChangeGlux = await UpdateTopDownCodePresenceInProject();
 
             UpdatePlatformerCodePresenceInProject();
+
+            didChangeGlux |= didMigrateCsvNames;
 
             if (didChangeGlux)
             {
@@ -98,6 +104,26 @@ namespace EntityInputMovementPlugin
             {
                 await FlatRedBall.PlatformerPlugin.Controllers.MainController.ForceCsvGenerationFor(firstPlatformerEntity);
             }
+        }
+
+        private static bool MigrateLegacyMovementCsvNames()
+        {
+            var didMigrateAny = false;
+
+            foreach (var entity in GlueState.Self.CurrentGlueProject.Entities)
+            {
+                if (FlatRedBall.PlatformerPlugin.Controllers.MainController.IsPlatformer(entity))
+                {
+                    didMigrateAny |= FlatRedBall.PlatformerPlugin.Controllers.MainController.MigrateLegacyCsvNameFor(entity);
+                }
+
+                if (TopDownPlugin.Controllers.MainController.IsTopDown(entity))
+                {
+                    didMigrateAny |= TopDownPlugin.Controllers.MainController.MigrateLegacyCsvNameFor(entity);
+                }
+            }
+
+            return didMigrateAny;
         }
 
         private async void HandleEntityImported(GlueElement newElement)

--- a/FRBDK/Glue/Glue/Managers/RenamedCsvMigrator.cs
+++ b/FRBDK/Glue/Glue/Managers/RenamedCsvMigrator.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Linq;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.IO;
+
+namespace FlatRedBall.Glue.Managers
+{
+    /// <summary>
+    /// Migrates an element's CSV ReferencedFileSave when the plugin that owns it has changed the file
+    /// name it generates. The platformer and top down plugins both switch their CSV name on glux
+    /// version (PlatformerValues -> PlatformerValuesStatic at CsvInheritanceSupport), and without this
+    /// an upgraded project keeps the old file, gets a second one added alongside it, and loses whatever
+    /// values were tuned in the original (the view model reads the new name, finds nothing, and writes
+    /// defaults back out).
+    /// </summary>
+    public static class RenamedCsvMigrator
+    {
+        /// <summary>
+        /// Renames element's "oldUnqualified".csv ReferencedFileSave to "newUnqualified".csv, moving the
+        /// file, fixing project build items, the owning CustomClassSave, and any CustomVariable default
+        /// values that name the old file.
+        /// </summary>
+        /// <returns>True if a rename happened.</returns>
+        public static bool MigrateCsvRename(GlueElement element, string oldUnqualified, string newUnqualified)
+        {
+            if (element == null || oldUnqualified == newUnqualified)
+            {
+                return false;
+            }
+
+            var oldFileName = oldUnqualified + ".csv";
+            var newFileName = newUnqualified + ".csv";
+
+            var oldRfs = element.ReferencedFiles.FirstOrDefault(item =>
+                FileManager.RemovePath(item.Name).Equals(oldFileName, StringComparison.OrdinalIgnoreCase));
+
+            if (oldRfs == null)
+            {
+                return false;
+            }
+
+            var newName = FileManager.GetDirectory(oldRfs.Name, RelativeType.Relative) + newFileName;
+
+            // Both present means this project already took the "second csv added alongside" path. Renaming
+            // on top of the new one would prompt about overwriting and could destroy whichever the user has
+            // since edited, so leave it alone - only the never-migrated case is unambiguous.
+            var alreadyHasNew = element.ReferencedFiles.Any(item =>
+                item.Name.Equals(newName, StringComparison.OrdinalIgnoreCase));
+
+            if (alreadyHasNew || GlueCommands.Self.GetAbsoluteFilePath(newName).Exists())
+            {
+                return false;
+            }
+
+            var oldRfsName = oldRfs.Name;
+
+            var didRename = GlueCommands.Self.FileCommands.RenameReferencedFileSave(oldRfs, newName);
+
+            if (!didRename)
+            {
+                return false;
+            }
+
+            UpdateCustomClass(oldRfsName, newName);
+            UpdateCustomVariableDefaultValues(element, oldFileName, newFileName);
+
+            PluginManager.ReceiveOutput($"Renamed {oldRfsName} to {newName}");
+
+            return true;
+        }
+
+        private static void UpdateCustomClass(string oldRfsName, string newRfsName)
+        {
+            var customClasses = GlueState.Self.CurrentGlueProject?.CustomClasses;
+
+            if (customClasses == null)
+            {
+                return;
+            }
+
+            foreach (var customClass in customClasses)
+            {
+                if (customClass.CsvFilesUsingThis.Remove(oldRfsName) &&
+                    customClass.CsvFilesUsingThis.Contains(newRfsName) == false)
+                {
+                    customClass.CsvFilesUsingThis.Add(newRfsName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Platformer/top down variables store their default as "Ground in PlatformerValues.csv" - the
+        /// " in &lt;file&gt;" suffix is which csv the value came from, and it's what the property grid
+        /// matches its dropdown against, so a stale one shows up blank in the editor.
+        /// </summary>
+        private static void UpdateCustomVariableDefaultValues(GlueElement element, string oldFileName, string newFileName)
+        {
+            var elements = new[] { element }
+                .Concat(ObjectFinder.Self.GetAllElementsThatInheritFrom(element));
+
+            var oldSuffix = " in " + oldFileName;
+            var newSuffix = " in " + newFileName;
+
+            foreach (var toUpdate in elements)
+            {
+                foreach (var variable in toUpdate.CustomVariables)
+                {
+                    if (variable.DefaultValue is string asString &&
+                        asString.EndsWith(oldSuffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        variable.DefaultValue = asString.Substring(0, asString.Length - oldSuffix.Length) + newSuffix;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/PlatformerPlugin/CodeGenerators/CsvGenerator.cs
+++ b/FRBDK/Glue/PlatformerPlugin/CodeGenerators/CsvGenerator.cs
@@ -19,6 +19,12 @@ namespace FlatRedBall.PlatformerPlugin.Generators
     {
         #region Fields/Properties
 
+        /// <summary>
+        /// What the csv was called before CsvInheritanceSupport. Projects made before that version still
+        /// have it under this name until they're migrated - see MainController.MigrateLegacyCsvNameFor.
+        /// </summary>
+        public const string LegacyStrippedCsvFile = "PlatformerValues";
+
         public static string StrippedCsvFile
         {
             get
@@ -29,7 +35,7 @@ namespace FlatRedBall.PlatformerPlugin.Generators
                 }
                 else
                 {
-                    return "PlatformerValues";
+                    return LegacyStrippedCsvFile;
                 }
             }
         }

--- a/FRBDK/Glue/PlatformerPlugin/Controllers/MainController.cs
+++ b/FRBDK/Glue/PlatformerPlugin/Controllers/MainController.cs
@@ -46,6 +46,15 @@ namespace FlatRedBall.PlatformerPlugin.Controllers
             return viewModel;
         }
 
+        /// <summary>
+        /// Drops the cached view model so the next GetViewModel hands back a clean one. Glue itself has no
+        /// use for this (one running instance, one view model), but tests share this singleton across
+        /// projects, where a left-over IsPlatformer = true makes the next "IsPlatformer = true" a silent
+        /// no-op. Clearing the field rather than setting the properties back avoids firing the handler
+        /// against an entity that no longer exists.
+        /// </summary>
+        public void ResetViewModel() => viewModel = null;
+
         public void MakeCurrentEntityPlatformer()
         {
             if(viewModel != null)
@@ -388,6 +397,23 @@ namespace FlatRedBall.PlatformerPlugin.Controllers
                     );
 
             }
+        }
+
+        /// <summary>
+        /// Renames a pre-CsvInheritanceSupport PlatformerValues.csv to the name this project's version
+        /// generates. Has to run before anything reads the csv: the view model loads from the current
+        /// name, so an unmigrated project reads nothing, falls back to defaults, and writes those defaults
+        /// back out as a second csv - losing whatever was tuned in the original.
+        /// </summary>
+        public static bool MigrateLegacyCsvNameFor(EntitySave entitySave)
+        {
+            if (CsvGenerator.StrippedCsvFile == CsvGenerator.LegacyStrippedCsvFile)
+            {
+                return false;
+            }
+
+            return RenamedCsvMigrator.MigrateCsvRename(
+                entitySave, CsvGenerator.LegacyStrippedCsvFile, CsvGenerator.StrippedCsvFile);
         }
 
         public static async Task ForceCsvGenerationFor(EntitySave entitySave)

--- a/FRBDK/Glue/Tests/GlueUnitTests/EntityInputMovementPlugin/EntityInputMovementTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/EntityInputMovementPlugin/EntityInputMovementTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using FlatRedBall.Glue.Elements;
@@ -74,10 +74,25 @@ public class EntityInputMovementTests : IDisposable
 
         TaskManager.SynchronousMode = true;
         TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+
+        ResetMovementViewModels();
+    }
+
+    /// <summary>
+    /// Both controllers' view models are process-wide singletons (MainController.GetViewModel creates one
+    /// lazily and keeps it). Left set from an earlier test, "IsPlatformer = true" is a no-op that raises no
+    /// PropertyChanged, so the next test's entity silently never becomes a platformer.
+    /// </summary>
+    private static void ResetMovementViewModels()
+    {
+        FlatRedBall.PlatformerPlugin.Controllers.MainController.Self.ResetViewModel();
+        TopDownPlugin.Controllers.MainController.Self.ResetViewModel();
     }
 
     public void Dispose()
     {
+        ResetMovementViewModels();
+
         GlueState.Self.CurrentMainProject = _originalMainProject;
         ObjectFinder.Self.GlueProject = _originalGlueProject;
         FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
@@ -156,6 +171,134 @@ public class EntityInputMovementTests : IDisposable
         customClass.ShouldNotBeNull();
         customClass!.CsvFilesUsingThis.ShouldContain(csvRfs.Name);
     }
+
+    #region Legacy csv name migration (issue #2055)
+
+    // The platformer csv is named on glux version - "PlatformerValues.csv" below CsvInheritanceSupport,
+    // "PlatformerValuesStatic.csv" at or above it (CsvGenerator.StrippedCsvFile). Nothing used to migrate a
+    // project across that rename, so upgrading left the old file behind, added a second one, and reset the
+    // values tuned in the original (the view model reads the new name, finds nothing, writes defaults out).
+
+    /// <summary>
+    /// Marks entity as a platformer on a pre-CsvInheritanceSupport project and tunes a value, so the
+    /// project is left in the state an upgrade has to migrate: a "PlatformerValues.csv" holding real data.
+    /// </summary>
+    private async System.Threading.Tasks.Task<EntitySave> CreatePreCsvInheritancePlatformer(float maxSpeedX)
+    {
+        GlueState.Self.CurrentGlueProject.FileVersion = (int)GlueProjectSave.GluxVersions.CsvInheritanceSupport - 1;
+
+        var entity = new EntitySave { Name = "Entities\\Player" };
+        GlueState.Self.CurrentGlueProject.Entities.Add(entity);
+        GlueState.Self.CurrentElement = entity;
+
+        var viewModel = FlatRedBall.PlatformerPlugin.Controllers.MainController.Self.GetViewModel();
+        viewModel.BackingData = entity;
+        viewModel.IsPlatformer = true;
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        viewModel.PlatformerValues[0].MaxSpeedX = maxSpeedX;
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        return entity;
+    }
+
+    private static void UpgradePastCsvRename() =>
+        GlueState.Self.CurrentGlueProject.FileVersion = (int)GlueProjectSave.GluxVersions.CsvInheritanceSupport;
+
+    [Fact]
+    public async System.Threading.Tasks.Task MigrateLegacyCsvNameFor_ShouldKeepTunedValues_WhenProjectIsUpgradedPastTheRename()
+    {
+        var entity = await CreatePreCsvInheritancePlatformer(maxSpeedX: 9999);
+        var legacyCsvPath = FlatRedBall.PlatformerPlugin.Generators.CsvGenerator.Self.CsvPlatformerFileFor(entity).FullPath;
+        File.ReadAllText(legacyCsvPath).ShouldContain("9999");
+
+        UpgradePastCsvRename();
+        FlatRedBall.PlatformerPlugin.Controllers.MainController.MigrateLegacyCsvNameFor(entity).ShouldBeTrue();
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        // What MainEntityInputMovementPlugin.HandleGluxLoaded runs right after, and what used to overwrite
+        // the values with defaults.
+        await FlatRedBall.PlatformerPlugin.Controllers.MainController.ForceCsvGenerationFor(entity);
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        var migratedCsvPath = FlatRedBall.PlatformerPlugin.Generators.CsvGenerator.Self.CsvPlatformerFileFor(entity).FullPath;
+        migratedCsvPath.ShouldEndWith("PlatformerValuesStatic.csv");
+        File.Exists(migratedCsvPath).ShouldBeTrue();
+        File.ReadAllText(migratedCsvPath).ShouldContain("9999");
+        File.Exists(legacyCsvPath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MigrateLegacyCsvNameFor_ShouldLeaveExactlyOneCsvOnTheEntity()
+    {
+        var entity = await CreatePreCsvInheritancePlatformer(maxSpeedX: 9999);
+
+        UpgradePastCsvRename();
+        FlatRedBall.PlatformerPlugin.Controllers.MainController.MigrateLegacyCsvNameFor(entity);
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        // The user then edits a platformer value, which is what re-runs GenerateAndAddCsv.
+        FlatRedBall.PlatformerPlugin.Controllers.MainController.Self.GetViewModel().PlatformerValues[0].MaxSpeedX = 123;
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        var csvNames = entity.ReferencedFiles.Where(item => item.Name.EndsWith(".csv")).Select(item => item.Name).ToArray();
+        csvNames.ShouldHaveSingleItem();
+        csvNames[0].ShouldEndWith("PlatformerValuesStatic.csv");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MigrateLegacyCsvNameFor_ShouldRebindTheCustomClassToTheNewName()
+    {
+        var entity = await CreatePreCsvInheritancePlatformer(maxSpeedX: 9999);
+
+        UpgradePastCsvRename();
+        FlatRedBall.PlatformerPlugin.Controllers.MainController.MigrateLegacyCsvNameFor(entity);
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        var customClass = GlueState.Self.CurrentGlueProject.CustomClasses.FirstOrDefault(c => c.Name == "PlatformerValues");
+        customClass.ShouldNotBeNull();
+        customClass!.CsvFilesUsingThis.ShouldHaveSingleItem();
+        customClass.CsvFilesUsingThis[0].ShouldEndWith("PlatformerValuesStatic.csv");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MigrateLegacyCsvNameFor_ShouldRepointCustomVariableDefaultsAtTheNewFile()
+    {
+        var entity = await CreatePreCsvInheritancePlatformer(maxSpeedX: 9999);
+        entity.CustomVariables.Select(v => v.DefaultValue as string)
+            .ShouldContain("Ground in PlatformerValues.csv");
+
+        UpgradePastCsvRename();
+        FlatRedBall.PlatformerPlugin.Controllers.MainController.MigrateLegacyCsvNameFor(entity);
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        var defaults = entity.CustomVariables.Select(v => v.DefaultValue as string).ToArray();
+        defaults.ShouldContain("Ground in PlatformerValuesStatic.csv");
+        defaults.ShouldNotContain("Ground in PlatformerValues.csv");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task MigrateLegacyCsvNameFor_ShouldDoNothing_OnAProjectThatNeverHadTheOldName()
+    {
+        GlueState.Self.CurrentGlueProject.FileVersion = (int)GlueProjectSave.GluxVersions.CsvInheritanceSupport;
+
+        var entity = new EntitySave { Name = "Entities\\Player" };
+        GlueState.Self.CurrentGlueProject.Entities.Add(entity);
+        GlueState.Self.CurrentElement = entity;
+
+        var viewModel = FlatRedBall.PlatformerPlugin.Controllers.MainController.Self.GetViewModel();
+        viewModel.BackingData = entity;
+        viewModel.IsPlatformer = true;
+        await TaskManager.Self.WaitForAllTasksFinished();
+
+        FlatRedBall.PlatformerPlugin.Controllers.MainController.MigrateLegacyCsvNameFor(entity).ShouldBeFalse();
+
+        var csvNames = entity.ReferencedFiles.Where(item => item.Name.EndsWith(".csv")).Select(item => item.Name).ToArray();
+        csvNames.ShouldHaveSingleItem();
+        csvNames[0].ShouldEndWith("PlatformerValuesStatic.csv");
+    }
+
+    #endregion
 
     [Fact]
     public async System.Threading.Tasks.Task MakeEntityTopDown_ShouldMarkEntityAsTopDown_AndAddCsv()

--- a/FRBDK/Glue/TopDownPlugin/Controllers/MainController.cs
+++ b/FRBDK/Glue/TopDownPlugin/Controllers/MainController.cs
@@ -57,6 +57,15 @@ namespace TopDownPlugin.Controllers
             return viewModel;
         }
 
+        /// <summary>
+        /// Drops the cached view model so the next GetViewModel hands back a clean one. Glue itself has no
+        /// use for this (one running instance, one view model), but tests share this singleton across
+        /// projects, where a left-over IsTopDown = true makes the next "IsTopDown = true" a silent no-op.
+        /// Clearing the field rather than setting the properties back avoids firing the handler against an
+        /// entity that no longer exists.
+        /// </summary>
+        public void ResetViewModel() => viewModel = null;
+
         public void MakeCurrentEntityTopDown()
         {
             if (viewModel != null)
@@ -351,9 +360,26 @@ namespace TopDownPlugin.Controllers
         }
 
 
+        /// <summary>
+        /// Renames a pre-CsvInheritanceSupport TopDownValues.csv to the name this project's version
+        /// generates. Has to run before anything reads the csv: the view model loads from the current
+        /// name, so an unmigrated project reads nothing, falls back to defaults, and writes those defaults
+        /// back out as a second csv - losing whatever was tuned in the original.
+        /// </summary>
+        public static bool MigrateLegacyCsvNameFor(EntitySave entitySave)
+        {
+            if (CsvGenerator.StrippedCsvFile == CsvGenerator.LegacyStrippedCsvFile)
+            {
+                return false;
+            }
+
+            return RenamedCsvMigrator.MigrateCsvRename(
+                entitySave, CsvGenerator.LegacyStrippedCsvFile, CsvGenerator.StrippedCsvFile);
+        }
+
         #region Update To / Refresh From Model
 
-        public static bool IsTopDown(EntitySave entitySave) => 
+        public static bool IsTopDown(EntitySave entitySave) =>
             entitySave.Properties.GetValue<bool>(nameof(TopDownEntityViewModel.IsTopDown));
 
         public bool GetIfInheritsFromTopDown(EntitySave entitySave) =>

--- a/FRBDK/Glue/TopDownPlugin/DataGenerators/CsvGenerator.cs
+++ b/FRBDK/Glue/TopDownPlugin/DataGenerators/CsvGenerator.cs
@@ -19,6 +19,12 @@ namespace TopDownPlugin.DataGenerators
     {
         #region Fields/Properties
 
+        /// <summary>
+        /// What the csv was called before CsvInheritanceSupport. Projects made before that version still
+        /// have it under this name until they're migrated - see MainController.MigrateLegacyCsvNameFor.
+        /// </summary>
+        public const string LegacyStrippedCsvFile = "TopDownValues";
+
         public static string StrippedCsvFile
         {
             get
@@ -31,7 +37,7 @@ namespace TopDownPlugin.DataGenerators
                 }
                 else
                 {
-                    return "TopDownValues";
+                    return LegacyStrippedCsvFile;
                 }
             }
         }


### PR DESCRIPTION
Closes #2055.

The platformer/top down csv is named on glux version: `PlatformerValues.csv` below `CsvInheritanceSupport`, `PlatformerValuesStatic.csv` at or above (`CsvGenerator.StrippedCsvFile`). Nothing migrated a project across that rename, so upgrading one left the old file in place, added a second `ReferencedFileSave` next to it, and silently reset whatever the user had tuned - the view model reads the current name, finds nothing, falls back to defaults, and writes those defaults out as the new csv.

`RenamedCsvMigrator` renames the legacy RFS on glux load, before anything reads the csv. `FileCommands.RenameReferencedFileSave` already handles the file move and csproj build items; this adds the two things it doesn't know about, the owning `CustomClassSave.CsvFilesUsingThis` and the `"Ground in PlatformerValues.csv"` style `CustomVariable` defaults.

A project that already has both files is left alone. Which of the two the user has since edited isn't knowable, and picking wrong destroys data.

Both plugins also get `MainController.ResetViewModel`. Their view models are process-wide singletons, so a left-over `IsPlatformer`/`IsTopDown` makes the next assignment a no-op that raises no `PropertyChanged` - which showed up as new tests passing alone and failing in the suite. Nothing in Glue calls it.

Tests: 5 in `EntityInputMovementTests`, covering value preservation, the duplicate RFS, the custom class rebind, the variable defaults, and that a project which never had the old name is untouched. Four fail without the migrator; the fifth is the negative case. Full non-BuildSmoke suite green (597).

Manual test: needed, since nothing here exercises a real upgraded project end to end. Open a game made before `CsvInheritanceSupport` that has a platformer entity (or hand-edit a `.gluj`'s `FileVersion` down to 4 with `PlatformerValues.csv` in place), load it in Glue, and confirm the entity ends up with one `PlatformerValuesStatic.csv` holding the original values rather than two csvs and defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
