### PR TITLE
Keep right panel open with empty state when selecting folders

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/MainPropertyGridPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/MainPropertyGridPlugin.cs
@@ -114,37 +114,35 @@ namespace OfficialPlugins.VariableDisplay
             var nos = GlueState.Self.CurrentNamedObjectSave;
             var element = GlueState.Self.CurrentElement;
 
-            if (nos != null)
-            {
-                HandleNamedObjectSelect(nos, element);
-            }
-            else if(GlueState.Self.CurrentStateSave != null || GlueState.Self.CurrentStateSaveCategory != null)
-            {
-                // For now we don't handle showing states, so let's hide it so the user doens't think
-                // they are editing states
-                variableTab?.Hide();
-            }
-            else if(GlueState.Self.CurrentElement != null && 
-                (selectedTreeNode?.IsRootCustomVariablesNode() == true 
-                // Feb 18, 2021 - It's annoying to have to select the Variables
-                // node. The user should be able to see variables just by selecting
-                // the entity itself.
-                || selectedTreeNode?.IsElementNode() == true))
-            {
-                ShowVariablesForCurrentElement();
-            }
-            else if(GlueState.Self.CurrentReferencedFileSave != null)
-            {
-                variableTab?.Hide();
-                ShowPropertiesForReferencedFileSave(GlueState.Self.CurrentReferencedFileSave);
-            }
-            else
-            {
-                variableTab?.Hide();
-                settingsTab?.Hide();
+            var mode = VariablePanelModeLogic.DetermineMode(
+                nos,
+                element,
+                GlueState.Self.CurrentStateSave,
+                GlueState.Self.CurrentStateSaveCategory,
+                selectedTreeNode,
+                GlueState.Self.CurrentReferencedFileSave);
 
+            switch (mode)
+            {
+                case VariablePanelMode.NamedObject:
+                    HandleNamedObjectSelect(nos, element);
+                    break;
+                case VariablePanelMode.Element:
+                    ShowVariablesForCurrentElement();
+                    break;
+                case VariablePanelMode.ReferencedFile:
+                    // Keep the Variables tab open (with an empty state) rather than hiding it -
+                    // hiding/re-showing it collapses and re-expands the right panel's width, which
+                    // flickers the whole main editor layout on every selection change:
+                    ShowEmptyVariables();
+                    ShowPropertiesForReferencedFileSave(GlueState.Self.CurrentReferencedFileSave);
+                    break;
+                case VariablePanelMode.Empty:
+                default:
+                    ShowEmptyVariables();
+                    settingsTab?.Hide();
+                    break;
             }
-
         }
 
         private void ShowPropertiesForReferencedFileSave(ReferencedFileSave referencedFileSave)
@@ -181,6 +179,7 @@ namespace OfficialPlugins.VariableDisplay
             AddOrShowVariableGrid();
 
             variableViewModel.CanAddVariable = true;
+            variableViewModel.HasNoVariablesToShow = false;
             VariableGrid.DataUiGrid.Instance = GlueState.Self.CurrentElement;
             ElementVariableShowingLogic.UpdateShownVariables(VariableGrid.DataUiGrid, GlueState.Self.CurrentElement);
         }
@@ -188,12 +187,12 @@ namespace OfficialPlugins.VariableDisplay
         private void HandleNamedObjectSelect(NamedObjectSave namedObject, GlueElement currentElement)
         {
             // Update August 17, 2021
-            // If it's a list, don't show the Variables tab. It's never got anything:
+            // If it's a list, don't show the Variables tab's content. It's never got anything:
             var hide = namedObject.IsList;
 
             if(hide)
             {
-                variableTab?.Hide();
+                ShowEmptyVariables();
                 return;
             }
 
@@ -266,6 +265,7 @@ namespace OfficialPlugins.VariableDisplay
             AddOrShowVariableGrid();
             // can't add variables on the instance:
             variableViewModel.CanAddVariable = false;
+            variableViewModel.HasNoVariablesToShow = false;
 
             // Setting the instance resets all categories. Categories get replaced
             // in the UpdateShownVariables method, so do we even need the instance set here?
@@ -346,6 +346,18 @@ namespace OfficialPlugins.VariableDisplay
                 //variableTab.Focus();
             }
             variableTab.Show();
+        }
+
+        // Keeps the Variables tab open showing an empty state, instead of hiding the tab. Hiding
+        // (removing) the tab collapses the right panel's width to 0, then re-showing it snaps the
+        // width back open - flickering the whole main editor layout on every selection change that
+        // toggles in/out of "nothing to show" (folders, states, lists, etc.). See GitHub issue #2134.
+        private void ShowEmptyVariables()
+        {
+            AddOrShowVariableGrid();
+            variableViewModel.CanAddVariable = false;
+            variableViewModel.HasNoVariablesToShow = true;
+            VariableGrid.DataUiGrid.Instance = null;
         }
     }
 }

