### PR TITLE
Add inline rename for new objects, skip New Object modal when type is predetermined

### DIFF
--- a/FRBDK/Glue/.claude/skills/glue-add-object-flow/SKILL.md
+++ b/FRBDK/Glue/.claude/skills/glue-add-object-flow/SKILL.md
@@ -21,13 +21,20 @@ validation logic. See [[glue-task-manager]] for how each path's save/codegen wor
 
 ## Gotchas
 
-- `IsTypePredetermined` (set when adding to a typed list, or explicitly by the caller) drives
-  `IsSelectionEnabled => !IsTypePredetermined`, which disables *both* the type radio group and the
-  type list, not just one. When true, the modal does zero type-selection work — it's pure naming
-  friction.
-- `IsOkButtonEnabled` only checks `SelectedItem != null`; name validity is checked *after* the modal
-  closes, in `ShowAddNewObjectDialog`. An invalid name discards the whole dialog and shows a message
-  box — no re-prompt.
+- `IsTypePredetermined` (set when adding to a typed list, or explicitly by the caller, e.g.
+  `HandleAddLayerClick`) drives `IsSelectionEnabled => !IsTypePredetermined`, which disables *both* the
+  type radio group and the type list, not just one. `CreateAndShowAddNamedObjectWindow` checks the
+  *final* value of this flag (it can be narrowed later, e.g. `AvailableEntities.Count < 2` for a typed
+  list whose generic type has derived entities to choose from) and skips constructing the WPF window
+  entirely when true — adds immediately with the `SetDefaultObjectName()` default, no modal shown at
+  all. `RightClickHelper.AddObjectAndBeginRename()` then drops the new tree node straight into inline
+  rename.
+- `IsOkButtonEnabled` only checks `SelectedItem != null` — it was never gated on name validity. The
+  name field itself no longer exists in `NewObjectTypeSelectionControlWpf.xaml`; naming happens via
+  inline tree rename after add, not before.
+- `DialogCommands.ShowAddNewObjectDialog` no longer calls `NameVerifier.IsNamedObjectNameValid` before
+  adding — the name is Glue's own computed default at that point, not free-typed input. It still checks
+  `RecursionManager.Self.CanContainInstanceOf` (unrelated to naming).
 - Double-clicking a type in the list (`StrongSelect`) immediately confirms the dialog with whatever's
   in the name box — no Enter/OK click needed.
 - Tree inline rename validates via `NameVerifier` and reverts on invalid input inside
@@ -36,3 +43,15 @@ validation logic. See [[glue-task-manager]] for how each path's save/codegen wor
 - Chaining Add then Rename queues two independent `SaveProjectAndElements(AddOrMoveToEnd)` calls with
   different `DisplayInfo`, so per `glue-task-manager`'s coalescing rule they run as two separate
   save/codegen passes, not one.
+- `AddNewNamedObjectToAsync` and `AddNamedObjectToAsync`'s own `TaskManager.Self.AddAsync` calls both use
+  `TaskExecutionPreference.Asap`, not the `AddAsync` default of `Fifo` — the add is a direct
+  user-triggered action `AddObjectAndBeginRename` depends on completing immediately, not something that
+  should sit behind unrelated Fifo-tier work. Bumping the inner (nested) call is defensive rather than
+  strictly required — see `glue-task-manager`'s note on why a nested `AddAsync` call runs inline
+  regardless of its own preference.
+- `RightClickHelper.AddObjectAndBeginRename()` is the single shared entry point for the tree's own "Add
+  Object"/"Add Layer" menu items and the Ctrl+N shortcut (`MainTreeViewControl.xaml.cs`) — it calls
+  `ShowAddNewObjectDialog`, then `SelectionLogic.Current.SelectByTag`/`.IsEditing = true`.
+  `DragDropManager.cs`'s drag-and-drop add and `QuickActionPlugin`'s add call `ShowAddNewObjectDialog`
+  directly instead (they get the modal-skip but not the auto-inline-rename trigger, since
+  `SelectionLogic` is internal to the TreeViewPlugin assembly and unreachable from those projects).

