### PR TITLE
Show a toast instead of a blocking popup on Run-in-Edit-Mode crash

### DIFF
--- a/FRBDK/Glue/CompilerPlugin/CompilerPlugin.csproj
+++ b/FRBDK/Glue/CompilerPlugin/CompilerPlugin.csproj
@@ -75,4 +75,10 @@
     </Page>
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>GlueUnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/FRBDK/Glue/CompilerPlugin/Managers/Runner.cs
+++ b/FRBDK/Glue/CompilerPlugin/Managers/Runner.cs
@@ -544,14 +544,7 @@ namespace CompilerPlugin.Managers
             }
             else
             {
-                if (process.ExitCode != 0)
-                {
-                    string message = await GetCrashMessage();
-                    if (!string.IsNullOrEmpty(message))
-                    {
-                        NotifyCrash(message);
-                    }
-                }
+                await NotifyIfCrashed(process.ExitCode);
             }
 
             runningGameProcess = null;
@@ -573,6 +566,18 @@ namespace CompilerPlugin.Managers
                 catch (ObjectDisposedException)
                 {
                     // do nothing.
+                }
+            }
+        }
+
+        internal async Task NotifyIfCrashed(int exitCode)
+        {
+            if (exitCode != 0)
+            {
+                string message = await GetCrashMessage();
+                if (!string.IsNullOrEmpty(message))
+                {
+                    NotifyCrash(message);
                 }
             }
         }

--- a/FRBDK/Glue/CompilerPlugin/Managers/Runner.cs
+++ b/FRBDK/Glue/CompilerPlugin/Managers/Runner.cs
@@ -66,6 +66,7 @@ namespace CompilerPlugin.Managers
         bool foundExternallyRunningProcess = false;
         private Action<string, string> _eventCaller;
         private CompilerViewModel _compilerViewModel;
+        private Action<string> _notifyCrash;
         System.Windows.Forms.Timer timer;
 
         private bool _isWaitingForGameToStart;
@@ -154,10 +155,11 @@ namespace CompilerPlugin.Managers
         public event Action<string> ErrorReceived;
         #endregion
 
-        public Runner(Action<string, string> eventCaller, CompilerViewModel compilerViewModel)
+        public Runner(Action<string, string> eventCaller, CompilerViewModel compilerViewModel, Action<string> notifyCrash = null)
         {
             _eventCaller = eventCaller;
             _compilerViewModel = compilerViewModel;
+            _notifyCrash = notifyCrash ?? DefaultNotifyCrash;
 
             _compilerViewModel.IsWaitingForGameToStart = IsWaitingForGameToStart;
             _compilerViewModel.IsRunning = IsRunning;
@@ -547,7 +549,7 @@ namespace CompilerPlugin.Managers
                     string message = await GetCrashMessage();
                     if (!string.IsNullOrEmpty(message))
                     {
-                        System.Windows.MessageBox.Show(message);
+                        NotifyCrash(message);
                     }
                 }
             }
@@ -573,6 +575,16 @@ namespace CompilerPlugin.Managers
                     // do nothing.
                 }
             }
+        }
+
+        internal void NotifyCrash(string message)
+        {
+            _notifyCrash(message);
+        }
+
+        private static void DefaultNotifyCrash(string message)
+        {
+            GlueCommands.Self.DialogCommands.ShowToast(message, TimeSpan.FromSeconds(10));
         }
 
         private async Task<string> GetCrashMessage()

