### PR TITLE
Clamp and use sliders for background color RGB in Glue View Settings

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/ViewModels/GlueViewSettingsViewModel.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/ViewModels/GlueViewSettingsViewModel.cs
@@ -52,20 +52,22 @@ namespace GameCommunicationPlugin.GlueControl.ViewModels
         public int BackgroundRed
         {
             get => Get<int>();
-            set => Set(value);
+            set => Set(ClampToByteRange(value));
         }
 
         public int BackgroundGreen
         {
             get => Get<int>();
-            set => Set(value);
+            set => Set(ClampToByteRange(value));
         }
 
         public int BackgroundBlue
         {
             get => Get<int>();
-            set => Set(value);
+            set => Set(ClampToByteRange(value));
         }
+
+        static int ClampToByteRange(int value) => Math.Clamp(value, 0, 255);
 
         public bool ShowGrid
         {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
@@ -120,20 +120,12 @@ namespace GameCommunicationPlugin.GlueControl.Views
                 colorProperties.Category = Localization.Texts.GridAndMarkings;
                 colorProperties.IsHiddenDelegate = (notused) => ViewModel.SetBackgroundColor == false;
                 colorProperties.PreferredDisplayer = typeof(WpfDataUi.Controls.SliderDisplay);
-            }
 
-            var lockScreenBoundsProperties = properties.GetOrCreateImdp(nameof(ViewModel.LockScreenBoundsToWorldSpace));
-            lockScreenBoundsProperties.Category = Localization.Texts.GridAndMarkings;
-            lockScreenBoundsProperties.DisplayName = Localization.Texts.LockScreenBoundsToWorldSpace;
-            lockScreenBoundsProperties.IsHiddenDelegate = (notused) => ViewModel.ShowScreenBounds == false;
-
-            DataUiGrid.Apply(properties);
-
-            ApplyColorSliderRange(nameof(ViewModel.BackgroundRed));
-            ApplyColorSliderRange(nameof(ViewModel.BackgroundGreen));
-            ApplyColorSliderRange(nameof(ViewModel.BackgroundBlue));
-            void ApplyColorSliderRange(string propertyName)
-            {
+                // Must happen before DataUiGrid.Apply(properties) below: SetBackgroundColor defaults to
+                // false, and Apply() ends by hiding newly-registered IsHiddenDelegate members (removing
+                // them from category.Members) - after that, GetMember can no longer find this member to
+                // set its MinValue/MaxValue, and the slider silently falls back to WPF Slider's own
+                // default range of 0-10.
                 var member = GetMember(propertyName);
                 if (member != null)
                 {
@@ -142,6 +134,12 @@ namespace GameCommunicationPlugin.GlueControl.Views
                 }
             }
 
+            var lockScreenBoundsProperties = properties.GetOrCreateImdp(nameof(ViewModel.LockScreenBoundsToWorldSpace));
+            lockScreenBoundsProperties.Category = Localization.Texts.GridAndMarkings;
+            lockScreenBoundsProperties.DisplayName = Localization.Texts.LockScreenBoundsToWorldSpace;
+            lockScreenBoundsProperties.IsHiddenDelegate = (notused) => ViewModel.ShowScreenBounds == false;
+
+            DataUiGrid.Apply(properties);
             DataUiGrid.Refresh();
         }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GlueViewSettings.xaml.cs
@@ -119,7 +119,7 @@ namespace GameCommunicationPlugin.GlueControl.Views
                 var colorProperties = properties.GetOrCreateImdp(propertyName);
                 colorProperties.Category = Localization.Texts.GridAndMarkings;
                 colorProperties.IsHiddenDelegate = (notused) => ViewModel.SetBackgroundColor == false;
-
+                colorProperties.PreferredDisplayer = typeof(WpfDataUi.Controls.SliderDisplay);
             }
 
             var lockScreenBoundsProperties = properties.GetOrCreateImdp(nameof(ViewModel.LockScreenBoundsToWorldSpace));
