### PR TITLE
Fix NullReferenceException deleting an object while the game is running

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
@@ -1753,7 +1753,9 @@ public class GluxCommands : IGluxCommands
         indexInChild = -1;
         containerOfRemoved = null;
         element = namedObjectToRemove.GetContainer();
-        if (wasSelected)
+        // element can be null if namedObjectToRemove was already removed from its container by a
+        // concurrent/duplicate removal (see the early-out in RemoveNamedObject for the sync equivalent).
+        if (wasSelected && element != null)
         {
             if (element.NamedObjects.Contains(namedObjectToRemove))
             {

--- a/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/DeleteObjectTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/DeleteObjectTests.cs
@@ -1,8 +1,10 @@
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces;
 using FlatRedBall.Glue.SaveClasses;
 using GlueUnitTests.TestSupport;
 using Shouldly;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -105,5 +107,37 @@ public class DeleteObjectTests : DeleteDialogTestBase
         ShownDeleteDialogs.Count.ShouldBe(1);
         OtherPrompts.ShouldBeEmpty(OtherPromptsMessage);
         screen.NamedObjects.ShouldBeEmpty();
+    }
+
+    // GlueState.CurrentNamedObjectSave's setter round-trips through Find.TreeNodeByTag, which FakeFindManager
+    // deliberately doesn't resolve for NamedObjectSave (see FakeFindManager's doc comment) - so this reaches
+    // past the snapshot field directly instead, to mark the object selected without touching real tree/plugin
+    // selection-reaction code that has nothing to do with the bug under test.
+    static void SetCurrentNamedObjectSaveDirectly(NamedObjectSave nos)
+    {
+        var snapshotField = typeof(GlueState).GetField("snapshot", BindingFlags.NonPublic | BindingFlags.Instance);
+        var snapshot = snapshotField.GetValue(GlueState.Self);
+        var namedObjectSavesField = snapshot.GetType().GetField("CurrentNamedObjectSaves");
+        namedObjectSavesField.SetValue(snapshot, new List<NamedObjectSave> { nos });
+    }
+
+    // Reported crash (GitHub issue #2142): removal is tasked, so a fast double-removal (e.g. the running
+    // game's live sync racing a manual delete) can find the object already gone from its element by the
+    // time RemoveNamedObjectAsync looks it up, while it's still the current selection. RemoveNamedObjectAsync
+    // isn't on IGluxCommands (it's an internal implementation detail used by RemoveNamedObjectListAsync), so
+    // this calls the concrete type directly to reproduce the exact method named in the reported stack trace.
+    [StaFact]
+    public async Task RemovingTheSelectedObject_ShouldNotThrow_WhenItWasAlreadyRemovedFromItsElement()
+    {
+        using var project = await LoadFormsSampleAsync();
+
+        var screen = await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen("AlreadyRemovedScreen");
+        var nos = await AddObjectAsync(screen, "DoomedSprite");
+
+        SetCurrentNamedObjectSaveDirectly(nos);
+        screen.NamedObjects.Remove(nos);
+
+        var gluxCommands = (GluxCommands)GlueCommands.Self.GluxCommands;
+        await gluxCommands.RemoveNamedObjectAsync(nos);
     }
 }


### PR DESCRIPTION
Fixes #2142.

`GetSelectionInfo` dereferenced `GetContainer()`'s result without checking for null when the object being removed was the current selection. If the object was already gone from its element by the time this runs — e.g. a concurrent/duplicate removal, which is exactly the race `RemoveNamedObject`'s early-out already guards against — this NRE's out of the removal pipeline before `DoRemovalInternal`'s existing `element != null` no-op guard ever gets a chance to run.

Fix mirrors that existing guard: skip the selection-index lookup when `element` is null.

## Test plan
- [x] `RemovingTheSelectedObject_ShouldNotThrow_WhenItWasAlreadyRemovedFromItsElement` reproduces the exact reported stack trace (`GetSelectionInfo` → `RemoveNamedObjectAsync`) when the fix is disabled, and passes with it.
- [x] Full non-BuildSmoke suite (720 tests) and the `DeleteObjectTests` class green.

Manual test: not needed — covered by the new unit test plus compilation.
