### PR TITLE
Add Copy to Clipboard button to Glue's error dialog

### DIFF
--- a/FRBDK/Glue/Glue/Controls/DialogService.cs
+++ b/FRBDK/Glue/Glue/Controls/DialogService.cs
@@ -87,7 +87,20 @@ namespace FlatRedBall.Glue.Controls
 
         private static void DefaultShowMessage(string text)
         {
-            System.Windows.MessageBox.Show(text);
+            if (!GlueGui.ShowGui)
+            {
+                return;
+            }
+
+            var mbmb = new MultiButtonMessageBoxWpf
+            {
+                MessageText = text
+            };
+
+            mbmb.AddActionButton("Copy to Clipboard", () => ClipboardService.SetText(text));
+            mbmb.AddButton("OK", DialogButton.Ok);
+
+            mbmb.ShowDialog();
         }
 
         private static bool DefaultShowDelete(DeleteOptionsViewModel viewModel)

--- a/FRBDK/Glue/Glue/Controls/MultiButtonMessageBoxWpf.xaml
+++ b/FRBDK/Glue/Glue/Controls/MultiButtonMessageBoxWpf.xaml
@@ -7,9 +7,14 @@
              mc:Ignorable="d" 
              Width="500" SizeToContent="Height">
     <Grid>
-        <StackPanel x:Name="MainPanel">
-            <TextBlock TextWrapping="Wrap" x:Name="LabelInstance" Margin="8,8,8,15" 
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <ScrollViewer Grid.Row="0" MaxHeight="400" VerticalScrollBarVisibility="Auto" Margin="8,8,8,15">
+            <TextBlock TextWrapping="Wrap" x:Name="LabelInstance"
                        Text="{x:Static localization:Texts.ValidationTextForWrapping}" />
-        </StackPanel>
+        </ScrollViewer>
+        <StackPanel x:Name="MainPanel" Grid.Row="1" />
     </Grid>
 </Window>

--- a/FRBDK/Glue/Glue/Controls/MultiButtonMessageBoxWpf.xaml
+++ b/FRBDK/Glue/Glue/Controls/MultiButtonMessageBoxWpf.xaml
@@ -4,14 +4,14 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:localization="clr-namespace:Localization;assembly=Localization"
-             mc:Ignorable="d" 
-             Width="500" SizeToContent="Height">
+             mc:Ignorable="d"
+             Width="500" Height="600" MinHeight="150">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <ScrollViewer Grid.Row="0" MaxHeight="400" VerticalScrollBarVisibility="Auto" Margin="8,8,8,15">
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto" Margin="8,8,8,15">
             <TextBlock TextWrapping="Wrap" x:Name="LabelInstance"
                        Text="{x:Static localization:Texts.ValidationTextForWrapping}" />
         </ScrollViewer>

--- a/FRBDK/Glue/Glue/Controls/MultiButtonMessageBoxWpf.xaml.cs
+++ b/FRBDK/Glue/Glue/Controls/MultiButtonMessageBoxWpf.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
@@ -49,10 +50,33 @@ namespace FlatRedBall.Glue.Controls
 
         public void AddButton(string text, object result)
         {
-            Button button = new Button();
+            Button button = CreateButton(text);
+            button.Tag = result;
             button.Click += HandleButtonClickInternal;
+
+            buttons.Add(button);
+
+            this.MainPanel.Children.Add(button);
+        }
+
+        /// <summary>
+        /// Adds a button that runs <paramref name="action"/> without closing the dialog, e.g. a
+        /// "Copy to Clipboard" button that a user may click before also clicking OK.
+        /// </summary>
+        public void AddActionButton(string text, Action action)
+        {
+            Button button = CreateButton(text);
+            button.Click += (sender, e) => action();
+
+            buttons.Add(button);
+
+            this.MainPanel.Children.Add(button);
+        }
+
+        private Button CreateButton(string text)
+        {
+            Button button = new Button();
             button.TabIndex = buttons.Count;
-            //button.Content = text;
 
             TextBlock myTextBlock = new TextBlock();
             // Set the TextWrapping property to Wrap
@@ -63,17 +87,13 @@ namespace FlatRedBall.Glue.Controls
             // Set the content of the Button to the TextBlock
             button.Content = myTextBlock;
 
-            button.Tag  = result;
-
             button.Margin = new Thickness(8,4,8,4);
 
-            // Make this 50 so that it is bigger and can have 2 lines of text. 
+            // Make this 50 so that it is bigger and can have 2 lines of text.
             // Eventually this could be automatic.
             button.Height = 50;
 
-            buttons.Add(button);
-
-            this.MainPanel.Children.Add(button);
+            return button;
         }
 
         private void HandleButtonClickInternal(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Adds a "Copy to Clipboard" button to Glue's error/message dialog (`DialogService.ShowMessage`), which is what shows unhandled exceptions and plugin errors with their full stack trace.

## Changes
- `DialogService.DefaultShowMessage` now shows `MultiButtonMessageBoxWpf` (Copy to Clipboard + OK) instead of a plain `MessageBox.Show`, using the existing `ClipboardService.SetText`.
- `MultiButtonMessageBoxWpf` gained an `AddActionButton` (runs an action without closing) alongside the existing `AddButton`, both now sharing a `CreateButton` helper.
- Wrapped the message text in a `ScrollViewer` (`MaxHeight="400"`) so long stack traces don't grow the window off-screen.

Closes #2143

Manual test: needed (WPF dialog change).
1. Open `FRBDK/Glue/Glue with All.sln` in this worktree and run Glue.
2. Trigger an error dialog (e.g. via a plugin exception, or temporarily call `DialogService.ShowMessage("test\nmultiline")` somewhere reachable).
3. Confirm the dialog shows "Copy to Clipboard" and "OK" buttons, clicking Copy puts the text on the clipboard without closing the dialog, and OK closes it.
4. Paste a very long multi-line message to confirm the text area scrolls instead of growing the window past the screen.
