### PR TITLE
Fix polygon point dragging not visibly snapping in live edit

### DIFF
--- a/FRBDK/Glue/CompilerLibrary/Models/CompilerSettingsModel.cs
+++ b/FRBDK/Glue/CompilerLibrary/Models/CompilerSettingsModel.cs
@@ -48,7 +48,7 @@ namespace CompilerLibrary.Models
 
             EnableSnapping = true;
             SnapSize = 8;
-            PolygonPointSnapSize = 1;
+            PolygonPointSnapSize = SnapSize;
         }
     }
 }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -220,6 +220,42 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     }
     #endregion
 
+    #region SetPolygonPointsForTesting
+
+    /// <summary>
+    /// Test-only: sets the currently-selected Polygon's Points directly (world-space, relative to the
+    /// polygon's own Position), bypassing codegen/InstructionSave so a test fixture doesn't depend on how
+    /// a freshly-added Polygon NamedObjectSave happens to default-initialize.
+    /// </summary>
+    public class SetPolygonPointsForTestingDto
+    {
+        public List<Microsoft.Xna.Framework.Vector2> Points { get; set; } = new List<Microsoft.Xna.Framework.Vector2>();
+    }
+    #endregion
+
+    #region SimulatePolygonPointDrag
+
+    /// <summary>
+    /// Test-only: drives the currently-selected Polygon's point-drag-and-snap logic without a real mouse.
+    /// See PolygonPointHandles.SimulateDragForTesting (Embedded) - grabs the point at PointIndex exactly
+    /// like a mouse-down on its handle would, then applies one drag step of (ScreenXChange, ScreenYChange).
+    /// </summary>
+    public class SimulatePolygonPointDragDto
+    {
+        public int PointIndex { get; set; }
+        public float ScreenXChange { get; set; }
+        public float ScreenYChange { get; set; }
+    }
+    #endregion
+
+    #region SimulatePolygonPointDragResponse
+    public class SimulatePolygonPointDragResponse
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+    }
+    #endregion
+
     #region GetCameraSave
     public class GetCameraSave
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -304,7 +304,6 @@ namespace GlueControl
                 Succeeded = true,
             };
 
-
             if (ScreenManager.CurrentScreen == null)
             {
                 response.Succeeded = false;
@@ -858,6 +857,39 @@ namespace GlueControl
             getCameraPositionResponse.Z = Camera.Main.Z;
             return getCameraPositionResponse;
         }
+
+        #region SetPolygonPointsForTesting
+
+        private static void HandleDto(GlueControl.Dtos.SetPolygonPointsForTestingDto dto)
+        {
+            var polygon = Editing.EditingManager.Self.PrimarySelectionAsPolygonForTesting;
+
+            polygon.Points = dto.Points
+                .Select(item => new FlatRedBall.Math.Geometry.Point(item.X, item.Y))
+                .ToList();
+            polygon.ForceUpdateDependencies();
+        }
+
+        #endregion
+
+        #region SimulatePolygonPointDrag
+
+        private static object HandleDto(GlueControl.Dtos.SimulatePolygonPointDragDto dto)
+        {
+            var polygon = Editing.EditingManager.Self.PrimarySelectionAsPolygonForTesting;
+            var handles = Editing.EditingManager.Self.PrimarySelectionPolygonPointHandlesForTesting;
+
+            handles.SimulateDragForTesting(polygon, dto.PointIndex, dto.ScreenXChange, dto.ScreenYChange);
+
+            var point = polygon.Points[dto.PointIndex];
+            return new GlueControl.Dtos.SimulatePolygonPointDragResponse
+            {
+                X = (float)point.X,
+                Y = (float)point.Y
+            };
+        }
+
+        #endregion
 
         #endregion
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -221,6 +221,42 @@ namespace GlueControl.Dtos
     }
     #endregion
 
