### PR TITLE
Glue: detect MonoGame.Framework / MGCB version mismatch before content build

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/ContentPipelinePlugin/BuildLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/ContentPipelinePlugin/BuildLogic.cs
@@ -634,6 +634,41 @@ namespace OfficialPlugins.MonoGameContent
             return toReturn;
         }
 
+        /// <summary>
+        /// Reads the version of the project's referenced MonoGame.Framework.* package (DesktopGL,
+        /// WindowsDX, Android, iOS, etc.), or null if the project doesn't reference one or the version
+        /// isn't parseable.
+        /// </summary>
+        internal static Version GetReferencedMonoGameFrameworkVersion(VisualStudioProject project)
+        {
+            var packageReference = project.EvaluatedItems
+                .FirstOrDefault(item => item.ItemType == "PackageReference" &&
+                    item.EvaluatedInclude.StartsWith("MonoGame.Framework."));
+
+            var versionText = packageReference?.GetMetadataValue("Version");
+
+            return Version.TryParse(versionText, out var version) ? version : null;
+        }
+
+        /// <summary>
+        /// Content built by a newer MGCB than the project's referenced MonoGame.Framework runtime fails
+        /// at runtime with "This MGFX effect seems to be for a newer release of MonoGame." - an older
+        /// MGCB building for a newer runtime is not this problem, so only that direction is flagged.
+        /// </summary>
+        internal static string GetMonoGameFrameworkMgcbMismatchError(Version referencedMonoGameVersion, Version mgcbVersion)
+        {
+            if (referencedMonoGameVersion == null || mgcbVersion == null || mgcbVersion <= referencedMonoGameVersion)
+            {
+                return null;
+            }
+
+            return $"The installed MGCB (content builder) version is {mgcbVersion}, but this project references " +
+                $"MonoGame.Framework version {referencedMonoGameVersion}, which is older. Content built by a newer " +
+                "MGCB than the referenced runtime can fail to load at runtime with \"This MGFX effect seems to be " +
+                $"for a newer release of MonoGame.\" Either upgrade the project's MonoGame.Framework.* package reference " +
+                $"to {mgcbVersion} or newer, or install a matching MGCB: dotnet tool install dotnet-mgcb --global --version {referencedMonoGameVersion}";
+        }
+
         // todo - this can be slow - like 100 ms. This only needs to happen 1 time per run per project type.
         static bool HasInstalledBuilder = false;
 
@@ -720,6 +755,13 @@ namespace OfficialPlugins.MonoGameContent
                     {
                         GlueCommands.PrintError($"dotnet-mgcb (the content pipeline) is already installed, but using version {versionFound}.");
                     }
+                }
+
+                var referencedMonoGameVersion = GetReferencedMonoGameFrameworkVersion(visualStudioProject);
+                var mismatchError = GetMonoGameFrameworkMgcbMismatchError(referencedMonoGameVersion, versionFound);
+                if(mismatchError != null)
+                {
+                    GlueCommands.PrintError(mismatchError);
                 }
             }
         }

