### PR TITLE
Fix crash opening a file with no Windows association

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
@@ -593,7 +593,11 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
                         var result = GlueCommands.Self.DialogCommands.ShowYesNoMessageBox(message);
                         if (result == System.Windows.MessageBoxResult.Yes)
                         {
-                            OpenProcess();
+                            // No association exists, so re-running OpenProcess() here would just
+                            // shell-execute the file again and fail with the same exception. Show
+                            // Windows' "Open With" picker instead - that's what "set the association"
+                            // actually promised.
+                            System.Diagnostics.Process.Start(CreateOpenWithDialogStartInfo(fileName));
                         }
                     }
                     else
@@ -652,6 +656,13 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
                 }
             }
         }
+
+        internal static ProcessStartInfo CreateOpenWithDialogStartInfo(string fileName) => new ProcessStartInfo
+        {
+            FileName = fileName,
+            UseShellExecute = true,
+            Verb = "openas"
+        };
 
         private FilePath TryToGetFilePathFromExtension(string textExtension)
         {

--- a/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/FileCommandsTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/FileCommandsTests.cs
@@ -1,0 +1,21 @@
+using FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces;
+using Shouldly;
+
+namespace GlueUnitTests.CommandInterfaces;
+
+public class FileCommandsTests
+{
+    // Regression test: when Windows has no file association for an extension (e.g. .achx) and the
+    // user agrees to "set the association", Glue used to just retry the exact same plain ShellExecute
+    // that got it into this branch in the first place, which fails again with the same
+    // Win32Exception (0x800401F5, ERROR_NO_ASSOCIATION) instead of showing Windows' "Open With" picker.
+    [Fact]
+    public void CreateOpenWithDialogStartInfo_ShouldUseOpenAsVerb_SoWindowsShowsThePicker()
+    {
+        var startInfo = FileCommands.CreateOpenWithDialogStartInfo(@"E:\Content\ResonatorAnimation.achx");
+
+        startInfo.Verb.ShouldBe("openas");
+        startInfo.UseShellExecute.ShouldBeTrue();
+        startInfo.FileName.ShouldBe(@"E:\Content\ResonatorAnimation.achx");
+    }
+}


### PR DESCRIPTION
## Summary

A user's crash report showed Glue throwing `Win32Exception (0x800401F5)` twice in a row trying to open an `.achx` file:

```
Error opening E:/.../ResonatorAnimation.achx
An error occurred trying to start process ... Application not found
```

Root cause: `FileCommands.OpenFileInDefaultProgram` detects Windows has no association for the extension and asks "Set the association now?" — but clicking **Yes** just re-ran the exact same plain `ShellExecute` on the file that got it into that branch in the first place, which fails again with the same exception. Clicking Yes never actually opened Windows' "Open With" picker.

Fix: the Yes branch now shell-executes with `Verb = "openas"`, which shows Windows' real "Open With" dialog (with the "always use this app" checkbox) instead of retrying the doomed call.

## Test plan
- [x] `FileCommandsTests.CreateOpenWithDialogStartInfo_ShouldUseOpenAsVerb_SoWindowsShowsThePicker` — pins the extracted `ProcessStartInfo` builder (`Verb == "openas"`), red before the fix (method didn't exist), green after.
- [x] Full `Category!=BuildSmoke` suite: 617/617 passing.

Manual test: needed — the unit test only pins which `ProcessStartInfo` gets built, not that Windows actually shows its picker for it.
1. Rename any file to an extension Windows has no association for (e.g. `test.frbnoassoc`), add it to a Glue project as a referenced file (or reuse an `.achx` on a machine without the AnimationEditor installed).
2. Try to open it from Glue (double-click in the tree, or right-click → Open in default program).
3. Click **Yes** on the "set the association" prompt.
4. Confirm Windows' "Open With" dialog appears (not another crash/error dialog).