+    #region SetPolygonPointsForTesting
+
+    /// <summary>
+    /// Test-only: sets the currently-selected Polygon's Points directly (world-space, relative to the
+    /// polygon's own Position), bypassing codegen/InstructionSave so a test fixture doesn't depend on how
+    /// a freshly-added Polygon NamedObjectSave happens to default-initialize.
+    /// </summary>
+    public class SetPolygonPointsForTestingDto
+    {
+        public List<Microsoft.Xna.Framework.Vector2> Points { get; set; } = new List<Microsoft.Xna.Framework.Vector2>();
+    }
+    #endregion
+
+    #region SimulatePolygonPointDrag
+
+    /// <summary>
+    /// Test-only: drives the currently-selected Polygon's point-drag-and-snap logic without a real mouse.
+    /// See PolygonPointHandles.SimulateDragForTesting - grabs the point at PointIndex exactly like a
+    /// mouse-down on its handle would, then applies one drag step of (ScreenXChange, ScreenYChange).
+    /// </summary>
+    public class SimulatePolygonPointDragDto
+    {
+        public int PointIndex { get; set; }
+        public float ScreenXChange { get; set; }
+        public float ScreenYChange { get; set; }
+    }
+    #endregion
+
+    #region SimulatePolygonPointDragResponse
+    public class SimulatePolygonPointDragResponse
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+    }
+    #endregion
+
     #region GetCameraSave
     public class GetCameraSave
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -194,6 +194,22 @@ namespace GlueControl.Editing
             }
         }
 
+        /// <summary>
+        /// The PolygonPointHandles for the primary selected marker, or null if nothing/non-polygon is
+        /// selected. Test-only - used by SimulatePolygonPointDragDto (see CommandReceiver.HandleDto) so a
+        /// LiveGameProcess-based test can drive a point drag without a real Cursor/mouse.
+        /// </summary>
+        internal PolygonPointHandles PrimarySelectionPolygonPointHandlesForTesting =>
+            (SelectedMarkers.FirstOrDefault() as SelectionMarker)?.PolygonPointHandlesForTesting;
+
+        /// <summary>
+        /// The primary selected item, if it is directly a Polygon (not a tunneled/wrapped one - see
+        /// PolygonPointHandles.EveryFrameUpdate). Test-only, alongside
+        /// <see cref="PrimarySelectionPolygonPointHandlesForTesting"/>.
+        /// </summary>
+        internal FlatRedBall.Math.Geometry.Polygon PrimarySelectionAsPolygonForTesting =>
+            itemsSelected.FirstOrDefault() as FlatRedBall.Math.Geometry.Polygon;
+
         List<ISelectionMarker> SelectedMarkers = new List<ISelectionMarker>();
         SelectionMarker HighlightMarker;
         MeasurementMarker MeasurementMarker;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/Markers/PolygonPointHandles.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/Markers/PolygonPointHandles.cs
@@ -300,14 +300,22 @@ namespace GlueControl.Editing
 
         private void DoCursorDownMovement(Polygon polygon, Cursor cursor)
         {
-            var isEndpoint = PointIndexGrabbed == 0 || PointIndexGrabbed == polygon.Points.Count - 1;
+            ApplyDrag(polygon, cursor.ScreenXChange, cursor.ScreenYChange, CameraLogic.CurrentZoomRatio);
+        }
 