--- a/FRBDK/Glue/.claude/skills/glue-add-object-flow/SKILL.md
+++ b/FRBDK/Glue/.claude/skills/glue-add-object-flow/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: glue-add-object-flow
+description: Glue's "New Object" add pipeline and the tree's inline-rename mechanism. Triggers: AddObjectViewModel, ShowAddNewObjectDialog, NewObjectTypeSelectionControlWpf, IsTypePredetermined, NodeViewModel.IsEditing, RenameNamedObjectSave.
+---
+
+# Glue Add-Object Flow
+
+Adding a `NamedObjectSave` and renaming one in the tree are two separate code paths that share
+validation logic. See [[glue-task-manager]] for how each path's save/codegen work gets queued.
+
+## File Map
+
+| File | Role |
+|---|---|
+| `Glue/Controls/NewObjectTypeSelectionControlWpf.xaml(.cs)` | "New Object" modal — type radios, filtered type list, name box |
+| `Glue/ViewModels/AddObjectViewModel.cs` | Backing VM; `SetDefaultObjectName()` auto-generates a unique name; `IsTypePredetermined`/`IsSelectionEnabled`/`IsObjectTypeGroupBoxEnabled` gate which controls are enabled |
+| `Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs` | `ShowAddNewObjectDialog` / `CreateAndShowAddNamedObjectWindow` — shows the modal, validates the name after it closes |
+| `Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs` | `AddNewNamedObjectToSelectedElementAsync` → `AddNewNamedObjectToAsync` → `AddNamedObjectToAsync` (actual add); `RenameNamedObjectSave` (separate rename path) |
+| `OfficialPlugins/TreeViewPlugin/ViewModels/NodeViewModel.cs` | `IsEditing` toggle drives in-place tree rename; `HandleRenameThroughEdit` dispatches by `Tag` type (`GlueElement`/`ReferencedFileSave`/`NamedObjectSave`/folder) |
+| `OfficialPlugins/TreeViewPlugin/Logic/RightClickHelper.cs` | `RenameItem()` — `SelectionLogic.Current.CurrentNode.IsEditing = true` is the whole mechanism for entering inline rename |
+
+## Gotchas
+
+- `IsTypePredetermined` (set when adding to a typed list, or explicitly by the caller) drives
+  `IsSelectionEnabled => !IsTypePredetermined`, which disables *both* the type radio group and the
+  type list, not just one. When true, the modal does zero type-selection work — it's pure naming
+  friction.
+- `IsOkButtonEnabled` only checks `SelectedItem != null`; name validity is checked *after* the modal
+  closes, in `ShowAddNewObjectDialog`. An invalid name discards the whole dialog and shows a message
+  box — no re-prompt.
+- Double-clicking a type in the list (`StrongSelect`) immediately confirms the dialog with whatever's
+  in the name box — no Enter/OK click needed.
+- Tree inline rename validates via `NameVerifier` and reverts on invalid input inside
+  `NodeViewModel.HandleRenameThroughEdit` → `GluxCommands.RenameNamedObjectSave` — the same validation
+  the Add path uses, so chaining add → immediate rename stays safe.
+- Chaining Add then Rename queues two independent `SaveProjectAndElements(AddOrMoveToEnd)` calls with
+  different `DisplayInfo`, so per `glue-task-manager`'s coalescing rule they run as two separate
+  save/codegen passes, not one.

--- a/FRBDK/Glue/Glue/Controls/NewObjectTypeSelectionControlWpf.xaml
+++ b/FRBDK/Glue/Glue/Controls/NewObjectTypeSelectionControlWpf.xaml
@@ -15,7 +15,6 @@
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
-            <RowDefinition Height="Auto"></RowDefinition>
         </Grid.RowDefinitions>
 
 
