### PR TITLE
Reconcile orphaned Glue-generated csproj entries at project load

### DIFF
--- a/FRBDK/Glue/Glue/Elements/DeletionPlanner.cs
+++ b/FRBDK/Glue/Glue/Elements/DeletionPlanner.cs
@@ -425,6 +425,25 @@ namespace FlatRedBall.Glue.Elements
         }
 
         /// <summary>
+        /// The Glue-generated (never hand-authored) relative paths an element owns: its ".Generated.cs",
+        /// ".Generated.Event.cs", and factory - the subset of <see cref="FillWithOwnedFiles"/>'s files that
+        /// are pure build output. Used by the load-time orphaned-csproj-entry reconciliation (issue #2103)
+        /// to know which currently-live elements still "claim" a generated file name, so an entry isn't
+        /// removed out from under an element whose file simply hasn't been regenerated yet (e.g. a fresh
+        /// checkout, where *.Generated.cs is gitignored and doesn't exist until Glue regenerates it).
+        /// Deliberately excludes the hand-authored ".cs"/".Event.cs" files <see cref="FillWithOwnedFiles"/>
+        /// also lists - reconciliation never touches those, so they don't need to be "owned" here.
+        /// </summary>
+        public static IEnumerable<string> GetOwnedGeneratedRelativePaths(GlueElement element)
+        {
+            var elementName = element.Name;
+
+            yield return elementName + ".Generated.cs";
+            yield return elementName + ".Generated.Event.cs";
+            yield return "Factories/" + FileManager.RemovePath(elementName) + "Factory.Generated.cs";
+        }
+
+        /// <summary>
         /// Adds the code and JSON files an element owns outright - its custom and generated .cs, its event
         /// files and factory if they exist on disk, and its .glsj/.glej. Shared by the planner (to show the
         /// user) and by the delete itself (to act on), all as canonical paths.

--- a/FRBDK/Glue/Glue/IO/ProjectLoader.cs
+++ b/FRBDK/Glue/Glue/IO/ProjectLoader.cs
@@ -426,7 +426,43 @@ namespace FlatRedBall.Glue.IO
 
                 GlueCommands.Self.GenerateCodeCommands.GenerateAllCode();
                 Section.EndContextAndTime();
+                Section.GetAndStartContextAndTime("RemoveOrphanedCsprojEntries");
 
+                RemoveOrphanedGeneratedCsprojEntries();
+                Section.EndContextAndTime();
+
+            }
+        }
+
+        /// <summary>
+        /// GitHub issue #2103: a Screen/Entity deleted or renamed outside Glue's own delete/rename flow
+        /// (a manual .glux edit, a merge, an older Glue version) can leave its ".Generated.cs" still
+        /// referenced in the .csproj, producing CS2001 the next time the project builds. Codegen above has
+        /// just run, so any file a live element still owns has been (re)created - anything still missing
+        /// and unclaimed by a current element is a leftover from an incomplete cleanup, not a fresh
+        /// checkout waiting on codegen.
+        /// </summary>
+        static void RemoveOrphanedGeneratedCsprojEntries()
+        {
+            var mainProject = GlueState.Self.CurrentMainProject;
+            if (mainProject == null || ObjectFinder.Self.GlueProject == null)
+            {
+                return;
+            }
+
+            var allElements = ObjectFinder.Self.GlueProject.Screens.Cast<GlueElement>()
+                .Concat(ObjectFinder.Self.GlueProject.Entities);
+
+            var removed = mainProject.RemoveOrphanedGeneratedCompileItems(allElements);
+
+            if (removed.Count > 0)
+            {
+                foreach (var relativePath in removed)
+                {
+                    PluginManager.ReceiveOutput("Removed orphaned csproj entry (no backing file, no owning element): " + relativePath);
+                }
+
+                GlueCommands.Self.ProjectCommands.SaveProjects();
             }
         }
 

