### PR TITLE
Fix NRE in AddToManagers when a SetByDerived TMX Map loads unset

### DIFF
--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
@@ -89,4 +89,37 @@ public class LiveGameProcessTests
 
         (await game.GetCurrentScreenName()).ShouldBe("EditorTest1.Screens.GameScreen_EditorPlaceholder");
     }
+
+    // Pins #2077: GameScreen's Map (a LayeredTileMap NamedObjectSave with ShiftMapToMoveGameplayLayerToZ0)
+    // is SetByDerived - only a concrete derived Screen assigns it, so on the AbstractScreenPlaceholderFactory
+    // placeholder from the test above it stays default(T), i.e. null. TmxCodeGenerator's
+    // TryGenerateShiftZ0Code/GenerateCreateEntitiesCode unconditionally emitted
+    // "Map.MapLayers.FindByName(...)" with no null guard, so AddToManagers() NREs the moment the
+    // placeholder loads - independent of the new-Entity repro in the issue, which only happened to be how
+    // it was noticed (see the issue's own "not yet root-caused" note).
+    //
+    // SelectObjectDto's response carries no failure signal (Succeeded is true either way - see the test
+    // above; ScreenManager.LoadScreen sets CurrentScreen before Initialize ever runs), so the only way to
+    // observe the exception from outside the game process is CommandReceiver.Receive's top-level
+    // catch-all, which Console.WriteLines it - captured via LiveGameProcess's redirected stdout.
+    [StaFact]
+    public async Task EditorTest1_SelectingGameScreenPlaceholder_DoesNotThrowInAddToManagers()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe");
+
+        var selectResponse = await game.SelectScreen("Screens\\GameScreen");
+        selectResponse.Succeeded.ShouldBeTrue(selectResponse.Message);
+
+        // Give the game a moment to process the DTO and, if it throws, flush the exception to stdout -
+        // there's no ack for "AddToManagers finished" to await instead.
+        await Task.Delay(1000);
+
+        var output = string.Join("\n", game.GetCapturedStandardOutputLines());
+        output.ShouldNotContain("NullReferenceException");
+    }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -33,14 +35,18 @@ internal sealed class LiveGameProcess : IDisposable
     readonly TempDir project;
     readonly System.Diagnostics.Process process;
     readonly GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager;
+    readonly ConcurrentQueue<string> capturedStandardOutput;
 
     public string ProjectRoot => project.Root;
 
-    LiveGameProcess(TempDir project, System.Diagnostics.Process process, GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager)
+    LiveGameProcess(TempDir project, System.Diagnostics.Process process,
+        GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager,
+        ConcurrentQueue<string> capturedStandardOutput)
     {
         this.project = project;
         this.process = process;
         this.connectionManager = connectionManager;
+        this.capturedStandardOutput = capturedStandardOutput;
     }
 
     /// <summary>
@@ -125,11 +131,32 @@ internal sealed class LiveGameProcess : IDisposable
             GameJsonCommunicationPlugin.Common.GameConnectionManager.Self = connectionManager;
 
             var exePath = Path.Combine(project.Root, exeRelativeToProjectRoot);
-            var process = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(exePath)
+            var capturedStandardOutput = new ConcurrentQueue<string>();
+            var process = new System.Diagnostics.Process
             {
-                UseShellExecute = false,
-                WorkingDirectory = Path.GetDirectoryName(exePath),
-            });
+                StartInfo = new System.Diagnostics.ProcessStartInfo(exePath)
+                {
+                    UseShellExecute = false,
+                    WorkingDirectory = Path.GetDirectoryName(exePath),
+                    RedirectStandardOutput = true,
+                }
+            };
+            // Async, event-based capture rather than ReadToEnd(): this process is long-lived (killed by
+            // Dispose, not naturally exiting), so a blocking read would never return - see NestedDotnetCli's
+            // doc comment for the same deadlock shape with dotnet build's child MSBuild nodes. This is what
+            // CommandReceiver.Receive's catch-all writes an unhandled DTO-handling exception to (see
+            // Embedded/CommandReceiver.cs) - the only way to observe a screen-load exception from outside
+            // the game process, since ScreenManager.LoadScreen sets CurrentScreen before Initialize runs and
+            // the SelectObjectDto response carries no failure signal either way.
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data != null)
+                {
+                    capturedStandardOutput.Enqueue(e.Data);
+                }
+            };
+            process.Start();
+            process.BeginOutputReadLine();
 
             var deadline = DateTime.UtcNow + (connectTimeout ?? TimeSpan.FromSeconds(20));
             while (!connectionManager.IsConnected && DateTime.UtcNow < deadline)
@@ -156,7 +183,7 @@ internal sealed class LiveGameProcess : IDisposable
             // IsPrintEditorToGameCheckboxChecked defaults false, so this only needs to exist.
             CommandSender.Self.CompilerViewModel = CompilerViewModel.Self;
 
-            return new LiveGameProcess(project, process, connectionManager);
+            return new LiveGameProcess(project, process, connectionManager, capturedStandardOutput);
         }
         catch
         {
@@ -175,6 +202,14 @@ internal sealed class LiveGameProcess : IDisposable
         var screenName = await CommandSender.Self.GetScreenName();
         return screenName ?? "";
     }
