### PR TITLE
Skip collision check when a sub-collision delegate returns null

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Math/Collision/CollisionRelationship.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Math/Collision/CollisionRelationship.cs
@@ -262,8 +262,36 @@ namespace FlatRedBall.Math.Collision
             }
         }
 
+        // A sub-collision delegate (set via SetFirstSubCollision/SetSecondSubCollision) may return
+        // null for a particular instance (e.g. a Composite whose optional sub-object isn't created
+        // this time), even though the entity-level null check in DoCollisionPhysicsInner passed.
+        // See issue #2118 - the entity-level check added for #2084 doesn't cover this case.
+        private bool FirstSubCollisionIsNull(FirstCollidableT first)
+        {
+            if (firstSubCollisionCircle != null) return firstSubCollisionCircle(first) == null;
+            if (firstSubCollisionRectangle != null) return firstSubCollisionRectangle(first) == null;
+            if (firstSubCollisionPolygon != null) return firstSubCollisionPolygon(first) == null;
+            if (firstSubCollisionLine != null) return firstSubCollisionLine(first) == null;
+            if (firstSubCollisionCollidable != null) return firstSubCollisionCollidable(first) == null;
+            return false;
+        }
+
+        private bool SecondSubCollisionIsNull(SecondCollidableT second)
+        {
+            if (secondSubCollisionCircle != null) return secondSubCollisionCircle(second) == null;
+            if (secondSubCollisionRectangle != null) return secondSubCollisionRectangle(second) == null;
+            if (secondSubCollisionPolygon != null) return secondSubCollisionPolygon(second) == null;
+            if (secondSubCollisionCollidable != null) return secondSubCollisionCollidable(second) == null;
+            return false;
+        }
+
         private bool CollideAgainstConsiderSubCollisionEventOnly(FirstCollidableT first, SecondCollidableT second)
         {
+            if (FirstSubCollisionIsNull(first) || SecondSubCollisionIsNull(second))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 if (secondSubCollisionCircle != null)
@@ -413,6 +441,11 @@ namespace FlatRedBall.Math.Collision
 
         private bool CollideAgainstConsiderSubCollisionMove(FirstCollidableT first, SecondCollidableT second)
         {
+            if (FirstSubCollisionIsNull(first) || SecondSubCollisionIsNull(second))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 if (secondSubCollisionCircle != null)
@@ -561,6 +594,11 @@ namespace FlatRedBall.Math.Collision
 
         private bool CollideAgainstConsiderSubCollisionMoveSoft(FirstCollidableT first, SecondCollidableT second)
         {
+            if (FirstSubCollisionIsNull(first) || SecondSubCollisionIsNull(second))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 //return firstSubCollisionCircle(first).CollideAgainstMoveSoft(secondSub)
@@ -637,6 +675,11 @@ namespace FlatRedBall.Math.Collision
 
         private bool CollideAgainstConsiderSubCollisionBounce(FirstCollidableT first, SecondCollidableT second)
         {
+            if (FirstSubCollisionIsNull(first) || SecondSubCollisionIsNull(second))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 if (secondSubCollisionCircle != null)
@@ -2142,8 +2185,25 @@ namespace FlatRedBall.Math.Collision
             }
         }
 
+        // A sub-collision delegate (set via SetFirstSubCollision) may return null for a particular
+        // instance even though the entity-level null check in DoCollisionPhysicsInner passed - see
+        // issue #2118.
+        private bool FirstSubCollisionIsNull(FirstCollidableT first)
+        {
+            if (firstSubCollisionCircle != null) return firstSubCollisionCircle(first) == null;
+            if (firstSubCollisionRectangle != null) return firstSubCollisionRectangle(first) == null;
+            if (firstSubCollisionPolygon != null) return firstSubCollisionPolygon(first) == null;
+            if (firstSubCollisionCollidable != null) return firstSubCollisionCollidable(first) == null;
+            return false;
+        }
+
         private bool CollideAgainstConsiderSubCollisionEventOnly(FirstCollidableT first, ShapeCollection second)
         {
+            if (FirstSubCollisionIsNull(first))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 return second.CollideAgainst(firstSubCollisionCircle(first));
@@ -2167,6 +2227,11 @@ namespace FlatRedBall.Math.Collision
         }
         private bool CollideAgainstConsiderSubCollisionMove(FirstCollidableT first, ShapeCollection second)
         {
+            if (FirstSubCollisionIsNull(first))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 return second.CollideAgainstMove(firstSubCollisionCircle(first), moveSecondMass, moveFirstMass);
@@ -2191,6 +2256,11 @@ namespace FlatRedBall.Math.Collision
 
         private bool CollideAgainstConsiderSubCollisionMoveSoft(FirstCollidableT first, ShapeCollection second)
         {
+            if (FirstSubCollisionIsNull(first))
+            {
+                return false;
+            }
+
             if(firstSubCollisionCircle != null)
             {
                 throw new NotImplementedException("Circle vs shapecollection move soft collision is not yet implemented.");
@@ -2215,6 +2285,11 @@ namespace FlatRedBall.Math.Collision
         }
         private bool CollideAgainstConsiderSubCollisionBounce(FirstCollidableT first, ShapeCollection second)
         {
+            if (FirstSubCollisionIsNull(first))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 return second.CollideAgainstBounce(firstSubCollisionCircle(first), moveSecondMass, moveFirstMass, bounceElasticity);
@@ -2349,8 +2424,25 @@ namespace FlatRedBall.Math.Collision
             }
         }
 
+        // A sub-collision delegate (set via SetFirstSubCollision) may return null for a particular
+        // instance even though the entity-level null check in DoCollisionPhysicsInner passed - see
+        // issue #2118.
+        private bool FirstSubCollisionIsNull(FirstCollidableT first)
+        {
+            if (firstSubCollisionCircle != null) return firstSubCollisionCircle(first) == null;
+            if (firstSubCollisionRectangle != null) return firstSubCollisionRectangle(first) == null;
+            if (firstSubCollisionPolygon != null) return firstSubCollisionPolygon(first) == null;
+            if (firstSubCollisionCollidable != null) return firstSubCollisionCollidable(first) == null;
+            return false;
+        }
+
         private bool CollideAgainstConsiderSubCollisionEventOnly(FirstCollidableT first, ShapeCollection second)
         {
+            if (FirstSubCollisionIsNull(first))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 return second.CollideAgainst(firstSubCollisionCircle(first));
@@ -2374,6 +2466,11 @@ namespace FlatRedBall.Math.Collision
         }
         private bool CollideAgainstConsiderSubCollisionMove(FirstCollidableT first, ShapeCollection second)
         {
+            if (FirstSubCollisionIsNull(first))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 return second.CollideAgainstMove(firstSubCollisionCircle(first), moveSecondMass, moveFirstMass);
@@ -2397,6 +2494,11 @@ namespace FlatRedBall.Math.Collision
         }
         private bool CollideAgainstConsiderSubCollisionMoveSoft(FirstCollidableT first, ShapeCollection second)
         {
+            if (FirstSubCollisionIsNull(first))
+            {
+                return false;
+            }
+
             {
                 if (firstSubCollisionCircle != null)
                 {
@@ -2423,6 +2525,11 @@ namespace FlatRedBall.Math.Collision
 
         private bool CollideAgainstConsiderSubCollisionBounce(FirstCollidableT first, ShapeCollection second)
         {
+            if (FirstSubCollisionIsNull(first))
+            {
+                return false;
+            }
+
             if (firstSubCollisionCircle != null)
             {
                 return second.CollideAgainstBounce(firstSubCollisionCircle(first), moveSecondMass, moveFirstMass, bounceElasticity);

--- a/Tests/EngineUnitTests/Math/Collision/CollisionRelationshipNullCollisionTests.cs
+++ b/Tests/EngineUnitTests/Math/Collision/CollisionRelationshipNullCollisionTests.cs
@@ -77,4 +77,45 @@ public class CollisionRelationshipNullCollisionTests
 
         didCollide.ShouldBeFalse();
     }
+
+    // Pins #2118: the entity-level check above doesn't cover sub-collisions set via
+    // SetFirstSubCollision/SetSecondSubCollision - those delegates can return null for a
+    // particular instance (e.g. a Composite whose optional sub-object isn't created this time)
+    // even though the entity's own Collision is non-null, and previously NRE'd inside
+    // AxisAlignedRectangle.CollideAgainst instead of being skipped.
+    [Theory]
+    [InlineData(CollisionRelationshipTestCollisionType.EventOnly)]
+    [InlineData(CollisionRelationshipTestCollisionType.Move)]
+    [InlineData(CollisionRelationshipTestCollisionType.Bounce)]
+    public void PositionedObjectVsPositionedObjectRelationship_DoCollisions_ShouldNotThrow_WhenSecondSubCollisionRectangleIsNull(CollisionRelationshipTestCollisionType collisionType)
+    {
+        var first = CreateEntityWithCollision();
+        var second = CreateEntityWithCollision();
+        var firstRectangle = new AxisAlignedRectangle { Width = 10, Height = 10 };
+
+        var relationship = new PositionedObjectVsPositionedObjectRelationship<NullableCollisionEntity, NullableCollisionEntity>(first, second);
+        relationship.SetFirstSubCollision((Func<NullableCollisionEntity, AxisAlignedRectangle>)(e => firstRectangle));
+        relationship.SetSecondSubCollision((Func<NullableCollisionEntity, AxisAlignedRectangle>)(e => null));
+
+        switch (collisionType)
+        {
+            case CollisionRelationshipTestCollisionType.Move:
+                relationship.SetMoveCollision(1, 1);
+                break;
+            case CollisionRelationshipTestCollisionType.Bounce:
+                relationship.SetBounceCollision(1, 1, 1);
+                break;
+        }
+
+        var didCollide = relationship.DoCollisions();
+
+        didCollide.ShouldBeFalse();
+    }
+
+    public enum CollisionRelationshipTestCollisionType
+    {
+        EventOnly,
+        Move,
+        Bounce
+    }
 }


### PR DESCRIPTION
Closes #2118.

#2084's entity-level `first.Collision == null || second.Collision == null` check in `DoCollisionPhysicsInner` doesn't cover sub-collisions set via `SetFirstSubCollision`/`SetSecondSubCollision`. Those delegates can return null for a particular instance (e.g. a Composite whose optional sub-object isn't created this time) even though the entity's own `Collision` is non-null, and previously NRE'd inside e.g. `AxisAlignedRectangle.CollideAgainst` instead of being skipped.

Added a `FirstSubCollisionIsNull`/`SecondSubCollisionIsNull` guard (evaluates whichever sub-collision delegate is set, once, before dispatch) to all four affected relationship classes' EventOnly/Move/Bounce/MoveSoft dispatch methods: `CollisionRelationship<First,Second>` (list vs list, single vs single) and `PositionedObjectVsShapeCollection`/`ListVsShapeCollectionRelationship` (vs ShapeCollection).

Watched the new tests NRE with the guard temporarily disabled (`&& false`) before re-enabling to confirm green.

Manual test: not needed - covered by unit tests plus compilation, same as #2084's pin.
