### PR TITLE
Fix cross-class race breaking EngineUnitTests CI

### DIFF
--- a/Tests/EngineUnitTests/Graphics/Animation/ReplaceTextureTests.cs
+++ b/Tests/EngineUnitTests/Graphics/Animation/ReplaceTextureTests.cs
@@ -1,12 +1,14 @@
 using System;
 using System.IO;
 using System.Runtime.Serialization;
+using EngineUnitTests.TestSupport;
 using FlatRedBall.Graphics.Animation;
 using Microsoft.Xna.Framework.Graphics;
 using Shouldly;
 
 namespace EngineUnitTests.Graphics.Animation;
 
+[Collection(nameof(EngineStatefulTestCollection))]
 public class ReplaceTextureTests
 {
     // FlatRedBallServices.ReplaceTexture is only ever exercised through a full MonoGame-backed game
@@ -16,20 +18,6 @@ public class ReplaceTextureTests
     // codepath, so an uninitialized instance stands in for a "real" loaded texture.
     static Texture2D FakeTexture() =>
         (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
-
-    static bool s_initialized;
-    static void EnsureInitialized()
-    {
-        // FlatRedBallServices initialization is process-wide static state and most of it (once set)
-        // can't be re-run without crashing (e.g. InstructionManager.CreateInterpolators re-adds keys
-        // to a static dictionary), so every test in this class must share a single InitializeCommandLine
-        // call rather than each calling it independently.
-        if (!s_initialized)
-        {
-            FlatRedBall.FlatRedBallServices.InitializeCommandLine();
-            s_initialized = true;
-        }
-    }
 
     static string WriteTempAchxWithOneEmptyChain(string chainName)
     {
@@ -47,7 +35,7 @@ public class ReplaceTextureTests
     [Fact]
     public void ReplaceTexture_ShouldUpdateAnimationChainListLoadedIntoContentManager()
     {
-        EnsureInitialized();
+        EngineTestBootstrap.EnsureInitialized();
 
         var achxPath = WriteTempAchxWithOneEmptyChain("Shadow");
         try
@@ -75,7 +63,7 @@ public class ReplaceTextureTests
         // AnimationChains textures"): SpriteManager.ReplaceTexture walks every live sprite's own
         // AnimationChains and fixes frame textures directly, independent of ContentManager tracking.
         // This was previously uncovered by any test.
-        EnsureInitialized();
+        EngineTestBootstrap.EnsureInitialized();
 
         var oldTexture = FakeTexture();
         var newTexture = FakeTexture();

--- a/Tests/EngineUnitTests/Graphics/Animation/VerifyNoRemainingTextureReferencesTests.cs
+++ b/Tests/EngineUnitTests/Graphics/Animation/VerifyNoRemainingTextureReferencesTests.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Runtime.Serialization;
+using EngineUnitTests.TestSupport;
 using FlatRedBall.Graphics.Animation;
 using Microsoft.Xna.Framework.Graphics;
 using Shouldly;
 
 namespace EngineUnitTests.Graphics.Animation;
 
+[Collection(nameof(EngineStatefulTestCollection))]
 public class VerifyNoRemainingTextureReferencesTests
 {
     // See ReplaceTextureTests.cs for why an uninitialized Texture2D stands in for a "real" one here:
@@ -14,22 +16,10 @@ public class VerifyNoRemainingTextureReferencesTests
     static Texture2D FakeTexture() =>
         (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
 
-    static bool s_initialized;
-    static void EnsureInitialized()
-    {
-        // See ReplaceTextureTests.cs: FlatRedBallServices initialization is process-wide static state
-        // that can only run once per process, so every test in this class shares one call.
-        if (!s_initialized)
-        {
-            FlatRedBall.FlatRedBallServices.InitializeCommandLine();
-            s_initialized = true;
-        }
-    }
-
     [Fact]
     public void ShouldThrow_WhenALiveSpriteTextureStillReferencesTheOldTexture()
     {
-        EnsureInitialized();
+        EngineTestBootstrap.EnsureInitialized();
 
         var oldTexture = FakeTexture();
         var sprite = FlatRedBall.SpriteManager.AddSprite(oldTexture);
@@ -51,7 +41,7 @@ public class VerifyNoRemainingTextureReferencesTests
     [Fact]
     public void ShouldThrow_WhenALiveSpriteAnimationChainFrameStillReferencesTheOldTexture()
     {
-        EnsureInitialized();
+        EngineTestBootstrap.EnsureInitialized();
 
         var oldTexture = FakeTexture();
         var newTexture = FakeTexture();
@@ -84,7 +74,7 @@ public class VerifyNoRemainingTextureReferencesTests
     [Fact]
     public void ShouldNotThrow_WhenNoLiveSpriteReferencesTheOldTexture()
     {
-        EnsureInitialized();
+        EngineTestBootstrap.EnsureInitialized();
 
         var oldTexture = FakeTexture();
         var newTexture = FakeTexture();
@@ -107,7 +97,7 @@ public class VerifyNoRemainingTextureReferencesTests
         // The happy path through the actual public entry point (not just the diagnostic in isolation):
         // confirms the automatic DEBUG-time check added to ReplaceTexture doesn't false-positive once
         // SpriteManager.ReplaceTexture has done its job.
-        EnsureInitialized();
+        EngineTestBootstrap.EnsureInitialized();
 
         var oldTexture = FakeTexture();
         var newTexture = FakeTexture();

--- a/Tests/EngineUnitTests/TestSupport/EngineTestBootstrap.cs
+++ b/Tests/EngineUnitTests/TestSupport/EngineTestBootstrap.cs
@@ -1,0 +1,27 @@
+namespace EngineUnitTests.TestSupport;
+
+internal static class EngineTestBootstrap
+{
+    static bool s_initialized;
+
+    // FlatRedBallServices initialization is process-wide static state and most of it (once set) can't
+    // be re-run without crashing (e.g. InstructionManager.CreateInterpolators re-adds keys to a static
+    // dictionary), so every test class that needs it must share this one guard rather than each keeping
+    // its own. Callers must also be in EngineStatefulTestCollection (see below) - xunit runs separate
+    // collections in parallel on separate threads, and whichever thread calls InitializeCommandLine
+    // first becomes FlatRedBall's "primary thread"; a class landing on a different thread then fails
+    // with "Objects can only be added on the primary thread" the moment it touches SpriteManager.
+    public static void EnsureInitialized()
+    {
+        if (!s_initialized)
+        {
+            FlatRedBall.FlatRedBallServices.InitializeCommandLine();
+            s_initialized = true;
+        }
+    }
+}
+
+[CollectionDefinition(nameof(EngineStatefulTestCollection), DisableParallelization = true)]
+public class EngineStatefulTestCollection
+{
+}


### PR DESCRIPTION
## Summary
`ReplaceTextureTests` and `VerifyNoRemainingTextureReferencesTests` (added together in #2065) each guarded `FlatRedBallServices.InitializeCommandLine()` with their own per-class `static bool`. Two bugs from that:
1. Whichever class ran second in the shared test process called `InitializeCommandLine()` again and crashed (`InstructionManager.CreateInterpolators` re-adding dictionary keys).
2. xunit runs separate test classes as separate collections **in parallel** by default, so the two classes could land on different threads even with a shared guard — whichever thread didn't call `InitializeCommandLine` first then fails FlatRedBall's primary-thread check in `SpriteManager`.

This was breaking the "Run engine unit tests" CI job on every open PR (#2069, #2070) since both files are already merged to NetStandard.

Fix: one shared `EngineTestBootstrap.EnsureInitialized()`, and both classes pinned to a shared, non-parallel xunit collection (`EngineStatefulTestCollection`) — same pattern Glue's own test suite already uses for process-wide static state (`TaskManagerSequentialCollection`).

Fixes #2072

## Test plan
- Reproduced the CI failure locally running both classes together.
- Green after the fix; full `EngineUnitTests` suite run 3x in a row, 38/38 passing each time.