@@ -113,13 +112,7 @@
         </Grid>
 
 
-        <StackPanel  Grid.Row="3">
-            <Label Margin="0,5,0,0" Content="{x:Static localization:Texts.EnterNewObjectName}" />
-            <TextBox Text="{Binding ObjectName}" KeyDown="HandleEnterEscape"></TextBox>
-            
-        </StackPanel>
-
-        <Grid HorizontalAlignment="Right" Margin="0,5,0,0"  Grid.Row="4" Height="40">
+        <Grid HorizontalAlignment="Right" Margin="0,5,0,0"  Grid.Row="3" Height="40">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="100"></ColumnDefinition>
                 <ColumnDefinition Width="10"></ColumnDefinition>

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
@@ -102,15 +102,17 @@ partial class DialogCommands : IDialogCommands
 
         if (shouldAdd == true)
         {
-            bool isValid = _nameVerifier.IsNamedObjectNameValid(addObjectViewModel.ObjectName, out string whyItIsntValid);
+            // The object name no longer comes from free-typed user input - it's either the
+            // AddObjectViewModel-computed default (SetDefaultObjectName, already unique/valid) or,
+            // once inline rename lands the user's typed name, validated separately by
+            // GluxCommands.RenameNamedObjectSave. See the glue-add-object-flow skill.
+            bool isValid = true;
+            string whyItIsntValid = null;
 
-            if (isValid)
+            if (addObjectViewModel.SourceType == SourceType.Entity && !RecursionManager.Self.CanContainInstanceOf(GlueState.Self.CurrentElement, addObjectViewModel.SourceClassType))
             {
-                if (addObjectViewModel.SourceType == SourceType.Entity && !RecursionManager.Self.CanContainInstanceOf(GlueState.Self.CurrentElement, addObjectViewModel.SourceClassType))
-                {
-                    isValid = false;
-                    whyItIsntValid = L.Texts.TypeInfiniteRecursion;
-                }
+                isValid = false;
+                whyItIsntValid = L.Texts.TypeInfiniteRecursion;
             }
 
             if (isValid)
@@ -132,7 +134,7 @@ partial class DialogCommands : IDialogCommands
     /// </summary>
     /// <param name="addObjectViewModel"></param>
     /// <returns>The WPF dialog result for showing the window.</returns>
-    private static bool? CreateAndShowAddNamedObjectWindow(ref AddObjectViewModel addObjectViewModel)
+    internal static bool? CreateAndShowAddNamedObjectWindow(ref AddObjectViewModel addObjectViewModel)
     {
         var currentObject = GlueState.Self.CurrentNamedObjectSave;
 
@@ -272,6 +274,15 @@ partial class DialogCommands : IDialogCommands
                     }
                 }
             }
+        }
+
+        if (addObjectViewModel.IsTypePredetermined)
+        {
+            // Nothing left to pick - the type radios and list are both disabled (see
+            // AddObjectViewModel.IsSelectionEnabled). Showing the window would just be a naming
+            // prompt; skip it and let the caller add immediately with the already-computed default
+            // name (SetDefaultObjectName). See the glue-add-object-flow skill.
+            return true;
         }
 
         var wpf = new NewObjectTypeSelectionControlWpf();

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
@@ -1565,19 +1565,15 @@ public class GluxCommands : IGluxCommands
 
             await AddNamedObjectToAsync(newNos, element, listToAddTo, selectNewNos);
 