+
+    /// <summary>
+    /// A snapshot of the game process's captured stdout so far, one entry per line. An unhandled exception
+    /// from a DTO handler (e.g. a screen failing to Initialize) lands here via
+    /// CommandReceiver.Receive's catch-all Console.WriteLine - see the capture wiring in StartAsync for why
+    /// this is the only way to observe that from outside the process.
+    /// </summary>
+    public IReadOnlyList<string> GetCapturedStandardOutputLines() => capturedStandardOutput.ToArray();
 
     /// <summary>
     /// Sends any DTO over the real CommandSender, for tests that care about what the running game answers

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCliTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCliTests.cs
@@ -54,6 +54,12 @@ public class NestedDotnetCliTests
             .EnumerateFiles(FindTestProjectRoot(), "*.cs", SearchOption.AllDirectories)
             .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
             .Where(file => !Path.GetFileName(file).StartsWith("NestedDotnetCli", StringComparison.Ordinal))
+            // LiveGameProcess.cs redirects the built game .exe's stdout - not a nested `dotnet` invocation,
+            // so NestedDotnetCli.Run (which expects a `dotnet <args>` command it runs to completion or
+            // times out) doesn't fit. It doesn't have the #1969 deadlock shape either: the process is
+            // long-lived by design (killed by Dispose, not awaited to exit), and output is drained via the
+            // async OutputDataReceived/BeginOutputReadLine event pair rather than a blocking ReadToEnd().
+            .Where(file => Path.GetFileName(file) != "LiveGameProcess.cs")
             .Where(file => File.ReadAllText(file).Contains("RedirectStandardOutput", StringComparison.Ordinal))
             .Select(Path.GetFileName)
             .ToList();

--- a/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/CodeGeneration/TmxCodeGenerator.cs
+++ b/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/CodeGeneration/TmxCodeGenerator.cs
@@ -134,12 +134,27 @@ namespace TileGraphicsPlugin.CodeGeneration
             {
                 if(nos.GetAssetTypeInfo()?.Extension == "tmx")
                 {
-                    TryGenerateShiftZ0Code(nos, codeBlock);
+                    // The map may not be instantiated at this point - e.g. SetByDerived, only assigned by a
+                    // derived Screen/Entity - in which case nos.InstanceName is null here and every line
+                    // below would NRE. See issue #2077.
+                    var shouldHaveIfNullCheck = nos.Instantiate == false || nos.SetByDerived;
+                    var innerCodeBlock = codeBlock;
+                    if (shouldHaveIfNullCheck)
+                    {
+                        innerCodeBlock = innerCodeBlock.If(nos.InstanceName + " != null");
+                    }
+
+                    TryGenerateShiftZ0Code(nos, innerCodeBlock);
 
                     // not sure if we need this for files, but for now
-                    // going to implement just on NOS's since that's the 
+                    // going to implement just on NOS's since that's the
                     // preferred pattern.
-                    GenerateCreateEntitiesCode(nos, element as GlueElement, codeBlock);
+                    GenerateCreateEntitiesCode(nos, element as GlueElement, innerCodeBlock);
+
+                    if (shouldHaveIfNullCheck)
+                    {
+                        innerCodeBlock.End();
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

`GameScreen`'s `Map` (a TMX-backed `LayeredTileMap`) is `SetByDerived` - only a concrete derived Screen assigns it. `TmxCodeGenerator` generated `Map.MapLayers.FindByName(...)` and `TileEntityInstantiator.CreateEntitiesFrom(Map)` unconditionally in `AddToManagers()`, so any time `Map` is still unset the screen NREs the moment it loads.

That's exactly what happens through live-edit's `AbstractScreenPlaceholderFactory` (#2006): selecting an abstract Screen with no concrete derived Screen synthesizes a throwaway subclass whose `SetByDerived` fields are just `default(T)`, i.e. `Map` is null. Adding a new Entity (the issue's repro) is unrelated to the root cause - it just happens to be how the reporter ended up selecting `GameScreen`, which auto-gains an `EntityList` NamedObject whenever a new Entity is added. The same crash reproduces with zero Entities added.

## Fix

Wrap the two generated calls in `if (Map != null)`, matching the existing `SetByDerived` null-check idiom already used elsewhere in `NamedObjectSaveCodeGenerator`.

## Testing

Pinned with a real end-to-end `LiveGameProcess` test: builds and launches EditorTest1, selects the abstract `GameScreen` placeholder over the actual live-edit socket protocol, and asserts no `NullReferenceException` in the game process's stdout. That's the only observable failure signal available - `SelectObjectDto`'s response is always `Succeeded: true` since `ScreenManager.LoadScreen` assigns `CurrentScreen` before `Initialize` runs, catch or no catch.

Confirmed red against the current code (real `NullReferenceException` in `GameScreen.AddToManagers()`, `GameScreen.Generated.cs`, matching the issue's stack trace verbatim) and green after the fix. Full non-BuildSmoke/non-LiveGame suite (614 tests) and BuildSmoke gold-project builds (48 tests, incl. Beefball/DoorsDemo which also generate TMX Map code) pass clean.

`LiveGameProcess.cs` also gained an `afterLoad` hook (mutate the loaded project before build+launch, needed to add the repro Entity before the game gets built) and async stdout capture - both reusable by future `LiveGameProcess`-based tests. Excluded it from `NestedDotnetCliTests`'s redirected-process hygiene guard with a comment, since it isn't a nested `dotnet` invocation and doesn't have that guard's blocking-`ReadToEnd()` deadlock shape.

Closes #2077
