### PR TITLE
Fix Screen.GetInstanceRecursive returning the container instead of resolving the final path segment

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Screens/Screen.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Screens/Screen.cs
@@ -597,7 +597,7 @@ namespace FlatRedBall.Screens
 
                 return GetInstanceRecursive(afterDot, instance);
             }
-            return container;
+            return GetInstance(variableName, container);
 
         }
 

--- a/Tests/EngineUnitTests/Screens/ScreenTests.cs
+++ b/Tests/EngineUnitTests/Screens/ScreenTests.cs
@@ -1,0 +1,33 @@
+using FlatRedBall;
+using FlatRedBall.Screens;
+using Shouldly;
+
+namespace EngineUnitTests.Screens;
+
+public class ScreenTests
+{
+    private class TestScreen : Screen
+    {
+        public Sprite ChildSprite { get; set; } = new Sprite();
+    }
+
+    [Fact]
+    public void GetInstanceRecursive_ShouldResolveNestedInstance_NotReturnScreenItself()
+    {
+        var screen = new TestScreen();
+
+        var result = screen.GetInstanceRecursive("this.ChildSprite");
+
+        result.ShouldBe(screen.ChildSprite);
+    }
+
+    [Fact]
+    public void GetInstanceRecursive_ShouldReturnNull_WhenInstanceNotFound()
+    {
+        var screen = new TestScreen();
+
+        var result = screen.GetInstanceRecursive("this.DoesNotExist");
+
+        result.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
Fixes #2063.

`Screen.GetInstanceRecursive`'s base case returned `container` instead of resolving `variableName` on it. For a two-segment path like `"this.Shadow"`, the first recursive step resolves `"this"` to the screen, then recurses with `("Shadow", screen)` — since `"Shadow"` has no dot, the old base case just returned `screen`, never looking `Shadow` up on it.

Live-edit's `VariableAssignmentLogic.SetValueOnObjectInElement` fallback calls this when the earlier, more specific instance lookup didn't find the target (e.g. an object nested inside an Entity). The bug made it silently resolve to the screen itself, so the variable got reflected onto the screen and crashed with a `LateBinder` error naming the screen class instead of the intended object — this is what a user hit trying to set `this.Shadow.AnimationChains` on a Sprite nested inside an Entity via `EntityViewingScreen`.

Fix: base case now calls `GetInstance(variableName, container)` to actually resolve the final segment.

## Test plan
- Added `Tests/EngineUnitTests/Screens/ScreenTests.cs`, watched both fail against unfixed code (both returned the screen instance instead of the expected value), fixed, watched them pass.
- Full `EngineUnitTests` suite: 31/31 passing, no regressions.