+        /// <summary>
+        /// Applies one frame of point-drag movement: accumulates the screen-space delta into the running
+        /// unsnapped position, snaps it if PointSnapSize is set, and applies it to the currently grabbed
+        /// point - keeping the polygon closed if that point is a merged first/last endpoint.
+        /// </summary>
+        private void ApplyDrag(Polygon polygon, float screenXChange, float screenYChange, float zoomRatio)
+        {
+            var isEndpoint = PointIndexGrabbed == 0 || PointIndexGrabbed == polygon.Points.Count - 1;
             var areEndPointsOverlapping =
                 polygon.AbsolutePointPosition(0) == polygon.AbsolutePointPosition(polygon.Points.Count - 1);
 
-
-            UnsnappedPosition.X += cursor.ScreenXChange / CameraLogic.CurrentZoomRatio;
-            UnsnappedPosition.Y += -cursor.ScreenYChange / CameraLogic.CurrentZoomRatio;
+            UnsnappedPosition.X += screenXChange / zoomRatio;
+            UnsnappedPosition.Y += -screenYChange / zoomRatio;
 
             float Snap(float value) =>
                 PointSnapSize > 0
@@ -321,12 +329,26 @@ namespace GlueControl.Editing
             {
                 polygon.SetPointFromAbsolutePosition(0, snappedX, snappedY);
                 polygon.SetPointFromAbsolutePosition(polygon.Points.Count - 1, snappedX, snappedY);
-
             }
             else
             {
                 polygon.SetPointFromAbsolutePosition(PointIndexGrabbed.Value, snappedX, snappedY);
             }
+        }
+
+        /// <summary>
+        /// Test-only entry point driven by SimulatePolygonPointDragDto (see CommandReceiver.HandleDto) -
+        /// grabs the point at pointIndex exactly like a real mouse-down on its handle would, then applies
+        /// one drag step, without needing a real Cursor/mouse. Exists so a LiveGameProcess-based test can
+        /// drive this class's actual drag+snap logic end to end (including whatever set PointSnapSize)
+        /// instead of the only way to reach it being a human physically dragging a mouse.
+        /// </summary>
+        internal void SimulateDragForTesting(Polygon polygon, int pointIndex, float screenXChange, float screenYChange)
+        {
+            PointIndexGrabbed = pointIndex;
+            UnsnappedPosition = polygon.AbsolutePointPosition(pointIndex);
+            ApplyDrag(polygon, screenXChange, screenYChange, zoomRatio: 1f);
+            PointIndexGrabbed = null;
         }
 
         private void DoCursorHoverActivity(Polygon polygon)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/Markers/SelectionMarker.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/Markers/SelectionMarker.cs
@@ -537,6 +537,7 @@ namespace GlueControl.Editing
 
         ResizeHandles ResizeHandles;
         PolygonPointHandles PolygonPointHandles;
