### PR TITLE
Warn in the Error tab when a Sprite sets texture coordinates without a Texture

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/SpritePlugin/Errors/SpriteMissingTextureErrorReporter.cs
+++ b/FRBDK/Glue/OfficialPlugins/SpritePlugin/Errors/SpriteMissingTextureErrorReporter.cs
@@ -1,0 +1,65 @@
+using FlatRedBall;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Errors;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using System.Collections.Generic;
+
+namespace OfficialPlugins.SpritePlugin.Errors
+{
+    internal class SpriteMissingTextureErrorReporter : ErrorReporterBase
+    {
+        public override ErrorViewModel[] GetAllErrors()
+        {
+            var errors = new List<ErrorViewModel>();
+
+            var project = GlueState.Self.CurrentGlueProject;
+
+            void AddErrorsFrom(GlueElement owner)
+            {
+                foreach (var namedObject in owner.AllNamedObjects)
+                {
+                    if (GetIfHasError(namedObject, owner))
+                    {
+                        errors.Add(new SpriteMissingTextureErrorViewModel(namedObject));
+                    }
+                }
+            }
+
+            foreach (var screen in project.Screens)
+            {
+                AddErrorsFrom(screen);
+            }
+            foreach (var entity in project.Entities)
+            {
+                AddErrorsFrom(entity);
+            }
+
+            return errors.ToArray();
+        }
+
+        public static bool GetIfHasError(NamedObjectSave namedObject, GlueElement owner)
+        {
+            if (namedObject.GetAssetTypeInfo() != AvailableAssetTypes.CommonAtis.Sprite)
+            {
+                return false;
+            }
+
+            var hasTextureCoordinateSet =
+                namedObject.GetCustomVariable(nameof(Sprite.LeftTexturePixel))?.Value != null ||
+                namedObject.GetCustomVariable(nameof(Sprite.RightTexturePixel))?.Value != null ||
+                namedObject.GetCustomVariable(nameof(Sprite.TopTexturePixel))?.Value != null ||
+                namedObject.GetCustomVariable(nameof(Sprite.BottomTexturePixel))?.Value != null;
+
+            if (!hasTextureCoordinateSet)
+            {
+                return false;
+            }
+
+            var textureValue = ObjectFinder.Self.GetValueRecursively(
+                namedObject, owner, nameof(Sprite.Texture)) as string;
+
+            return string.IsNullOrEmpty(textureValue);
+        }
+    }
+}

--- a/FRBDK/Glue/OfficialPlugins/SpritePlugin/Errors/SpriteMissingTextureErrorViewModel.cs
+++ b/FRBDK/Glue/OfficialPlugins/SpritePlugin/Errors/SpriteMissingTextureErrorViewModel.cs
@@ -1,0 +1,41 @@
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Errors;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using System.Linq;
+
+namespace OfficialPlugins.SpritePlugin.Errors
+{
+    internal class SpriteMissingTextureErrorViewModel : ErrorViewModel
+    {
+        NamedObjectSave namedObject;
+
+        public override string UniqueId => Details;
+
+        public SpriteMissingTextureErrorViewModel(NamedObjectSave namedObject)
+        {
+            this.namedObject = namedObject;
+
+            Details = $"{namedObject} sets texture coordinates (LeftTexturePixel/RightTexturePixel/TopTexturePixel/BottomTexturePixel) " +
+                $"but does not have a Texture assigned. This will throw an exception at runtime.";
+        }
+
+        public override bool GetIfIsFixed()
+        {
+            var owner = ObjectFinder.Self.GetElementContaining(namedObject);
+
+            if (owner == null || owner.AllNamedObjects.Contains(namedObject) == false)
+            {
+                return true;
+            }
+
+            return SpriteMissingTextureErrorReporter.GetIfHasError(namedObject, owner) == false;
+        }
+
+        public override void HandleDoubleClick()
+        {
+            GlueState.Self.CurrentNamedObjectSave = namedObject;
+            GlueCommands.Self.DialogCommands.FocusTab("Properties");
+        }
+    }
+}

