### PR TITLE
Fix .achx global-content live reload not updating live Sprites

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
@@ -118,7 +118,7 @@ namespace FlatRedBall
         public int Version;
     }
 
-    [SyntaxVersion(Version=68)]
+    [SyntaxVersion(Version=69)]
     public static partial class FlatRedBallServices
     {
         internal static SingleThreadSynchronizationContext singleThreadSynchronizationContext;

--- a/Engines/FlatRedBallXNA/FlatRedBall/Graphics/Animation/AnimationChainList.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Graphics/Animation/AnimationChainList.cs
@@ -138,6 +138,21 @@ namespace FlatRedBall.Graphics.Animation
             return newList;
         }
 
+        /// <summary>
+        /// Replaces the contents of this list with the contents of newValues, keeping this instance's
+        /// identity so existing references to it (such as a Sprite's AnimationChains) see the update
+        /// without needing to be reassigned.
+        /// </summary>
+        public void ReplaceValues(AnimationChainList newValues)
+        {
+            Clear();
+            AddRange(newValues);
+
+            mName = newValues.mName;
+            mFileRelativeTextures = newValues.mFileRelativeTextures;
+            mTimeMeasurementUnit = newValues.mTimeMeasurementUnit;
+        }
+
 		void IDisposable.Dispose()
 		{
 			// No need to do anything here - all referenced textures are

--- a/FRBDK/Glue/CLAUDE.md
+++ b/FRBDK/Glue/CLAUDE.md
@@ -9,6 +9,12 @@ deprecated and being stripped out: write new user-facing text as a plain string 
 touch a line that reads `L.Texts.Something`, inline the English text instead of leaving it or adding a
 new resource.
 
+## Behavioral Fixes Need a Test, Not Just a Manual Retest
+
+A fix to Glue behavior (RefreshManager, CodeGeneration, etc.) isn't done until a `GlueUnitTests` test
+exercises it — one that fails against the old code and passes against the new. Don't substitute "it
+compiles" plus asking the user to manually rebuild/retest for this.
+
 ## Refactoring Approach
 
 See [REFACTORING.md](REFACTORING.md) for the full refactoring philosophy, checklist, and progress notes.

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
@@ -180,17 +180,6 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                 var firstRfs = rfses.FirstOrDefault();
                 var isGlobalContent = rfses.Any(item => item.GetContainer() == null);
 
-                // TEMPORARY DIAGNOSTIC - remove once the achx live-reload issue is confirmed fixed.
-                try
-                {
-                    var dump = string.Join(" | ", rfses.Select(item =>
-                        $"Name={item.Name} Container={item.GetContainer()?.Name ?? "(null)"} InstanceName={item.GetInstanceName()} IsSharedStatic={item.IsSharedStatic}"));
-                    System.IO.File.AppendAllText(
-                        @"C:\Users\Vic Personal\AppData\Local\Temp\claude\C--Users-Vic-Personal-Documents-GitHub-FlatRedBall\c3dbb8d3-7415-4b77-bd64-5a9ec0f1c9a7\scratchpad\glue-refresh-diagnostic.log",
-                        $"{DateTime.Now:HH:mm:ss.fff} HandleFileChanged({fileName}): isGlobalContent={isGlobalContent}, firstRfs.Name={firstRfs?.Name}, firstRfs.InstanceName={firstRfs?.GetInstanceName()}. rfses: {dump}{Environment.NewLine}");
-                }
-                catch { }
-
                 bool canSendCommands = ViewModel.IsGenerateGlueControlManagerInGame1Checked;
 
                 var handled = false;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
@@ -302,10 +302,14 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                         await Task.Delay(500);
 
                         // it's part of global content and can be reloaded, so let's just tell
-                        // it to reload:
+                        // it to reload. GlobalContent.GetFile/Reload key off the folder-qualified
+                        // instance name (e.g. "Entities_Player_AnimationChainListFile"), not the bare
+                        // stripped file name used above for ForceReloadFileDto - sending the bare name
+                        // here made GetFile silently return null for any global file nested in a
+                        // subfolder, so GlobalContent.Reload(null) matched nothing and never reloaded.
                         await CommandSender.Self.Send(new ReloadGlobalContentDto
                         {
-                            StrippedGlobalContentFileName = strippedName
+                            StrippedGlobalContentFileName = firstRfs.GetInstanceName()
                         });
 
                         printOutput($"Reloading global file {strippedName}");

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
@@ -302,14 +302,10 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                         await Task.Delay(500);
 
                         // it's part of global content and can be reloaded, so let's just tell
-                        // it to reload. GlobalContent.GetFile/Reload key off the folder-qualified
-                        // instance name (e.g. "Entities_Player_AnimationChainListFile"), not the bare
-                        // stripped file name used above for ForceReloadFileDto - sending the bare name
-                        // here made GetFile silently return null for any global file nested in a
-                        // subfolder, so GlobalContent.Reload(null) matched nothing and never reloaded.
+                        // it to reload:
                         await CommandSender.Self.Send(new ReloadGlobalContentDto
                         {
-                            StrippedGlobalContentFileName = firstRfs.GetInstanceName()
+                            StrippedGlobalContentFileName = GetGlobalContentReloadIdentifier(firstRfs)
                         });
 
                         printOutput($"Reloading global file {strippedName}");
@@ -335,6 +331,16 @@ namespace GameCommunicationPlugin.GlueControl.Managers
             }
             return false;
         }
