### PR TITLE
Add test coverage for Ctrl+click multi-select in Edit Mode

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -280,6 +280,29 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     }
     #endregion
 
+    #region SimulateClickSelect
+
+    /// <summary>
+    /// Test-only: drives EditingManager's click-to-select logic without a real mouse/keyboard. See
+    /// EditingManager.SimulateClickSelectForTesting (Embedded) - selects ObjectName exactly as a real click
+    /// on it would, replacing the current selection unless AdditiveModifierDown is true (Ctrl or Shift
+    /// held), in which case it's added to (or toggled off of) the existing selection. See #2125.
+    /// </summary>
+    public class SimulateClickSelectDto
+    {
+        /// <summary>InstanceName of the NamedObjectSave clicked, or null/empty for a click on empty space.</summary>
+        public string ObjectName { get; set; }
+        public bool AdditiveModifierDown { get; set; }
+    }
+    #endregion
+
+    #region SimulateClickSelectResponse
+    public class SimulateClickSelectResponse
+    {
+        public List<string> SelectedObjectNames { get; set; }
+    }
+    #endregion
+
     #region GetCameraSave
     public class GetCameraSave
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -285,8 +285,8 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     /// <summary>
     /// Test-only: drives EditingManager's click-to-select logic without a real mouse/keyboard. See
     /// EditingManager.SimulateClickSelectForTesting (Embedded) - selects ObjectName exactly as a real click
-    /// on it would, replacing the current selection unless AdditiveModifierDown is true (Ctrl or Shift
-    /// held), in which case it's added to (or toggled off of) the existing selection. See #2125.
+    /// on it would, replacing the current selection unless AdditiveModifierDown is true (Ctrl held), in
+    /// which case it's added to (or toggled off of) the existing selection.
     /// </summary>
     public class SimulateClickSelectDto
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -910,6 +910,22 @@ namespace GlueControl
 
         #endregion
 
+        #region SimulateClickSelect
+
+        private static object HandleDto(GlueControl.Dtos.SimulateClickSelectDto dto)
+        {
+            var editingManager = Editing.EditingManager.Self;
+
+            editingManager.SimulateClickSelectForTesting(dto.ObjectName, dto.AdditiveModifierDown);
+
+            return new GlueControl.Dtos.SimulateClickSelectResponse
+            {
+                SelectedObjectNames = editingManager.ItemsSelected.Select(item => item.Name).ToList()
+            };
+        }
+
+        #endregion
+
         #endregion
 
         #region Set Camera Position

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -286,8 +286,8 @@ namespace GlueControl.Dtos
     /// <summary>
     /// Test-only: drives EditingManager's click-to-select logic without a real mouse/keyboard. See
     /// EditingManager.SimulateClickSelectForTesting - selects ObjectName exactly as a real click on it
-    /// would, replacing the current selection unless AdditiveModifierDown is true (Ctrl or Shift held), in
-    /// which case it's added to (or toggled off of) the existing selection. See #2125.
+    /// would, replacing the current selection unless AdditiveModifierDown is true (Ctrl held), in which
+    /// case it's added to (or toggled off of) the existing selection.
     /// </summary>
     public class SimulateClickSelectDto
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -281,6 +281,29 @@ namespace GlueControl.Dtos
     }
     #endregion
 
+    #region SimulateClickSelect
+
+    /// <summary>
+    /// Test-only: drives EditingManager's click-to-select logic without a real mouse/keyboard. See
+    /// EditingManager.SimulateClickSelectForTesting - selects ObjectName exactly as a real click on it
+    /// would, replacing the current selection unless AdditiveModifierDown is true (Ctrl or Shift held), in
+    /// which case it's added to (or toggled off of) the existing selection. See #2125.
+    /// </summary>
+    public class SimulateClickSelectDto
+    {
+        /// <summary>InstanceName of the NamedObjectSave clicked, or null/empty for a click on empty space.</summary>
+        public string ObjectName { get; set; }
+        public bool AdditiveModifierDown { get; set; }
+    }
+    #endregion
+
+    #region SimulateClickSelectResponse
+    public class SimulateClickSelectResponse
+    {
+        public List<string> SelectedObjectNames { get; set; }
+    }
+    #endregion
+
     #region GetCameraSave
     public class GetCameraSave
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -646,79 +646,107 @@ namespace GlueControl.Editing
             if (shouldTreatAsPush)
             {
                 var itemOver = itemsOver.FirstOrDefault();
-                itemGrabbed = itemOver as IStaticPositionable;
+                // Ctrl and Shift both toggle add/remove from the current selection (see #2125) rather than
+                // replacing it, matching the common convention of both modifiers behaving the same way for
+                // click-to-select.
+                var additiveModifierDown = InputManager.Keyboard.IsCtrlDown || InputManager.Keyboard.IsShiftDown;
 
-                var clickedOnSelectedItem = itemsSelected.Contains(itemOver);
+                PerformClickSelection(itemOver, additiveModifierDown);
+            }
+        }
 