--- a/FRBDK/Glue/OfficialPlugins/SpritePlugin/MainSpritePlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/SpritePlugin/MainSpritePlugin.cs
@@ -7,6 +7,7 @@ using FlatRedBall.Glue.SaveClasses;
 using FlatRedBall.Math;
 using OfficialPlugins.Common.Controls;
 using OfficialPlugins.SpritePlugin.CodeGenerators;
+using OfficialPlugins.SpritePlugin.Errors;
 using OfficialPlugins.SpritePlugin.Managers;
 using OfficialPlugins.SpritePlugin.Views;
 using System;
@@ -29,6 +30,8 @@ namespace OfficialPlugins.SpritePlugin
 
             this.RegisterCodeGenerator(new SpriteCodeGenerator());
 
+            this.AddErrorReporter(new SpriteMissingTextureErrorReporter());
+
             AssignEvents();
         }
 
@@ -48,6 +51,10 @@ namespace OfficialPlugins.SpritePlugin
             {
                 TextureVariableManager.Self.HandleChange(variable);
             }
+
+            // Refresh reactively so a missing-Texture warning shows up immediately rather than
+            // only after a manual Refresh click or project reload.
+            GlueCommands.Self.RefreshCommands.RefreshErrors();
         }
 
         private void HandleGluxLoaded()