--- a/FRBDK/Glue/Tests/GlueUnitTests/ContentPipelinePlugin/BuildLogicMonoGameVersionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/ContentPipelinePlugin/BuildLogicMonoGameVersionTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using GlueUnitTests.TestSupport;
+using OfficialPlugins.MonoGameContent;
+using Shouldly;
+
+namespace GlueUnitTests.ContentPipelinePlugin;
+
+public class BuildLogicMonoGameVersionTests
+{
+    [Fact]
+    public void GetMonoGameFrameworkMgcbMismatchError_ShouldReturnError_WhenMgcbIsNewerThanReferencedVersion()
+    {
+        var error = BuildLogic.GetMonoGameFrameworkMgcbMismatchError(
+            referencedMonoGameVersion: new Version("3.8.4.1"),
+            mgcbVersion: new Version("3.8.5.1"));
+
+        error.ShouldNotBeNull();
+        error.ShouldContain("3.8.4.1");
+        error.ShouldContain("3.8.5.1");
+    }
+
+    [Fact]
+    public void GetMonoGameFrameworkMgcbMismatchError_ShouldReturnNull_WhenVersionsMatch()
+    {
+        var error = BuildLogic.GetMonoGameFrameworkMgcbMismatchError(
+            referencedMonoGameVersion: new Version("3.8.1.303"),
+            mgcbVersion: new Version("3.8.1.303"));
+
+        error.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetMonoGameFrameworkMgcbMismatchError_ShouldReturnNull_WhenMgcbIsOlderThanReferencedVersion()
+    {
+        var error = BuildLogic.GetMonoGameFrameworkMgcbMismatchError(
+            referencedMonoGameVersion: new Version("3.8.5.1"),
+            mgcbVersion: new Version("3.8.4.1"));
+
+        error.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetMonoGameFrameworkMgcbMismatchError_ShouldReturnNull_WhenEitherVersionIsUnknown()
+    {
+        BuildLogic.GetMonoGameFrameworkMgcbMismatchError(null, new Version("3.8.5.1")).ShouldBeNull();
+        BuildLogic.GetMonoGameFrameworkMgcbMismatchError(new Version("3.8.4.1"), null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetReferencedMonoGameFrameworkVersion_ShouldReturnParsedVersion_WhenProjectReferencesMonoGameFramework()
+    {
+        string directory = null;
+        try
+        {
+            var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out directory,
+                extraItemGroupXml: "<PackageReference Include=\"MonoGame.Framework.DesktopGL\" Version=\"3.8.4.1\" />");
+
+            var version = BuildLogic.GetReferencedMonoGameFrameworkVersion(project);
+
+            version.ShouldBe(new Version("3.8.4.1"));
+        }
+        finally
+        {
+            if (directory != null)
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void GetReferencedMonoGameFrameworkVersion_ShouldReturnNull_WhenProjectDoesNotReferenceMonoGameFramework()
+    {
+        string directory = null;
+        try
+        {
+            var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out directory);
+
+            var version = BuildLogic.GetReferencedMonoGameFrameworkVersion(project);
+
+            version.ShouldBeNull();
+        }
+        finally
+        {
+            if (directory != null)
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
@@ -24,7 +24,8 @@ internal static class TestVisualStudioProjectFactory
     /// a freshly-written, minimal .csproj in a new temp directory. Callers own cleanup of the returned
     /// directory.
     /// </summary>
-    public static ClassLibraryProject CreateInNewTempDirectory(out string directory, string projectName = "TestProject")
+    public static ClassLibraryProject CreateInNewTempDirectory(out string directory, string projectName = "TestProject",
+        string extraItemGroupXml = null)
     {
         directory = Path.Combine(Path.GetTempPath(), "GlueUnitTests_" + Guid.NewGuid());
         Directory.CreateDirectory(directory);
@@ -34,6 +35,9 @@ internal static class TestVisualStudioProjectFactory
   <PropertyGroup>
     <RootNamespace>{projectName}</RootNamespace>
   </PropertyGroup>
+  <ItemGroup>
+    {extraItemGroupXml}
+  </ItemGroup>
 </Project>");
 
         // Some production paths (e.g. GluxCommands.AddSingleFileTo, via ProjectManager.ProjectRootDirectory


### PR DESCRIPTION
Closes #2106.

## What
Glue now compares a project's referenced `MonoGame.Framework.*` package version against the resolved `dotnet-mgcb` version before building content. When MGCB is newer, it prints an error naming both versions instead of letting the mismatch surface later as a runtime `"This MGFX effect seems to be for a newer release of MonoGame."` exception.

## Where
`BuildLogic.cs`: `GetReferencedMonoGameFrameworkVersion` (reads the PackageReference version, same pattern already used for KNI's `nkast.Kni.Platform.Blazor.GL`) and `GetMonoGameFrameworkMgcbMismatchError` (pure comparison — only flags MGCB > referenced, the actual failure direction). Wired into `InstallBuilderIfNecessary`, alongside its existing installed-version check.

`TestVisualStudioProjectFactory.CreateInNewTempDirectory` gained an optional `extraItemGroupXml` param (default `null`, no behavior change for existing 20+ call sites) so tests can inject a `PackageReference`.

## Testing
6 new unit tests, pure-function + real-MSBuild-backed-project cases. Full suite (668 tests) green on a from-scratch rebuild.

Manual test: not needed — behavior is a new error message on an existing, already-tested code path; covered by the unit tests plus compilation.