+
+        /// <summary>
+        /// The identifier to send in a ReloadGlobalContentDto for referencedFile. This must match what
+        /// GlobalContent.GetFile's generated switch keys on (ReferencedFileSaveCodeGenerator.GenerateGetFileMethodByName
+        /// uses referencedFile.GetInstanceName() as the case label) - a bare, path-stripped file name only
+        /// matches for global files with no container folder; anything nested (e.g. Entities/Player/Foo.achx,
+        /// whose instance name is "Entities_Player_Foo") would make GetFile return null and Reload silently no-op.
+        /// </summary>
+        internal static string GetGlobalContentReloadIdentifier(ReferencedFileSave referencedFile) =>
+            referencedFile.GetInstanceName();
 
         private bool GetIfShouldReactToFileChange(FilePath filePath)
         {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
@@ -180,6 +180,17 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                 var firstRfs = rfses.FirstOrDefault();
                 var isGlobalContent = rfses.Any(item => item.GetContainer() == null);
 
+                // TEMPORARY DIAGNOSTIC - remove once the achx live-reload issue is confirmed fixed.
+                try
+                {
+                    var dump = string.Join(" | ", rfses.Select(item =>
+                        $"Name={item.Name} Container={item.GetContainer()?.Name ?? "(null)"} InstanceName={item.GetInstanceName()} IsSharedStatic={item.IsSharedStatic}"));
+                    System.IO.File.AppendAllText(
+                        @"C:\Users\Vic Personal\AppData\Local\Temp\claude\C--Users-Vic-Personal-Documents-GitHub-FlatRedBall\c3dbb8d3-7415-4b77-bd64-5a9ec0f1c9a7\scratchpad\glue-refresh-diagnostic.log",
+                        $"{DateTime.Now:HH:mm:ss.fff} HandleFileChanged({fileName}): isGlobalContent={isGlobalContent}, firstRfs.Name={firstRfs?.Name}, firstRfs.InstanceName={firstRfs?.GetInstanceName()}. rfses: {dump}{Environment.NewLine}");
+                }
+                catch { }
+
                 bool canSendCommands = ViewModel.IsGenerateGlueControlManagerInGame1Checked;
 
                 var handled = false;
@@ -303,9 +314,10 @@ namespace GameCommunicationPlugin.GlueControl.Managers
 
                         // it's part of global content and can be reloaded, so let's just tell
                         // it to reload:
+                        var globalRfs = SelectGlobalReferencedFile(rfses, firstRfs);
                         await CommandSender.Self.Send(new ReloadGlobalContentDto
                         {
-                            StrippedGlobalContentFileName = GetGlobalContentReloadIdentifier(firstRfs)
+                            StrippedGlobalContentFileName = GetGlobalContentReloadIdentifier(globalRfs)
                         });
 
                         printOutput($"Reloading global file {strippedName}");
@@ -341,6 +353,19 @@ namespace GameCommunicationPlugin.GlueControl.Managers
         /// </summary>
         internal static string GetGlobalContentReloadIdentifier(ReferencedFileSave referencedFile) =>
             referencedFile.GetInstanceName();
+
+        /// <summary>
+        /// The same physical file can be referenced by more than one ReferencedFileSave - e.g. a shared
+        /// .achx declared as global content AND separately referenced (also as IsSharedStatic) by a test
+        /// entity for standalone testing. Only the entry with no container is the actual global one whose
+        /// GetInstanceName() matches GlobalContent.GetFile's switch keys (this mirrors the same
+        /// GetContainer() == null check HandleFileChanged already uses to compute isGlobalContent) - a
+        /// non-global entry's instance name is relative to ITS OWN container instead, which silently
+        /// doesn't match any GetFile case.
+        /// </summary>
+        internal static ReferencedFileSave SelectGlobalReferencedFile(
+            IEnumerable<ReferencedFileSave> referencedFiles, ReferencedFileSave fallback) =>
+            referencedFiles.FirstOrDefault(item => item.GetContainer() == null) ?? fallback;
 
         private bool GetIfShouldReactToFileChange(FilePath filePath)
         {

--- a/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
@@ -1023,9 +1023,27 @@ namespace FlatRedBall.Glue.CodeGeneration
                     GetInitializationForReferencedFile(referencedFile, container, codeBlock, loadType);
                     codeBlock.Line($"FlatRedBall.FlatRedBallServices.ReplaceTexture(oldTexture, {referencedFile.GetInstanceName()});");
                 }
+                else if (ati?.QualifiedRuntimeTypeName.QualifiedType == "FlatRedBall.Graphics.Animation.AnimationChainList")
+                {
+                    // AnimationChainList is referenced directly by live objects (e.g. a Sprite's
+                    // AnimationChains), so reloading can't just reassign this field to a newly-loaded
+                    // instance - anything already holding the old reference would keep seeing stale data.
+                    // Instead we mutate the existing instance in place and keep the content manager's
+                    // cache pointed at that same instance so the next reload can find it again.
+                    var instanceName = referencedFile.GetInstanceName();
+                    var fileToLoad = GetFileToLoadForRfs(referencedFile, ati);
+                    var newlyLoadedVariable = $"newlyLoaded{instanceName}";
+
+                    codeBlock.Line($"var cm = FlatRedBall.FlatRedBallServices.GetContentManagerByName(\"Global\");");
+                    codeBlock.Line($"cm.UnloadAsset({instanceName});");
+                    codeBlock.Line($"var {newlyLoadedVariable} = FlatRedBall.FlatRedBallServices.Load<FlatRedBall.Graphics.Animation.AnimationChainList>(\"{fileToLoad}\");");
+                    codeBlock.Line($"{instanceName}.ReplaceValues({newlyLoadedVariable});");
+                    codeBlock.Line($"cm.UnloadAsset({newlyLoadedVariable});");
+                    codeBlock.Line($"cm.AddDisposable(\"{fileToLoad}\", {instanceName});");
+                }
                 else if (ati?.CustomReloadFunc != null)
                 {
-                    var line = 
+                    var line =
                         ati.CustomReloadFunc(container, null, referencedFile, "Global");
 
                     codeBlock.Line(line);

--- a/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
@@ -1023,13 +1023,19 @@ namespace FlatRedBall.Glue.CodeGeneration
                     GetInitializationForReferencedFile(referencedFile, container, codeBlock, loadType);
                     codeBlock.Line($"FlatRedBall.FlatRedBallServices.ReplaceTexture(oldTexture, {referencedFile.GetInstanceName()});");
                 }
-                else if (ati?.QualifiedRuntimeTypeName.QualifiedType == "FlatRedBall.Graphics.Animation.AnimationChainList")
+                else if (ati?.QualifiedRuntimeTypeName.QualifiedType == "FlatRedBall.Graphics.Animation.AnimationChainList" &&
+                    (GlueState.Self.CurrentGlueProject.FileVersion >= (int)GlueProjectSave.GluxVersions.AnimationChainListHasReplaceValues ||
+                    GlueState.Self.CurrentMainProject.IsFrbSourceLinked()))
                 {
                     // AnimationChainList is referenced directly by live objects (e.g. a Sprite's
                     // AnimationChains), so reloading can't just reassign this field to a newly-loaded
                     // instance - anything already holding the old reference would keep seeing stale data.
                     // Instead we mutate the existing instance in place and keep the content manager's
                     // cache pointed at that same instance so the next reload can find it again.
+                    // ReplaceValues only exists on engines new enough to declare
+                    // GluxVersions.AnimationChainListHasReplaceValues (or when source-linked, which always
+                    // builds against current engine source) - older/unlinked projects fall through to the
+                    // reassign-the-field codegen below, same as before this method existed.
                     var instanceName = referencedFile.GetInstanceName();
                     var fileToLoad = GetFileToLoadForRfs(referencedFile, ati);
                     var newlyLoadedVariable = $"newlyLoaded{instanceName}";

--- a/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
+++ b/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
@@ -207,6 +207,12 @@ namespace FlatRedBall.Glue.SaveClasses
             // now implement.
             GumHasFrbRuntimeInterfaces = 68,
 
+            // August 20, 2026 - AnimationChainList has ReplaceValues, which the .achx global-content
+            // reload codegen now calls to update an existing instance in place (instead of reassigning
+            // the field to a new instance, which live objects like Sprites had already grabbed a
+            // reference away from).
+            AnimationChainListHasReplaceValues = 69,
+
             // Stop! If adding an entry here, modify SyntaxVersionAttribute on FlatRedBallServices
             // and LatestVersion down below
             // and update the docs
@@ -216,7 +222,7 @@ namespace FlatRedBall.Glue.SaveClasses
 
         #region Versions
 
-        public const int LatestVersion = (int)GluxVersions.GumHasFrbRuntimeInterfaces;
+        public const int LatestVersion = (int)GluxVersions.AnimationChainListHasReplaceValues;
 
         public int FileVersion { get; set; }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/GlobalContentReloadIdentifierTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/GlobalContentReloadIdentifierTests.cs
@@ -3,6 +3,7 @@ using FlatRedBall.Glue.SaveClasses;
 using GameCommunicationPlugin.GlueControl.Managers;
 using Shouldly;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace GlueUnitTests.GlueControlTests;
@@ -16,6 +17,12 @@ namespace GlueUnitTests.GlueControlTests;
 // doesn't match any switch case, so GetFile returned null and GlobalContent.Reload(null) silently
 // did nothing - a live .achx (or any nested global content) edit reloaded the file on disk but never
 // visibly updated the running game.
+//
+// Fixing the identifier's formatting alone wasn't enough: the same physical file can also be
+// separately referenced by one or more elements (e.g. a test entity referencing a shared .achx
+// directly for standalone testing), each producing its own non-global ReferencedFileSave.
+// HandleFileChanged's firstRfs was whichever of those happened to come first - not necessarily the
+// actual global entry - so SelectGlobalReferencedFileTests reproduces that multi-reference scenario.
 public class GlobalContentReloadIdentifierTests : IDisposable
 {
     private readonly GlueProjectSave _originalGlueProject;
@@ -23,10 +30,6 @@ public class GlobalContentReloadIdentifierTests : IDisposable
     public GlobalContentReloadIdentifierTests()
     {
         _originalGlueProject = ObjectFinder.Self.GlueProject;
-        // GetInstanceName()'s "GlobalContent/" folder-qualification path only applies when the
-        // referenced file has no containing element (GetContainer() returns null) - matching a
-        // real global content file, which isn't listed in any Screen/Entity's ReferencedFiles.
-        ObjectFinder.Self.GlueProject = null;
     }
 
     public void Dispose()
@@ -37,6 +40,11 @@ public class GlobalContentReloadIdentifierTests : IDisposable
     [Fact]
     public void GetGlobalContentReloadIdentifier_ForFileNestedInSubfolder_ReturnsFolderQualifiedName()
     {
+        // GetInstanceName()'s "GlobalContent/" folder-qualification path only applies when the
+        // referenced file has no containing element (GetContainer() returns null) - matching a
+        // real global content file, which isn't listed in any Screen/Entity's ReferencedFiles.
+        ObjectFinder.Self.GlueProject = null;
+
         var rfs = new ReferencedFileSave
         {
             Name = "GlobalContent/Entities/Player/AnimationChainListFile.achx",
@@ -51,6 +59,8 @@ public class GlobalContentReloadIdentifierTests : IDisposable
     [Fact]
     public void GetGlobalContentReloadIdentifier_ForFileAtGlobalContentRoot_ReturnsBareName()
     {
+        ObjectFinder.Self.GlueProject = null;
+
         var rfs = new ReferencedFileSave
         {
             Name = "GlobalContent/ChibiCthulhuTiles.tmx",
@@ -60,5 +70,48 @@ public class GlobalContentReloadIdentifierTests : IDisposable
         var identifier = RefreshManager.GetGlobalContentReloadIdentifier(rfs);
 
         identifier.ShouldBe("ChibiCthulhuTiles");
+    }
+
+    [Fact]
+    public void SelectGlobalReferencedFile_WhenSameFileIsAlsoReferencedByEntities_PicksTheEntryWithNoContainer()
+    {
+        // Reproduces CrankyChibiCthulhu's Entities/Player/AnimationChainListFile.achx: declared
+        // IsSharedStatic in both Player.glej and TestEntity.glej (each producing an owned,
+        // non-global ReferencedFileSave), plus the actual global entry with no container.
+        var project = new GlueProjectSave { FileVersion = GlueProjectSave.LatestVersion };
+        ObjectFinder.Self.GlueProject = project;
+
+        var playerOwnedRfs = new ReferencedFileSave
+        {
+            Name = "Entities/Player/AnimationChainListFile.achx",
+            IncludeDirectoryRelativeToContainer = true,
+        };
+        var playerEntity = new EntitySave { Name = "Entities\\Player" };
+        playerEntity.ReferencedFiles.Add(playerOwnedRfs);
+        project.Entities.Add(playerEntity);
+
+        var testEntityOwnedRfs = new ReferencedFileSave
+        {
+            Name = "Entities/Player/AnimationChainListFile.achx",
+            IncludeDirectoryRelativeToContainer = true,
+        };
+        var testEntity = new EntitySave { Name = "Entities\\TestEntity" };
+        testEntity.ReferencedFiles.Add(testEntityOwnedRfs);
+        project.Entities.Add(testEntity);
+
+        var globalRfs = new ReferencedFileSave
+        {
+            Name = "GlobalContent/Entities/Player/AnimationChainListFile.achx",
+            IncludeDirectoryRelativeToContainer = true,
+        };
+
+        var rfses = new List<ReferencedFileSave> { playerOwnedRfs, testEntityOwnedRfs, globalRfs };
+
+        // firstRfs mirrors HandleFileChanged's rfses.FirstOrDefault() - the (wrong) value it used
+        // to send before this fix.
+        var selected = RefreshManager.SelectGlobalReferencedFile(rfses, fallback: playerOwnedRfs);
+
+        selected.ShouldBeSameAs(globalRfs);
+        RefreshManager.GetGlobalContentReloadIdentifier(selected).ShouldBe("Entities_Player_AnimationChainListFile");
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/GlobalContentReloadIdentifierTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/GlobalContentReloadIdentifierTests.cs
@@ -1,0 +1,64 @@
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GameCommunicationPlugin.GlueControl.Managers;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace GlueUnitTests.GlueControlTests;
+
+// RefreshManager.HandleFileChanged used to send a bare, path-stripped file name
+// (FileManager.RemovePath(FileManager.RemoveExtension(rfs.Name))) as the
+// ReloadGlobalContentDto identifier. GlobalContent.GetFile's generated switch keys on
+// rfs.GetInstanceName() instead (ReferencedFileSaveCodeGenerator.GenerateGetFileMethodByName),
+// which is folder-qualified for anything nested under a subfolder. For a global file like
+// GlobalContent/Entities/Player/AnimationChainListFile.achx, the bare name "AnimationChainListFile"
+// doesn't match any switch case, so GetFile returned null and GlobalContent.Reload(null) silently
+// did nothing - a live .achx (or any nested global content) edit reloaded the file on disk but never
+// visibly updated the running game.
+public class GlobalContentReloadIdentifierTests : IDisposable
+{
+    private readonly GlueProjectSave _originalGlueProject;
+
+    public GlobalContentReloadIdentifierTests()
+    {
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        // GetInstanceName()'s "GlobalContent/" folder-qualification path only applies when the
+        // referenced file has no containing element (GetContainer() returns null) - matching a
+        // real global content file, which isn't listed in any Screen/Entity's ReferencedFiles.
+        ObjectFinder.Self.GlueProject = null;
+    }
+
+    public void Dispose()
+    {
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+    }
+
+    [Fact]
+    public void GetGlobalContentReloadIdentifier_ForFileNestedInSubfolder_ReturnsFolderQualifiedName()
+    {
+        var rfs = new ReferencedFileSave
+        {
+            Name = "GlobalContent/Entities/Player/AnimationChainListFile.achx",
+            IncludeDirectoryRelativeToContainer = true,
+        };
+
+        var identifier = RefreshManager.GetGlobalContentReloadIdentifier(rfs);
+
+        identifier.ShouldBe("Entities_Player_AnimationChainListFile");
+    }
+
+    [Fact]
+    public void GetGlobalContentReloadIdentifier_ForFileAtGlobalContentRoot_ReturnsBareName()
+    {
+        var rfs = new ReferencedFileSave
+        {
+            Name = "GlobalContent/ChibiCthulhuTiles.tmx",
+            IncludeDirectoryRelativeToContainer = true,
+        };
+
+        var identifier = RefreshManager.GetGlobalContentReloadIdentifier(rfs);
+
+        identifier.ShouldBe("ChibiCthulhuTiles");
+    }
+}


### PR DESCRIPTION
## Summary
- Live-editing a `.achx` used as global content reloaded the file but never updated already-instantiated Sprites, because `GlobalContent.Reload()` reassigned the static field to a new `AnimationChainList` object instead of updating the one Sprites already held a reference to.
- Added `AnimationChainList.ReplaceValues` (mutates contents in place, preserving object identity) and switched the reload codegen to use it, re-registering the same instance with the content manager so repeated reloads keep working.

## Test plan
- [x] `Engines/FlatRedBallXNA/FlatRedBallDesktopGLNet6/FlatRedBallDesktopGLNet6.csproj` builds clean.
- [x] `FRBDK/Glue/Glue/Glue.csproj` compiles with no `CS` errors (output-copy step failed only due to a locally running Glue instance holding file locks, unrelated to this change).
- [ ] Manual repro: edit an `.achx` used as global content in the AnimationEditor while a game is running in Glue edit mode, verify the entity picks up the new coordinates without a screen restart.