### PR TITLE
Glue: add right-click Rename for objects (NamedObjectSave)

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/Logic/RightClickHelper.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/Logic/RightClickHelper.cs
@@ -464,6 +464,7 @@ public static class RightClickHelper
             }
 
             // Common ops
+            list.Add(RenameItem());
             list.Add(new RightClickItemDescriptor { Text = "Duplicate", Handler = () => DuplicateClick(null, EventArgs.Empty) });
             list.AddRange(RemoveItems());
             list.Add(RightClickItemDescriptor.Separator);

--- a/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/RightClickDescriptorTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/RightClickDescriptorTests.cs
@@ -1,6 +1,7 @@
 using FlatRedBall.Glue.FormHelpers;
 using FlatRedBall.Glue.Plugins.ExportedInterfaces;
 using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
 using Moq;
 using Shouldly;
 
@@ -13,6 +14,13 @@ namespace GlueUnitTests.TreeViewPlugin;
 /// </summary>
 public class RightClickDescriptorTests
 {
+    public RightClickDescriptorTests()
+    {
+        // IsNamedObjectNode's branch reads AvailableAssetTypes.CommonAtis (via GetAssetTypeInfo()
+        // comparisons), which is only populated by real Glue startup / this bootstrap.
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
     static Mock<ITreeNode> MakeNode(TreeNodeType type, object tag = null)
     {
         var mock = new Mock<ITreeNode>() { CallBase = true };
@@ -247,6 +255,38 @@ public class RightClickDescriptorTests
 
         removeIdx.ShouldBeGreaterThanOrEqualTo(0);
         copyNameIdx.ShouldBeGreaterThan(removeIdx);
+    }
+
+    #endregion
+
+    #region NamedObjectNode
+
+    [Fact]
+    public void NamedObjectNode_ContainsRename()
+    {
+        var nos = new NamedObjectSave { InstanceName = "PlayerInstance" };
+        var node = MakeNode(TreeNodeType.NamedObjectSaveNode, nos);
+
+        var texts = GetTexts(node.Object);
+
+        texts.ShouldContain("Rename");
+    }
+
+    [Fact]
+    public void NamedObjectNode_RenameComesBeforeDuplicate()
+    {
+        var nos = new NamedObjectSave { InstanceName = "PlayerInstance" };
+        var node = MakeNode(TreeNodeType.NamedObjectSaveNode, nos);
+
+        var items = RightClickHelper.GetItemDescriptors(node.Object, MakeGlueState().Object, MenuShowingAction.RegularRightClick)
+                                    .Where(d => !d.IsSeparator)
+                                    .ToList();
+
+        int renameIdx = items.FindIndex(d => d.Text == "Rename");
+        int duplicateIdx = items.FindIndex(d => d.Text == "Duplicate");
+
+        renameIdx.ShouldBeGreaterThanOrEqualTo(0);
+        duplicateIdx.ShouldBeGreaterThan(renameIdx);
     }
 
     #endregion


### PR DESCRIPTION
Closes #2080.

F2 already renames a `NamedObjectSave` (object instance) via `NodeViewModel.HandleRenameThroughEdit -> GluxCommands.RenameNamedObjectSave`, since `NamedObjectsRootNodeViewModel` sets `IsEditable = true` for those nodes. The right-click menu's `IsNamedObjectNode()` branch in `RightClickHelper.GetItemDescriptors` never called the shared `RenameItem()` though, unlike the Screen/Entity/ReferencedFile branches - so right-click went straight to Duplicate/Remove with no Rename entry.

Added `RenameItem()` to that branch, same handler used elsewhere (sets `IsEditing = true` on the selected node, which the existing F2 path already handles for objects).

## Testing
TDD: added `NamedObjectNode_ContainsRename` / `NamedObjectNode_RenameComesBeforeDuplicate` to `RightClickDescriptorTests`, watched them fail (first as a `NullReferenceException` from `AvailableAssetTypes.CommonAtis` not being initialized in a bare test host - fixed by adding `GlueTestBootstrap.EnsureInitialized()` to the test class's constructor - then as a real assertion failure with `Rename` missing from the descriptor list), then made them pass with the one-line fix. Full non-BuildSmoke suite (628 tests) green from a clean build.

Manual test: not needed - covered by the unit tests above plus the fact that the Rename handler (`RenameItem()`) and the F2 rename path it triggers are both pre-existing, unmodified code; this PR only adds a menu entry that calls the same handler already used for Screens/Entities/Files.
