### PR TITLE
Fix IndexOutOfRangeException in StateDataControl.FocusTextBoxAt

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/StateDataPlugin/Controls/StateDataControl.xaml.cs
+++ b/FRBDK/Glue/OfficialPlugins/StateDataPlugin/Controls/StateDataControl.xaml.cs
@@ -170,8 +170,17 @@ namespace OfficialPlugins.StateDataPlugin.Controls
             ///////////End Early Out/////////////////
 
 
-            var childrenOfChildren = currentRow.Descendants<DataGridCell>()
-                .OfType<DataGridCell>().ToArray()[currentColumnIndex.Value];
+            var cellsInRow = currentRow.Descendants<DataGridCell>()
+                .OfType<DataGridCell>().ToArray();
+
+            // The row's cells may not all be visually realized yet due to virtualization,
+            // so the array can be shorter than the column count.
+            if (currentColumnIndex.Value < 0 || currentColumnIndex.Value >= cellsInRow.Length)
+            {
+                return false;
+            }
+
+            var childrenOfChildren = cellsInRow[currentColumnIndex.Value];
 
             var textBox = childrenOfChildren.Descendants<TextBox>()
                 .OfType<TextBox>()


### PR DESCRIPTION
Closes #2082

`FocusTextBoxAt` indexed the row's realized `DataGridCell` descendants by `DisplayIndex` with no bounds check. When the row's cells aren't all visually realized yet (WPF `DataGrid` virtualization), that array is shorter than the column count, so pressing Enter (or Tab/arrow keys) throws `IndexOutOfRangeException` and crashes the plugin. Added an early-out bounds check, matching the existing `currentRow == null` guard right above it.

Manual test: needed — this is a WPF visual-tree virtualization timing race, not pinnable with a fast unit test (no existing test drives real DataGrid rendering).
1. Open a project's StateData grid with several states/variables (enough rows/columns to trigger virtualization).
2. Click a cell, then press Enter (also try Tab and Up/Down arrows) repeatedly, including near the grid's edges.
3. Confirm no crash / no "FRB Sync Plugin" shutdown error.
