### PR TITLE
Add nuget packages to synced projects too

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ProjectCommands.cs
@@ -986,20 +986,38 @@ class ProjectCommands : IProjectCommands
                     throw new NullReferenceException("Main Project");
                 }
 
-                var codeProject = mainProject.CodeProject as VisualStudioProject;
+                // A synced project (Glue > Add Synced Project) has its own .csproj, and the general
+                // per-save sync (VisualStudioProject.SyncTo) only mirrors Compile/Content items, not
+                // PackageReference - so it needs the package added here too or it's missing the
+                // reference and full of compile errors.
+                var projectsToUpdate = new List<VisualStudioProject> { mainProject };
+                projectsToUpdate.AddRange(_glueState.SyncedProjects.OfType<VisualStudioProject>());
 
-                if (!codeProject.HasPackage(packageName, out var existingVersionNumber))
+                string addedOrExistingVersionNumber = null;
+                bool anyPackageAdded = false;
+
+                foreach (var projectToUpdate in projectsToUpdate)
                 {
+                    var codeProject = projectToUpdate.CodeProject as VisualStudioProject;
 
-                    codeProject.AddNugetPackage(packageName, versionNumber);
+                    if (!codeProject.HasPackage(packageName, out var existingVersionNumber))
+                    {
+                        codeProject.AddNugetPackage(packageName, versionNumber);
+                        anyPackageAdded = true;
+                        addedOrExistingVersionNumber = versionNumber;
+                    }
+                    else
+                    {
+                        addedOrExistingVersionNumber ??= existingVersionNumber;
+                    }
+                }
+
+                if (anyPackageAdded)
+                {
                     GlueCommands.Self.ProjectCommands.SaveProjects();
+                }
 
-                    return versionNumber;
-                }
-                else
-                {
-                    return existingVersionNumber;
-                }
+                return addedOrExistingVersionNumber;
             }, $"Adding Nuget Package {packageName}");
         }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/ProjectCommandsTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/ProjectCommandsTests.cs
@@ -1,5 +1,15 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.VSHelpers.Projects;
 using FlatRedBall.IO;
+using GlueUnitTests.Tasks;
+using GlueUnitTests.TestSupport;
 using Shouldly;
 
 namespace GlueUnitTests.CommandInterfaces;
@@ -24,5 +34,61 @@ public class ProjectCommandsTests
     public void ShouldSkipBecauseDirectory_ShouldReturnFalse_ForFilePath(string path)
     {
         ProjectCommands.ShouldSkipBecauseDirectory(new FilePath(path)).ShouldBeFalse();
+    }
+}
+
+// Regression test for GitHub issue #1734: AddNugetIfNotAdded (used to push Newtonsoft.Json into the game
+// project whenever live edit is enabled, and by NAudioPlugin/ProfilePlugin) only ever touched
+// GlueState.CurrentMainProject. A "synced project" (Glue > Add Synced Project) has its own .csproj that
+// mirrors the main project's Compile/Content items (VisualStudioProject.SyncTo), but SyncTo never touches
+// PackageReference items - so a synced project's .csproj never got the package and users saw a wall of
+// compile errors in it.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class ProjectCommandsAddNugetIfNotAddedTests : IDisposable
+{
+    private readonly bool _originalSynchronousMode;
+
+    public ProjectCommandsAddNugetIfNotAddedTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        TaskManager.SynchronousMode = true;
+    }
+
+    public void Dispose()
+    {
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+    }
+
+    [Fact]
+    public async Task AddNugetIfNotAddedWithReturn_ShouldAddPackage_ToSyncedProjectsToo()
+    {
+        var mainProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var mainDirectory, "MainProject");
+        var syncedProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var syncedDirectory, "SyncedProject");
+
+        try
+        {
+            var glueState = new FlatRedBall.Glue.Plugins.ExportedInterfaces.GlueStateSnapshot
+            {
+                CurrentGlueProject = new GlueProjectSave
+                {
+                    FileVersion = (int)GlueProjectSave.GluxVersions.NugetPackageInCsproj
+                },
+                CurrentMainProject = mainProject,
+                SyncedProjects = new ProjectBase[] { syncedProject }
+            };
+
+            var projectCommands = new ProjectCommands { _glueState = glueState };
+
+            await projectCommands.AddNugetIfNotAddedWithReturn("Newtonsoft.Json", "13.0.3");
+
+            syncedProject.HasPackage("Newtonsoft.Json", out var syncedVersion).ShouldBeTrue();
+            syncedVersion.ShouldBe("13.0.3");
+        }
+        finally
+        {
+            Directory.Delete(mainDirectory, recursive: true);
+            Directory.Delete(syncedDirectory, recursive: true);
+        }
     }
 }


### PR DESCRIPTION
## Summary
`AddNugetIfNotAddedWithReturn` (used to add Newtonsoft.Json to the game project when live edit is enabled, and by NAudioPlugin/ProfilePlugin) only ever touched `GlueState.CurrentMainProject`. A synced project (Glue > Add Synced Project) has its own `.csproj`, and the general per-save sync (`VisualStudioProject.SyncTo`) only mirrors Compile/Content items, not PackageReference — so synced projects never got the package and users hit a wall of compile errors in them.

Now adds the package to the main project and every synced project (skipping any that already have it).

Fixes #1734

## Test plan
- Added `ProjectCommandsAddNugetIfNotAddedTests` (real MSBuild-backed main + synced `VisualStudioProject`s via `TestVisualStudioProjectFactory`), watched it fail against the unfixed code, then pass after the fix.
- Full `GlueUnitTests` suite (excluding BuildSmoke): 618/618 passed.
