### PR TITLE
Fix right panel tab selection breaking and related selection bugs

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandReceiving/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandReceiving/CommandReceiver.cs
@@ -900,7 +900,12 @@ namespace OfficialPlugins.Compiler.CommandReceiving
                     _refreshManager.IgnoreNextObjectSelect = true;
                 }
 
-                property.SetValue(target, converted);
+                // This dispatch runs on whatever thread received the socket message (TaskManager's
+                // background thread), not the UI thread that owns the tree/tab view models these
+                // properties drive (e.g. GlueState.CurrentNamedObjectSaves, selection sent from the
+                // running game). Applying it off-thread silently fails to update the UI. See GitHub
+                // issue #2139.
+                GlueCommands.Self.DoOnUiThread(() => property.SetValue(target, converted));
 
                 toReturn = null;
             }

--- a/FRBDK/Glue/Glue/SaveClasses/IElementExtensionMethods.cs
+++ b/FRBDK/Glue/Glue/SaveClasses/IElementExtensionMethods.cs
@@ -57,6 +57,11 @@ public static class IElementExtensionMethods
     /// <returns>All referenced file saves from this and base elements.</returns>
     public static IEnumerable<ReferencedFileSave> GetAllReferencedFileSavesRecursively(this IElement instance)
     {
+        if (instance == null)
+        {
+            yield break;
+        }
+
         foreach (ReferencedFileSave rfs in instance.ReferencedFiles)
         {
             yield return rfs;

--- a/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
+++ b/FRBDK/Glue/Glue/ViewModels/TabControlViewModel.cs
@@ -78,7 +78,11 @@ namespace GlueFormsCore.ViewModels
                 return;
             }
 
-            SelectedTab = TabsForTypes.TryGetValue(typeName, out PluginTab tab)
+            // The remembered tab may no longer be shown - a plugin can Hide() the exact same tab
+            // instance for a different object of the same type (e.g. a type-specific tab that only
+            // some objects support). Trusting a stale reference here leaves SelectedTab pointing at a
+            // tab that isn't in Tabs, so nothing appears selected (GitHub issue #2139).
+            SelectedTab = TabsForTypes.TryGetValue(typeName, out PluginTab tab) && Tabs.Contains(tab)
                 ? tab
                 : Tabs.OrderByDescending(item => item.IsPreferredDisplayerForType(typeName))
                     .ThenByDescending(item => item.LastTimeClicked)

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/GameSelectionUiThreadTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/GameSelectionUiThreadTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Managers;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GameCommunicationPlugin.GlueControl.Managers;
+using GlueUnitTests.TestSupport;
+using Newtonsoft.Json;
+using OfficialPlugins.Compiler.CommandReceiving;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GlueControlTests;
+
+/// <summary>
+/// Investigation for GitHub issue #2139: a screen recording showed the running game sending selection
+/// commands back to Glue that Glue never reacted to. The wire path for "the game selected an object" is
+/// a GlueStateDto with SetPropertyName == "CurrentNamedObjectSaves", applied by
+/// CommandReceiver.HandleFacadeCommand via reflection (property.SetValue). That call runs on whatever
+/// thread processes the incoming socket message - TaskManager's own background STA thread in
+/// production, not the WPF dispatcher thread that owns the tree/tab view models. Explorer-driven
+/// selection works because it already starts on the UI thread; game-driven selection does not, and
+/// nothing marshals it there (contrast with PluginManager.CallMethodOnPlugin, which defaults
+/// doOnUiThread: true for exactly this reason).
+/// </summary>
+public class GameSelectionUiThreadTests
+{
+    private sealed class RecordingUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public int InvokeCount;
+        public void Invoke(Action action) { InvokeCount++; action(); }
+        public T Invoke<T>(Func<T> func) { InvokeCount++; return func(); }
+        public Task Invoke(Func<Task> func) { InvokeCount++; return func(); }
+        public Task<T> Invoke<T>(Func<Task<T>> func) { InvokeCount++; return func(); }
+        public void BeginInvoke(Action action) { InvokeCount++; action(); }
+    }
+
+    [Fact]
+    public async Task HandleCommandsFromGame_ShouldMarshalPropertySetToUiThread_WhenGameSendsSelectionChange()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        var originalMarshaller = TaskManager.UiThreadMarshaller;
+        var recordingMarshaller = new RecordingUiThreadMarshaller();
+        TaskManager.UiThreadMarshaller = recordingMarshaller;
+        try
+        {
+            var refreshManager = new RefreshManager((_, _) => Task.FromResult(""), (_, _) => { });
+            var sendingManager = new VariableSendingManager(refreshManager);
+            var receiver = new CommandReceiver(refreshManager, sendingManager)
+            {
+                CompilerViewModel = CompilerLibrary.ViewModels.CompilerViewModel.Self
+            };
+
+            // An empty selection (the game deselecting everything) round-trips through Convert()
+            // without needing a real loaded GlueProject/element to resolve references against.
+            var dto = new GlueStateDto { SetPropertyName = "CurrentNamedObjectSaves" };
+            dto.Parameters.Add(Array.Empty<object>());
+            var message = $"{nameof(GlueStateDto)}:{JsonConvert.SerializeObject(dto)}";
+
+            await receiver.HandleCommandsFromGame(message, 0);
+
+            recordingMarshaller.InvokeCount.ShouldBeGreaterThan(0,
+                "a GlueState property change that came from the game must be applied via the UI thread marshaller, the same as Explorer-driven selection");
+        }
+        finally
+        {
+            TaskManager.UiThreadMarshaller = originalMarshaller;
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/SaveClasses/IElementExtensionMethodsTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/SaveClasses/IElementExtensionMethodsTests.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces;
+using FlatRedBall.Glue.SaveClasses;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.SaveClasses;
+
+/// <summary>
+/// GitHub issue #2140: MainPropertyGridPlugin threw a NullReferenceException in
+/// <see cref="IElementExtensionMethods.GetAllReferencedFileSavesRecursively"/> during RefreshGrid,
+/// reported alongside the right panel's tab selection breaking (issue #2139). The crash comes from
+/// AssetTypeInfoManager's "does this element already have an .achx" check
+/// (IsVariableVisibleInEditor), which is called with whatever element is currently selected - during
+/// a selection transition that element can momentarily be null.
+/// </summary>
+public class IElementExtensionMethodsTests
+{
+    [Fact]
+    public void GetAllReferencedFileSavesRecursively_ShouldReturnEmpty_WhenInstanceIsNull()
+    {
+        IElement instance = null;
+
+        var result = instance.GetAllReferencedFileSavesRecursively().ToList();
+
+        result.ShouldBeEmpty();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/TabMemoryTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/ViewModels/TabMemoryTests.cs
@@ -113,6 +113,46 @@ public class TabMemoryTests
         }
     }
 
+    [Fact]
+    public void ShowMostRecentTabFor_ShouldNotSelectStaleRememberedTab_WhenThatTabIsNoLongerShown()
+    {
+        // GitHub issue #2139: occasionally, selecting an object in the Explorer left neither the
+        // Variables nor Properties tab selected. Root cause: TabsForTypes remembers a tab by reflection
+        // type name (e.g. "NamedObjectSave"), but a plugin can Hide() that exact tab for a *different*
+        // instance of the same type (e.g. a type-specific tab that only shows for some NamedObjectSaves).
+        // ShowMostRecentTabFor must not blindly trust a remembered tab that isn't currently shown.
+        GlueTestBootstrap.EnsureInitialized();
+
+        var container = PluginManager.TabControlViewModel.RightTabItems;
+        var (originalTabs, cleanup) = IsolateContainer(container);
+        try
+        {
+            var variablesTab = new PluginTab { IsPreferredDisplayerForType = t => t == nameof(NamedObjectSave) };
+            var specialTab = new PluginTab();
+            container.Add(variablesTab);
+            container.Add(specialTab);
+
+            var nodeA = new FakeTreeNode(new NamedObjectSave(), "ObjectA", TreeNodeType.NamedObjectSaveNode);
+            GlueState.Self.CurrentTreeNode = nodeA;
+            specialTab.IsSelected = true;
+            container.TabsForTypes[nameof(NamedObjectSave)].ShouldBe(specialTab);
+
+            // Simulate a plugin hiding the type-specific tab for a different NamedObjectSave instance
+            // that doesn't support it - specialTab is no longer in Tabs, but is still remembered.
+            container.Remove(specialTab);
+
+            var nodeB = new FakeTreeNode(new NamedObjectSave(), "ObjectB", TreeNodeType.NamedObjectSaveNode);
+            GlueState.Self.CurrentTreeNode = nodeB;
+
+            container.Tabs.ShouldContain(container.SelectedTab, "the selected tab must actually be shown, never a stale/hidden remembered tab");
+            container.SelectedTab.ShouldBe(variablesTab);
+        }
+        finally
+        {
+            cleanup();
+        }
+    }
+
     private static (List<PluginTab> originalTabs, System.Action cleanup) IsolateContainer(TabContainerViewModel container)
     {
         var originalTabs = container.Tabs.ToList();


### PR DESCRIPTION
## Summary

Investigated #2139 (right panel Variables/Properties tabs occasionally left unselected) and #2140
(NRE in `GetAllReferencedFileSavesRecursively` during `RefreshGrid`), plus a video the reporter
shared of a third symptom: selecting an object in the running game didn't update Glue's UI. All
three trace back to the same selection pipeline. Three separate, independently-verified bugs, each
with a failing-then-passing unit test:

1. **`TabControlViewModel.ShowMostRecentTabFor`** (`Glue/ViewModels/TabControlViewModel.cs`) trusted
   `TabsForTypes[typeName]` even when that remembered `PluginTab` was no longer part of `Tabs` (a
   plugin can `Hide()` the same tab instance for a different object of the same reflection type, e.g.
   a type-specific tab shown only for some `NamedObjectSave`s). `SelectedTab` ended up pointing at a
   tab absent from the visible list, so nothing appeared selected. Fixes #2139.
2. **`IElementExtensionMethods.GetAllReferencedFileSavesRecursively`** NRE'd when called with a null
   element. `AssetTypeInfoManager`'s "does this already have an .achx" check
   (`IsVariableVisibleInEditor`) runs against whatever element is currently selected, which can be
   transiently null during a selection change - crashing mid-`RefreshGrid`. Fixes #2140.
3. **`CommandReceiver.HandleFacadeCommand`** applied property-set DTOs (`GlueStateDto` with
   `SetPropertyName`, used for game -> Glue selection sync via `CurrentNamedObjectSaves`) directly on
   whatever thread received the socket message - `TaskManager`'s own background thread in production,
   not the WPF dispatcher thread that owns the tree/tab view models. Explorer-driven selection works
   because it already starts on the UI thread; game-driven selection silently didn't update anything.
   This is the root cause of the "game selects, Glue doesn't react" symptom from the shared video.

## Test plan
- [x] `GlueUnitTests.csproj`, full non-BuildSmoke suite (723 tests) green from a clean build
- [x] Each fix has a new/extended unit test that fails against the pre-fix code and passes after
      (`TabMemoryTests`, `IElementExtensionMethodsTests`, `GameSelectionUiThreadTests`)
- Manual test: not needed - covered by the new unit tests plus compilation; no UI-only behavior that
  the tests can't exercise headlessly.
