### PR TITLE
Route DialogCommands.ShowToast/HideToast through TaskManager.OnUiThread

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/DialogCommands.cs
@@ -1027,13 +1027,30 @@ partial class DialogCommands : IDialogCommands
 
     #region Toast
 
+    // Swappable so tests can pin the OnUiThread routing below without a live MainPanelControl (only ever
+    // constructed by real WPF startup - see GlueTestBootstrap). Same pattern as DialogService's *Impl seam.
+    internal static Action<string> ShowToastPanelImpl { get; set; } = DefaultShowToastPanel;
+    internal static Action HideToastPanelImpl { get; set; } = DefaultHideToastPanel;
+
+    private static void DefaultShowToastPanel(string text)
+    {
+        var panel = MainPanelControl.Self;
+        panel.ToastLabel.Content = text;
+        panel.Toast.Visibility = System.Windows.Visibility.Visible;
+    }
+
+    private static void DefaultHideToastPanel()
+    {
+        MainPanelControl.Self.Toast.Visibility = System.Windows.Visibility.Collapsed;
+    }
+
     CancellationTokenSource lastToastCancellation = null;
     public async void ShowToast(string text, TimeSpan? timeToShowToast = null)
     {
-        var panel = MainPanelControl.Self;
-
-        panel.ToastLabel.Content = text;
-        panel.Toast.Visibility = System.Windows.Visibility.Visible;
+        // ShowToast can be called from a background TaskManager task (e.g. an Edit Mode load or an
+        // add-object response) - see #2130, a WPF cross-thread crash from touching ToastLabel/Toast
+        // directly off the UI thread. Route through TaskManager.Self.OnUiThread like DialogService does.
+        TaskManager.Self.OnUiThread(() => ShowToastPanelImpl(text));
 
         if(lastToastCancellation != null)
         {
@@ -1063,8 +1080,7 @@ partial class DialogCommands : IDialogCommands
 
     public void HideToast()
     {
-        var panel = MainPanelControl.Self;
-        panel.Toast.Visibility = System.Windows.Visibility.Collapsed;
+        TaskManager.Self.OnUiThread(HideToastPanelImpl);
     }
 
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Controls/DialogCommandsToastTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Controls/DialogCommandsToastTests.cs
@@ -51,14 +51,24 @@ public class DialogCommandsToastTests : IDisposable
         TaskManager.UiThreadMarshaller = marshaller;
         string passedText = null;
         DialogCommands.ShowToastPanelImpl = text => passedText = text;
+        var hidden = new TaskCompletionSource<bool>();
+        DialogCommands.HideToastPanelImpl = () => hidden.TrySetResult(true);
 
         TaskManager.Self.IsOnUiThread.ShouldBeFalse();
-        new DialogCommands().ShowToast("hello world", TimeSpan.FromMilliseconds(1));
-        // ShowToast is async void; give the pre-await portion a chance to run before asserting.
-        await Task.Yield();
+        // ShowToast is async void, but it runs synchronously up to its first await (Task.Delay) before
+        // returning here - so the OnUiThread call for the show itself has already happened.
+        new DialogCommands().ShowToast("hello world", TimeSpan.FromMilliseconds(10));
 
         passedText.ShouldBe("hello world");
         marshaller.InvokeActionCallCount.ShouldBe(1);
+
+        // Drain the toast's own real-time auto-hide before the test ends instead of leaving its
+        // Task.Delay pending - an earlier version of this test used a long delay to dodge that, but the
+        // leftover timer kept the test host process alive until it fired against already-restored
+        // (real, WPF-touching) impls from a later test's Dispose(), NRE-ing there (issue #2130 PR).
+        var completed = await Task.WhenAny(hidden.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        completed.ShouldBe(hidden.Task, "the toast's auto-hide should have fired via HideToastPanelImpl within 5 seconds");
+        marshaller.InvokeActionCallCount.ShouldBe(2);
     }
 
     [Fact]

--- a/FRBDK/Glue/Tests/GlueUnitTests/Controls/DialogCommandsToastTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Controls/DialogCommandsToastTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces;
+using GlueUnitTests.Tasks;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+
+namespace GlueUnitTests.Controls;
+
+// Covers issue #2130: ShowToast/HideToast used to touch MainPanelControl's WPF elements directly, so a
+// call reached from a background TaskManager task (e.g. an Edit Mode load, or an add-object failure
+// response) crashed Glue with a WPF cross-thread InvalidOperationException. Both should route through
+// TaskManager.Self.OnUiThread like DialogService does (see DialogServiceTests) instead of touching WPF
+// directly - shares TaskManagerSequentialCollection since both mutate TaskManager's process-wide
+// UiThreadMarshaller state.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class DialogCommandsToastTests : IDisposable
+{
+    private readonly Action<string> _originalShowToastPanelImpl = DialogCommands.ShowToastPanelImpl;
+    private readonly Action _originalHideToastPanelImpl = DialogCommands.HideToastPanelImpl;
+    private readonly IUiThreadMarshaller _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+    public DialogCommandsToastTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    public void Dispose()
+    {
+        DialogCommands.ShowToastPanelImpl = _originalShowToastPanelImpl;
+        DialogCommands.HideToastPanelImpl = _originalHideToastPanelImpl;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+    }
+
+    private class RecordingInlineMarshaller : IUiThreadMarshaller
+    {
+        public int InvokeActionCallCount;
+
+        public void Invoke(Action action) { InvokeActionCallCount++; action(); }
+        public T Invoke<T>(Func<T> func) => func();
+        public Task Invoke(Func<Task> func) => func();
+        public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+
+    [Fact]
+    public async Task ShowToast_ShouldRouteThroughOnUiThread_WhenNotOnUiThread()
+    {
+        var marshaller = new RecordingInlineMarshaller();
+        TaskManager.UiThreadMarshaller = marshaller;
+        string passedText = null;
+        DialogCommands.ShowToastPanelImpl = text => passedText = text;
+
+        TaskManager.Self.IsOnUiThread.ShouldBeFalse();
+        new DialogCommands().ShowToast("hello world", TimeSpan.FromMilliseconds(1));
+        // ShowToast is async void; give the pre-await portion a chance to run before asserting.
+        await Task.Yield();
+
+        passedText.ShouldBe("hello world");
+        marshaller.InvokeActionCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void HideToast_ShouldRouteThroughOnUiThread_WhenNotOnUiThread()
+    {
+        var marshaller = new RecordingInlineMarshaller();
+        TaskManager.UiThreadMarshaller = marshaller;
+        var wasHidden = false;
+        DialogCommands.HideToastPanelImpl = () => wasHidden = true;
+
+        TaskManager.Self.IsOnUiThread.ShouldBeFalse();
+        new DialogCommands().HideToast();
+
+        wasHidden.ShouldBeTrue();
+        marshaller.InvokeActionCallCount.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
`DialogCommands.ShowToast`/`HideToast` mutated `MainPanelControl`'s WPF elements (`ToastLabel.Content`, `Toast.Visibility`) directly, with no thread check. `ShowToast` is also called from background `TaskManager` tasks (an Edit Mode load, an add-object failure response), so a call from off the UI thread threw a WPF cross-thread `InvalidOperationException`. Since `ShowToast` is `async void`, that exception went unhandled and crashed Glue.

Routes both through `TaskManager.Self.OnUiThread(...)`, the same seam `DialogService` already uses for `ShowMessage`/`ShowConfirm`/etc. for this exact crash class (#1894/#1921). Added a swappable `ShowToastPanelImpl`/`HideToastPanelImpl` seam (mirroring `DialogService`'s `*Impl` pattern) so the routing is unit-testable without a live `MainPanelControl`.

Fixes #2130

## Testing
- New `DialogCommandsToastTests` pins both methods routing through `TaskManager.UiThreadMarshaller` when off the UI thread. Verified red (reverted the `OnUiThread` wrap, watched both tests fail) before re-adding the fix.
- Full `GlueUnitTests` suite (`Category!=BuildSmoke`, 707 tests) green from a clean build.

Manual test: not needed — behavior-preserving on the UI thread (still the same direct WPF calls, just marshalled), and the new tests cover the off-thread routing that was the actual bug.
