### PR TITLE
Fix AnimationChainList double-registration; add ReplaceTexture regression tests

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Content/ContentManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Content/ContentManager.cs
@@ -752,7 +752,10 @@ namespace FlatRedBall.Content
 
                         }
 
-                        mNonDisposableDictionary.Add(fullNameWithType, loadedAsset);
+                        // AnimationChainList implements IDisposable, so it belongs in mDisposableDictionary
+                        // (added below, alongside every other IDisposable loadedAsset) rather than here -
+                        // otherwise code that scans DisposableObjects (e.g. FlatRedBallServices.ReplaceTexture)
+                        // would only find it by the accident of also falling through to that shared block.
                     }
 
                     #endregion

--- a/Tests/EngineUnitTests/Content/AnimationChain/ContentManagerAnimationChainListLoadTests.cs
+++ b/Tests/EngineUnitTests/Content/AnimationChain/ContentManagerAnimationChainListLoadTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using FlatRedBall.Graphics.Animation;
+using Shouldly;
+
+namespace EngineUnitTests.Content.AnimationChain;
+
+class NullServiceProvider : IServiceProvider
+{
+    public object? GetService(Type serviceType) => null;
+}
+
+public class ContentManagerAnimationChainListLoadTests
+{
+    const string AchxContents =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+        "<AnimationChainArraySave>\n" +
+        "  <AnimationChain>\n" +
+        "    <Name>Animation1</Name>\n" +
+        "  </AnimationChain>\n" +
+        "</AnimationChainArraySave>\n";
+
+    [Fact]
+    public void Load_AnimationChainList_ShouldRegisterItAsDisposableOnly()
+    {
+        var achxPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".achx");
+        File.WriteAllText(achxPath, AchxContents);
+
+        try
+        {
+            var contentManager = new FlatRedBall.Content.ContentManager("Test", new NullServiceProvider());
+
+            var loaded = contentManager.Load<AnimationChainList>(achxPath);
+
+            // AnimationChainList implements IDisposable, so it should be filed under the disposable
+            // dictionary only. FlatRedBallServices.ReplaceTexture (and anything else that walks
+            // DisposableObjects) depends on this to find achx-loaded animation chains. Filing it in
+            // the non-disposable dictionary too is a wasted, confusing duplicate registration - assert
+            // on ToString()'s counts (the only public window into both dictionaries at once) rather
+            // than the key format, since disposable/non-disposable keys are built differently and a
+            // key-based lookup can't tell "wrong dictionary" apart from "wrong key".
+            contentManager.DisposableObjects.ShouldContain(loaded);
+            contentManager.ToString().ShouldBe("Test with 1 disposables, 0 non disposables, 0 assets");
+        }
+        finally
+        {
+            File.Delete(achxPath);
+        }
+    }
+}