-        }, $"Adding Named Object {addObjectViewModel.ObjectName} to {element.Name}");
+        }, $"Adding Named Object {addObjectViewModel.ObjectName} to {element.Name}", TaskExecutionPreference.Asap);
         return newNos;
     }
 
     public async Task AddNamedObjectToAsync(NamedObjectSave newNos, GlueElement elementToAddTo, NamedObjectSave? listToAddTo = null, bool selectNewNos = true,
          bool performSaveAndGenerateCode = true, bool updateUi = true)
     {
-        var frameId1 = System.Threading.Thread.CurrentThread.ManagedThreadId;
         await TaskManager.Self.AddAsync(async () =>
         {
-            
-            var frameId2 = System.Threading.Thread.CurrentThread.ManagedThreadId;
-
             var ati = newNos.GetAssetTypeInfo();
 
             if (listToAddTo != null)
@@ -1659,7 +1655,7 @@ public class GluxCommands : IGluxCommands
             {
                 GlueCommands.Self.GluxCommands.SaveProjectAndElements();
             }
-        }, $"Adding named object {newNos.InstanceName} to {elementToAddTo.Name}");
+        }, $"Adding named object {newNos.InstanceName} to {elementToAddTo.Name}", TaskExecutionPreference.Asap);
     }
 
     public void RemoveNamedObject(NamedObjectSave namedObjectToRemove, bool performSaveAndGenerateCode = true,

--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/Logic/RightClickHelper.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/Logic/RightClickHelper.cs
@@ -334,7 +334,7 @@ public static class RightClickHelper
             }
             else
             {
-                list.Add(new RightClickItemDescriptor { Text = "Add Object", Handler = () => GlueCommands.Self.DialogCommands.ShowAddNewObjectDialog() });
+                list.Add(new RightClickItemDescriptor { Text = "Add Object", Handler = async () => await AddObjectAndBeginRename() });
             }
         }
 
@@ -453,13 +453,13 @@ public static class RightClickHelper
                 }
                 if (shouldAdd)
                 {
-                    list.Add(new RightClickItemDescriptor { Text = "Add Object", Handler = () => GlueCommands.Self.DialogCommands.ShowAddNewObjectDialog() });
+                    list.Add(new RightClickItemDescriptor { Text = "Add Object", Handler = async () => await AddObjectAndBeginRename() });
                     list.Add(RightClickItemDescriptor.Separator);
                 }
             }
             else if (currentNamedObject?.GetAssetTypeInfo() == AvailableAssetTypes.CommonAtis.ShapeCollection)
             {
-                list.Add(new RightClickItemDescriptor { Text = "Add Object", Handler = () => GlueCommands.Self.DialogCommands.ShowAddNewObjectDialog() });
+                list.Add(new RightClickItemDescriptor { Text = "Add Object", Handler = async () => await AddObjectAndBeginRename() });
                 list.Add(RightClickItemDescriptor.Separator);
             }
 
@@ -889,7 +889,7 @@ public static class RightClickHelper
         }
     }
 
-    private static void HandleAddLayerClick(object sender, EventArgs e)
+    private static async void HandleAddLayerClick(object sender, EventArgs e)
     {
         var viewModel = new AddObjectViewModel();
 
@@ -898,7 +898,28 @@ public static class RightClickHelper
         viewModel.SelectedAti = AvailableAssetTypes.CommonAtis.Layer;
         viewModel.IsTypePredetermined = true;
 
-        GlueCommands.Self.DialogCommands.ShowAddNewObjectDialog(viewModel);
+        await AddObjectAndBeginRename(viewModel);
+    }
+
+    /// <summary>
+    /// Shows the "New Object" dialog (or skips it entirely when the type is already predetermined -
+    /// see DialogCommands.CreateAndShowAddNamedObjectWindow) and, once the object is added and
+    /// selected, drops the new tree node straight into inline-rename mode - the same mechanism
+    /// RenameItem() uses. See the glue-add-object-flow skill.
+    /// </summary>
+    internal static async Task AddObjectAndBeginRename(AddObjectViewModel viewModel = null)
+    {
+        var newNamedObject = await GlueCommands.Self.DialogCommands.ShowAddNewObjectDialog(viewModel);
+
+        if (newNamedObject != null)
+        {
+            await SelectionLogic.Current.SelectByTag(newNamedObject, false);
+
+            if (SelectionLogic.Current.CurrentNode?.IsEditable == true)
+            {
+                SelectionLogic.Current.CurrentNode.IsEditing = true;
+            }
+        }
     }
 
     private static void HandleCopyToBuildFolder(object sender, EventArgs e)