--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/VariablePanelModeLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/VariablePanelModeLogic.cs
@@ -1,0 +1,54 @@
+using FlatRedBall.Glue.FormHelpers;
+using FlatRedBall.Glue.SaveClasses;
+
+namespace OfficialPlugins.VariableDisplay
+{
+    public enum VariablePanelMode
+    {
+        NamedObject,
+        Element,
+        ReferencedFile,
+        Empty
+    }
+
+    public static class VariablePanelModeLogic
+    {
+        public static VariablePanelMode DetermineMode(
+            NamedObjectSave currentNamedObjectSave,
+            GlueElement currentElement,
+            StateSave currentStateSave,
+            StateSaveCategory currentStateSaveCategory,
+            ITreeNode selectedTreeNode,
+            ReferencedFileSave currentReferencedFileSave)
+        {
+            if (currentNamedObjectSave != null)
+            {
+                // Lists never have properties to show:
+                return currentNamedObjectSave.IsList ? VariablePanelMode.Empty : VariablePanelMode.NamedObject;
+            }
+            else if (currentStateSave != null || currentStateSaveCategory != null)
+            {
+                // For now we don't handle showing states, so we show the empty state so the user
+                // doesn't think they are editing states
+                return VariablePanelMode.Empty;
+            }
+            else if (currentElement != null &&
+                (selectedTreeNode?.IsRootCustomVariablesNode() == true
+                // It's annoying to have to select the Variables node - the user should be able to
+                // see variables just by selecting the entity/screen itself.
+                || selectedTreeNode?.IsElementNode() == true))
+            {
+                return VariablePanelMode.Element;
+            }
+            else if (currentReferencedFileSave != null)
+            {
+                return VariablePanelMode.ReferencedFile;
+            }
+            else
+            {
+                // Nothing selected, or something without properties (e.g. a folder):
+                return VariablePanelMode.Empty;
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/ViewModels/VariableViewModel.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/ViewModels/VariableViewModel.cs
@@ -16,5 +16,17 @@ namespace OfficialPlugins.PropertyGrid.ViewModels
 
         [DependsOn(nameof(CanAddVariable))]
         public Visibility AddVariableVisibility => CanAddVariable.ToVisibility();
+
+        public bool HasNoVariablesToShow
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        [DependsOn(nameof(HasNoVariablesToShow))]
+        public Visibility EmptyStateVisibility => HasNoVariablesToShow.ToVisibility();
+
+        [DependsOn(nameof(HasNoVariablesToShow))]
+        public Visibility DataUiGridVisibility => (!HasNoVariablesToShow).ToVisibility();
     }
 }

--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/Views/VariableView.xaml
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/Views/VariableView.xaml
@@ -14,7 +14,7 @@
     </Grid.RowDefinitions>
 
     <wpfdataui:DataUiGrid x:Name="DataUiGrid" Grid.Row="0" Visibility="{Binding DataUiGridVisibility}"></wpfdataui:DataUiGrid>
-    <TextBlock Grid.Row="0" Text="No properties available" HorizontalAlignment="Center" VerticalAlignment="Top"
+    <TextBlock Grid.Row="0" Text="No variables available" HorizontalAlignment="Center" VerticalAlignment="Top"
                Margin="0,12,0,0" Foreground="Gray" Visibility="{Binding EmptyStateVisibility}" />
     <Button Grid.Row="1" Visibility="{Binding AddVariableVisibility}" Click="AddVariableButtonClick" Content="{x:Static localization:Texts.VariableCreate}" />
   </Grid>

--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/Views/VariableView.xaml
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/Views/VariableView.xaml
@@ -13,7 +13,9 @@
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
 
-    <wpfdataui:DataUiGrid x:Name="DataUiGrid"></wpfdataui:DataUiGrid>
+    <wpfdataui:DataUiGrid x:Name="DataUiGrid" Grid.Row="0" Visibility="{Binding DataUiGridVisibility}"></wpfdataui:DataUiGrid>
+    <TextBlock Grid.Row="0" Text="No properties available" HorizontalAlignment="Center" VerticalAlignment="Top"
+               Margin="0,12,0,0" Foreground="Gray" Visibility="{Binding EmptyStateVisibility}" />
     <Button Grid.Row="1" Visibility="{Binding AddVariableVisibility}" Click="AddVariableButtonClick" Content="{x:Static localization:Texts.VariableCreate}" />
   </Grid>
 </UserControl>

--- a/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/VariablePanelModeLogicTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/VariablePanelModeLogicTests.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using System.Linq;
+using FlatRedBall.Glue.FormHelpers;
+using FlatRedBall.Glue.SaveClasses;
+using OfficialPlugins.VariableDisplay;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.PropertyGrid;
+
+// GitHub issue #2134: selecting a folder (or anything else with no properties to show) hid the
+// Variables tab entirely, which collapsed the right panel to 0 width and snapped it back open on
+// the next selection - flickering the whole main editor layout. VariablePanelModeLogic.DetermineMode
+// is the decision extracted out of MainPropertyGridPlugin.HandleItemSelect so the "what should the
+// panel show" branching can be pinned without standing up GlueState/WPF.
+public class VariablePanelModeLogicTests
+{
+    private sealed class FakeTreeNode : ITreeNode
+    {
+        public TreeNodeType TreeNodeType { get; set; }
+        public object Tag { get; set; }
+        public ITreeNode Parent => null;
+        public string Text { get; set; } = "";
+        public IEnumerable<ITreeNode> Children => Enumerable.Empty<ITreeNode>();
+        public void Remove(ITreeNode child) { }
+        public void Add(ITreeNode child) { }
+        public ITreeNode FindByName(string name) => null;
+        public void RemoveGlobalContentTreeNodesIfDoesntExist(ITreeNode treeNode) { }
+        public ITreeNode FindByTagRecursive(object tag) => null;
+        public void SortByTextConsideringDirectories() { }
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnEmpty_WhenFolderSelected()
+    {
+        // A folder node selection means none of the "current" GlueState values are set, and the
+        // selected node is neither an element node nor the root custom variables node:
+        var folderNode = new FakeTreeNode { TreeNodeType = TreeNodeType.GeneralDirectoryNode };
+
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSave: null,
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: folderNode,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.Empty);
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnEmpty_WhenNamedObjectIsList()
+    {
+        var nos = new NamedObjectSave { SourceType = SourceType.FlatRedBallType, SourceClassType = "PositionedObjectList<T>" };
+
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSave: nos,
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: null,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.Empty);
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnNamedObject_WhenNamedObjectIsNotList()
+    {
+        var nos = new NamedObjectSave { SourceType = SourceType.FlatRedBallType, SourceClassType = "Sprite" };
+
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSave: nos,
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: null,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.NamedObject);
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnEmpty_WhenStateSelected()
+    {
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSave: null,
+            currentElement: null,
+            currentStateSave: new StateSave(),
+            currentStateSaveCategory: null,
+            selectedTreeNode: null,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.Empty);
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnEmpty_WhenStateCategorySelected()
+    {
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSave: null,
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: new StateSaveCategory(),
+            selectedTreeNode: null,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.Empty);
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnElement_WhenElementNodeSelected()
+    {
+        var screen = new ScreenSave { Name = "Screens/GameScreen/GameScreen" };
+        var elementNode = new FakeTreeNode { TreeNodeType = TreeNodeType.ScreenNode };
+
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSave: null,
+            currentElement: screen,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: elementNode,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.Element);
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnEmpty_WhenElementSetButUnrelatedNodeSelected()
+    {
+        // Regression guard: an element being "current" isn't enough on its own - e.g. a folder
+        // under the currently-open screen/entity shouldn't show that element's variables:
+        var screen = new ScreenSave { Name = "Screens/GameScreen/GameScreen" };
+        var folderNode = new FakeTreeNode { TreeNodeType = TreeNodeType.GeneralDirectoryNode };
+
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSave: null,
+            currentElement: screen,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: folderNode,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.Empty);
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnReferencedFile_WhenReferencedFileSelected()
+    {
+        var rfs = new ReferencedFileSave { Name = "GlobalContent/Test.png" };
+
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSave: null,
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: null,
+            currentReferencedFileSave: rfs);
+
+        mode.ShouldBe(VariablePanelMode.ReferencedFile);
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnEmpty_WhenNothingSelected()
+    {
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSave: null,
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: null,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.Empty);
+    }
+}


### PR DESCRIPTION
Closes #2134

Selecting a folder (or a state, a list NOS, etc.) hid the Variables tab entirely. Hiding removes it from the right panel's tab container, which snaps the panel's width to 0; showing it again snaps the width back open. That collapse/expand on every selection change was the flicker.

Now the Variables tab stays open and just shows a "No properties available" message when there's nothing to display, so the panel width never changes on selection.

The branching that decides what the panel should show (`HandleItemSelect`) was pulled into a pure `VariablePanelModeLogic.DetermineMode`, pinned with unit tests, since the WPF/GlueState-coupled plugin code itself isn't a testable seam.

Manual test: needed (WPF layout/visual change, not covered by the unit tests).
1. Open a project in Glue.
2. Select a folder in the tree - Variables panel should stay the same width and show "No properties available" instead of collapsing.
3. Select an object with properties again - panel should not flicker, just swap content.
4. Also check states and a list-type object - same "no properties" behavior.