--- a/FRBDK/Glue/Glue/VSHelpers/OrphanedGeneratedCompileItemFinder.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/OrphanedGeneratedCompileItemFinder.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FlatRedBall.Glue.VSHelpers
+{
+    /// <summary>
+    /// A csproj &lt;Compile Include&gt; entry to consider for orphan removal, described with just the data
+    /// needed to decide (not a live MSBuild <c>ProjectItem</c>), so the decision logic below is testable
+    /// without a loaded project or any Glue bootstrap.
+    /// </summary>
+    public struct CandidateCompileItem
+    {
+        public string UnevaluatedInclude;
+        public bool IsWildcard;
+        public bool IsConditional;
+    }
+
+    /// <summary>
+    /// Decides which &lt;Compile Include&gt; entries for Glue-generated files are safe to remove because
+    /// their backing file no longer exists and no current element owns that path anymore - see GitHub issue
+    /// #2103. Deliberately narrow: only files matching Glue's own generated-file naming (".Generated.cs",
+    /// ".Generated.Event.cs") are candidates. Hand-authored files such as "X.cs" or "X.Event.cs" are never
+    /// touched here, even when orphaned - that's what the explicit delete flow
+    /// (<see cref="FlatRedBall.Glue.Elements.DeletionPlanner"/>) is for, since it asks the user first.
+    /// </summary>
+    public static class OrphanedGeneratedCompileItemFinder
+    {
+        public static bool IsGlueGeneratedFileName(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return false;
+            }
+
+            return fileName.EndsWith(".Generated.cs", StringComparison.OrdinalIgnoreCase)
+                || fileName.EndsWith(".Generated.Event.cs", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="CandidateCompileItem.UnevaluatedInclude"/> of every entry that should be
+        /// removed: a Glue-generated file name, not a wildcard/conditional entry, whose file is missing on
+        /// disk and whose relative path isn't in <paramref name="ownedRelativePaths"/>.
+        /// </summary>
+        public static List<string> FindOrphanedIncludes(
+            IEnumerable<CandidateCompileItem> compileItems,
+            Func<string, bool> fileExists,
+            HashSet<string> ownedRelativePaths)
+        {
+            var toReturn = new List<string>();
+
+            foreach (var item in compileItems)
+            {
+                if (item.IsWildcard || item.IsConditional)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(item.UnevaluatedInclude))
+                {
+                    continue;
+                }
+
+                var fileName = item.UnevaluatedInclude
+                    .Replace('\\', '/')
+                    .Split('/')
+                    .Last();
+
+                if (!IsGlueGeneratedFileName(fileName))
+                {
+                    continue;
+                }
+
+                if (ownedRelativePaths.Contains(item.UnevaluatedInclude))
+                {
+                    continue;
+                }
+
+                if (fileExists(item.UnevaluatedInclude))
+                {
+                    continue;
+                }
+
+                toReturn.Add(item.UnevaluatedInclude);
+            }
+
+            return toReturn;
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -17,6 +17,7 @@ using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Plugins.ExportedInterfaces;
 using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.Glue.Utilities;
+using FlatRedBall.Glue.VSHelpers;
 using FlatRedBall.IO;
 using Microsoft.Build.Evaluation;
 using Newtonsoft.Json.Linq;
@@ -1237,6 +1238,52 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             }
 
             return anyRemoved;
+        }
+
+        /// <summary>
+        /// Removes &lt;Compile Include&gt; entries for Glue-generated files (".Generated.cs",
+        /// ".Generated.Event.cs", factories) whose backing file no longer exists on disk and which no
+        /// element in <paramref name="ownerElements"/> currently owns - see GitHub issue #2103. Run at
+        /// project load, after codegen has had a chance to (re)create any file a live element still owns,
+        /// so "missing on disk" plus "unowned" together are a safe signal the entry is a leftover from a
+        /// delete/rename that didn't clean up the csproj (a merge, a manual edit, an older Glue version).
+        /// Never touches wildcard or conditional (platform-specific) entries, or hand-authored files - only
+        /// Glue's own generated-file naming is a candidate. Returns the removed entries' Include values.
+        /// </summary>
+        public List<string> RemoveOrphanedGeneratedCompileItems(IEnumerable<GlueElement> ownerElements)
+        {
+            var ownedRelativePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var element in ownerElements ?? Enumerable.Empty<GlueElement>())
+            {
+                foreach (var relativePath in DeletionPlanner.GetOwnedGeneratedRelativePaths(element))
+                {
+                    ownedRelativePaths.Add(relativePath.Replace('/', '\\'));
+                }
+            }
+
+            var candidates = EvaluatedItems
+                .Where(item => item.ItemType == "Compile")
+                .Select(item => new CandidateCompileItem
+                {
+                    UnevaluatedInclude = item.UnevaluatedInclude,
+                    IsWildcard = item.UnevaluatedInclude?.Contains("*") == true,
+                    IsConditional = !string.IsNullOrEmpty(item.Xml?.Condition)
+                        || !string.IsNullOrEmpty((item.Xml?.Parent as Microsoft.Build.Construction.ProjectItemGroupElement)?.Condition)
+                });
+
+            var orphanedIncludes = OrphanedGeneratedCompileItemFinder.FindOrphanedIncludes(
+                candidates,
+                include => File.Exists(this.Directory + include.Replace('\\', '/')),
+                ownedRelativePaths);
+
+            var itemsToRemove = orphanedIncludes
+                .Select(include => GetItem(include))
+                .Where(item => item != null)
+                .ToList();
+
+            RemoveItems(itemsToRemove);
+
+            return orphanedIncludes;
         }
 
         public override bool RemoveItem(string itemName)