--- a/Tests/EngineUnitTests/Graphics/Animation/ReplaceTextureTests.cs
+++ b/Tests/EngineUnitTests/Graphics/Animation/ReplaceTextureTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using FlatRedBall.Graphics.Animation;
+using Microsoft.Xna.Framework.Graphics;
+using Shouldly;
+
+namespace EngineUnitTests.Graphics.Animation;
+
+public class ReplaceTextureTests
+{
+    // FlatRedBallServices.ReplaceTexture is only ever exercised through a full MonoGame-backed game
+    // in this repo (Tests/TestProjectDesktopNet6/Screens/ReloadContentScreen.cs), whose generated code
+    // is gitignored and needs Glue + a real display to run. These tests cover it without a
+    // GraphicsDevice: Texture2D only needs to support reference-equality and a settable Name for this
+    // codepath, so an uninitialized instance stands in for a "real" loaded texture.
+    static Texture2D FakeTexture() =>
+        (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
+
+    static bool s_initialized;
+    static void EnsureInitialized()
+    {
+        // FlatRedBallServices initialization is process-wide static state and most of it (once set)
+        // can't be re-run without crashing (e.g. InstructionManager.CreateInterpolators re-adds keys
+        // to a static dictionary), so every test in this class must share a single InitializeCommandLine
+        // call rather than each calling it independently.
+        if (!s_initialized)
+        {
+            FlatRedBall.FlatRedBallServices.InitializeCommandLine();
+            s_initialized = true;
+        }
+    }
+
+    static string WriteTempAchxWithOneEmptyChain(string chainName)
+    {
+        var achxPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".achx");
+        File.WriteAllText(achxPath,
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+            "<AnimationChainArraySave>\n" +
+            "  <AnimationChain>\n" +
+            $"    <Name>{chainName}</Name>\n" +
+            "  </AnimationChain>\n" +
+            "</AnimationChainArraySave>\n");
+        return achxPath;
+    }
+
+    [Fact]
+    public void ReplaceTexture_ShouldUpdateAnimationChainListLoadedIntoContentManager()
+    {
+        EnsureInitialized();
+
+        var achxPath = WriteTempAchxWithOneEmptyChain("Shadow");
+        try
+        {
+            var oldTexture = FakeTexture();
+            var newTexture = FakeTexture();
+
+            var animationChainList = FlatRedBall.FlatRedBallServices.Load<AnimationChainList>(achxPath, "Global");
+            animationChainList[0].Add(new AnimationFrame { Texture = oldTexture });
+
+            FlatRedBall.FlatRedBallServices.ReplaceTexture(oldTexture, newTexture);
+
+            animationChainList[0][0].Texture.ShouldBe(newTexture);
+        }
+        finally
+        {
+            File.Delete(achxPath);
+        }
+    }
+
+    [Fact]
+    public void ReplaceTexture_ShouldUpdateAnimationChainsOnALiveSprite()
+    {
+        // Regression test for the fix in commit 59b2d1ea6d ("ReplaceTexture automatically replaces
+        // AnimationChains textures"): SpriteManager.ReplaceTexture walks every live sprite's own
+        // AnimationChains and fixes frame textures directly, independent of ContentManager tracking.
+        // This was previously uncovered by any test.
+        EnsureInitialized();
+
+        var oldTexture = FakeTexture();
+        var newTexture = FakeTexture();
+
+        var sprite = FlatRedBall.SpriteManager.AddSprite(oldTexture);
+        try
+        {
+            var animationChainList = new AnimationChainList();
+            var chain = new FlatRedBall.Graphics.Animation.AnimationChain { Name = "Shadow" };
+            chain.Add(new AnimationFrame { Texture = oldTexture });
+            animationChainList.Add(chain);
+            sprite.AnimationChains = animationChainList;
+
+            FlatRedBall.FlatRedBallServices.ReplaceTexture(oldTexture, newTexture);
+
+            sprite.AnimationChains[0][0].Texture.ShouldBe(newTexture);
+        }
+        finally
+        {
+            FlatRedBall.SpriteManager.RemoveSprite(sprite);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Investigated a reported crash: replacing a texture at runtime (hot-reload) supposedly left `AnimationChain` frames pointing at a disposed texture, because achx-loaded `AnimationChainList`s never reach `ContentManager.DisposableObjects` (filed as non-disposable) and so `FlatRedBallServices.ReplaceTexture`'s scan never finds them.

That specific mechanism doesn't reproduce on current `NetStandard` — verified with real end-to-end tests (`ReplaceTextureTests.ReplaceTexture_ShouldUpdateAnimationChainListLoadedIntoContentManager`) that pass unmodified. The actual crash was already fixed by 59b2d1ea6d (2025-03-29, "ReplaceTexture automatically replaces AnimationChains textures"): `SpriteManager.ReplaceTexture` walks every live sprite's own `AnimationChains` and fixes frame textures directly (`SpriteManager.cs:2683-2695`), independent of `ContentManager` tracking. That fix had zero test coverage.

What this PR actually does:

- **Fixes a real, smaller bug found along the way**: `AnimationChainList` implements `IDisposable`, but `ContentManager.LoadFromFile` filed achx-loaded lists directly into `mNonDisposableDictionary`, then *also* ended up in `mDisposableDictionary` via an unrelated shared fallthrough block (any non-null `loadedAsset` gets added there if not already present). Net effect: harmless but confusing double bookkeeping, and the only reason `DisposableObjects` scans work at all was incidental. Filed it only where its declared `IDisposable`-ness says it belongs.
- **Adds regression coverage** for both the `ContentManager` filing behavior and the `SpriteManager.ReplaceTexture` live-sprite `AnimationChains` fix, using `FormatterServices.GetUninitializedObject(typeof(Texture2D))` for reference-identity-only fake textures (no `GraphicsDevice` needed — this repo's own CI excludes GraphicsDevice-dependent tests as unreliable on hosted Windows runners).

## Test plan

- [x] `Load_AnimationChainList_ShouldRegisterItAsDisposableOnly` — watched fail against unfixed code (`git stash`), confirmed real double-registration (`"1 disposables, 1 non disposables"`), then confirmed green with the fix.
- [x] `ReplaceTexture_ShouldUpdateAnimationChainListLoadedIntoContentManager` / `ReplaceTexture_ShouldUpdateAnimationChainsOnALiveSprite` — pass unmodified (locking in already-correct behavior that previously had no coverage).
- [x] Full `EngineUnitTests` suite: 34/34 passing, clean rebuild.

Manual test: not needed — covered by the unit tests plus compilation; no user-facing behavior changes since the crash itself was already fixed before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