--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/Views/MainTreeViewControl.xaml.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/Views/MainTreeViewControl.xaml.cs
@@ -89,7 +89,7 @@ public partial class MainTreeViewControl : UserControl, ITreeViewDisplay
             }
             else if(currentNode.IsRootNamedObjectNode())
             {
-                await GlueCommands.Self.DialogCommands.ShowAddNewObjectDialog();
+                await RightClickHelper.AddObjectAndBeginRename();
             }
             else if(currentNode.IsRootCustomVariablesNode())
             {

--- a/FRBDK/Glue/Tests/GlueUnitTests/NewObjectDialogTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/NewObjectDialogTests.cs
@@ -1,0 +1,41 @@
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.ViewModels;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests;
+
+/// <summary>
+/// When AddObjectViewModel.IsTypePredetermined is true (e.g. adding to a typed list, or "Add Layer"),
+/// there is no type to pick, so the "New Object" WPF window should never be constructed - see
+/// glue-add-object-flow skill. If this regresses, the window pops up on a thread with no message
+/// pump / no STA apartment, which throws instead of showing anything.
+/// </summary>
+public class NewObjectDialogTests
+{
+    public NewObjectDialogTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+    }
+
+    [Fact]
+    public void CreateAndShowAddNamedObjectWindow_TypePredetermined_DoesNotShowWindow()
+    {
+        var entity = new EntitySave { Name = "Entities\\Player" };
+        AddObjectViewModel viewModel = new AddObjectViewModel
+        {
+            ForcedElementToAddTo = entity,
+            SourceType = SourceType.FlatRedBallType,
+            SelectedAti = AvailableAssetTypes.CommonAtis.Layer,
+            IsTypePredetermined = true
+        };
+
+        var result = DialogCommands.CreateAndShowAddNamedObjectWindow(ref viewModel);
+
+        result.ShouldBe(true);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/NewObjectTaskPriorityTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/NewObjectTaskPriorityTests.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.Tasks;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests;
+
+/// <summary>
+/// GluxCommands.AddNamedObjectToAsync (the task that actually mutates NamedObjects and updates the
+/// tree/selection AddObjectAndBeginRename depends on - see glue-add-object-flow) must queue Asap, not
+/// the AddAsync default of Fifo, or it sits behind unrelated Fifo-tier work and the "add feels instant"
+/// goal of #2086 breaks. See glue-task-manager for why tier beats enqueue order.
+/// </summary>
+public class NewObjectTaskPriorityTests
+{
+    public NewObjectTaskPriorityTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    [Fact]
+    public async Task AddNamedObjectToAsync_QueuesItsTaskAsap()
+    {
+        var entity = new EntitySave { Name = "Entities\\Player" };
+        var newNos = new NamedObjectSave { InstanceName = "TestInstance", SourceType = SourceType.FlatRedBallType };
+
+        var recorded = new List<TaskExecutionPreference>();
+        void Handler(TaskEvent evt, GlueTaskBase task)
+        {
+            if (task.DisplayInfo != null && task.DisplayInfo.Contains("Adding named object"))
+            {
+                recorded.Add(task.TaskExecutionPreference);
+            }
+        }
+        TaskManager.Self.TaskAddedOrRemoved += Handler;
+        try
+        {
+            // performSaveAndGenerateCode/updateUi: false - this test only cares about the queued
+            // preference, not the real codegen/UI side effects of a full add.
+            await GlueCommands.Self.GluxCommands.AddNamedObjectToAsync(
+                newNos, entity, listToAddTo: null, selectNewNos: false,
+                performSaveAndGenerateCode: false, updateUi: false);
+        }
+        finally
+        {
+            TaskManager.Self.TaskAddedOrRemoved -= Handler;
+        }
+
+        recorded.ShouldNotBeEmpty();
+        recorded.ShouldAllBe(p => p == TaskExecutionPreference.Asap);
+    }
+}


### PR DESCRIPTION
Closes #2086.

## Summary
- When `AddObjectViewModel.IsTypePredetermined` is true (e.g. adding to a typed list - the case in the issue's screenshot), the "New Object" modal is skipped entirely. It adds immediately using the already-computed default name (`AddObjectViewModel.SetDefaultObjectName`, already unique/valid), then drops the new tree node straight into the inline-rename mode #2080 added (`NodeViewModel.IsEditing` -> `GluxCommands.RenameNamedObjectSave`, which validates and reverts on bad input).
- When the type genuinely isn't known yet, the modal still shows for type selection, but the now-redundant "Enter the new object's name" field is removed from `NewObjectTypeSelectionControlWpf.xaml` - naming happens via the same inline rename after add.
- Dropped the pre-add `NameVerifier.IsNamedObjectNameValid` gate in `DialogCommands.ShowAddNewObjectDialog` (kept the unrelated recursion check) since the name is no longer free-typed user input at that point.
- Added `FRBDK/Glue/.claude/skills/glue-add-object-flow/SKILL.md` documenting the add-object pipeline and the tree's inline-rename mechanism, since wiring these two together required reading across 6 files with nothing pointing at either.

## Known gap (see issue comment)
`DragDropManager.cs`'s drag-and-drop add and `QuickActionPlugin`'s add both get the modal-skip (shared `DialogCommands` code path) but not the auto-inline-rename trigger, since that needs `TreeViewPlugin`'s internal `SelectionLogic`, which those projects can't reference.

## Test plan
- [x] `NewObjectDialogTests.CreateAndShowAddNamedObjectWindow_TypePredetermined_DoesNotShowWindow` - pins the modal-skip. Before the fix it throws `InvalidOperationException: The calling thread must be STA` from constructing the WPF window; watched it fail with that exact exception before implementing the fix.
- [x] Full non-BuildSmoke suite: 629/629 passed.
- [x] Manual test needed (Glue editor UI) - see below.

## Manual test
Opening `FRBDK/Glue/Glue with All.sln` in this worktree for you.

1. **Predetermined-type case (the issue's screenshot):** open/create a project, add an object to an Entity, then right-click that Entity's tree node -> Add Object -> pick a list-producing option (or right-click an existing list of that type) -> Add Object. Confirm no modal pops up at all and the new node appears in the tree already in rename-edit mode (a text box, ready to type).
2. **Non-predetermined case:** right-click an Entity or Screen's "Objects" root node (where type isn't known yet) -> Add Object. Confirm the modal still appears for type selection only (no name field), and after clicking OK / double-clicking a type, the new node lands in the tree already in rename-edit mode.
3. Type a new name in the inline editor and press Enter; confirm the rename applies (matches existing F2/right-click-rename behavior). Press Escape or click away without typing; confirm the default name is kept.


## Follow-up: queue the add Asap, not Fifo
Manual testing surfaced that the add-object flow was queued at `TaskManager`'s `Fifo` tier (the `AddAsync` default when unspecified) - it could sit behind unrelated pending Fifo work, undercutting the "feels instant" goal. Both `GluxCommands.AddNewNamedObjectToAsync` and `AddNamedObjectToAsync` now queue `TaskExecutionPreference.Asap`. Added `NewObjectTaskPriorityTests` to pin it. Details on why this is safe (no downstream task depends on ordering relative to this one) and how nested `AddAsync` calls interact with `IsInTask()`'s fast path are in the `glue-add-object-flow` and `glue-task-manager` skills.

### Additional manual-test step
4. Trigger some other Fifo-tier work first (e.g. rename a different object elsewhere, or add an existing file via "Existing File(s)"), then immediately right-click Add Object on a typed list before that finishes. Confirm the new object still appears (and enters rename mode) without waiting for the earlier action to finish.