--- a/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/OrphanedCsprojEntryProjectLoadTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/OrphanedCsprojEntryProjectLoadTests.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.CommandInterfaces;
+
+/// <summary>
+/// GitHub issue #2103: end-to-end pin that a real <c>ProjectLoader.LoadProject</c> - the same call
+/// Glue.exe makes on File > Load Project - removes an orphaned generated-file csproj entry (no backing
+/// file, no owning element) on its own, reproducing the reported symptom (CS2001 for a deleted Forms
+/// screen's ".Generated.cs") and then proving it's gone. <see cref="OrphanedGeneratedCompileItemReconciliationTests"/>
+/// and <see cref="GlueUnitTests.VSHelpers.OrphanedGeneratedCompileItemFinderTests"/> cover the decision
+/// matrix; this covers the wiring - that <c>ProjectLoader</c> actually calls it, in the right order
+/// relative to codegen.
+/// </summary>
+[Trait("Category", "BuildSmoke")]
+public class OrphanedCsprojEntryProjectLoadTests
+{
+    [StaFact]
+    public async Task LoadProject_ShouldRemoveOrphanedGeneratedCsprojEntry_AndLoadCleanly()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var project = GoldProject.CopyOutOfRepo("Samples/FormsSampleProject");
+        var csprojPath = Path.Combine(project.Root, "FormsSampleProject", "FormsSampleProject.csproj");
+
+        const string orphanedInclude = @"Screens\Issue2102DoesNotExist.Generated.cs";
+        AddStrayCompileItem(csprojPath, orphanedInclude);
+
+        await GoldProject.LoadInGlueAsync(csprojPath);
+
+        var mainProject = GlueState.Self.CurrentMainProject;
+        mainProject.IsFilePartOfProject(orphanedInclude, BuildItemMembershipType.CompileOrContentPipeline)
+            .ShouldBeFalse("the orphaned entry should have been reconciled away on load");
+
+        ErrorRecordingPlugin.Errors
+            .Any(e => e.Contains("Issue2102DoesNotExist"))
+            .ShouldBeFalse("no error should reference the file the orphaned entry pointed at");
+    }
+
+    static void AddStrayCompileItem(string csprojPath, string include)
+    {
+        var document = XDocument.Load(csprojPath);
+        var ns = document.Root!.Name.Namespace;
+
+        var itemGroup = new XElement(ns + "ItemGroup",
+            new XElement(ns + "Compile", new XAttribute("Include", include)));
+
+        document.Root.Add(itemGroup);
+        document.Save(csprojPath);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/OrphanedGeneratedCompileItemReconciliationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/OrphanedGeneratedCompileItemReconciliationTests.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using System.IO;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// GitHub issue #2103: a Screen/Entity deleted or renamed outside Glue's own delete/rename flow can leave
+/// its ".Generated.cs" still referenced in the .csproj, producing CS2001 on the next build. These pin
+/// <see cref="VisualStudioProject.RemoveOrphanedGeneratedCompileItems"/> - the load-time reconciliation
+/// pass - against a real, MSBuild-backed project (via <see cref="TestVisualStudioProjectFactory"/>), no
+/// full Glue bootstrap needed since the method only takes an explicit element list and touches the project
+/// it's called on.
+/// </summary>
+public class OrphanedGeneratedCompileItemReconciliationTests
+{
+    static void WriteFile(string directory, string relativePath)
+    {
+        var fullPath = Path.Combine(directory, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, "// test file");
+    }
+
+    [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldRemove_OrphanedGeneratedCsWithNoOwner()
+    {
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            project.AddCodeBuildItem(@"Screens\MultiPartAGumForms.Generated.cs");
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(new List<GlueElement>());
+
+            removed.ShouldBe(new[] { @"Screens\MultiPartAGumForms.Generated.cs" });
+            project.IsFilePartOfProject(@"Screens\MultiPartAGumForms.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline)
+                .ShouldBeFalse();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldKeep_EntryWhoseFileExistsOnDisk()
+    {
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            project.AddCodeBuildItem(@"Screens\StillOnDisk.Generated.cs");
+            WriteFile(directory, @"Screens\StillOnDisk.Generated.cs");
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(new List<GlueElement>());
+
+            removed.ShouldBeEmpty();
+            project.IsFilePartOfProject(@"Screens\StillOnDisk.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline)
+                .ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldKeep_EntryOwnedByALiveElement_EvenThoughFileIsMissing()
+    {
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            // Simulates a fresh checkout: the .Generated.cs is gitignored and hasn't been regenerated yet,
+            // but MyScreen is still a live element - the entry must survive.
+            project.AddCodeBuildItem(@"Screens\MyScreen.Generated.cs");
+            var liveScreen = new ScreenSave { Name = @"Screens\MyScreen" };
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(new List<GlueElement> { liveScreen });
+
+            removed.ShouldBeEmpty();
+            project.IsFilePartOfProject(@"Screens\MyScreen.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline)
+                .ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldKeep_WildcardCompileIncludes()
+    {
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            project.Project.AddItem("Compile", @"Screens\**\*.Generated.cs");
+            project.Project.ReevaluateIfNecessary();
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(new List<GlueElement>());
+
+            removed.ShouldBeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldKeep_ConditionalCompileIncludes()
+    {
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            var item = project.AddCodeBuildItem(@"Screens\PlatformOnly.Generated.cs");
+            item.Xml.Condition = "'$(OS)' == 'Windows_NT'";
+            project.Project.ReevaluateIfNecessary();
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(new List<GlueElement>());
+
+            removed.ShouldBeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldKeep_HandAuthoredMissingSourceFile()
+    {
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            // "MyScreen.cs" is hand-authored, not Glue-generated - even orphaned, reconciliation must not
+            // touch it. That's the explicit delete flow's job (it asks the user first).
+            project.AddCodeBuildItem(@"Screens\MyScreen.cs");
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(new List<GlueElement>());
+
+            removed.ShouldBeEmpty();
+            project.IsFilePartOfProject(@"Screens\MyScreen.cs", BuildItemMembershipType.CompileOrContentPipeline)
+                .ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldRemove_MultipleOrphanedEntries_AndKeepTheRest()
+    {
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            project.AddCodeBuildItem(@"Screens\OrphanedOne.Generated.cs");
+            project.AddCodeBuildItem(@"Entities\OrphanedTwo.Generated.cs");
+            project.AddCodeBuildItem(@"Screens\LiveScreen.Generated.cs");
+            WriteFile(directory, @"Screens\StillOnDisk.Generated.cs");
+            project.AddCodeBuildItem(@"Screens\StillOnDisk.Generated.cs");
+
+            var liveScreen = new ScreenSave { Name = @"Screens\LiveScreen" };
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(new List<GlueElement> { liveScreen });
+
+            removed.ShouldBe(new[] { @"Screens\OrphanedOne.Generated.cs", @"Entities\OrphanedTwo.Generated.cs" }, ignoreOrder: true);
+            project.IsFilePartOfProject(@"Screens\LiveScreen.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline).ShouldBeTrue();
+            project.IsFilePartOfProject(@"Screens\StillOnDisk.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline).ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/OrphanedGeneratedCompileItemFinderTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/OrphanedGeneratedCompileItemFinderTests.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using FlatRedBall.Glue.VSHelpers;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.VSHelpers;
+
+/// <summary>
+/// GitHub issue #2103: a Screen/Entity deleted or renamed outside Glue's own delete/rename flow can leave
+/// its ".Generated.cs" (or similar) still referenced in the .csproj, producing CS2001 on the next build.
+/// These pin the pure decision logic - which candidate &lt;Compile Include&gt; entries are safe to treat as
+/// orphaned - independent of any real project or Glue bootstrap.
+/// </summary>
+public class OrphanedGeneratedCompileItemFinderTests
+{
+    static CandidateCompileItem Item(string include, bool isWildcard = false, bool isConditional = false) =>
+        new CandidateCompileItem { UnevaluatedInclude = include, IsWildcard = isWildcard, IsConditional = isConditional };
+
+    static List<string> Find(
+        IEnumerable<CandidateCompileItem> items,
+        HashSet<string> existingFiles = null,
+        HashSet<string> ownedRelativePaths = null)
+    {
+        existingFiles ??= new HashSet<string>();
+        ownedRelativePaths ??= new HashSet<string>();
+
+        return OrphanedGeneratedCompileItemFinder.FindOrphanedIncludes(
+            items,
+            include => existingFiles.Contains(include),
+            ownedRelativePaths);
+    }
+
+    #region IsGlueGeneratedFileName
+
+    [Theory]
+    [InlineData("MultiPartAGumForms.Generated.cs")]
+    [InlineData("Screens\\MultiPartAGumForms.Generated.cs")]
+    [InlineData("MyScreen.Generated.Event.cs")]
+    [InlineData("Factories\\MyEntityFactory.Generated.cs")]
+    [InlineData("myscreen.generated.cs")] // case-insensitive
+    public void IsGlueGeneratedFileName_ShouldReturnTrue_ForGlueGeneratedNames(string fileName)
+    {
+        OrphanedGeneratedCompileItemFinder.IsGlueGeneratedFileName(fileName).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("MyScreen.cs")]
+    [InlineData("MyScreen.Event.cs")] // hand-authored event file, not ".Generated.Event.cs"
+    [InlineData("Program.cs")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsGlueGeneratedFileName_ShouldReturnFalse_ForNonGeneratedNames(string fileName)
+    {
+        OrphanedGeneratedCompileItemFinder.IsGlueGeneratedFileName(fileName).ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region Positive - should be removed
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldRemove_OrphanedGeneratedCs()
+    {
+        var items = new[] { Item(@"Screens\MultiPartAGumForms.Generated.cs") };
+
+        var result = Find(items);
+
+        result.ShouldBe(new[] { @"Screens\MultiPartAGumForms.Generated.cs" });
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldRemove_OrphanedGeneratedEventCs()
+    {
+        var items = new[] { Item(@"Screens\MyScreen.Generated.Event.cs") };
+
+        var result = Find(items);
+
+        result.ShouldBe(new[] { @"Screens\MyScreen.Generated.Event.cs" });
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldRemove_OrphanedFactoryGeneratedCs()
+    {
+        var items = new[] { Item(@"Factories\MyEntityFactory.Generated.cs") };
+
+        var result = Find(items);
+
+        result.ShouldBe(new[] { @"Factories\MyEntityFactory.Generated.cs" });
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldRemove_MultipleOrphanedEntriesInOnePass()
+    {
+        var items = new[]
+        {
+            Item(@"Screens\First.Generated.cs"),
+            Item(@"Screens\Second.Generated.cs"),
+            Item(@"Entities\Third.Generated.cs"),
+        };
+
+        var result = Find(items);
+
+        result.ShouldBe(new[]
+        {
+            @"Screens\First.Generated.cs",
+            @"Screens\Second.Generated.cs",
+            @"Entities\Third.Generated.cs",
+        });
+    }
+
+    #endregion
+
+    #region Negative - must NOT be removed
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldKeep_FileThatStillExistsOnDisk_EvenIfUnowned()
+    {
+        var include = @"Screens\StillOnDisk.Generated.cs";
+        var items = new[] { Item(include) };
+
+        var result = Find(items, existingFiles: new HashSet<string> { include });
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldKeep_EntryOwnedByALiveElement_EvenIfMissingOnDisk()
+    {
+        var include = @"Screens\MyScreen.Generated.cs";
+        var items = new[] { Item(include) };
+
+        var result = Find(items, ownedRelativePaths: new HashSet<string> { include });
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldKeep_WildcardIncludes()
+    {
+        var items = new[] { Item(@"**\*.Generated.cs", isWildcard: true) };
+
+        var result = Find(items);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldKeep_ConditionalIncludes()
+    {
+        var items = new[] { Item(@"Screens\PlatformOnly.Generated.cs", isConditional: true) };
+
+        var result = Find(items);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldKeep_NonGlueOwnedMissingSourceFile()
+    {
+        // A hand-authored .cs (or .Event.cs) that happens to be missing is never a candidate - only
+        // Glue's own generated-file naming is. Deleting it isn't reconciliation's job; the explicit
+        // delete flow (DeletionPlanner) is, since it asks the user first.
+        var items = new[] { Item(@"Screens\MyScreen.cs"), Item(@"Screens\MyScreen.Event.cs") };
+
+        var result = Find(items);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldKeep_WhenOwnershipMatchIgnoresNothingButExactPath()
+    {
+        // A different element's generated file with a similar name must not be treated as owning this one.
+        var items = new[] { Item(@"Screens\MyScreenExtra.Generated.cs") };
+
+        var result = Find(items, ownedRelativePaths: new HashSet<string> { @"Screens\MyScreen.Generated.cs" });
+
+        result.ShouldBe(new[] { @"Screens\MyScreenExtra.Generated.cs" });
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Closes #2103.

Glue's csproj cleanup was purely reactive — only fired on explicit delete/rename through `DeletionPlanner`/`ProjectCommands.RemoveFromProjects`. Nothing reconciled the csproj against disk, so a Screen/Entity deleted outside that flow (manual `.glux` edit, merge, older Glue version) could leave its `.Generated.cs` referenced forever, breaking the build with CS2001. The existing `ReferencedFileSaveErrorReporter` unreferenced-file checker only scans `PreserveNewest` content items, so it never saw this class of entry either.

Adds a load-time pass (`ProjectLoader.RemoveOrphanedGeneratedCsprojEntries`, after codegen has run) that removes `<Compile Include>` entries for Glue-generated files (`.Generated.cs`, `.Generated.Event.cs`, factories) whose file is missing on disk **and** unowned by any current element. Deliberately narrow — `OrphanedGeneratedCompileItemFinder` only matches Glue's own generated-file naming, and skips wildcard/glob includes, conditional (platform-specific) entries, and anything that still exists on disk or is claimed by a live element.

27 new tests (positive: orphaned `.Generated.cs`/`.Generated.Event.cs`/factory entries removed, multiple at once; negative: file exists despite no owner, owned by a live element, wildcard include, conditional include, path-separator/case variation, non-Glue-owned missing file). Full non-BuildSmoke suite (662 tests) green.

Manual test: not needed — covered by the unit tests above plus a clean build of the whole solution during `dotnet test`.
