### PR TITLE
Glue: UI toggle for FRB2 GenerateCode setting

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Frb2SettingsPlugin/Frb2SettingsControl.xaml
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Frb2SettingsPlugin/Frb2SettingsControl.xaml
@@ -1,0 +1,16 @@
+<UserControl x:Class="FlatRedBall.Glue.Plugins.EmbeddedPlugins.Frb2SettingsPlugin.Frb2SettingsControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignWidth="350">
+    <StackPanel Margin="10">
+        <CheckBox VerticalContentAlignment="Center"
+                  IsChecked="{Binding GenerateCode}"
+                  Content="Generate code for Screens and Entities" />
+        <TextBlock Margin="0,8,0,0" TextWrapping="Wrap" Opacity="0.7">
+            When enabled, Glue generates a typed [Name].Generated.cs file beside each Screen and Entity, giving typed access to the objects this project already builds from its JSON at runtime. Off by default - the project can run entirely from the JSON with no generated code.
+        </TextBlock>
+    </StackPanel>
+</UserControl>

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Frb2SettingsPlugin/Frb2SettingsControl.xaml.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Frb2SettingsPlugin/Frb2SettingsControl.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+
+namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.Frb2SettingsPlugin
+{
+    /// <summary>
+    /// Interaction logic for Frb2SettingsControl.xaml
+    /// </summary>
+    public partial class Frb2SettingsControl : UserControl
+    {
+        public Frb2SettingsControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Frb2SettingsPlugin/Frb2SettingsViewModel.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Frb2SettingsPlugin/Frb2SettingsViewModel.cs
@@ -1,0 +1,13 @@
+using FlatRedBall.Glue.MVVM;
+
+namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.Frb2SettingsPlugin
+{
+    public class Frb2SettingsViewModel : ViewModel
+    {
+        public bool GenerateCode
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Frb2SettingsPlugin/MainFrb2SettingsPlugin.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/Frb2SettingsPlugin/MainFrb2SettingsPlugin.cs
@@ -1,0 +1,107 @@
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Windows.Forms;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using L = Localization;
+
+namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.Frb2SettingsPlugin
+{
+    /// <summary>
+    /// UI toggle for <see cref="SaveClasses.GlueProjectSave.GenerateCode"/>, the per-project opt-in
+    /// for FlatRedBall 2 code generation (previously only settable by hand-editing the .gluj).
+    /// </summary>
+    [Export(typeof(PluginBase))]
+    public class MainFrb2SettingsPlugin : EmbeddedPlugin
+    {
+        Frb2SettingsControl control;
+        PluginTab tab;
+        ToolStripMenuItem menuItem;
+        readonly Frb2SettingsViewModel viewModel = new Frb2SettingsViewModel();
+
+        bool isInitializing;
+
+        public override void StartUp()
+        {
+            menuItem = base.AddMenuItemTo("FRB2 Code Generation", HandleMenuClicked, L.MenuIds.SettingsId);
+
+            viewModel.PropertyChanged += HandleViewModelChanged;
+
+            this.ReactToLoadedGlux += HandleLoadedGlux;
+            this.ReactToUnloadedGlux += HandleUnloadedGlux;
+        }
+
+        private void HandleLoadedGlux()
+        {
+            menuItem.Visible = GlueState.Self.CurrentMainProject is Frb2Project;
+        }
+
+        private void HandleUnloadedGlux()
+        {
+            menuItem.Visible = false;
+            tab?.Hide();
+        }
+
+        private void HandleMenuClicked(object sender, System.EventArgs e)
+        {
+            var glueProject = GlueState.Self.CurrentGlueProject;
+            if (glueProject == null)
+            {
+                return;
+            }
+
+            if (control == null)
+            {
+                control = new Frb2SettingsControl();
+                tab = base.CreateTab(control, "FRB2 Code Generation");
+                control.DataContext = viewModel;
+            }
+
+            isInitializing = true;
+            {
+                viewModel.GenerateCode = glueProject.GenerateCode;
+            }
+            isInitializing = false;
+
+            tab.Show();
+            tab.Focus();
+        }
+
+        private void HandleViewModelChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (isInitializing)
+            {
+                return;
+            }
+
+            var glueProject = GlueState.Self.CurrentGlueProject;
+            if (glueProject == null)
+            {
+                return;
+            }
+
+            ApplyGenerateCodeSetting(glueProject, viewModel.GenerateCode);
+        }
+
+        /// <summary>
+        /// Applies a new <see cref="GlueProjectSave.GenerateCode"/> value, saves the .gluj, and - when
+        /// the setting just turned on - generates code immediately rather than requiring a project
+        /// reload. Split out from <see cref="HandleViewModelChanged"/> so it can be driven directly by
+        /// tests without going through the WPF checkbox/ViewModel plumbing.
+        /// </summary>
+        internal static void ApplyGenerateCodeSetting(GlueProjectSave glueProject, bool generateCode)
+        {
+            var wasEnabled = glueProject.GenerateCode;
+
+            glueProject.GenerateCode = generateCode;
+
+            GlueCommands.Self.GluxCommands.SaveGlujFile(Managers.TaskExecutionPreference.AddOrMoveToEnd);
+
+            if (!wasEnabled && generateCode)
+            {
+                GlueCommands.Self.GenerateCodeCommands.GenerateAllCode();
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Frb2SettingsPlugin/MainFrb2SettingsPluginTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Frb2SettingsPlugin/MainFrb2SettingsPluginTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.EmbeddedPlugins.Frb2SettingsPlugin;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueFormsCore.ViewModels;
+using GlueUnitTests.TestSupport;
+using Xunit;
+
+namespace GlueUnitTests.Frb2SettingsPlugin;
+
+/// <summary>
+/// GitHub issue #2058: <see cref="MainFrb2SettingsPlugin.ApplyGenerateCodeSetting"/> is the seam the new
+/// "FRB2 Code Generation" checkbox drives - it flips <c>GlueProjectSave.GenerateCode</c>, saves the
+/// .gluj, and (unlike hand-editing the .gluj, which only took effect on the next project load per
+/// <see cref="Frb2CodeGenerationLoadTests"/>) generates code immediately so the checkbox is useful
+/// without asking the user to reload.
+/// </summary>
+/// <remarks>
+/// See <see cref="GlueUnitTests.Projects.Frb2CodeGenerationLoadTests"/> for the "hand-edit the .gluj,
+/// reload" path this plugin is meant to shortcut.
+/// </remarks>
+[Collection("Frb2ProjectLoad")]
+public class MainFrb2SettingsPluginTests : IDisposable
+{
+    readonly VisualStudioProject _previousMainProject;
+    readonly GlueProjectSave _previousGlueProject;
+    readonly string _previousRelativeDirectory;
+
+    public MainFrb2SettingsPluginTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        _previousMainProject = GlueState.Self.CurrentMainProject;
+        _previousGlueProject = GlueState.Self.CurrentGlueProject;
+        _previousRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+    }
+
+    public void Dispose()
+    {
+        // GenerateCode is a setting nothing else in this process turns on, so leaving it set on a
+        // shared GlueProjectSave would change what a later, unrelated test (e.g.
+        // Frb2CodeGenerationSuppressionTests, which deliberately loads no GlueProjectSave of its own)
+        // sees as ambient state - the assembly disables test parallelization, but every test still
+        // shares this one process.
+        GlueState.Self.CurrentMainProject = _previousMainProject;
+        ObjectFinder.Self.GlueProject = _previousGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _previousRelativeDirectory;
+    }
+
+    static IReadOnlyList<string> CodeFilesUnder(string root) =>
+        Directory.GetFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Select(f => Path.GetRelativePath(root, f).Replace('\\', '/'))
+            .Where(f => f != Frb2ProjectFixture.HandWrittenCodeFile)
+            .OrderBy(f => f, System.StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    [StaFact]
+    public async Task TurningOn_GeneratesCodeImmediately_WithoutRequiringAReload()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2SettingsOn_");
+        using var dialogs = new RecordedChoiceDialogs();
+
+        var csprojPath = Frb2ProjectFixture.Write(temp.Root);
+        await GoldProject.LoadInGlueAsync(csprojPath);
+
+        await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen("GameScreen");
+        var entity = await GlueCommands.Self.GluxCommands.EntityCommands.AddEntityAsync(
+            new AddEntityViewModel { Name = "PlayerEntity" });
+
+        var wasSynchronous = TaskManager.SynchronousMode;
+        TaskManager.SynchronousMode = true;
+        try
+        {
+            MainFrb2SettingsPlugin.ApplyGenerateCodeSetting(GlueState.Self.CurrentGlueProject, generateCode: true);
+        }
+        finally
+        {
+            TaskManager.SynchronousMode = wasSynchronous;
+        }
+
+        Assert.Equal(
+            new[]
+            {
+                "Content/FrbEditor/Entities/PlayerEntity.Generated.cs",
+                "Content/FrbEditor/Entities/PlayerEntity.cs",
+                "Content/FrbEditor/Screens/GameScreen.Generated.cs",
+                "Content/FrbEditor/Screens/GameScreen.cs",
+            }.OrderBy(f => f, System.StringComparer.OrdinalIgnoreCase),
+            CodeFilesUnder(temp.Root));
+    }
+
+    [StaFact]
+    public async Task TurningOn_PersistsAcrossReload()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2SettingsPersist_");
+        using var dialogs = new RecordedChoiceDialogs();
+
+        var csprojPath = Frb2ProjectFixture.Write(temp.Root);
+        await GoldProject.LoadInGlueAsync(csprojPath);
+
+        var wasSynchronous = TaskManager.SynchronousMode;
+        TaskManager.SynchronousMode = true;
+        try
+        {
+            MainFrb2SettingsPlugin.ApplyGenerateCodeSetting(GlueState.Self.CurrentGlueProject, generateCode: true);
+        }
+        finally
+        {
+            TaskManager.SynchronousMode = wasSynchronous;
+        }
+
+        await GoldProject.LoadInGlueAsync(csprojPath);
+
+        Assert.True(GlueState.Self.CurrentGlueProject.GenerateCode);
+    }
+}


### PR DESCRIPTION
Closes #2058.

`GlueProjectSave.GenerateCode` (added in #2040) was only settable by hand-editing the `.gluj`. Adds a Settings > "FRB2 Code Generation" menu item - visible only for a loaded FRB2 project - that opens a tab with a checkbox bound to the setting.

Checking it now generates code immediately (`GenerateAllCode()`), instead of requiring the "hand-edit the .gluj, reload" round trip #2040 shipped with.

## Design

- New embedded plugin (`Glue/Plugins/EmbeddedPlugins/Frb2SettingsPlugin`), modeled on `AboutPlugin`/`CameraPlugin`: WPF `UserControl` + `ViewModel`, opened as a docked tab via `PluginBase.CreateTab`. Menu item + tab visibility toggle off `GlueState.Self.CurrentMainProject is Frb2Project` on `ReactToLoadedGlux`/`ReactToUnloadedGlux`.
- Considered exposing `GlueProjectSave` through the generic reflection `PropertyGrid` (used for `GlobalContentSettingsSave`) instead - rejected because it has no `[Browsable]` filtering and would leak unrelated `GlueProjectSave` members (`In2D`, `RunFullscreen`, etc., several already owned by other UI) into one raw grid.
- The save/generate logic is a `static internal ApplyGenerateCodeSetting(GlueProjectSave, bool)`, split out of the WPF property-changed handler so it's directly unit-testable.

## Testing

Two new tests in `MainFrb2SettingsPluginTests`, alongside the existing `Frb2CodeGenerationLoadTests`:
- `TurningOn_GeneratesCodeImmediately_WithoutRequiringAReload` - watched red (temporarily disabled the immediate-generate branch, rebuilt, confirmed the file-list assertion actually fails) before confirming green.
- `TurningOn_PersistsAcrossReload`

Full `GlueUnitTests` suite: 688/689 passed. The one failure (`GoldProjectCompileTests.DoorsDemoProject_LoadInGlue_ThenBuild_ShouldSucceed`) reproduces identically with this branch's new test file excluded entirely - pre-existing, unrelated to this change.

**Manual test: needed** - opening VS for you.
