### PR TITLE
Resolve .gluj and .slnx picks to the right .csproj

### DIFF
--- a/FRBDK/Glue/Glue/Managers/CommandLineManager.cs
+++ b/FRBDK/Glue/Glue/Managers/CommandLineManager.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using FlatRedBall.Glue.VSHelpers;
+using FlatRedBall.IO;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,6 +11,13 @@ namespace FlatRedBall.Glue.Managers
     {
         const string ExitWhenQuietArg = "exitwhenquiet";
         const int DefaultExitWhenQuietSeconds = 5;
+
+        /// <summary>
+        /// What can be passed as the project to open - the same set the Load Project dialog offers,
+        /// since a file that opens by double-clicking should also open from a shortcut or a script.
+        /// </summary>
+        static readonly HashSet<string> ProjectExtensions =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "csproj", "sln", "slnx", "glux", "gluj" };
 
         string mProjectToLoad = null;
 
@@ -37,19 +46,9 @@ namespace FlatRedBall.Glue.Managers
 
             foreach(string var in commandLineArgs)
             {
-                if (var.Contains(".glux"))
+                if (ProjectExtensions.Contains(FileManager.GetExtension(var)))
                 {
-                    mProjectToLoad = var;
-                    mProjectToLoad = mProjectToLoad.Replace(".glux", ".csproj");
-                }
-                if (var.Contains(".gluj"))
-                {
-                    mProjectToLoad = var;
-                    mProjectToLoad = mProjectToLoad.Replace(".gluj", ".csproj");
-                }
-                if (var.Contains(".csproj"))
-                {
-                    mProjectToLoad = var;
+                    mProjectToLoad = ProjectFileResolver.ResolveCsproj(var);
                 }
                 if (var.Equals(ExitWhenQuietArg, StringComparison.OrdinalIgnoreCase))
                 {

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
@@ -55,37 +55,22 @@ partial class DialogCommands : IDialogCommands
             // by removing this, we can fix
             // this bug: https://github.com/vchelaru/FlatRedBall/issues/1620
             //openFileDialog.InitialDirectory = "c:\\";
-            openFileDialog.Filter = "Project/Solution files (*.vcproj;*.csproj;*.sln;*.glux;*.gluj)|*.vcproj;*.csproj;*.sln;*.glux;*.gluj";
+            openFileDialog.Filter = "Project/Solution files (*.vcproj;*.csproj;*.sln;*.slnx;*.glux;*.gluj)|*.vcproj;*.csproj;*.sln;*.slnx;*.glux;*.gluj";
             openFileDialog.FilterIndex = 1;
             openFileDialog.RestoreDirectory = true;
 
             if (openFileDialog.ShowDialog() == DialogResult.OK)
             {
-                string projectFileName = openFileDialog.FileName;
+                string projectFileName = ProjectFileResolver.ResolveCsproj(openFileDialog.FileName);
 
-                var extension = FileManager.GetExtension(projectFileName);
-                if (extension == "sln")
+                if (projectFileName == null)
                 {
-                    var solution = VSSolution.FromFile(projectFileName);
-
-                    string solutionName = projectFileName;
-
-                    var foundProject = solution.ReferencedProjects.FirstOrDefault(item =>
-                    {
-                        var isRegularProject = FileManager.GetExtension(item.Name) == "csproj" || FileManager.GetExtension(item.Name) == "vsproj";
-
-                        bool hasSameName = FileManager.RemovePath(FileManager.RemoveExtension(solutionName)).ToLowerInvariant() ==
-                            FileManager.RemovePath(FileManager.RemoveExtension(item.Name)).ToLowerInvariant();
-
-
-                        return isRegularProject && hasSameName;
-                    });
-
-                    projectFileName = FileManager.GetDirectory(solutionName) + foundProject.Name;
-                }
-                else if(extension == "gluj")
-                {
-                    projectFileName = FileManager.RemoveExtension(projectFileName) + ".csproj";
+                    // A solution with several projects and none named after it - picking one would be
+                    // a guess, and the user can point at the .csproj they mean.
+                    GlueCommands.Self.DialogCommands.ShowMessageBox(
+                        $"Could not tell which project in {FileManager.RemovePath(openFileDialog.FileName)} to open. " +
+                        $"Please select the .csproj instead.");
+                    return;
                 }
 
                 try

--- a/FRBDK/Glue/Glue/VSHelpers/ProjectFileResolver.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/ProjectFileResolver.cs
@@ -1,0 +1,148 @@
+using FlatRedBall.Glue.VSHelpers.Projects;
+using FlatRedBall.IO;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace FlatRedBall.Glue.VSHelpers
+{
+    /// <summary>
+    /// Turns whatever the user picked - a .gluj, a solution, a .csproj - into the .csproj Glue loads.
+    /// Shared by the Load Project dialog and the command line so both accept the same set of files.
+    /// </summary>
+    public static class ProjectFileResolver
+    {
+        /// <summary>
+        /// The .csproj for <paramref name="selectedFileName"/>, or null if the selection names no
+        /// project this can identify.
+        /// </summary>
+        /// <remarks>
+        /// A returned path is not guaranteed to exist: when a Glue project has no .csproj anywhere
+        /// near it, the sibling path comes back so the load reports "Could not find the project
+        /// &lt;path&gt;" against something recognizable rather than against the .gluj.
+        /// </remarks>
+        public static string ResolveCsproj(string selectedFileName)
+        {
+            if (string.IsNullOrEmpty(selectedFileName))
+            {
+                return null;
+            }
+
+            switch (FileManager.GetExtension(selectedFileName))
+            {
+                case "sln":
+                case "slnx":
+                    return ResolveFromSolution(selectedFileName);
+                case "gluj":
+                case "glux":
+                    return ResolveFromGlueProject(selectedFileName);
+                default:
+                    return selectedFileName;
+            }
+        }
+
+        /// <remarks>
+        /// FRB1 keeps the .gluj beside the .csproj, so the sibling answers first and none of the rest
+        /// applies. FRB2 puts everything Glue authors under Content/FrbEditor, so the project root is
+        /// that folder's grandparent - and only that folder, deliberately: walking up "until a .csproj
+        /// turns up" happily leaves the game and opens whatever unrelated project sits above it.
+        /// </remarks>
+        static string ResolveFromGlueProject(string glueProjectFileName)
+        {
+            var siblingCsproj = FileManager.RemoveExtension(glueProjectFileName) + ".csproj";
+
+            if (File.Exists(siblingCsproj))
+            {
+                return siblingCsproj;
+            }
+
+            var projectRoot = Frb2ProjectRootFor(glueProjectFileName);
+
+            if (projectRoot != null)
+            {
+                var baseName = FileManager.RemovePath(FileManager.RemoveExtension(glueProjectFileName));
+                var sameName = Path.Combine(projectRoot, baseName + ".csproj");
+
+                if (File.Exists(sameName))
+                {
+                    return sameName;
+                }
+
+                // Renaming a project in Visual Studio leaves the .gluj under its old name, so names
+                // that disagree do not mean this is the wrong project. Only when there is exactly one
+                // though - choosing between two is a guess the user is better placed to make.
+                var csprojFiles = Directory.GetFiles(projectRoot, "*.csproj");
+
+                if (csprojFiles.Length == 1)
+                {
+                    return csprojFiles[0];
+                }
+            }
+
+            return siblingCsproj;
+        }
+
+        /// <summary>
+        /// The directory an FRB2 game's .csproj lives in, given its .gluj - or null when the .gluj is
+        /// not in the FRB2 layout at all.
+        /// </summary>
+        static string Frb2ProjectRootFor(string glueProjectFileName)
+        {
+            var directory = Path.GetDirectoryName(Path.GetFullPath(glueProjectFileName));
+            var expectedSuffix = Frb2Project.Frb2GlueProjectSubdirectory
+                .Trim('/')
+                .Replace('/', Path.DirectorySeparatorChar);
+
+            var root = directory;
+
+            for (int i = 0; i < expectedSuffix.Split(Path.DirectorySeparatorChar).Length; i++)
+            {
+                root = Path.GetDirectoryName(root);
+
+                if (root == null)
+                {
+                    return null;
+                }
+            }
+
+            return string.Equals(Path.Combine(root, expectedSuffix), directory, StringComparison.OrdinalIgnoreCase)
+                ? root
+                : null;
+        }
+
+        static string ResolveFromSolution(string solutionFileName)
+        {
+            var solution = VSSolution.FromFile(solutionFileName);
+            var solutionDirectory = FileManager.GetDirectory(solutionFileName);
+
+            var projects = solution.ReferencedProjects
+                .Where(item => FileManager.GetExtension(item.Name) == "csproj" ||
+                               FileManager.GetExtension(item.Name) == "vsproj")
+                .ToArray();
+
+            var solutionName = FileManager.RemovePath(FileManager.RemoveExtension(solutionFileName));
+
+            var found =
+                projects.FirstOrDefault(item =>
+                    string.Equals(FileManager.RemovePath(FileManager.RemoveExtension(item.Name)), solutionName,
+                        StringComparison.OrdinalIgnoreCase))
+                // An FRB2 solution lists the engine projects alongside the game, so this only helps
+                // the single-project case - where a renamed solution leaves nothing to match on.
+                ?? (projects.Length == 1 ? projects[0] : null);
+
+            if (found == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return Path.GetFullPath(Path.Combine(solutionDirectory, found.Name));
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/VSHelpers/ProjectFileResolver.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/ProjectFileResolver.cs
@@ -118,26 +118,44 @@ namespace FlatRedBall.Glue.VSHelpers
             var projects = solution.ReferencedProjects
                 .Where(item => FileManager.GetExtension(item.Name) == "csproj" ||
                                FileManager.GetExtension(item.Name) == "vsproj")
+                .Select(item => AbsolutePathOf(item.Name, solutionDirectory))
+                .Where(item => item != null)
                 .ToArray();
 
             var solutionName = FileManager.RemovePath(FileManager.RemoveExtension(solutionFileName));
 
-            var found =
-                projects.FirstOrDefault(item =>
-                    string.Equals(FileManager.RemovePath(FileManager.RemoveExtension(item.Name)), solutionName,
-                        StringComparison.OrdinalIgnoreCase))
-                // An FRB2 solution lists the engine projects alongside the game, so this only helps
-                // the single-project case - where a renamed solution leaves nothing to match on.
-                ?? (projects.Length == 1 ? projects[0] : null);
+            var named = projects.FirstOrDefault(item =>
+                string.Equals(FileManager.RemovePath(FileManager.RemoveExtension(item)), solutionName,
+                    StringComparison.OrdinalIgnoreCase));
 
-            if (found == null)
+            if (named != null)
             {
-                return null;
+                return named;
             }
 
+            // Renaming a solution leaves nothing to match on, and there is only one thing it can mean.
+            if (projects.Length == 1)
+            {
+                return projects[0];
+            }
+
+            // `dotnet new frb2-desktop` names neither of its projects after the solution - MyGame.slnx
+            // holds MyGame.Common and MyGame.Desktop. Both lead to Common, which is the project Glue
+            // edits, so asking each one which FRB2 game it belongs to settles it without guessing.
+            var frb2GameProjects = projects
+                .Select(Frb2ProjectDetector.FindFrb2GameProjectFor)
+                .Where(item => item != null)
+                .GroupBy(item => FileManager.Standardize(item), StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            return frb2GameProjects.Length == 1 ? frb2GameProjects[0].First() : null;
+        }
+
+        static string AbsolutePathOf(string projectInSolution, string solutionDirectory)
+        {
             try
             {
-                return Path.GetFullPath(Path.Combine(solutionDirectory, found.Name));
+                return Path.GetFullPath(Path.Combine(solutionDirectory, projectInSolution));
             }
             catch (ArgumentException)
             {

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2Project.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2Project.cs
@@ -51,7 +51,9 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         /// Self-contained, so the game copies it to output with one rule and no exclusions, and so it
         /// parallels the Gum project's own Content/GumProject/ folder.
         /// </summary>
-        public override string GlueProjectSubdirectory => "Content/FrbEditor/";
+        public const string Frb2GlueProjectSubdirectory = "Content/FrbEditor/";
+
+        public override string GlueProjectSubdirectory => Frb2GlueProjectSubdirectory;
 
         public override bool AllowContentCompile => false;
 

--- a/FRBDK/Glue/Glue/VSHelpers/VSSolution.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/VSSolution.cs
@@ -305,11 +305,25 @@ namespace FlatRedBall.Glue.VSHelpers
             return $"Project(\"{{{projectTypeId.ToString().ToUpperInvariant()}}}\") = \"{projectName}\", \"{relativePath}\", \"{{{projectId.ToString().ToUpperInvariant()}}}\"\r\nEndProject";
         }
 
+        /// <summary>
+        /// Reads a solution's referenced projects. Handles both the classic .sln text format and
+        /// Visual Studio's XML .slnx.
+        /// </summary>
+        /// <remarks>
+        /// Reading only - everything on this class that *writes* a solution assumes the .sln text
+        /// format and does not apply to .slnx.
+        /// </remarks>
         public static VSSolution FromFile(FilePath fileName)
         {
             VSSolution toReturn = new VSSolution();
 
             toReturn.FullFileName = fileName.FullPath;
+
+            if (fileName.Extension?.ToLowerInvariant() == "slnx")
+            {
+                ParseSlnx(fileName, toReturn);
+                return toReturn;
+            }
 
             var lines = System.IO.File.ReadAllLines(fileName.FullPath);
 
@@ -319,6 +333,23 @@ namespace FlatRedBall.Glue.VSHelpers
             }
 
             return toReturn;
+        }
+
+        // Projects can be nested inside <Folder> elements, so this looks at every descendant rather
+        // than the root's children.
+        private static void ParseSlnx(FilePath fileName, VSSolution solution)
+        {
+            var document = System.Xml.Linq.XDocument.Load(fileName.FullPath);
+
+            foreach (var element in document.Descendants("Project"))
+            {
+                var path = element.Attribute("Path")?.Value;
+
+                if (!string.IsNullOrEmpty(path))
+                {
+                    solution.ReferencedProjects.Add(new CsprojReference { Name = path });
+                }
+            }
         }
 
         private static void ParseLine(string line, VSSolution solution)

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2OpenBySelectionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2OpenBySelectionTests.cs
@@ -1,0 +1,85 @@
+using System.IO;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.VSHelpers;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using FlatRedBall.IO;
+using GlueUnitTests.TestSupport;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// Everything File &gt; Load Project does after the file picker closes, for the files an FRB2 project
+/// actually offers. <c>ProjectFileResolverTests</c> pins what the resolver returns; these prove the
+/// path it returns opens the game.
+/// </summary>
+/// <remarks>
+/// Same collection as <see cref="Frb2ProjectLoadTests"/>: loading a project is process-wide state.
+/// The one part of the dialog no test can reach is the file filter itself.
+/// </remarks>
+[Collection("Frb2ProjectLoad")]
+public class Frb2OpenBySelectionTests
+{
+    const string ProjectName = Frb2ProjectFixture.ProjectName;
+
+    [StaFact]
+    public async Task PickingTheGluj_OfAnFrb2Project_OpensTheGame()
+    {
+        // The reported bug: the .gluj lives under Content/FrbEditor, so swapping the extension in place
+        // pointed at Content/FrbEditor/<name>.csproj and the load stopped at "Could not find the
+        // project".
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2OpenGluj_");
+        var csprojPath = Frb2ProjectFixture.Write(temp.Root);
+
+        // The .gluj is written by the first load, so open by .csproj once to get the state a user's
+        // project is already in.
+        await GoldProject.LoadInGlueAsync(csprojPath);
+
+        var gluj = Path.Combine(temp.Root, "Content", "FrbEditor", ProjectName + ".gluj");
+        Assert.True(File.Exists(gluj), "The first load should have written the .gluj.");
+
+        await GoldProject.LoadInGlueAsync(ProjectFileResolver.ResolveCsproj(gluj));
+
+        Assert.IsType<Frb2Project>(GlueState.Self.CurrentMainProject);
+        Assert.Equal(new FilePath(csprojPath), GlueState.Self.CurrentMainProject.FullFileName);
+        Assert.Empty(GlueTestBootstrap.RecordedDialogMessages);
+    }
+
+    [StaFact]
+    public async Task PickingTheSlnx_OfAnFrb2Project_OpensTheGame()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2OpenSlnx_");
+        var csprojPath = Frb2ProjectFixture.Write(temp.Root);
+        var slnx = Path.Combine(temp.Root, ProjectName + ".slnx");
+
+        await GoldProject.LoadInGlueAsync(ProjectFileResolver.ResolveCsproj(slnx));
+
+        Assert.IsType<Frb2Project>(GlueState.Self.CurrentMainProject);
+        Assert.Equal(new FilePath(csprojPath), GlueState.Self.CurrentMainProject.FullFileName);
+        Assert.Empty(GlueTestBootstrap.RecordedDialogMessages);
+    }
+
+    [StaFact]
+    public async Task PickingTheSlnx_OfATemplateCreatedFrb2Project_OpensTheGame()
+    {
+        // `dotnet new frb2-desktop` names neither project after the solution - MyGame.slnx holds
+        // MyGame.Common and MyGame.Desktop - so there is nothing to match on and the pick has to be
+        // settled by which project is the FRB2 game.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2OpenTemplateSlnx_");
+        var commonCsproj = Frb2ProjectFixture.WriteTemplateShaped(temp.Root);
+        var slnx = Path.Combine(temp.Root, ProjectName + ".slnx");
+
+        await GoldProject.LoadInGlueAsync(ProjectFileResolver.ResolveCsproj(slnx));
+
+        Assert.IsType<Frb2Project>(GlueState.Self.CurrentMainProject);
+        Assert.Equal(new FilePath(commonCsproj), GlueState.Self.CurrentMainProject.FullFileName);
+        Assert.Empty(GlueTestBootstrap.RecordedDialogMessages);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/ProjectFileResolverTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/ProjectFileResolverTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.VSHelpers;
+using FlatRedBall.IO;
+using Xunit;
+
+namespace GlueUnitTests.VSHelpers;
+
+/// <summary>
+/// The Load Project dialog offers .gluj and solution files, but Glue can only load a .csproj, so
+/// <see cref="ProjectFileResolver"/> stands between the two. Getting it wrong means the pick fails
+/// with "Could not find the project" even though the project is perfectly loadable by its .csproj.
+/// </summary>
+public class ProjectFileResolverTests : IDisposable
+{
+    readonly string _directory;
+
+    public ProjectFileResolverTests()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "GlueUnitTests_Resolve_" + Guid.NewGuid());
+        Directory.CreateDirectory(_directory);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_directory, recursive: true); } catch (IOException) { }
+    }
+
+    string Write(string relativePath, string contents = "<Project />")
+    {
+        var full = Path.Combine(_directory, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full));
+        File.WriteAllText(full, contents);
+        return full;
+    }
+
+    // FilePath rather than string: the resolver composes paths with forward slashes on Windows.
+    static void AssertResolves(string expected, string selected) =>
+        Assert.Equal(new FilePath(expected), new FilePath(ProjectFileResolver.ResolveCsproj(selected)));
+
+    [Fact]
+    public void Csproj_IsReturnedUnchanged()
+    {
+        var csproj = Write("TestGame.csproj");
+
+        AssertResolves(csproj, csproj);
+    }
+
+    [Fact]
+    public void Gluj_BesideTheCsproj_ResolvesToIt()
+    {
+        // FRB1 keeps the .gluj and the .csproj side by side.
+        var csproj = Write("TestGame.csproj");
+        var gluj = Write("TestGame.gluj", "{}");
+
+        AssertResolves(csproj, gluj);
+    }
+
+    [Fact]
+    public void Glux_BesideTheCsproj_ResolvesToIt()
+    {
+        var csproj = Write("TestGame.csproj");
+        var glux = Write("TestGame.glux", "<GlueProjectSave />");
+
+        AssertResolves(csproj, glux);
+    }
+
+    [Fact]
+    public void Gluj_UnderContentFrbEditor_ResolvesToTheCsprojAboveIt()
+    {
+        // FRB2 puts everything Glue authors under Content/FrbEditor, so the .csproj is two up.
+        var csproj = Write("TestGame.csproj");
+        var gluj = Write("Content/FrbEditor/TestGame.gluj", "{}");
+
+        AssertResolves(csproj, gluj);
+    }
+
+    [Fact]
+    public void Gluj_UnderContentFrbEditor_ResolvesToADifferentlyNamedCsproj()
+    {
+        // Nothing forces the .gluj's name to match the .csproj's - a renamed project leaves the two
+        // disagreeing, and the .csproj is still the one to open.
+        var csproj = Write("RenamedGame.csproj");
+        var gluj = Write("Content/FrbEditor/TestGame.gluj", "{}");
+
+        AssertResolves(csproj, gluj);
+    }
+
+    [Fact]
+    public void Gluj_UnderContentFrbEditor_WithTwoCsprojsAbove_ResolvesToTheOneNamedAfterIt()
+    {
+        var csproj = Write("TestGame.csproj");
+        Write("TestGame.Desktop.csproj");
+        var gluj = Write("Content/FrbEditor/TestGame.gluj", "{}");
+
+        AssertResolves(csproj, gluj);
+    }
+
+    [Fact]
+    public void Gluj_InSomeOtherSubdirectory_DoesNotWanderUpToAnUnrelatedProject()
+    {
+        // Searching upward for any .csproj reaches out of the project entirely - a .gluj in a temp
+        // folder found an unrelated project sitting in %TEMP%.
+        Write("TestGame.csproj");
+        var gluj = Write("SomeFolder/TestGame.gluj", "{}");
+
+        AssertResolves(Path.Combine(_directory, "SomeFolder", "TestGame.csproj"), gluj);
+    }
+
+    [Fact]
+    public void Gluj_WithNoCsprojAnywhere_ResolvesToTheSiblingCsproj()
+    {
+        // Nothing to find, so hand back the path the old swap produced: it does not exist, and the
+        // load reports "Could not find the project <that path>", which is the truth.
+        var gluj = Write("TestGame.gluj", "{}");
+
+        AssertResolves(Path.Combine(_directory, "TestGame.csproj"), gluj);
+    }
+
+    [Fact]
+    public void Sln_ResolvesToTheProjectMatchingTheSolutionName()
+    {
+        var csproj = Write("TestGame.csproj");
+        var sln = Write("TestGame.sln",
+            "Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"TestGame\", \"TestGame.csproj\", \"{1}\"");
+
+        AssertResolves(csproj, sln);
+    }
+
+    [Fact]
+    public void Sln_WithOneProjectNotMatchingTheSolutionName_ResolvesToThatProject()
+    {
+        // Renaming a solution without renaming the project used to be a NullReferenceException.
+        var csproj = Write("TestGame.csproj");
+        var sln = Write("Renamed.sln",
+            "Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"TestGame\", \"TestGame.csproj\", \"{1}\"");
+
+        AssertResolves(csproj, sln);
+    }
+
+    [Fact]
+    public void Slnx_ResolvesToTheProjectMatchingTheSolutionName()
+    {
+        // Visual Studio's XML solution format, which the FRB2 sample ships. The engine projects come
+        // first in it, so the name match - not "the first project" - is what picks the game.
+        var csproj = Write("TestGame.csproj");
+        Write("engine/FlatRedBall2.csproj");
+        var slnx = Write("TestGame.slnx",
+            "<Solution>\n  <Project Path=\"engine/FlatRedBall2.csproj\" />\n  <Project Path=\"TestGame.csproj\" />\n</Solution>");
+
+        AssertResolves(csproj, slnx);
+    }
+
+    [Fact]
+    public void Slnx_WithOneProjectNotMatchingTheSolutionName_ResolvesToThatProject()
+    {
+        var csproj = Write("TestGame.csproj");
+        var slnx = Write("Renamed.slnx",
+            "<Solution>\n  <Project Path=\"TestGame.csproj\" />\n</Solution>");
+
+        AssertResolves(csproj, slnx);
+    }
+
+    [Fact]
+    public void Slnx_ResolvesAProjectInASubdirectory()
+    {
+        var csproj = Write("src/TestGame/TestGame.csproj");
+        var slnx = Write("TestGame.slnx",
+            "<Solution>\n  <Project Path=\"src/TestGame/TestGame.csproj\" />\n</Solution>");
+
+        AssertResolves(csproj, slnx);
+    }
+}


### PR DESCRIPTION
Closes #2054

The Load Project dialog let you pick a `.gluj` but resolved it by swapping the extension in place, which only holds for FRB1's side-by-side layout. FRB2 keeps the `.gluj` under `Content/FrbEditor/`, so the pick ended at "Could not find the project `Content/FrbEditor/X.csproj`". `.slnx` was not in the filter at all, and `.glux` was in the filter with no branch handling it, so picking one handed the `.glux` itself to the loader.

Resolution moved out of the dialog into `ProjectFileResolver`, shared with `CommandLineManager` so a shortcut or script accepts the same files:

- `.gluj`/`.glux`: sibling `.csproj` first (FRB1), else the FRB2 project root, which is the `Content/FrbEditor` grandparent. Only that directory. Walking up until a `.csproj` turns up leaves the project entirely; the test that caught this found an unrelated `.csproj` sitting in `%TEMP%`.
- `.sln`/`.slnx`: `VSSolution.FromFile` now parses the XML format. The project is picked by name match against the solution, since an FRB2 `.slnx` lists the engine projects ahead of the game. Failing that: the only project if there is one (used to be a `NullReferenceException`), then whichever FRB2 game project the candidates lead to, which is what resolves a `dotnet new frb2-desktop` solution holding `MyGame.Common` and `MyGame.Desktop` and named after neither.
- Still ambiguous gets a message box instead of a load failure naming the `.slnx`.

Tests: 13 in `ProjectFileResolverTests` for what the resolver returns, and 3 in `Frb2OpenBySelectionTests` driving the resolved path through the real `ProjectLoader.LoadProject`, so "the pick opens the game" is covered rather than left to manual testing. All 3 fail on the pre-fix behavior, the `.gluj` one with the reported message verbatim. The file filter itself is the only part no test can reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