-                var isCtrlDown = InputManager.Keyboard.IsCtrlDown;
-                if (!clickedOnSelectedItem)
+        /// <summary>
+        /// Core click-to-select decision: replaces the selection with itemOver, or when
+        /// additiveModifierDown is true, adds itemOver to the existing selection (toggling it off if it was
+        /// already selected). Parameterized on itemOver/additiveModifierDown instead of reading
+        /// InputManager.Mouse/Keyboard directly, so SimulateClickSelectForTesting (LiveGameProcess tests,
+        /// see #2125) can drive it without a real Cursor/mouse/keyboard.
+        /// </summary>
+        private void PerformClickSelection(INameable itemOver, bool additiveModifierDown)
+        {
+            itemGrabbed = itemOver as IStaticPositionable;
+
+            var clickedOnSelectedItem = itemsSelected.Contains(itemOver);
+
+            if (!clickedOnSelectedItem)
+            {
+                if (itemOver?.Name == null)
                 {
-                    if (itemOver?.Name == null)
-                    {
-                        Select((NamedObjectSave)null, addToExistingSelection: isCtrlDown, playBump: true);
-                    }
-                    else
-                    {
-                        NamedObjectSave nos = null;
-                        if (itemOver?.Name != null)
-                        {
-                            nos = GetNosFromItemName(itemOver.Name);
-                        }
-
-                        if (nos != null)
-                        {
-                            Select(nos, addToExistingSelection: isCtrlDown, playBump: true);
-                        }
-                        else
-                        {
-                            if (!isCtrlDown)
-                            {
-                                CurrentNamedObjects.Clear();
-                            }
-                            // this shouldn't happen, but for now we tolerate it until the current is sent
-                            Select(itemOver?.Name, addToExistingSelection: isCtrlDown, playBump: true);
-                        }
-                    }
+                    Select((NamedObjectSave)null, addToExistingSelection: additiveModifierDown, playBump: true);
                 }
-                else if (isCtrlDown)
+                else
                 {
                     NamedObjectSave nos = null;
                     if (itemOver?.Name != null)
                     {
                         nos = GetNosFromItemName(itemOver.Name);
                     }
+
                     if (nos != null)
                     {
-                        RemoveFromSelection(nos);
+                        Select(nos, addToExistingSelection: additiveModifierDown, playBump: true);
                     }
-                }
-
-                if (itemGrabbed != null)
-                {
-                    foreach (var item in itemsSelected)
+                    else
                     {
-                        var marker = MarkerFor(item);
-
-                        marker.CanMoveItem = item == itemGrabbed;
-                    }
-
-                    if (!clickedOnSelectedItem)
-                    {
-                        if (isCtrlDown)
+                        if (!additiveModifierDown)
                         {
-                            ObjectSelected(itemsSelected);
+                            CurrentNamedObjects.Clear();
                         }
-                        else
-                        {
-                            ObjectSelected(new List<INameable> { itemGrabbed as INameable });
-                        }
+                        // this shouldn't happen, but for now we tolerate it until the current is sent
+                        Select(itemOver?.Name, addToExistingSelection: additiveModifierDown, playBump: true);
                     }
-                }
-                else if (!clickedOnSelectedItem)
-                {
-                    ObjectSelected(new List<INameable>());
                 }
             }
+            else if (additiveModifierDown)
+            {
+                NamedObjectSave nos = null;
+                if (itemOver?.Name != null)
+                {
+                    nos = GetNosFromItemName(itemOver.Name);
+                }
+                if (nos != null)
+                {
+                    RemoveFromSelection(nos);
+                }
+            }
+
+            if (itemGrabbed != null)
+            {
+                foreach (var item in itemsSelected)
+                {
+                    var marker = MarkerFor(item);
+
+                    marker.CanMoveItem = item == itemGrabbed;
+                }
+
+                if (!clickedOnSelectedItem)
+                {
+                    if (additiveModifierDown)
+                    {
+                        ObjectSelected(itemsSelected);
+                    }
+                    else
+                    {
+                        ObjectSelected(new List<INameable> { itemGrabbed as INameable });
+                    }
+                }
+            }
+            else if (!clickedOnSelectedItem)
+            {
+                ObjectSelected(new List<INameable>());
+            }
+        }
+
+        /// <summary>
+        /// Test-only entry point mirroring DoGrabLogic's click-selection decision (see #2125) - resolves
+        /// objectName the same way a real click resolves whatever the ray hit, then runs the identical
+        /// add/toggle logic, without needing a real Cursor/mouse or keyboard modifier state. Driven by
+        /// SimulateClickSelectDto (see CommandReceiver.HandleDto).
+        /// </summary>
+        internal void SimulateClickSelectForTesting(string objectName, bool additiveModifierDown)
+        {
+            INameable itemOver = string.IsNullOrEmpty(objectName) ? null : GetObjectByName(objectName);
+            PerformClickSelection(itemOver, additiveModifierDown);
         }
 
         private NamedObjectSave GetNosFromItemName(string itemName)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -646,10 +646,7 @@ namespace GlueControl.Editing
             if (shouldTreatAsPush)
             {
                 var itemOver = itemsOver.FirstOrDefault();
-                // Ctrl and Shift both toggle add/remove from the current selection (see #2125) rather than
-                // replacing it, matching the common convention of both modifiers behaving the same way for
-                // click-to-select.
-                var additiveModifierDown = InputManager.Keyboard.IsCtrlDown || InputManager.Keyboard.IsShiftDown;
+                var additiveModifierDown = InputManager.Keyboard.IsCtrlDown;
 
                 PerformClickSelection(itemOver, additiveModifierDown);
             }
