### PR TITLE
Fix NRE in CollisionManager when an ICollidable's Collision is null

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Math/Collision/CollisionRelationship.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Math/Collision/CollisionRelationship.cs
@@ -231,6 +231,13 @@ namespace FlatRedBall.Math.Collision
             }
 #endif
 
+            // An instance may intentionally have a null Collision (e.g. it doesn't need one), so skip
+            // rather than NRE - see issue #2084.
+            if (first.Collision == null || second.Collision == null)
+            {
+                return false;
+            }
+
             this.DeepCollisionsThisFrame++;
 
             if (CollisionType == CollisionType.EventOnlyCollision || eventOnly)
@@ -2104,6 +2111,13 @@ namespace FlatRedBall.Math.Collision
 
         private bool DoCollisionPhysicsInner(FirstCollidableT first, ShapeCollection second, bool eventOnly)
         {
+            // An instance may intentionally have a null Collision (e.g. it doesn't need one), so skip
+            // rather than NRE - see issue #2084.
+            if (first.Collision == null)
+            {
+                return false;
+            }
+
             this.DeepCollisionsThisFrame++;
 
             if (CollisionType == CollisionType.EventOnlyCollision || eventOnly)
@@ -2174,7 +2188,7 @@ namespace FlatRedBall.Math.Collision
                 return first.CollideAgainstMove(second, moveFirstMass, moveSecondMass);
             }
         }
-                
+
         private bool CollideAgainstConsiderSubCollisionMoveSoft(FirstCollidableT first, ShapeCollection second)
         {
             if(firstSubCollisionCircle != null)
@@ -2304,6 +2318,13 @@ namespace FlatRedBall.Math.Collision
 
         private bool DoCollisionPhysicsInner(FirstCollidableT first, ShapeCollection second, bool eventOnly)
         {
+            // An instance may intentionally have a null Collision (e.g. it doesn't need one), so skip
+            // rather than NRE - see issue #2084.
+            if (first.Collision == null)
+            {
+                return false;
+            }
+
             this.DeepCollisionsThisFrame++;
 
             if (CollisionType == CollisionType.EventOnlyCollision || eventOnly)

--- a/Tests/EngineUnitTests/Math/Collision/CollisionRelationshipNullCollisionTests.cs
+++ b/Tests/EngineUnitTests/Math/Collision/CollisionRelationshipNullCollisionTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using FlatRedBall;
+using FlatRedBall.Math;
+using FlatRedBall.Math.Collision;
+using FlatRedBall.Math.Geometry;
+using Shouldly;
+
+namespace EngineUnitTests.Math.Collision;
+
+// Pins #2084: an ICollidable instance may intentionally have a null Collision (e.g. it doesn't
+// need one), so CollisionRelationship's DoCollisions should skip it rather than NRE inside
+// ShapeCollection.CollideAgainst.
+public class CollisionRelationshipNullCollisionTests
+{
+    class NullableCollisionEntity : PositionedObject, ICollidable
+    {
+        public ShapeCollection Collision { get; set; }
+        public HashSet<string> ItemsCollidedAgainst { get; } = new HashSet<string>();
+        public HashSet<string> LastFrameItemsCollidedAgainst { get; } = new HashSet<string>();
+        public HashSet<object> ObjectsCollidedAgainst { get; } = new HashSet<object>();
+        public HashSet<object> LastFrameObjectsCollidedAgainst { get; } = new HashSet<object>();
+    }
+
+    static NullableCollisionEntity CreateEntityWithCollision()
+    {
+        var entity = new NullableCollisionEntity { Name = "WithCollision" };
+        entity.Collision = new ShapeCollection();
+        entity.Collision.Add(new Circle { Radius = 10 });
+        return entity;
+    }
+
+    static ShapeCollection CreateOverlappingShapeCollection()
+    {
+        var shapeCollection = new ShapeCollection();
+        shapeCollection.Add(new Circle { Radius = 10 });
+        return shapeCollection;
+    }
+
+    [Fact]
+    public void PositionedObjectVsPositionedObjectRelationship_DoCollisions_ShouldNotThrow_WhenSecondCollisionIsNull()
+    {
+        var first = CreateEntityWithCollision();
+        var second = new NullableCollisionEntity { Name = "NullCollision", Collision = null };
+
+        var relationship = new PositionedObjectVsPositionedObjectRelationship<NullableCollisionEntity, NullableCollisionEntity>(first, second);
+
+        var didCollide = relationship.DoCollisions();
+
+        didCollide.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PositionedObjectVsShapeCollection_DoCollisions_ShouldNotThrow_WhenEntityCollisionIsNull()
+    {
+        var entity = new NullableCollisionEntity { Name = "NullCollision", Collision = null };
+        var shapeCollection = CreateOverlappingShapeCollection();
+
+        var relationship = new PositionedObjectVsShapeCollection<NullableCollisionEntity>(entity, shapeCollection);
+
+        var didCollide = relationship.DoCollisions();
+
+        didCollide.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ListVsShapeCollectionRelationship_DoCollisions_ShouldNotThrow_WhenListItemCollisionIsNull()
+    {
+        var list = new PositionedObjectList<NullableCollisionEntity>
+        {
+            new NullableCollisionEntity { Name = "NullCollision", Collision = null }
+        };
+        var shapeCollection = CreateOverlappingShapeCollection();
+
+        var relationship = new ListVsShapeCollectionRelationship<NullableCollisionEntity>(list, shapeCollection);
+
+        var didCollide = relationship.DoCollisions();
+
+        didCollide.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Root cause: an `ICollidable` instance is allowed to have a null `Collision` (e.g. a background entity that doesn't need one), but `CollisionRelationship`'s three `DoCollisionPhysicsInner` funnels (entity-vs-entity/list, entity-vs-ShapeCollection, list-vs-ShapeCollection) dereferenced `.Collision` unconditionally in their no-sub-collision fallback path. This threw `NullReferenceException` inside `ShapeCollection.CollideAgainst` as soon as such an instance took part in a `CollisionManager` relationship.

Fix: each of the three funnels now returns `false` (no collision) if either side's `Collision` is null, instead of dereferencing it.

Pinned with 3 new `EngineUnitTests` (one per relationship shape: entity-vs-entity, entity-vs-ShapeCollection, list-vs-ShapeCollection), each watched red (NRE) against the pre-fix code and green after.

Manual test: not needed - pure engine logic, covered by the new unit tests plus compilation.

Closes #2084.
