### PR TITLE
Fix rename running before pending add-triggered codegen

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ElementCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ElementCommands.cs
@@ -112,6 +112,10 @@ public class ElementCommands : IScreenCommands, IEntityCommands,IElementCommands
     public async Task RenameElement(GlueElement elementToRename, string newFullElementName, bool showRenameWindow = true)
     {
         newFullElementName = newFullElementName.Replace("/", "\\");
+        // GitHub issue #2085: AddEntity queues its follow-up codegen (GenerateElementCode) at
+        // AddOrMoveToEnd. A rename immediately following an add must queue at the same tier, or the
+        // AddAsync default of Fifo lets it jump ahead of that still-pending codegen (tier beats enqueue
+        // order - see glue-task-manager) instead of running after it.
         await TaskManager.Self.AddAsync(() =>
         {
             bool isValid = true;
@@ -134,7 +138,7 @@ public class ElementCommands : IScreenCommands, IEntityCommands,IElementCommands
             {
                 DoRenameInner(elementToRename, newFullElementName, showRenameWindow);
             }
-        }, $"Renaming {elementToRename} to {newFullElementName}");
+        }, $"Renaming {elementToRename} to {newFullElementName}", TaskExecutionPreference.AddOrMoveToEnd);
     }
 
     private void DoRenameInner(GlueElement elementToRename, string newElementName, bool showRenameWindow)

--- a/FRBDK/Glue/Glue/Tasks/TaskManager.cs
+++ b/FRBDK/Glue/Glue/Tasks/TaskManager.cs
@@ -396,6 +396,12 @@ namespace FlatRedBall.Glue.Managers
         {
             if(task.IsCancelled == false)
             {
+                // Restored (not unconditionally nulled) in the finally block below - a nested RunTask
+                // (e.g. an AddOrMoveToEnd task queued from inside an already-running task; see
+                // AddOrRunIfTasked, which always routes AddOrMoveToEnd through the real Add/RunTask path
+                // even when already "in a task") would otherwise clobber the outer task's "currently
+                // running" marker out from under it once the inner call finishes.
+                var previouslyRunningTask = CurrentlyRunningTask;
                 if(markAsCurrent) CurrentlyRunningTask = task;
                 TaskAddedOrRemoved?.Invoke(TaskEvent.Started, task);
                 task.TimeStarted = DateTime.Now;
@@ -406,8 +412,9 @@ namespace FlatRedBall.Glue.Managers
                 finally
                 {
                     task.TimeEnded = DateTime.Now;
-                    // Set it to null before raising the event so that the TaskCount uses a null object.
-                    if (markAsCurrent) CurrentlyRunningTask = null;
+                    // Set it to null (or restore the outer task) before raising the event so that the
+                    // TaskCount uses a null object.
+                    if (markAsCurrent) CurrentlyRunningTask = previouslyRunningTask;
                     TaskAddedOrRemoved?.Invoke(TaskEvent.Removed, task);
                 }
             }

--- a/FRBDK/Glue/Tests/GlueUnitTests/RenameElementTaskPriorityTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/RenameElementTaskPriorityTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Tasks;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests;
+
+/// <summary>
+/// GitHub issue #2085 (originally reported on a different machine, lost before it was TDD'd): adding a new
+/// Entity queues its follow-up codegen (ElementCommands.AddEntity -> GenerateCodeCommands.GenerateElementCode)
+/// at TaskManager's AddOrMoveToEnd tier, but ElementCommands.RenameElement queues its own work at AddAsync's
+/// default of Fifo. Per glue-task-manager, tier beats enqueue order - a Fifo task always runs before an
+/// AddOrMoveToEnd task, regardless of which was queued first. So a rename that follows an add can run before
+/// the add's own deferred codegen finishes, instead of after it as intended. The fix is for RenameElement to
+/// also queue AddOrMoveToEnd, so it queues behind (and runs after) any pending add-triggered codegen for the
+/// same element.
+/// </summary>
+public class RenameElementTaskPriorityTests
+{
+    public RenameElementTaskPriorityTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+    }
+
+    [Fact]
+    public async Task RenameElement_QueuesItsTaskAddOrMoveToEnd_SoItRunsAfterPendingAddCodegen()
+    {
+        var entity = new EntitySave { Name = "Entities\\OldName" };
+        ObjectFinder.Self.GlueProject.Entities.Add(entity);
+
+        var recorded = new List<TaskExecutionPreference>();
+        void Handler(TaskEvent evt, GlueTaskBase task)
+        {
+            if (task.DisplayInfo != null && task.DisplayInfo.StartsWith("Renaming "))
+            {
+                recorded.Add(task.TaskExecutionPreference);
+            }
+        }
+        TaskManager.Self.TaskAddedOrRemoved += Handler;
+        try
+        {
+            // The preference is recorded at enqueue time, before the queued action runs, so this test does
+            // not depend on (and does not need to tolerate failures from) the rest of RenameElement's real
+            // file-system side effects actually succeeding in a bare test host.
+            try
+            {
+                await GlueCommands.Self.GluxCommands.EntityCommands.RenameElement(entity, "Entities\\NewName", showRenameWindow: false);
+            }
+            catch
+            {
+                // Only the queued task's priority is under test here - see comment above.
+            }
+        }
+        finally
+        {
+            TaskManager.Self.TaskAddedOrRemoved -= Handler;
+        }
+
+        recorded.ShouldNotBeEmpty();
+        recorded.ShouldAllBe(p => p == TaskExecutionPreference.AddOrMoveToEnd);
+    }
+}


### PR DESCRIPTION
Closes #2095.

`AddEntity`/`AddScreen` queue their follow-up codegen (`GenerateElementCode`) at `TaskManager`'s `AddOrMoveToEnd` tier. `RenameElement` queued at `AddAsync`'s default `Fifo` tier. Tier beats enqueue order, so a rename right after an add could run before the add's own deferred codegen finished. Now `RenameElement` queues `AddOrMoveToEnd` too, so it lines up behind (and runs after) pending add-triggered codegen.

That change routes `RenameElement` through the real `Add`/`RunTask` path even when called from inside an already-running task (`AddOrMoveToEnd` is excluded from the nested "run inline" fast path in `AddOrRunIfTasked`). That exposed a latent bug: `RunTask` unconditionally nulled `CurrentlyRunningTask` on exit instead of restoring the prior value, so a nested call could clobber the outer task's marker mid-flight. Fixed alongside - the rename fix isn't safe without it.

## Testing
TDD: `RenameElementTaskPriorityTests.RenameElement_QueuesItsTaskAddOrMoveToEnd_SoItRunsAfterPendingAddCodegen` records the `TaskExecutionPreference` `RenameElement` enqueues with, watched it fail (`Fifo` recorded, not `AddOrMoveToEnd`) before the fix, passes after.

Full non-BuildSmoke suite (632/632) green from a clean build. Note: applying only the `RenameElement` tier change (without the `TaskManager.RunTask` fix) caused 32 unrelated failures in a full-suite run despite every affected test passing in isolation - the `CurrentlyRunningTask` clobbering bug, confirmed by fixing it and rerunning clean.