### PR TITLE
Restore per-node-type tab memory

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/PluginBase.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginBase.cs
@@ -190,6 +190,7 @@ namespace FlatRedBall.Glue.Plugins
             if (GlueFormsCore.ViewModels.TabControlViewModel.IsRecordingSelection)
             {
                 LastTimeClicked = DateTime.Now;
+                ParentContainer?.SetTabForCurrentType(this);
             }
         }
 

--- a/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
+++ b/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
@@ -39,6 +39,12 @@ namespace GlueFormsCore.ViewModels
         public int Count => Tabs.Count;
         public ObservableCollection<PluginTab> Tabs { get; private set; } = new ObservableCollection<PluginTab>();
 
+        // Per-node-type tab memory (issue #2068). Keyed by type name rather than a single global
+        // "most recently clicked" timestamp (which is what issue #1593 actually broke - see
+        // ShowMostRecentTabFor) so a tab manually chosen while viewing one node type never overrides
+        // the default/bookmark tab for an unrelated type.
+        public Dictionary<string, PluginTab> TabsForTypes { get; private set; } = new Dictionary<string, PluginTab>();
+
         public TabContainerViewModel()
         {
             Tabs.CollectionChanged += OnTabsCollectionChanged;
@@ -54,6 +60,17 @@ namespace GlueFormsCore.ViewModels
             }
         }
 
+        public void SetTabForCurrentType(PluginTab tab)
+        {
+            var treeNode = GlueState.Self.CurrentTreeNode;
+            var selectedType = treeNode?.Tag?.GetType()?.Name ?? treeNode?.Text;
+
+            if (selectedType != null)
+            {
+                TabsForTypes[selectedType] = tab;
+            }
+        }
+
         public void ShowMostRecentTabFor(string typeName)
         {
             if (Count == 0 || typeName is null)
@@ -61,14 +78,10 @@ namespace GlueFormsCore.ViewModels
                 return;
             }
 
-            // removing remembering of last tabs clicked
-            // https://github.com/vchelaru/FlatRedBall/issues/1593
-            //SelectedTab =
-            //    Tabs.OrderByDescending(item => item.LastTimeClicked)
-            //        .ThenByDescending(item => item.IsPreferredDisplayerForType(typeName))
-            //        .First();
-            SelectedTab =
-                Tabs.OrderByDescending(item => item.IsPreferredDisplayerForType(typeName))
+            SelectedTab = TabsForTypes.TryGetValue(typeName, out PluginTab tab)
+                ? tab
+                : Tabs.OrderByDescending(item => item.IsPreferredDisplayerForType(typeName))
+                    .ThenByDescending(item => item.LastTimeClicked)
                     .First();
         }
     }

