### PR TITLE
Add DEBUG-time diagnostic to ReplaceTexture for missed texture references

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
@@ -1061,6 +1061,61 @@ namespace FlatRedBall
             }
 
             ReplaceTextureCalled?.Invoke(oldTexture, newTexture);
+
+#if DEBUG
+            // A missed replacement doesn't fail here - it fails much later and much more confusingly,
+            // as an ObjectDisposedException deep in the renderer once oldTexture is actually disposed.
+            // Failing loudly at the reload site instead names the exact Sprite/AnimationChain responsible.
+            VerifyNoRemainingTextureReferences(oldTexture);
+#endif
+        }
+
+        #region XML Docs
+        /// <summary>
+        /// Checks every Sprite managed by SpriteManager (including AnimationChains frames) for a
+        /// remaining reference to oldTexture, throwing immediately if one is found. Called automatically
+        /// by ReplaceTexture in DEBUG builds. Only covers SpriteManager-tracked sprites - sprites living
+        /// in a SpriteGrid/TextureGrid are outside SpriteManager's lists and have their own ReplaceTexture
+        /// methods that must be called separately.
+        /// </summary>
+        /// <param name="oldTexture">The texture that should no longer be referenced by any live sprite.</param>
+        #endregion
+        public static void VerifyNoRemainingTextureReferences(Texture2D oldTexture)
+        {
+            foreach (var sprite in SpriteManager.AutomaticallyUpdatedSprites)
+            {
+                ThrowIfSpriteReferencesTexture(sprite, oldTexture);
+            }
+            foreach (var sprite in SpriteManager.ManuallyUpdatedSprites)
+            {
+                ThrowIfSpriteReferencesTexture(sprite, oldTexture);
+            }
+        }
+
+        private static void ThrowIfSpriteReferencesTexture(Sprite sprite, Texture2D oldTexture)
+        {
+            if (sprite.Texture == oldTexture)
+            {
+                throw new InvalidOperationException(
+                    $"ReplaceTexture did not update the Texture on Sprite \"{sprite.Name}\" - " +
+                    "it still references the old texture, which is about to be disposed.");
+            }
+
+            if (sprite.AnimationChains != null)
+            {
+                foreach (var chain in sprite.AnimationChains)
+                {
+                    for (int i = 0; i < chain.Count; i++)
+                    {
+                        if (chain[i].Texture == oldTexture)
+                        {
+                            throw new InvalidOperationException(
+                                $"ReplaceTexture did not update frame {i} of AnimationChain \"{chain.Name}\" " +
+                                $"on Sprite \"{sprite.Name}\" - it still references the old texture, which is about to be disposed.");
+                        }
+                    }
+                }
+            }
         }
 
         #region XML Docs