@@ -659,8 +656,8 @@ namespace GlueControl.Editing
         /// Core click-to-select decision: replaces the selection with itemOver, or when
         /// additiveModifierDown is true, adds itemOver to the existing selection (toggling it off if it was
         /// already selected). Parameterized on itemOver/additiveModifierDown instead of reading
-        /// InputManager.Mouse/Keyboard directly, so SimulateClickSelectForTesting (LiveGameProcess tests,
-        /// see #2125) can drive it without a real Cursor/mouse/keyboard.
+        /// InputManager.Mouse/Keyboard directly, so SimulateClickSelectForTesting (LiveGameProcess tests)
+        /// can drive it without a real Cursor/mouse/keyboard.
         /// </summary>
         private void PerformClickSelection(INameable itemOver, bool additiveModifierDown)
         {
@@ -738,7 +735,7 @@ namespace GlueControl.Editing
         }
 
         /// <summary>
-        /// Test-only entry point mirroring DoGrabLogic's click-selection decision (see #2125) - resolves
+        /// Test-only entry point mirroring DoGrabLogic's click-selection decision - resolves
         /// objectName the same way a real click resolves whatever the ray hit, then runs the identical
         /// add/toggle logic, without needing a real Cursor/mouse or keyboard modifier state. Driven by
         /// SimulateClickSelectDto (see CommandReceiver.HandleDto).

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/CtrlClickMultiSelectTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/CtrlClickMultiSelectTests.cs
@@ -11,19 +11,18 @@ using Xunit;
 namespace GlueUnitTests.Projects;
 
 /// <summary>
