### PR TITLE
Fix NRE when editing variables after an unresolvable game selection

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueState.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueState.cs
@@ -164,7 +164,17 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations
                 }
                 else
                 {
-                    List<ITreeNode> treeNodes = value.Select(item =>GlueState.Self.Find.TreeNodeByTag(item)).ToList();
+                    // A NamedObjectSave the caller couldn't resolve to a tree node (e.g. a selection
+                    // reported by the running game that no longer matches anything in the loaded
+                    // project - see GitHub issue #2149) must be dropped here rather than passed through
+                    // as a null ITreeNode: TakeSnapshot's GetCurrentNamedObjectSavesFromSelection
+                    // dereferences every node's Tag, so a null entry throws mid-snapshot - after
+                    // CurrentElement has already been recomputed (and cleared) but before
+                    // CurrentNamedObjectSaves is, leaving them mismatched.
+                    List<ITreeNode> treeNodes = value
+                        .Select(item => GlueState.Self.Find.TreeNodeByTag(item))
+                        .Where(node => node != null)
+                        .ToList();
                     CurrentTreeNodes = treeNodes;
                 }
             }

--- a/FRBDK/Glue/Tests/GlueUnitTests/ExportedImplementations/GlueStateCurrentNamedObjectSavesTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/ExportedImplementations/GlueStateCurrentNamedObjectSavesTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.ExportedImplementations;
+
+/// <summary>
+/// GitHub issue #2149: selecting an object in the running game (edit mode) sends Glue a
+/// NamedObjectSave the game reported as clicked. CommandReceiver.Convert resolves it by name against
+/// the loaded project and, if it can't find a match, adds a null entry to the list instead of filtering
+/// it out (see also #2131/#2133, which fixed a related but different symptom of this same null entry).
+/// That null flows into GlueState.CurrentNamedObjectSaves's setter, which maps every entry through
+/// Find.TreeNodeByTag - a real, populated WPF tree in production, but FakeFindManager here, which never
+/// resolves a NamedObjectSave tag (see its own doc comment). Either way, an unresolvable entry produces
+/// a null ITreeNode in the list passed to CurrentTreeNodes, and TakeSnapshot's
+/// GetCurrentNamedObjectSavesFromSelection NREs dereferencing that null node's Tag - mid-snapshot, after
+/// CurrentElement has already been recomputed (and wiped to null) but before CurrentNamedObjectSaves is.
+/// That leaves GlueState with CurrentElement == null and a stale, non-null CurrentNamedObjectSave from
+/// whatever was selected before - exactly the combination that crashes
+/// MainPropertyGridPlugin.RefreshVariables -> NamedObjectSaveVariableDataGridItem.RefreshAddContextMenuEvents
+/// (Container is null) the next time a variable is edited.
+/// </summary>
+public class GlueStateCurrentNamedObjectSavesTests
+{
+    public GlueStateCurrentNamedObjectSavesTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    [Fact]
+    public void CurrentNamedObjectSaves_WithUnresolvableEntry_DoesNotThrow()
+    {
+        try
+        {
+            var unresolvable = new NamedObjectSave { InstanceName = "SomeObject" };
+
+            Should.NotThrow(() =>
+                GlueState.Self.CurrentNamedObjectSaves = new List<NamedObjectSave> { unresolvable });
+        }
+        finally
+        {
+            GlueState.Self.CurrentTreeNode = null;
+        }
+    }
+
+    [Fact]
+    public void CurrentNamedObjectSaves_WithUnresolvableEntry_ClearsSelectionInsteadOfCorruptingIt()
+    {
+        try
+        {
+            var unresolvable = new NamedObjectSave { InstanceName = "SomeObject" };
+
+            GlueState.Self.CurrentNamedObjectSaves = new List<NamedObjectSave> { unresolvable };
+
+            // An unresolvable selection should behave like "nothing selected", not leave CurrentElement
+            // and CurrentNamedObjectSave in a mismatched (one null, one stale-non-null) state.
+            GlueState.Self.CurrentNamedObjectSave.ShouldBeNull();
+            GlueState.Self.CurrentElement.ShouldBeNull();
+        }
+        finally
+        {
+            GlueState.Self.CurrentTreeNode = null;
+        }
+    }
+}


### PR DESCRIPTION
Closes #2149.

## Root cause
Selecting an object in the running game (edit mode) sends Glue a `NamedObjectSave` reference that `CommandReceiver.Convert` resolves by name against the loaded project. When it can't find a match, it adds a `null` entry to the list instead of filtering it out (same underlying null highlighted by #2131/#2133, a different symptom of it).

That null flows into `GlueState.CurrentNamedObjectSaves`'s setter, which maps every entry through `Find.TreeNodeByTag`. An unresolved entry becomes a null `ITreeNode`, and `TakeSnapshot`'s `GetCurrentNamedObjectSavesFromSelection` NREs dereferencing that null node's `Tag` - **mid-snapshot**, after `CurrentElement` has already been recomputed (and wiped to null) but before `CurrentNamedObjectSaves` is. That leaves `GlueState` with `CurrentElement == null` next to a stale, non-null `CurrentNamedObjectSave` from whatever was selected before.

The next variable edit then crashes in `MainPropertyGridPlugin.RefreshVariables` -> `NamedObjectSaveVariableDataGridItem.RefreshAddContextMenuEvents`, matching the reported stack trace exactly: `Container` (built from `CurrentElement`) is null.

I also verified empirically (via `LiveGameProcess`, temporarily) that pushing a variable to an `AttachToContainer` child object works correctly when `GlueState` isn't in this corrupted state - so the "edited value doesn't reach the running game" half of the report is very likely just a visible symptom of this same corruption, not a second, independent bug.

## Fix
`GlueState.CurrentNamedObjectSaves`'s setter now filters out unresolved (null) tree nodes before assigning `CurrentTreeNodes`, so an unresolvable selection behaves like a clean deselect instead of corrupting the snapshot.

## Testing
New unit test (`GlueStateCurrentNamedObjectSavesTests`) reproduces the NRE headlessly via `FakeFindManager` (which never resolves a `NamedObjectSave` tag, exactly simulating an unresolvable game selection) - red before the fix, green after. Full `Category!=BuildSmoke&Category!=LiveGame` suite (714 tests) passes on a clean rebuild.

Manual test: not needed - the fix is fully covered by the new unit test plus compilation; the crash's root cause is in headless-testable `GlueState` snapshot logic, not UI rendering.