--- a/Tests/EngineUnitTests/Graphics/Animation/VerifyNoRemainingTextureReferencesTests.cs
+++ b/Tests/EngineUnitTests/Graphics/Animation/VerifyNoRemainingTextureReferencesTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Runtime.Serialization;
+using FlatRedBall.Graphics.Animation;
+using Microsoft.Xna.Framework.Graphics;
+using Shouldly;
+
+namespace EngineUnitTests.Graphics.Animation;
+
+public class VerifyNoRemainingTextureReferencesTests
+{
+    // See ReplaceTextureTests.cs for why an uninitialized Texture2D stands in for a "real" one here:
+    // this codepath only needs reference-equality and a settable Name, and this repo's CI excludes
+    // GraphicsDevice-dependent tests as unreliable on hosted runners.
+    static Texture2D FakeTexture() =>
+        (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
+
+    static bool s_initialized;
+    static void EnsureInitialized()
+    {
+        // See ReplaceTextureTests.cs: FlatRedBallServices initialization is process-wide static state
+        // that can only run once per process, so every test in this class shares one call.
+        if (!s_initialized)
+        {
+            FlatRedBall.FlatRedBallServices.InitializeCommandLine();
+            s_initialized = true;
+        }
+    }
+
+    [Fact]
+    public void ShouldThrow_WhenALiveSpriteTextureStillReferencesTheOldTexture()
+    {
+        EnsureInitialized();
+
+        var oldTexture = FakeTexture();
+        var sprite = FlatRedBall.SpriteManager.AddSprite(oldTexture);
+        sprite.Name = "ShadowSprite";
+
+        try
+        {
+            var exception = Should.Throw<InvalidOperationException>(
+                () => FlatRedBall.FlatRedBallServices.VerifyNoRemainingTextureReferences(oldTexture));
+
+            exception.Message.ShouldContain("ShadowSprite");
+        }
+        finally
+        {
+            FlatRedBall.SpriteManager.RemoveSprite(sprite);
+        }
+    }
+
+    [Fact]
+    public void ShouldThrow_WhenALiveSpriteAnimationChainFrameStillReferencesTheOldTexture()
+    {
+        EnsureInitialized();
+
+        var oldTexture = FakeTexture();
+        var newTexture = FakeTexture();
+
+        // Give the sprite a *different* current texture so only the AnimationChains frame is stale -
+        // isolates the AnimationChains check from the plain sprite.Texture check above.
+        var sprite = FlatRedBall.SpriteManager.AddSprite(newTexture);
+        sprite.Name = "ShadowSprite";
+
+        var animationChainList = new AnimationChainList();
+        var chain = new FlatRedBall.Graphics.Animation.AnimationChain { Name = "Shadow" };
+        chain.Add(new AnimationFrame { Texture = oldTexture });
+        animationChainList.Add(chain);
+        sprite.AnimationChains = animationChainList;
+
+        try
+        {
+            var exception = Should.Throw<InvalidOperationException>(
+                () => FlatRedBall.FlatRedBallServices.VerifyNoRemainingTextureReferences(oldTexture));
+
+            exception.Message.ShouldContain("ShadowSprite");
+            exception.Message.ShouldContain("Shadow");
+        }
+        finally
+        {
+            FlatRedBall.SpriteManager.RemoveSprite(sprite);
+        }
+    }
+
+    [Fact]
+    public void ShouldNotThrow_WhenNoLiveSpriteReferencesTheOldTexture()
+    {
+        EnsureInitialized();
+
+        var oldTexture = FakeTexture();
+        var newTexture = FakeTexture();
+        var sprite = FlatRedBall.SpriteManager.AddSprite(newTexture);
+
+        try
+        {
+            Should.NotThrow(
+                () => FlatRedBall.FlatRedBallServices.VerifyNoRemainingTextureReferences(oldTexture));
+        }
+        finally
+        {
+            FlatRedBall.SpriteManager.RemoveSprite(sprite);
+        }
+    }
+
+    [Fact]
+    public void FullReplaceTexturePipeline_ShouldNotThrow_ForALiveSpriteWithAnimationChains()
+    {
+        // The happy path through the actual public entry point (not just the diagnostic in isolation):
+        // confirms the automatic DEBUG-time check added to ReplaceTexture doesn't false-positive once
+        // SpriteManager.ReplaceTexture has done its job.
+        EnsureInitialized();
+
+        var oldTexture = FakeTexture();
+        var newTexture = FakeTexture();
+        var sprite = FlatRedBall.SpriteManager.AddSprite(oldTexture);
+
+        var animationChainList = new AnimationChainList();
+        var chain = new FlatRedBall.Graphics.Animation.AnimationChain { Name = "Shadow" };
+        chain.Add(new AnimationFrame { Texture = oldTexture });
+        animationChainList.Add(chain);
+        sprite.AnimationChains = animationChainList;
+
+        try
+        {
+            Should.NotThrow(() => FlatRedBall.FlatRedBallServices.ReplaceTexture(oldTexture, newTexture));
+
+            sprite.Texture.ShouldBe(newTexture);
+            sprite.AnimationChains[0][0].Texture.ShouldBe(newTexture);
+        }
+        finally
+        {
+            FlatRedBall.SpriteManager.RemoveSprite(sprite);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2065. A missed `ReplaceTexture` fixup currently fails silently until much later — an `ObjectDisposedException` deep in the renderer, once the old texture is actually disposed, with no clue at that point which reload caused it.

Adds `FlatRedBallServices.VerifyNoRemainingTextureReferences(oldTexture)`, called automatically at the end of `ReplaceTexture` in `DEBUG` builds: walks every `SpriteManager`-tracked sprite (including `AnimationChains` frames) and throws immediately, naming the exact Sprite/AnimationChain, if anything still references the old texture. Turns a delayed, unattributed crash into an immediate one pointing at the actual gap.

Scoped to `SpriteManager`'s own lists (`AutomaticallyUpdatedSprites`/`ManuallyUpdatedSprites`) — sprites living in a `SpriteGrid`/`TextureGrid` are outside those lists and already have their own `ReplaceTexture` methods callers must invoke separately; this doesn't change that, and doesn't claim to cover it.

## Test plan

- [x] `ShouldThrow_WhenALiveSpriteTextureStillReferencesTheOldTexture` — watched fail as a compile error (method didn't exist), then pass once implemented.
- [x] `ShouldThrow_WhenALiveSpriteAnimationChainFrameStillReferencesTheOldTexture`
- [x] `ShouldNotThrow_WhenNoLiveSpriteReferencesTheOldTexture`
- [x] `FullReplaceTexturePipeline_ShouldNotThrow_ForALiveSpriteWithAnimationChains` — confirms the new automatic check doesn't false-positive on the already-correct path.
- [x] Full `EngineUnitTests` suite: 35/35, clean rebuild.

Manual test: not needed — DEBUG-only and additive; no behavior change on any currently-correct path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
