### PR TITLE
Fix clicking an object in Edit Mode selecting the Screen folder instead

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/NodeViewModel.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/NodeViewModel.cs
@@ -442,7 +442,14 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
 
         internal NodeViewModel GetNodeByTag(object tag)
         {
-            if(tag == this.Tag)
+            if(tag == null)
+            {
+                // Directory/category nodes (Screens, Entities, folders) have a null Tag, so a null
+                // search tag must never match them - otherwise callers passing an unresolved object
+                // (e.g. a NamedObjectSave that couldn't be found) land on an arbitrary untagged node.
+                return null;
+            }
+            else if(tag == this.Tag)
             {
                 return this;
             }

--- a/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/SearchNavigationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/SearchNavigationTests.cs
@@ -254,6 +254,17 @@ public class SearchNavigationTests
         _vm.GetTreeNodeByTag(tag).ShouldBeNull();
     }
 
+    [WpfFact]
+    public void GetTreeNodeByTag_NullTag_DoesNotMatchUntaggedFolderNodes()
+    {
+        // Folder/category nodes (like a Screen's directory node) have a null Tag. An unresolved
+        // selection (e.g. a NamedObjectSave the game couldn't be matched to) must not land on one
+        // of these - see issue #2131 (clicking an object in Edit Mode selected the Screen folder).
+        AddDir(_vm.ScreenRootNode, "GameScreen");
+
+        _vm.GetTreeNodeByTag(null).ShouldBeNull();
+    }
+
     #endregion
 
     #region IsInTreeView


### PR DESCRIPTION
## Root cause

`NodeViewModel.GetNodeByTag` matched with `tag == this.Tag`. Folder/category nodes (Screens, Entities,
GlobalContent, and plain directory nodes) all have `Tag == null`, so calling it with a `null` tag matched
the first untagged node in the walk instead of "not found".

Clicking an object in the embedded Edit Mode game preview sends the clicked `NamedObjectSave` to Glue by
name (`CommandReceiver.Convert`, `GlueControl/CommandReceiving/CommandReceiver.cs`). When that name can't
be resolved against the project (e.g. a dynamically-created/list-member instance not backed by a real
`NamedObjectSave`), `Convert` adds a `null` to the list instead of filtering it out. That `null` flows into
`GlueState.CurrentNamedObjectSaves` → `TreeNodeByTag(null)` → `GetNodeByTag(null)`, which returned the
Screens root folder — matching the reported symptom exactly.

## Fix

`GetNodeByTag` now returns `null` immediately when the search tag is `null`, matching the contract already
used elsewhere in the codebase (`SelectionLogic.SelectByTag` special-cases `value == null` before calling
in).

## Testing

Added `GetTreeNodeByTag_NullTag_DoesNotMatchUntaggedFolderNodes` (`SearchNavigationTests.cs`) — fails
against the old code (`GetTreeNodeByTag(null)` returns the "Screens" folder node), passes with the fix.
Full non-BuildSmoke suite (706 tests) green from a clean build.

Manual test: not needed — the unit test reproduces the exact reported symptom (tag lookup returning the
Screens folder), and the fix is a pure guard with no other behavior change. The original trigger (an
unresolved `NamedObjectSave` name from the game) is intermittent per the issue's own report ("restarting
fixed it") and can't be reliably forced for a manual repro.

Closes #2131