--- a/FRBDK/Glue/Tests/GlueUnitTests/SpritePlugin/SpriteMissingTextureErrorReporterTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/SpritePlugin/SpriteMissingTextureErrorReporterTests.cs
@@ -1,0 +1,130 @@
+using FlatRedBall;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using OfficialPlugins.SpritePlugin.Errors;
+using Shouldly;
+using System;
+
+namespace GlueUnitTests.SpritePlugin;
+
+// GitHub issue #2110: a Sprite NamedObjectSave with a texture-coordinate CustomVariable
+// (LeftTexturePixel/RightTexturePixel/TopTexturePixel/BottomTexturePixel) set but no Texture throws
+// "You must have a Texture set before setting this value" at runtime (Sprite.set_LeftTexturePixel) -
+// codegen emits the coordinate assignment unconditionally, with nothing in the editor warning that the
+// combination is invalid. SpriteMissingTextureErrorReporter surfaces this in the Error tab instead of
+// letting it reach a runtime crash.
+public class SpriteMissingTextureErrorReporterTests : IDisposable
+{
+    private readonly GlueProjectSave _originalGlueProject;
+
+    public SpriteMissingTextureErrorReporterTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+    }
+
+    public void Dispose()
+    {
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+    }
+
+    [Fact]
+    public void GetIfHasError_ShouldReturnTrue_WhenTextureCoordinateIsSetButTextureIsNot()
+    {
+        var container = new EntitySave();
+        var sprite = AddSprite(container, "SpriteInstance");
+        SetInstruction(sprite, nameof(Sprite.LeftTexturePixel), 10f);
+
+        SpriteMissingTextureErrorReporter.GetIfHasError(sprite, container).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetIfHasError_ShouldReturnFalse_WhenTextureIsAlsoSet()
+    {
+        var container = new EntitySave();
+        var sprite = AddSprite(container, "SpriteInstance");
+        SetInstruction(sprite, nameof(Sprite.LeftTexturePixel), 10f);
+        SetInstruction(sprite, nameof(Sprite.Texture), "SomeTexture.png");
+
+        SpriteMissingTextureErrorReporter.GetIfHasError(sprite, container).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetIfHasError_ShouldReturnFalse_WhenNoTextureCoordinatesAreSet()
+    {
+        var container = new EntitySave();
+        var sprite = AddSprite(container, "SpriteInstance");
+
+        SpriteMissingTextureErrorReporter.GetIfHasError(sprite, container).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetIfHasError_ShouldReturnFalse_WhenNamedObjectIsNotASprite()
+    {
+        var container = new EntitySave();
+        var nos = new NamedObjectSave
+        {
+            InstanceName = "TextInstance",
+            SourceType = SourceType.FlatRedBallType,
+            SourceClassType = "FlatRedBall.Graphics.Text"
+        };
+        container.NamedObjects.Add(nos);
+        SetInstruction(nos, nameof(Sprite.LeftTexturePixel), 10f);
+
+        SpriteMissingTextureErrorReporter.GetIfHasError(nos, container).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetAllErrors_ShouldIncludeSprite_WhenTextureCoordinateIsSetButTextureIsNot()
+    {
+        var container = new EntitySave { Name = "Entities\\SomeEntity\\SomeEntity" };
+        var sprite = AddSprite(container, "SpriteInstance");
+        SetInstruction(sprite, nameof(Sprite.TopTexturePixel), 4f);
+        ObjectFinder.Self.GlueProject.Entities.Add(container);
+
+        var reporter = new SpriteMissingTextureErrorReporter();
+
+        var errors = reporter.GetAllErrors();
+
+        errors.ShouldContain(error => error is SpriteMissingTextureErrorViewModel);
+    }
+
+    [Fact]
+    public void GetIfIsFixed_ShouldReturnTrue_AfterATextureIsAssigned()
+    {
+        var container = new EntitySave { Name = "Entities\\SomeEntity\\SomeEntity" };
+        var sprite = AddSprite(container, "SpriteInstance");
+        SetInstruction(sprite, nameof(Sprite.LeftTexturePixel), 10f);
+        ObjectFinder.Self.GlueProject.Entities.Add(container);
+
+        var error = new SpriteMissingTextureErrorViewModel(sprite);
+        error.GetIfIsFixed().ShouldBeFalse();
+
+        SetInstruction(sprite, nameof(Sprite.Texture), "SomeTexture.png");
+
+        error.GetIfIsFixed().ShouldBeTrue();
+    }
+
+    static NamedObjectSave AddSprite(EntitySave container, string instanceName)
+    {
+        var nos = new NamedObjectSave
+        {
+            InstanceName = instanceName,
+            SourceType = SourceType.FlatRedBallType,
+            SourceClassType = "FlatRedBall.Sprite"
+        };
+        container.NamedObjects.Add(nos);
+        return nos;
+    }
+
+    static void SetInstruction(NamedObjectSave nos, string member, object value)
+    {
+        nos.InstructionSaves.Add(new CustomVariableInNamedObject
+        {
+            Member = member,
+            Value = value
+        });
+    }
+}


### PR DESCRIPTION
## Summary
Sprite.LeftTexturePixel/Right/Top/BottomTexturePixel throw `"You must have a Texture set before setting this value"` at runtime if Texture is null. Glue let a Sprite NamedObjectSave have those texture-coordinate CustomVariables set without ever setting Texture, and codegen emitted the assignment unconditionally with no warning - see #2110's log.

There's already a partial mitigation (`TextureVariableManager`) that prompts to clear coordinates when Texture is cleared on a Sprite that already has coordinates set, but it doesn't cover the reverse order (coordinates set first, Texture never set), which is this bug.

Adds `SpriteMissingTextureErrorReporter`/`SpriteMissingTextureErrorViewModel` (mirrors `AnimationChainErrorReporter`'s pattern) to flag this in the Error tab, wired to refresh reactively off the same `ReactToNamedObjectChangedValueList` hook `TextureVariableManager` already uses (same reactive-refresh pattern as #2121/743bf0918 for CollisionRelationship errors), so it shows immediately instead of only after a manual refresh/reload/crash.

## Test plan
- [x] `SpriteMissingTextureErrorReporterTests` (6 new unit tests): error detection with/without Texture set, non-Sprite objects excluded, `GetAllErrors()` inclusion, `GetIfIsFixed()` clears after Texture is assigned.
- [x] Full `GlueUnitTests` suite (`Category!=BuildSmoke`), clean rebuild: 694/694 passing.
- Manual test: not needed - this only adds an Error-tab entry; no codegen or runtime behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
