### PR TITLE
Fix exitwhenquiet never firing when load drains before the watcher's first poll

### DIFF
--- a/FRBDK/Glue/Glue/MainGlueWindow.cs
+++ b/FRBDK/Glue/Glue/MainGlueWindow.cs
@@ -717,8 +717,6 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
 
 
     private System.Windows.Forms.Timer _exitWhenQuietTimer;
-    private bool _exitWhenQuietHasBeenBusy;
-    private DateTime _exitWhenQuietLastBusyTime;
 
     /// <summary>
     /// Automation hook (see CommandLineManager.ExitWhenQuietSeconds): once tasks have gone from
@@ -736,24 +734,12 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
             return;
         }
 
+        var watcher = new QuietExitWatcher(TimeSpan.FromSeconds(quietSeconds.Value), () => DateTime.Now);
+
         _exitWhenQuietTimer = new System.Windows.Forms.Timer { Interval = 500 };
         _exitWhenQuietTimer.Tick += (_, _) =>
         {
-            if (!TaskManager.Self.AreAllAsyncTasksDone)
-            {
-                _exitWhenQuietHasBeenBusy = true;
-                _exitWhenQuietLastBusyTime = DateTime.Now;
-                return;
-            }
-
-            // Don't exit before any work has even been queued yet (e.g. the project load's
-            // task hasn't been added to TaskManager yet) - only arm once we've seen busy.
-            if (!_exitWhenQuietHasBeenBusy)
-            {
-                return;
-            }
-
-            if ((DateTime.Now - _exitWhenQuietLastBusyTime).TotalSeconds >= quietSeconds.Value)
+            if (watcher.Tick(isBusy: !TaskManager.Self.AreAllAsyncTasksDone))
             {
                 _exitWhenQuietTimer.Stop();
                 this.Close();

--- a/FRBDK/Glue/Glue/Managers/QuietExitWatcher.cs
+++ b/FRBDK/Glue/Glue/Managers/QuietExitWatcher.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace FlatRedBall.Glue.Managers
+{
+    /// <summary>
+    /// Decides when TaskManager has been idle long enough for the "exitwhenquiet" automation hook
+    /// (see <see cref="CommandLineManager.ExitWhenQuietSeconds"/>) to close Glue. Extracted from
+    /// MainGlueWindow's WinForms timer so the idle/quiet bookkeeping can be unit tested without a
+    /// real window.
+    /// </summary>
+    public class QuietExitWatcher
+    {
+        readonly TimeSpan quietDuration;
+        readonly Func<DateTime> now;
+        DateTime lastBusyTime;
+
+        public QuietExitWatcher(TimeSpan quietDuration, Func<DateTime> now)
+        {
+            this.quietDuration = quietDuration;
+            this.now = now;
+            // Seed the clock as of construction rather than requiring a busy tick to be observed
+            // first: by the time this watcher is created, the load it's watching for has already
+            // been kicked off (and, for a fast-loading project, may have already fully drained
+            // before the first Tick ever runs) - see #2053.
+            lastBusyTime = now();
+        }
+
+        /// <summary>
+        /// Reports the current busy state. Returns true once TaskManager has been continuously idle
+        /// for at least <see cref="quietDuration"/> since the last observed busy tick (or since
+        /// construction, if it has never been busy).
+        /// </summary>
+        public bool Tick(bool isBusy)
+        {
+            if (isBusy)
+            {
+                lastBusyTime = now();
+                return false;
+            }
+
+            return (now() - lastBusyTime) >= quietDuration;
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Tasks/QuietExitWatcherTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Tasks/QuietExitWatcherTests.cs
@@ -1,0 +1,57 @@
+using System;
+using FlatRedBall.Glue.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Tasks;
+
+// Pins GitHub issue #2053: exitwhenquiet never fired for projects whose queued work finished
+// draining before the watcher's first poll ever observed a busy tick.
+public class QuietExitWatcherTests
+{
+    [Fact]
+    public void Tick_ReturnsTrue_WhenIdleForQuietDuration_EvenIfNeverObservedBusy()
+    {
+        var current = new DateTime(2026, 1, 1, 0, 0, 0);
+        var watcher = new QuietExitWatcher(TimeSpan.FromSeconds(12), () => current);
+
+        // All of the project's work ran (and drained) before the watcher started polling - every
+        // tick sees an already-idle TaskManager, exactly like the GlueLoaderScratch repro in #2053.
+        watcher.Tick(isBusy: false).ShouldBeFalse();
+
+        current = current.AddSeconds(12);
+
+        watcher.Tick(isBusy: false).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Tick_ReturnsFalse_WhileBusy()
+    {
+        var current = new DateTime(2026, 1, 1, 0, 0, 0);
+        var watcher = new QuietExitWatcher(TimeSpan.FromSeconds(12), () => current);
+
+        watcher.Tick(isBusy: true).ShouldBeFalse();
+
+        current = current.AddSeconds(20);
+
+        watcher.Tick(isBusy: true).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Tick_ResetsQuietClock_WhenBusyAgainAfterIdle()
+    {
+        var current = new DateTime(2026, 1, 1, 0, 0, 0);
+        var watcher = new QuietExitWatcher(TimeSpan.FromSeconds(12), () => current);
+
+        watcher.Tick(isBusy: false).ShouldBeFalse();
+
+        current = current.AddSeconds(6);
+        watcher.Tick(isBusy: true).ShouldBeFalse();
+
+        current = current.AddSeconds(6);
+        watcher.Tick(isBusy: false).ShouldBeFalse();
+
+        current = current.AddSeconds(12);
+        watcher.Tick(isBusy: false).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Fixes #2053.

`StartExitWhenQuietWatcherIfRequested`'s timer only armed once a tick observed `TaskManager` busy. When a project's queued load work fully drains before the 500ms timer's first tick fires (repro: FlatRedBall2's `GlueLoaderScratch` sample, whose load is fast enough to finish before the watcher even starts polling), every tick sees an already-idle `TaskManager` and `_exitWhenQuietHasBeenBusy` never gets set, so the watcher never closes Glue.

Confirmed with a stack dump + probe logging: the task-manager thread was genuinely blocked on an empty queue the whole time, not stuck running anything - `AreAllAsyncTasksDone` was `True` from the very first tick.

Fix: extracted the idle/quiet bookkeeping into `QuietExitWatcher`, seeded to "now" at construction instead of requiring an observed busy tick before it's allowed to arm. Verified against the real repro: exits ~20s after launch (load + the 12s quiet window) instead of never.

## Test plan
- [x] `QuietExitWatcherTests` (red against the ported original logic, green after the fix)
- [x] Full `Category!=BuildSmoke` suite: 595/595 passing
- [x] Manual: launched `GlueFormsCore.exe` against `FlatRedBall2/samples/GlueLoaderScratch/GlueLoaderScratch.csproj` with `exitwhenquiet=12`, confirmed clean exit (previously hung indefinitely)