@@ -128,6 +128,20 @@ namespace GameCommunicationPlugin.GlueControl.Views
             lockScreenBoundsProperties.IsHiddenDelegate = (notused) => ViewModel.ShowScreenBounds == false;
 
             DataUiGrid.Apply(properties);
+
+            ApplyColorSliderRange(nameof(ViewModel.BackgroundRed));
+            ApplyColorSliderRange(nameof(ViewModel.BackgroundGreen));
+            ApplyColorSliderRange(nameof(ViewModel.BackgroundBlue));
+            void ApplyColorSliderRange(string propertyName)
+            {
+                var member = GetMember(propertyName);
+                if (member != null)
+                {
+                    member.PropertiesToSetOnDisplayer[nameof(WpfDataUi.Controls.SliderDisplay.MinValue)] = 0.0;
+                    member.PropertiesToSetOnDisplayer[nameof(WpfDataUi.Controls.SliderDisplay.MaxValue)] = 255.0;
+                }
+            }
+
             DataUiGrid.Refresh();
         }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GlueViewSettingsViewModelTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GlueViewSettingsViewModelTests.cs
@@ -32,4 +32,44 @@ public class GlueViewSettingsViewModelTests
 
         viewModel.PolygonPointSnapSize.ShouldBeGreaterThan(0);
     }
+
+    [Theory]
+    [InlineData(-3999, 0)]
+    [InlineData(-1, 0)]
+    [InlineData(0, 0)]
+    [InlineData(255, 255)]
+    [InlineData(256, 255)]
+    [InlineData(10000, 255)]
+    public void BackgroundRed_OutOfRangeValue_ClampsTo0To255(int input, int expected)
+    {
+        var viewModel = new GlueViewSettingsViewModel();
+
+        viewModel.BackgroundRed = input;
+
+        viewModel.BackgroundRed.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(-3999, 0)]
+    [InlineData(10000, 255)]
+    public void BackgroundGreen_OutOfRangeValue_ClampsTo0To255(int input, int expected)
+    {
+        var viewModel = new GlueViewSettingsViewModel();
+
+        viewModel.BackgroundGreen = input;
+
+        viewModel.BackgroundGreen.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(-3999, 0)]
+    [InlineData(10000, 255)]
+    public void BackgroundBlue_OutOfRangeValue_ClampsTo0To255(int input, int expected)
+    {
+        var viewModel = new GlueViewSettingsViewModel();
+
+        viewModel.BackgroundBlue = input;
+
+        viewModel.BackgroundBlue.ShouldBe(expected);
+    }
 }


### PR DESCRIPTION
Fixes #2126.

The background-color R/G/B fields in Glue's view settings (screen-run overlay) accepted any int, including negatives and values over 255. That flowed unclamped into `CameraLogic.BackgroundRed/Green/Blue` → `Sprite.Red/Green/Blue`, which is undefined behavior for out-of-range floats on cast to the vertex-color byte.

- `GlueViewSettingsViewModel.BackgroundRed/Green/Blue` setters now clamp to `[0, 255]` (also protects against already-corrupt values in a persisted `CompilerSettings.json`, since `SetFrom` assigns through these setters).
- Swapped the background-color textboxes for `WpfDataUi`'s `SliderDisplay` (0-255 range), so the UI itself steers away from invalid values, per the issue's suggested solution.

## Test plan
- [x] `GlueViewSettingsViewModelTests`: new clamping tests, watched red (clamp disabled) then green.
- [x] Full `GlueUnitTests` suite (`Category!=BuildSmoke`): 705/705 passed.

Manual test: needed — opening VS for you.
1. Open `FRBDK/Glue/Glue with All.sln` **from this worktree**.
2. Run Glue, open any project, go to the view settings (screen-run overlay settings), enable "Set Background Color".
3. Confirm Red/Green/Blue are now sliders (0-255), and typing an out-of-range number into the box snaps back into range on losing focus.