--- a/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/TabMemoryTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/TabMemoryTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using System.Linq;
+using FlatRedBall.Glue.FormHelpers;
+using FlatRedBall.Glue.Plugins;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueFormsCore.ViewModels;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.ViewModels;
+
+/// <summary>
+/// GitHub issue #2068: selecting a new file/object reset whichever tab (Variables/Events/Custom
+/// Code/...) the user had open back to a fixed default, because <c>4183732ae</c> removed all
+/// tab memory in response to issue #1593. #1593 was actually caused by a different, since-replaced
+/// design (a single *global* "most recently clicked" timestamp, added by <c>3d39674aa</c>) that let a
+/// tab clicked while viewing one node type keep winning for every other type too. These tests drive
+/// the real <see cref="PluginManager.TabControlViewModel"/> through <see cref="GlueState.CurrentTreeNode"/>
+/// the same way a real tree click does, so they cover the actual reported symptom rather than calling
+/// <see cref="TabContainerViewModel.ShowMostRecentTabFor"/> directly.
+/// </summary>
+public class TabMemoryTests
+{
+    // A standalone ITreeNode, not resolved through any real tree - same idea as TestSupport's
+    // SyntheticTreeNode, but not tied to that type's ReferencedFileSave-only constructor.
+    private sealed class FakeTreeNode : ITreeNode
+    {
+        public FakeTreeNode(object tag, string text, TreeNodeType treeNodeType)
+        {
+            Tag = tag;
+            Text = text;
+            TreeNodeType = treeNodeType;
+        }
+
+        public object Tag { get; set; }
+        public ITreeNode Parent => null;
+        public string Text { get; set; }
+        public IEnumerable<ITreeNode> Children => Enumerable.Empty<ITreeNode>();
+        public TreeNodeType TreeNodeType { get; }
+        public void Remove(ITreeNode child) { }
+        public void Add(ITreeNode child) { }
+        public ITreeNode FindByName(string name) => null;
+        public void RemoveGlobalContentTreeNodesIfDoesntExist(ITreeNode treeNode) { }
+        public ITreeNode FindByTagRecursive(object tag) => Equals(tag, Tag) ? this : null;
+        public void SortByTextConsideringDirectories() { }
+    }
+
+    [Fact]
+    public void ShowMostRecentTabFor_ShouldKeepManuallySelectedTab_WhenSelectingAnotherObjectOfSameType()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        var container = PluginManager.TabControlViewModel.RightTabItems;
+        var (originalTabs, cleanup) = IsolateContainer(container);
+        try
+        {
+            var variablesTab = new PluginTab { IsPreferredDisplayerForType = t => t == nameof(EntitySave) };
+            var eventsTab = new PluginTab();
+            container.Add(variablesTab);
+            container.Add(eventsTab);
+
+            var nodeA = new FakeTreeNode(new EntitySave(), "EntityA", TreeNodeType.EntityNode);
+            GlueState.Self.CurrentTreeNode = nodeA;
+            container.SelectedTab.ShouldBe(variablesTab, "no tab has been manually selected yet, so the preferred default should show");
+
+            eventsTab.IsSelected = true;
+
+            var nodeB = new FakeTreeNode(new EntitySave(), "EntityB", TreeNodeType.EntityNode);
+            GlueState.Self.CurrentTreeNode = nodeB;
+
+            container.SelectedTab.ShouldBe(eventsTab, "selecting another EntitySave should keep showing the tab the user last chose for that type");
+        }
+        finally
+        {
+            cleanup();
+        }
+    }
+
+    [Fact]
+    public void ShowMostRecentTabFor_ShouldNotLeakRememberedTab_AcrossDifferentNodeTypes()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        var container = PluginManager.TabControlViewModel.RightTabItems;
+        var (originalTabs, cleanup) = IsolateContainer(container);
+        try
+        {
+            var variablesTab = new PluginTab
+            {
+                IsPreferredDisplayerForType = t => t == nameof(EntitySave) || t == "Variables"
+            };
+            var eventsTab = new PluginTab();
+            container.Add(variablesTab);
+            container.Add(eventsTab);
+
+            var nodeA = new FakeTreeNode(new EntitySave(), "EntityA", TreeNodeType.EntityNode);
+            GlueState.Self.CurrentTreeNode = nodeA;
+            eventsTab.IsSelected = true;
+
+            // A "Variables" bookmark node (as clicked from search/bookmarks) is a distinct type key
+            // ("Variables", via Text since Tag is null) from "EntitySave" - this is the #1593 scenario:
+            // it must always show Variables, regardless of what was last clicked while viewing an entity.
+            var bookmarkNode = new FakeTreeNode(null, "Variables", TreeNodeType.Other);
+            GlueState.Self.CurrentTreeNode = bookmarkNode;
+
+            container.SelectedTab.ShouldBe(variablesTab, "a distinct node type must not inherit another type's remembered tab");
+        }
+        finally
+        {
+            cleanup();
+        }
+    }
+
+    private static (List<PluginTab> originalTabs, System.Action cleanup) IsolateContainer(TabContainerViewModel container)
+    {
+        var originalTabs = container.Tabs.ToList();
+        var originalTabsForTypes = new Dictionary<string, PluginTab>(container.TabsForTypes);
+        var originalTreeNode = GlueState.Self.CurrentTreeNode;
+
+        foreach (var tab in originalTabs)
+        {
+            container.Remove(tab);
+        }
+        container.TabsForTypes.Clear();
+
+        return (originalTabs, () =>
+        {
+            GlueState.Self.CurrentTreeNode = null;
+
+            foreach (var tab in container.Tabs.ToList())
+            {
+                container.Remove(tab);
+            }
+            foreach (var tab in originalTabs)
+            {
+                container.Add(tab);
+            }
+
+            container.TabsForTypes.Clear();
+            foreach (var kvp in originalTabsForTypes)
+            {
+                container.TabsForTypes[kvp.Key] = kvp.Value;
+            }
+
+            GlueState.Self.CurrentTreeNode = originalTreeNode;
+        });
+    }
+}


### PR DESCRIPTION
Closes #2068.

Selecting a new file/object always reset the right-hand tab (Variables/Events/Custom Code/...) to a fixed default, because `4183732ae` removed all tab-selection memory in response to #1593.

#1593 wasn't caused by remembering tabs in general. It was caused by `3d39674aa`, which had replaced the original per-node-type memory (`03f31a91c`, in production 2022-2024 with no complaints) with a single *global* "most recently clicked" timestamp. That let a tab clicked while viewing one node type keep winning for every other type too, including bookmark/default-tab navigation to an unrelated type - which is what #1593 actually reported.

This restores the original per-type shape: `TabContainerViewModel.TabsForTypes` remembers the last manually-selected tab per node type name, consulted before falling back to the existing preferred/recency sort. A tab clicked while browsing entities no longer overrides a bookmark or default tab for a different node type, so this shouldn't reintroduce #1593.

Manual test: not needed - covered by the two new unit tests below, which drive the real `PluginManager.TabControlViewModel` through `GlueState.CurrentTreeNode` the same way a real tree click does (not just the ViewModel in isolation).

## Test plan
- `TabMemoryTests.ShowMostRecentTabFor_ShouldKeepManuallySelectedTab_WhenSelectingAnotherObjectOfSameType` - the #2068 fix. Watched this fail against the unfixed code (temporarily short-circuited the memory lookup) before restoring the fix.
- `TabMemoryTests.ShowMostRecentTabFor_ShouldNotLeakRememberedTab_AcrossDifferentNodeTypes` - #1593 regression guard.
- Full non-BuildSmoke suite (619 tests) green from a clean build.