-/// Reproduces issue #2125 end to end against a real running game: Edit Mode selection previously only
-/// let Ctrl+click add/remove an object from the current selection - Shift+click did nothing but replace
-/// it, same as a plain click. Drives EditingManager.SimulateClickSelectForTesting (Embedded) - the exact
-/// same production click-selection decision (EditingManager.PerformClickSelection) a real mouse click with
-/// a modifier key held would run, just fed an explicit "modifier held" bool instead of reading
-/// InputManager.Keyboard, so this exercises the real DTO -> EditingManager wiring, not just the modifier
-/// key read in isolation.
+/// Pins Edit Mode's Ctrl+click add/remove multi-selection (previously untested - see #2125, where the
+/// request turned out to already be covered by existing Ctrl+click behavior). Drives
+/// EditingManager.SimulateClickSelectForTesting (Embedded) - the exact same production click-selection
+/// decision (EditingManager.PerformClickSelection) a real Ctrl+click would run, just fed an explicit
+/// "modifier held" bool instead of reading InputManager.Keyboard, so this exercises the real DTO ->
+/// EditingManager wiring, not just the modifier key read in isolation.
 /// </summary>
 [Trait("Category", "LiveGame")]
-public class ShiftClickMultiSelectTests
+public class CtrlClickMultiSelectTests
 {
     [StaFact]
-    public async Task ShiftClickingAnUnselectedObject_AddsItToTheSelection_AndShiftClickingItAgain_RemovesIt()
+    public async Task CtrlClickingAnUnselectedObject_AddsItToTheSelection_AndCtrlClickingItAgain_RemovesIt()
     {
         GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
 
@@ -60,23 +59,23 @@ public class ShiftClickMultiSelectTests
         clickAResponse.Succeeded.ShouldBeTrue(clickAResponse.Message);
         clickAResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectA" });
 
-        // Shift+click on TestObjectB - adds it, TestObjectA stays selected.
-        var shiftClickBResponse = await game.Send<SimulateClickSelectResponse>(new SimulateClickSelectDto
+        // Ctrl+click on TestObjectB - adds it, TestObjectA stays selected.
+        var ctrlClickBResponse = await game.Send<SimulateClickSelectResponse>(new SimulateClickSelectDto
         {
             ObjectName = "TestObjectB",
             AdditiveModifierDown = true,
         });
-        shiftClickBResponse.Succeeded.ShouldBeTrue(shiftClickBResponse.Message);
-        shiftClickBResponse.Data.SelectedObjectNames.OrderBy(name => name).ShouldBe(new[] { "TestObjectA", "TestObjectB" });
+        ctrlClickBResponse.Succeeded.ShouldBeTrue(ctrlClickBResponse.Message);
+        ctrlClickBResponse.Data.SelectedObjectNames.OrderBy(name => name).ShouldBe(new[] { "TestObjectA", "TestObjectB" });
 
-        // Shift+click on TestObjectA again - toggles it back off, TestObjectB stays selected.
-        var shiftClickARemoveResponse = await game.Send<SimulateClickSelectResponse>(new SimulateClickSelectDto
+        // Ctrl+click on TestObjectA again - toggles it back off, TestObjectB stays selected.
+        var ctrlClickARemoveResponse = await game.Send<SimulateClickSelectResponse>(new SimulateClickSelectDto
         {
             ObjectName = "TestObjectA",
             AdditiveModifierDown = true,
         });
-        shiftClickARemoveResponse.Succeeded.ShouldBeTrue(shiftClickARemoveResponse.Message);
-        shiftClickARemoveResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectB" });
+        ctrlClickARemoveResponse.Succeeded.ShouldBeTrue(ctrlClickARemoveResponse.Message);
+        ctrlClickARemoveResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectB" });
     }
 
     static async Task AddTwoTestObjectsToGameScreen()

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/ShiftClickMultiSelectTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/ShiftClickMultiSelectTests.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// Reproduces issue #2125 end to end against a real running game: Edit Mode selection previously only
+/// let Ctrl+click add/remove an object from the current selection - Shift+click did nothing but replace
+/// it, same as a plain click. Drives EditingManager.SimulateClickSelectForTesting (Embedded) - the exact
+/// same production click-selection decision (EditingManager.PerformClickSelection) a real mouse click with
+/// a modifier key held would run, just fed an explicit "modifier held" bool instead of reading
+/// InputManager.Keyboard, so this exercises the real DTO -> EditingManager wiring, not just the modifier
+/// key read in isolation.
+/// </summary>
+[Trait("Category", "LiveGame")]
+public class ShiftClickMultiSelectTests
+{
+    [StaFact]
+    public async Task ShiftClickingAnUnselectedObject_AddsItToTheSelection_AndShiftClickingItAgain_RemovesIt()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
+            afterLoadBeforeEmbed: AddTwoTestObjectsToGameScreen);
+
+        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        var loadScreenResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Screens\\GameScreen",
+            ScreenSave = screen,
+        });
+        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
+
+        // See PolygonPointDragSnapTests for why edit mode must be entered before selecting.
+        var editModeResponse = await game.Send(new SetEditMode
+        {
+            IsInEditMode = true,
+            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        });
+        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
+        await Task.Delay(1000);
+
+        // Plain click on TestObjectA - selects it alone.
+        var clickAResponse = await game.Send<SimulateClickSelectResponse>(new SimulateClickSelectDto
+        {
+            ObjectName = "TestObjectA",
+            AdditiveModifierDown = false,
+        });
+        clickAResponse.Succeeded.ShouldBeTrue(clickAResponse.Message);
+        clickAResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectA" });
+
+        // Shift+click on TestObjectB - adds it, TestObjectA stays selected.
+        var shiftClickBResponse = await game.Send<SimulateClickSelectResponse>(new SimulateClickSelectDto
+        {
+            ObjectName = "TestObjectB",
+            AdditiveModifierDown = true,
+        });
+        shiftClickBResponse.Succeeded.ShouldBeTrue(shiftClickBResponse.Message);
+        shiftClickBResponse.Data.SelectedObjectNames.OrderBy(name => name).ShouldBe(new[] { "TestObjectA", "TestObjectB" });
+
+        // Shift+click on TestObjectA again - toggles it back off, TestObjectB stays selected.
+        var shiftClickARemoveResponse = await game.Send<SimulateClickSelectResponse>(new SimulateClickSelectDto
+        {
+            ObjectName = "TestObjectA",
+            AdditiveModifierDown = true,
+        });
+        shiftClickARemoveResponse.Succeeded.ShouldBeTrue(shiftClickARemoveResponse.Message);
+        shiftClickARemoveResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectB" });
+    }
+
+    static async Task AddTwoTestObjectsToGameScreen()
+    {
+        var gameScreen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        foreach (var instanceName in new[] { "TestObjectA", "TestObjectB" })
+        {
+            var nos = new NamedObjectSave();
+            nos.SetDefaults();
+            nos.InstanceName = instanceName;
+            nos.SourceType = SourceType.FlatRedBallType;
+            nos.SourceClassType = "FlatRedBall.Math.Geometry.AxisAlignedRectangle";
+
+            await GlueCommands.Self.GluxCommands.AddNamedObjectToAsync(
+                nos, gameScreen, listToAddTo: null, selectNewNos: false,
+                performSaveAndGenerateCode: true, updateUi: false);
+        }
+    }
+}


### PR DESCRIPTION
Related to #2125 - that request turned out to already be covered by existing Ctrl+click behavior (`EditingManager.DoGrabLogic` already gated add/remove-from-selection on `IsCtrlDown`), so this PR no longer adds Shift as a second trigger for the same thing. It just adds test coverage for the existing Ctrl+click behavior, which had none.

## Change

`EditingManager.DoGrabLogic`'s click-selection decision is extracted into `PerformClickSelection(itemOver, additiveModifierDown)` - a pure extract-method, no behavior change.

## Testing

Added `SimulateClickSelectForTesting`/`SimulateClickSelectDto` (mirrors the existing `SimulateResizeDragForTesting`/`SimulateResizeDragDto` pattern) so a `LiveGameProcess` test can drive the click-selection decision without real mouse/keyboard hardware. `CtrlClickMultiSelectTests` pins: plain click selects alone, Ctrl+click on a second object adds it, Ctrl+click on the first again toggles it off.

**Manual test: not needed** - pure extract-method refactor plus new test coverage, no behavior change.