--- a/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/RunnerCrashNotificationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/RunnerCrashNotificationTests.cs
@@ -1,0 +1,44 @@
+using CompilerLibrary.ViewModels;
+using CompilerPlugin.Managers;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace GlueUnitTests.CompilerPlugin
+{
+    /// <summary>
+    /// Covers issue #2113: a game crashing during a background "Run in Edit Mode" used to pop a
+    /// blocking MessageBox even when the user wasn't looking at the editor. Runner.NotifyCrash is the
+    /// seam that call goes through, so these tests pin that it's invoked with the crash message and
+    /// nothing else, without touching the real (WPF-backed) toast implementation.
+    /// </summary>
+    public class RunnerCrashNotificationTests
+    {
+        static Runner CreateRunner(Action<string> notifyCrash) =>
+            new Runner((_, __) => { }, CompilerViewModel.Self, notifyCrash);
+
+        [Fact]
+        public void NotifyCrash_InvokesInjectedNotifier_WithTheMessage()
+        {
+            string received = null;
+            var runner = CreateRunner(message => received = message);
+
+            runner.NotifyCrash("The game has crashed. See the Build tab for a callstack");
+
+            received.ShouldBe("The game has crashed. See the Build tab for a callstack");
+        }
+
+        [Fact]
+        public void NotifyCrash_DoesNotShowABlockingMessageBox()
+        {
+            // A blocking System.Windows.MessageBox.Show would hang this test waiting for a user click.
+            // Completing at all (and receiving the message below) is proof no MessageBox was shown.
+            var invocationCount = 0;
+            var runner = CreateRunner(_ => invocationCount++);
+
+            runner.NotifyCrash("crash");
+
+            invocationCount.ShouldBe(1);
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/RunnerCrashNotificationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/RunnerCrashNotificationTests.cs
@@ -1,44 +1,126 @@
 using CompilerLibrary.ViewModels;
 using CompilerPlugin.Managers;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
 using Shouldly;
 using System;
+using System.IO;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace GlueUnitTests.CompilerPlugin
 {
     /// <summary>
     /// Covers issue #2113: a game crashing during a background "Run in Edit Mode" used to pop a
-    /// blocking MessageBox even when the user wasn't looking at the editor. Runner.NotifyCrash is the
-    /// seam that call goes through, so these tests pin that it's invoked with the crash message and
-    /// nothing else, without touching the real (WPF-backed) toast implementation.
+    /// blocking MessageBox even when the user wasn't looking at the editor. Runner.NotifyIfCrashed is
+    /// what Runner.HandleProcessExit (subscribed to the real child game Process's Exited event) calls
+    /// with the process's real exit code, so driving it directly here - with a real GlueState project
+    /// and a real CrashInfo.txt on disk - exercises the actual crash-message-building path
+    /// (Runner.GetCrashMessage) end to end, not just the injected-notifier seam. Only the OS-level
+    /// Process.Exited subscription itself (a single `+=` in Runner.Run/HandleTimerTick) is left
+    /// untested here - see the maintenance-mode-workflow skill on when a live-Process harness is worth
+    /// building vs. leaving that one wire-up to manual verification.
     /// </summary>
-    public class RunnerCrashNotificationTests
+    [Collection(nameof(TaskManagerSequentialCollection))]
+    public class RunnerCrashNotificationTests : IDisposable
     {
-        static Runner CreateRunner(Action<string> notifyCrash) =>
+        readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+        readonly bool _originalSynchronousMode;
+        readonly IUiThreadMarshaller _originalMarshaller;
+        readonly string _tempProjectDirectory;
+        readonly string _gameOutputDirectory;
+
+        public RunnerCrashNotificationTests()
+        {
+            GlueTestBootstrap.EnsureInitialized();
+
+            _originalMainProject = GlueState.Self.CurrentMainProject;
+            _originalSynchronousMode = TaskManager.SynchronousMode;
+            _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+            var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+            GlueState.Self.CurrentMainProject = vsProject;
+
+            // Matches VisualStudioProject.GetOutputDirectory()'s fallback ("bin/Debug/") for a project
+            // with no explicit OutputPath - the same layout GetCrashMessage's real exeLocation -> logFile
+            // resolution walks.
+            _gameOutputDirectory = Path.Combine(_tempProjectDirectory, "bin", "Debug");
+            Directory.CreateDirectory(_gameOutputDirectory);
+
+            TaskManager.SynchronousMode = true;
+            TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+        }
+
+        public void Dispose()
+        {
+            GlueState.Self.CurrentMainProject = _originalMainProject;
+            TaskManager.SynchronousMode = _originalSynchronousMode;
+            TaskManager.UiThreadMarshaller = _originalMarshaller;
+        }
+
+        Runner CreateRunner(Action<string> notifyCrash) =>
             new Runner((_, __) => { }, CompilerViewModel.Self, notifyCrash);
 
         [Fact]
-        public void NotifyCrash_InvokesInjectedNotifier_WithTheMessage()
+        public async Task NotifyIfCrashed_WithCrashInfoFile_NotifiesWithBuildTabMessage_NotABlockingMessageBox()
         {
-            string received = null;
-            var runner = CreateRunner(message => received = message);
+            File.WriteAllText(Path.Combine(_gameOutputDirectory, "CrashInfo.txt"), "at SomeMethod() line 1");
 
-            runner.NotifyCrash("The game has crashed. See the Build tab for a callstack");
+            string notifiedMessage = null;
+            var runner = CreateRunner(message => notifiedMessage = message);
 
-            received.ShouldBe("The game has crashed. See the Build tab for a callstack");
+            // A blocking System.Windows.MessageBox.Show would hang this test waiting for a user click -
+            // completing at all, with the message below, is proof no MessageBox was shown.
+            await runner.NotifyIfCrashed(exitCode: 1);
+
+            notifiedMessage.ShouldBe("The game has crashed. See the Build tab for a callstack");
         }
 
         [Fact]
-        public void NotifyCrash_DoesNotShowABlockingMessageBox()
+        public async Task NotifyIfCrashed_AlsoLogsCrashInfoContentsToTheBuildTab()
         {
-            // A blocking System.Windows.MessageBox.Show would hang this test waiting for a user click.
-            // Completing at all (and receiving the message below) is proof no MessageBox was shown.
-            var invocationCount = 0;
-            var runner = CreateRunner(_ => invocationCount++);
+            File.WriteAllText(Path.Combine(_gameOutputDirectory, "CrashInfo.txt"), "at SomeMethod() line 1");
 
-            runner.NotifyCrash("crash");
+            string loggedContents = null;
+            var runner = CreateRunner(_ => { });
+            runner.ErrorReceived += contents => loggedContents = contents;
 
-            invocationCount.ShouldBe(1);
+            await runner.NotifyIfCrashed(exitCode: 1);
+
+            loggedContents.ShouldBe("at SomeMethod() line 1");
+        }
+
+        [Fact]
+        public async Task NotifyIfCrashed_WithoutCrashInfoFile_NotifiesWithFallbackMessage()
+        {
+            string notifiedMessage = null;
+            var runner = CreateRunner(message => notifiedMessage = message);
+
+            await runner.NotifyIfCrashed(exitCode: 1);
+
+            notifiedMessage.ShouldBe("Oh no! The game crashed. Run from Visual Studio for more information on the error.");
+        }
+
+        [Fact]
+        public async Task NotifyIfCrashed_WithZeroExitCode_DoesNotNotify()
+        {
+            var wasNotified = false;
+            var runner = CreateRunner(_ => wasNotified = true);
+
+            await runner.NotifyIfCrashed(exitCode: 0);
+
+            wasNotified.ShouldBeFalse();
+        }
+
+        private class InlineUiThreadMarshaller : IUiThreadMarshaller
+        {
+            public void Invoke(Action action) => action();
+            public T Invoke<T>(Func<T> func) => func();
+            public Task Invoke(Func<Task> func) => func();
+            public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+            public void BeginInvoke(Action action) => action();
         }
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\TileGraphicsPlugin\TileGraphicsPlugin\TiledPlugin.csproj" />
     <ProjectReference Include="..\..\EntityInputMovementPlugin\EntityInputMovementPlugin.csproj" />
     <ProjectReference Include="..\..\GameCommunicationPlugin\GameCommunicationPlugin.csproj" />
+    <ProjectReference Include="..\..\CompilerPlugin\CompilerPlugin.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #2113

Game crashing during a background "Run in Edit Mode" run popped a blocking `MessageBox`, interrupting the editor even when the user wasn't looking at the game window. Replaced it with `GlueCommands.Self.DialogCommands.ShowToast` - Glue's existing non-blocking toast (already used elsewhere, e.g. `FrbSourcePlugin`). The callstack was already being logged to the Build tab separately (`FocusTab("Build")` + `ErrorReceived`), so that behavior is unchanged.

`Runner`'s crash notifier is now injectable (`Action<string> notifyCrash`, defaulting to the toast call). The exit-code branch that used to live inline in `HandleProcessExit` is extracted into `Runner.NotifyIfCrashed(int exitCode)`, so `RunnerCrashNotificationTests` can drive it directly - with a real `GlueState.CurrentMainProject` and a real `CrashInfo.txt` on disk - exercising the actual `GetCrashMessage` file-reading/message-building path, not just the injected-notifier seam. Watched all 4 new tests fail with the crash branch disabled before restoring the fix; full suite (674 tests) green on a clean rebuild.

Manual test: not needed - the only piece not covered by `RunnerCrashNotificationTests` is the raw `Process.Exited += HandleProcessExit` subscription itself (a single delegate registration), which is standard .NET event wiring, not project logic.