+        internal PolygonPointHandles PolygonPointHandlesForTesting => PolygonPointHandles;
 
         public float ExtraPaddingInPixels { get; set; } = 2;
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/ViewModels/GlueViewSettingsViewModel.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/ViewModels/GlueViewSettingsViewModel.cs
@@ -112,7 +112,14 @@ namespace GameCommunicationPlugin.GlueControl.ViewModels
         public decimal PolygonPointSnapSize
         {
             get => Get<decimal>();
-            set => Set(value);
+            set
+            {
+                // 0 (or below) makes PolygonPointHandles.ApplyDrag's Snap() a no-op - polygon point
+                // dragging looks completely unsnapped, with no error or visual sign anything is wrong.
+                const decimal minValue = 1;
+                value = Math.Max(value, minValue);
+                Set(value);
+            }
         }
 
         [DependsOn(nameof(EnableLiveEdit))]

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/CompilerSettingsSnapDefaultsTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/CompilerSettingsSnapDefaultsTests.cs
@@ -1,0 +1,24 @@
+using CompilerLibrary.Models;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin;
+
+/// <summary>
+/// Live edit drags a whole object using SnapSize but drags a Polygon point using the separate
+/// PolygonPointSnapSize. If that default is much finer than SnapSize, point dragging is
+/// technically snapping but the increments are too small to see, so it reads as "not snapping."
+/// </summary>
+public class CompilerSettingsSnapDefaultsTests
+{
+    [Fact]
+    public void SetDefaults_PolygonPointSnapSize_MatchesSnapSize()
+    {
+        var model = new CompilerSettingsModel();
+
+        model.SetDefaults();
+
+        model.PolygonPointSnapSize.ShouldBe(model.SnapSize,
+            "polygon point dragging should visibly snap like whole-object dragging out of the box");
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GlueViewSettingsViewModelTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GlueViewSettingsViewModelTests.cs
@@ -1,0 +1,35 @@
+using GameCommunicationPlugin.GlueControl.ViewModels;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin;
+
+/// <summary>
+/// PolygonPointSnapSize=0 silently disables all polygon-point snapping (PolygonPointHandles.ApplyDrag's
+/// Snap() only rounds when PointSnapSize > 0), and unlike GridSize this field had no minimum-value guard
+/// - so an existing project with 0 already persisted in CompilerSettings.json drags points completely
+/// unsnapped, with no error or visual indication anything is wrong.
+/// </summary>
+public class GlueViewSettingsViewModelTests
+{
+    [Fact]
+    public void PolygonPointSnapSize_SetToZero_ClampsToAMinimumThatStillSnaps()
+    {
+        var viewModel = new GlueViewSettingsViewModel();
+
+        viewModel.PolygonPointSnapSize = 0;
+
+        viewModel.PolygonPointSnapSize.ShouldBeGreaterThan(0,
+            "0 disables snapping entirely and silently - it must never be reachable through this setter");
+    }
+
+    [Fact]
+    public void PolygonPointSnapSize_SetToNegative_ClampsToAMinimumThatStillSnaps()
+    {
+        var viewModel = new GlueViewSettingsViewModel();
+
+        viewModel.PolygonPointSnapSize = -5;
+
+        viewModel.PolygonPointSnapSize.ShouldBeGreaterThan(0);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/PolygonPointDragSnapTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/PolygonPointDragSnapTests.cs
@@ -147,4 +147,92 @@ public class PolygonPointDragSnapTests
             nos, gameScreen, listToAddTo: null, selectNewNos: false,
             performSaveAndGenerateCode: true, updateUi: false);
     }
+
+    /// <summary>
+    /// Mirrors a real reported case (issue #2074): a Polygon that's a NamedObject nested inside an Entity,
+    /// exposed via HasPublicProperty rather than a bare Screen object. PolygonPointHandles.EveryFrameUpdate
+    /// has an entirely separate "tunneled" code path for a Polygon reached through a CustomVariable whose
+    /// SourceObjectProperty is "Points" - this entity deliberately has no such CustomVariable, matching the
+    /// real .glej (ResonatorPyramid) that reported the bug, so this exercises the plain
+    /// "item as Polygon"/EntityViewingScreen-resolved-instance path instead.
+    ///
+    /// Adds the Polygon to the existing Entities\Entity1 rather than creating a new entity:
+    /// EntityCommands.AddEntityAsync auto-creates a "&lt;EntityName&gt;List" NamedObject on GameScreen
+    /// (mirroring Entity1List), and that addition alone broke GameScreen.AddToManagers with an NRE - a
+    /// separate, unrelated bug in that codegen path this test isn't trying to pin.
+    /// </summary>
+    [StaFact]
+    public async Task DraggingAPolygonPointNestedInAnEntity_WithSnappingEnabled_SnapsToGrid()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
+            afterLoadBeforeEmbed: AddNestedPolygonToEntity1);
+
+        // Selecting the entity loads EntityViewingScreen (a real Screen), which is enough to satisfy
+        // SetEditMode's "there must be a current screen to restart" requirement - no need to touch
+        // GameScreen at all for this test.
+        var selectEntityResponse = await game.SelectEntity("Entities\\Entity1");
+        selectEntityResponse.Succeeded.ShouldBeTrue(selectEntityResponse.Message);
+
+        var editModeResponse = await game.Send(new SetEditMode
+        {
+            IsInEditMode = true,
+            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        });
+        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
+        await Task.Delay(1000);
+
+        var entity = ObjectFinder.Self.GetEntitySave("Entities\\Entity1");
+        var selectPolygonResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Entities\\Entity1",
+            EntitySave = entity,
+            NamedObjectNames = { "PolygonInstance" },
+        });
+        selectPolygonResponse.Succeeded.ShouldBeTrue(selectPolygonResponse.Message);
+
+        var setPointsResponse = await game.Send(new SetPolygonPointsForTestingDto { Points = InitialPoints });
+        setPointsResponse.Succeeded.ShouldBeTrue(setPointsResponse.Message);
+
+        var settingsResponse = await game.Send(new GlueViewSettingsDto
+        {
+            EnableSnapping = true,
+            SnapSize = 8,
+            PolygonPointSnapSize = 8,
+        });
+        settingsResponse.Succeeded.ShouldBeTrue(settingsResponse.Message);
+
+        var dragResponse = await game.Send<SimulatePolygonPointDragResponse>(new SimulatePolygonPointDragDto
+        {
+            PointIndex = 0,
+            ScreenXChange = 3,
+            ScreenYChange = 0,
+        });
+
+        dragResponse.Succeeded.ShouldBeTrue(dragResponse.Message);
+        dragResponse.Data.X.ShouldBe(-8,
+            "a 3-pixel drag with an 8-unit snap should round back to the starting grid line, not move by a fraction of a unit");
+    }
+
+    static async Task AddNestedPolygonToEntity1()
+    {
+        var entity = ObjectFinder.Self.GetEntitySave("Entities\\Entity1");
+
+        var nos = new NamedObjectSave();
+        nos.SetDefaults();
+        nos.InstanceName = "PolygonInstance";
+        nos.SourceType = SourceType.FlatRedBallType;
+        nos.SourceClassType = "FlatRedBall.Math.Geometry.Polygon";
+        // Matches ResonatorPyramid.glej: exposed as a public property on the entity, not tunneled through
+        // a CustomVariable.
+        nos.HasPublicProperty = true;
+
+        await GlueCommands.Self.GluxCommands.AddNamedObjectToAsync(
+            nos, entity, listToAddTo: null, selectNewNos: false,
+            performSaveAndGenerateCode: true, updateUi: false);
+    }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/PolygonPointDragSnapTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/PolygonPointDragSnapTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GlueUnitTests.TestSupport;
+using Microsoft.Xna.Framework;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// Reproduces issue #2074 end to end against a real running game: whole-object dragging in live edit
+/// snaps to SnapSize, but dragging a Polygon point did not, even with PolygonPointSnapSize/EnableSnapping
+/// configured exactly like production Glue sends them. Drives PolygonPointHandles.SimulateDragForTesting
+/// (Embedded) - the exact same production drag+snap code a real mouse drag would run, just fed an explicit
+/// delta instead of reading Cursor/hardware, so this exercises the real DTO -> EditingManager ->
+/// SelectionMarker -> PolygonPointHandles wiring, not just the snap arithmetic in isolation.
+/// </summary>
+[Trait("Category", "LiveGame")]
+public class PolygonPointDragSnapTests
+{
+    static readonly List<Vector2> InitialPoints = new List<Vector2>
+    {
+        new Vector2(-8, 8),
+        new Vector2(8, 8),
+        new Vector2(8, -8),
+        new Vector2(-8, -8),
+        new Vector2(-8, 8),
+    };
+
+    [StaFact]
+    public async Task DraggingAPolygonPoint_WithSnappingEnabled_SnapsToGrid()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
+            afterLoadBeforeEmbed: AddTestPolygonToGameScreen);
+
+        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        // Load the screen first, with nothing selected yet.
+        var loadScreenResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Screens\\GameScreen",
+            ScreenSave = screen,
+        });
+        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
+
+        // Must happen before selecting the polygon: while ScreenManager.IsInEditMode is false,
+        // EditingManager's per-frame update takes its "not in edit mode" branch, which clears
+        // itemsSelected/SelectedMarkers (but not CurrentNamedObjects) every frame. Selecting first and
+        // enabling edit mode after leaves CurrentNamedObjects stale-"selected" while itemsSelected is
+        // empty, so the next select is treated as a no-op echo of an already-current selection and never
+        // actually re-applied.
+        var editModeResponse = await game.Send(new SetEditMode
+        {
+            IsInEditMode = true,
+            // The game's own ObjectFinder.Self.GlueProject is null until this loads it - without it,
+            // entering edit mode NREs inside GlueCommands.LoadProject/GlueProjectSaveExtensions.Load.
+            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        });
+        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
+
+        // SetEditMode only sets ScreenManager.IsNextScreenInEditMode and restarts the current screen
+        // (RestartScreenRerunCommands) - IsInEditMode itself only flips once that restart's ScreenLoaded
+        // callback actually runs, which happens on a later frame, not synchronously within the DTO
+        // handler that already returned above.
+        await Task.Delay(1000);
+
+        var selectResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Screens\\GameScreen",
+            ScreenSave = screen,
+            NamedObjectNames = { "TestPolygon" },
+        });
+        selectResponse.Succeeded.ShouldBeTrue(selectResponse.Message);
+
+        var setPointsResponse = await game.Send(new SetPolygonPointsForTestingDto { Points = InitialPoints });
+        setPointsResponse.Succeeded.ShouldBeTrue(setPointsResponse.Message);
+
+        // The exact DTO/values production Glue sends on entering edit mode - see
+        // MainCompilerPlugin.SendGlueViewSettingsToGame and CompilerSettingsModel.SetDefaults.
+        var settingsResponse = await game.Send(new GlueViewSettingsDto
+        {
+            EnableSnapping = true,
+            SnapSize = 8,
+            PolygonPointSnapSize = 8,
+        });
+        settingsResponse.Succeeded.ShouldBeTrue(settingsResponse.Message);
+
+        // Drag point 0 by 3 pixels - smaller than one 8-unit grid step. An unsnapped drag lands on a
+        // fraction of a unit, which is the exact reported symptom ("point editing was smooth and moved
+        // fractions of a unit"). A working snap rounds this back down to the starting grid line.
+        var dragResponse = await game.Send<SimulatePolygonPointDragResponse>(new SimulatePolygonPointDragDto
+        {
+            PointIndex = 0,
+            ScreenXChange = 3,
+            ScreenYChange = 0,
+        });
+
+        dragResponse.Succeeded.ShouldBeTrue(dragResponse.Message);
+        dragResponse.Data.X.ShouldBe(-8,
+            "a 3-pixel drag with an 8-unit snap should round back to the starting grid line, not move by a fraction of a unit");
+
+        // Same drag again, but with snapping disabled - proves this test can tell snapped from unsnapped
+        // rather than the point always landing on -8 regardless of settings.
+        var disableSnappingResponse = await game.Send(new GlueViewSettingsDto
+        {
+            EnableSnapping = false,
+            SnapSize = 8,
+            PolygonPointSnapSize = 8,
+        });
+        disableSnappingResponse.Succeeded.ShouldBeTrue(disableSnappingResponse.Message);
+
+        var unsnappedDragResponse = await game.Send<SimulatePolygonPointDragResponse>(new SimulatePolygonPointDragDto
+        {
+            PointIndex = 0,
+            ScreenXChange = 3,
+            ScreenYChange = 0,
+        });
+
+        unsnappedDragResponse.Succeeded.ShouldBeTrue(unsnappedDragResponse.Message);
+        unsnappedDragResponse.Data.X.ShouldBe(-5,
+            "with snapping disabled, a 3-pixel drag should move by exactly 3 units instead of rounding to a grid line");
+    }
+
+    static async Task AddTestPolygonToGameScreen()
+    {
+        var gameScreen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        var nos = new NamedObjectSave();
+        nos.SetDefaults();
+        nos.InstanceName = "TestPolygon";
+        nos.SourceType = SourceType.FlatRedBallType;
+        nos.SourceClassType = "FlatRedBall.Math.Geometry.Polygon";
+
+        // AddNamedObjectToAsync (not AddNewNamedObjectToAsync - see CollisionAssetTypeRegistrationTests for
+        // why) is the same production add-and-generate path Glue.exe uses; performSaveAndGenerateCode:true
+        // makes "TestPolygon" a real field in the built GameScreen.Generated.cs.
+        await GlueCommands.Self.GluxCommands.AddNamedObjectToAsync(
+            nos, gameScreen, listToAddTo: null, selectNewNos: false,
+            performSaveAndGenerateCode: true, updateUi: false);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
@@ -62,12 +62,20 @@ internal sealed class LiveGameProcess : IDisposable
     /// in. Game1.Generated.cs is preserved exactly as checked in either way - see the class doc comment for
     /// why (its GlueControlManager wiring can't be regenerated in the test host) - only its port is patched.
     /// </param>
+    /// <param name="afterLoadBeforeEmbed">
+    /// Optional hook that runs after the project is loaded into Glue (so <c>ObjectFinder.Self</c>/
+    /// <c>GlueCommands.Self</c> are usable, real project-editing APIs like
+    /// <c>GluxCommands.AddNamedObjectToAsync</c> can add fixture objects) but before the live-edit closure
+    /// is embedded and the project built - so a test-only object added here reaches the built exe. Only
+    /// called when <paramref name="refreshLiveEditCodeFromSource"/> is true.
+    /// </param>
     public static async Task<LiveGameProcess> StartAsync(
         string repoRelativeProjectDirectory,
         string csprojRelativeToProjectRoot,
         string exeRelativeToProjectRoot,
         bool refreshLiveEditCodeFromSource = true,
-        TimeSpan? connectTimeout = null)
+        TimeSpan? connectTimeout = null,
+        Func<Task> afterLoadBeforeEmbed = null)
     {
         var project = GoldProject.CopyOutOfRepo(repoRelativeProjectDirectory);
         try
@@ -87,6 +95,12 @@ internal sealed class LiveGameProcess : IDisposable
                 // (MainCompilerPlugin owns that - see the class doc comment). Everything else still gets a
                 // real regenerate-if-changed pass from LoadInGlueAsync, same as any other gold project.
                 await GoldProject.LoadInGlueAsync(csprojPath);
+
+                if (afterLoadBeforeEmbed != null)
+                {
+                    await afterLoadBeforeEmbed();
+                }
+
                 GoldProject.EmbedLiveEditCode();
 
                 // LoadInGlueAsync's normal codegen pass may have rewritten Game1.Generated.cs without the
@@ -167,6 +181,13 @@ internal sealed class LiveGameProcess : IDisposable
     /// rather than about a particular editor gesture.
     /// </summary>
     public Task<GeneralResponse<string>> Send(object dto) => CommandSender.Self.Send(dto);
+
+    /// <summary>
+    /// Same as <see cref="Send"/>, but deserializes the game's raw JSON reply into <typeparamref name="T"/>
+    /// - see <see cref="CommandSender.Send{T}"/> - for tests that need the handler's typed return value
+    /// rather than just success/failure.
+    /// </summary>
+    public Task<GeneralResponse<T>> Send<T>(object dto) => CommandSender.Self.Send<T>(dto);
 
     /// <summary>
     /// Sends the same SelectObjectDto Glue sends when the user clicks an entity in the tree, over the real


### PR DESCRIPTION
## Summary
- **Root cause (confirmed via live logging against the reporter's real project):** `PolygonPointSnapSize` was persisted as `0` in an existing project's settings. `PolygonPointHandles.ApplyDrag`'s `Snap()` only rounds when `PointSnapSize > 0`, so `0` silently disabled all point snapping — dragging looked completely unsnapped, no error, no visual sign anything was wrong. Confirmed with temp logging showing `PointSnapSize=0` on every drag frame in the real session.
- Unlike `GridSize`, `PolygonPointSnapSize`'s ViewModel setter had no minimum-value guard, so `0`/negative was reachable and — once persisted — stayed that way regardless of the earlier default-value fix (1 → 8, still worth keeping for brand-new projects).
- **Fix:** clamp `GlueViewSettingsViewModel.PolygonPointSnapSize` to a minimum of 1. `SetFrom` loads persisted settings through this same setter, so reloading a project with a stale `0` self-heals it — no migration needed.
- `SnapSize` (the whole-object equivalent) has the identical missing guard but isn't reported broken — noted here as a follow-up, not fixed, to keep this scoped.
- Along the way, built real end-to-end regression tests (`PolygonPointDragSnapTests`, `Category=LiveGame`) that drive a real running game over the actual DTO socket protocol — covering both a bare Polygon on a Screen and one nested in an Entity (the reporter's actual structural shape). Both prove the snap wiring itself is correct once a point is grabbed and `PointSnapSize` is a valid positive value.
- Filed #2077 for an unrelated bug tripped over along the way (adding a new Entity crashes `GameScreen.AddToManagers`) — not touched here.

## Test plan
- [x] `GlueViewSettingsViewModelTests` — watched fail (0 and -5 both un-clamped), then pass after the fix. This is the test that pins the actual reported bug.
- [x] `CompilerSettingsSnapDefaultsTests` — config default, 1 → 8.
- [x] `PolygonPointDragSnapTests` (Category=LiveGame, 2 tests) — real running game, real DTO protocol, both bare-Polygon and entity-nested-Polygon shapes.
- [x] Full `GlueUnitTests` suite (`Category!=BuildSmoke`, includes LiveGame): 625/625 passing.
- [x] Manual: reporter to confirm dragging a polygon point in their real project now snaps.

Part of #2074 (root cause fixed and TDD'd; holding the closing keyword until the reporter confirms the actual drag now snaps in their real project)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
