### PR TITLE
Fix Edit Mode processing clicks while window is unfocused/covered

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -303,6 +303,31 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     }
     #endregion
 
+    #region SimulateClickSelectRespectingActivityGate
+
+    /// <summary>
+    /// Test-only: same as SimulateClickSelectDto, but routed through EditingManager.IsGameOrGlueActive
+    /// first - the same gate a real click goes through in EditingManager.Activity (DoGrabLogic is only
+    /// reached when the game/Glue window is active). SimulateClickSelectDto deliberately bypasses that
+    /// gate (see its own doc comment), so it can't pin issue #2154 (Edit Mode processing clicks while the
+    /// window is unfocused/covered) - this DTO exists specifically for that.
+    /// </summary>
+    public class SimulateClickSelectRespectingActivityGateDto
+    {
+        /// <summary>InstanceName of the NamedObjectSave clicked, or null/empty for a click on empty space.</summary>
+        public string ObjectName { get; set; }
+        public bool AdditiveModifierDown { get; set; }
+    }
+    #endregion
+
+    #region SimulateClickSelectRespectingActivityGateResponse
+    public class SimulateClickSelectRespectingActivityGateResponse
+    {
+        public bool WasProcessed { get; set; }
+        public List<string> SelectedObjectNames { get; set; }
+    }
+    #endregion
+
     #region GetCameraSave
     public class GetCameraSave
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -924,6 +924,20 @@ namespace GlueControl
             };
         }
 
+        private static object HandleDto(GlueControl.Dtos.SimulateClickSelectRespectingActivityGateDto dto)
+        {
+            var editingManager = Editing.EditingManager.Self;
+
+            var wasProcessed = editingManager.SimulateClickSelectRespectingActivityGateForTesting(
+                dto.ObjectName, dto.AdditiveModifierDown);
+
+            return new GlueControl.Dtos.SimulateClickSelectRespectingActivityGateResponse
+            {
+                WasProcessed = wasProcessed,
+                SelectedObjectNames = editingManager.ItemsSelected.Select(item => item.Name).ToList()
+            };
+        }
+
         #endregion
 
         #endregion

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -304,6 +304,31 @@ namespace GlueControl.Dtos
     }
     #endregion
 
+    #region SimulateClickSelectRespectingActivityGate
+
+    /// <summary>
+    /// Test-only: same as SimulateClickSelectDto, but routed through EditingManager.IsGameOrGlueActive
+    /// first - the same gate a real click goes through in EditingManager.Activity (DoGrabLogic is only
+    /// reached when the game/Glue window is active). SimulateClickSelectDto deliberately bypasses that
+    /// gate (see its own doc comment), so it can't pin issue #2154 (Edit Mode processing clicks while the
+    /// window is unfocused/covered) - this DTO exists specifically for that.
+    /// </summary>
+    public class SimulateClickSelectRespectingActivityGateDto
+    {
+        /// <summary>InstanceName of the NamedObjectSave clicked, or null/empty for a click on empty space.</summary>
+        public string ObjectName { get; set; }
+        public bool AdditiveModifierDown { get; set; }
+    }
+    #endregion
+
+    #region SimulateClickSelectRespectingActivityGateResponse
+    public class SimulateClickSelectRespectingActivityGateResponse
+    {
+        public bool WasProcessed { get; set; }
+        public List<string> SelectedObjectNames { get; set; }
+    }
+    #endregion
+
     #region GetCameraSave
     public class GetCameraSave
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -253,7 +253,13 @@ namespace GlueControl.Editing
 
         public bool IsEmbeddedInActiveGlue => EmbeddedWindowLogic.IsParentGlueFocused;
 
-        public bool IsGameOrGlueActive => IsEmbeddedInActiveGlue || FlatRedBallServices.Game.IsActive;
+        // When embedded, the game window is reparented into Glue (SetParent) and never receives normal
+        // WM_ACTIVATE/deactivate notifications, so FlatRedBallServices.Game.IsActive gets stuck true -
+        // it can't be trusted here. Only IsEmbeddedInActiveGlue (a real foreground-window check) reflects
+        // whether Glue is actually the active window. See issue #2154.
+        public bool IsGameOrGlueActive => EmbeddedWindowLogic.IsEmbedded
+            ? IsEmbeddedInActiveGlue
+            : FlatRedBallServices.Game.IsActive;
 
         #endregion
 
@@ -744,6 +750,24 @@ namespace GlueControl.Editing
         {
             INameable itemOver = string.IsNullOrEmpty(objectName) ? null : GetObjectByName(objectName);
             PerformClickSelection(itemOver, additiveModifierDown);
+        }
+
+        /// <summary>
+        /// Test-only entry point for issue #2154 (Edit Mode processing clicks while the game/Glue window
+        /// is unfocused or covered) - same as SimulateClickSelectForTesting, but first checks
+        /// IsGameOrGlueActive, the same gate EditingManager.Activity applies before ever reaching
+        /// DoGrabLogic for a real click. Returns false (and performs no selection change) when the gate
+        /// would have blocked a real click too. Driven by SimulateClickSelectRespectingActivityGateDto.
+        /// </summary>
+        internal bool SimulateClickSelectRespectingActivityGateForTesting(string objectName, bool additiveModifierDown)
+        {
+            if (!IsGameOrGlueActive)
+            {
+                return false;
+            }
+
+            SimulateClickSelectForTesting(objectName, additiveModifierDown);
+            return true;
         }
 
         private NamedObjectSave GetNosFromItemName(string itemName)

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
@@ -1,0 +1,138 @@
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// Reproduces issue #2154: Edit Mode keeps processing mouse clicks even when the game/Glue window is
+/// out of focus or covered by another window. Root cause: EditingManager.IsGameOrGlueActive OR's
+/// IsEmbeddedInActiveGlue with FlatRedBallServices.Game.IsActive - but in embedded Edit Mode the game
+/// window is reparented into Glue (SetParent), so it never receives normal WM_ACTIVATE/deactivate
+/// notifications and Game.IsActive gets stuck true, masking the correct IsEmbeddedInActiveGlue check.
+///
+/// Drives EditingManager.SimulateClickSelectRespectingActivityGateForTesting (Embedded) - unlike
+/// SimulateClickSelectForTesting (used by CtrlClickMultiSelectTests etc.), this respects
+/// IsGameOrGlueActive first, the same gate a real click goes through in EditingManager.Activity.
+/// SetBorderlessDto{IsBorderless=true} is the exact DTO real Glue sends to mark the window embedded
+/// (CommandReceiver.HandleDto(SetBorderlessDto), GameHostView.EmbedHwnd) - it's what sets
+/// EmbeddedWindowLogic.IsEmbedded=true here, same production wiring as a real embedded session. There's
+/// no real Glue.exe (process name "GlueFormsCore") running in this test process, so
+/// EmbeddedWindowLogic.IsParentGlueFocused deterministically returns false - exactly the "window is not
+/// the foreground window" state issue #2154 reports, without needing to fake real OS focus/covering.
+/// </summary>
+[Trait("Category", "LiveGame")]
+public class EditModeActivityGateTests
+{
+    [StaFact]
+    public async Task ClickWhileEmbeddedAndNotForegroundGlue_IsIgnored()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
+            afterLoadBeforeEmbed: AddTestObjectToGameScreen);
+
+        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        var loadScreenResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Screens\\GameScreen",
+            ScreenSave = screen,
+        });
+        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
+
+        var editModeResponse = await game.Send(new SetEditMode
+        {
+            IsInEditMode = true,
+            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        });
+        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
+        await Task.Delay(1000);
+
+        // Real Glue sends this to mark the window embedded when it reparents the game window into
+        // itself. No real Glue.exe (process name "GlueFormsCore") is running here, so
+        // EmbeddedWindowLogic.IsParentGlueFocused is false - this is the "Glue is not the foreground
+        // window" state.
+        var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
+        borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
+
+        var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
+            new SimulateClickSelectRespectingActivityGateDto
+            {
+                ObjectName = "TestObjectA",
+                AdditiveModifierDown = false,
+            });
+
+        clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
+        clickResponse.Data.WasProcessed.ShouldBeFalse(
+            "a click should be ignored while the game window is embedded but Glue is not the foreground window (issue #2154)");
+        clickResponse.Data.SelectedObjectNames.ShouldBeEmpty();
+    }
+
+    [StaFact]
+    public async Task ClickWhileNotEmbedded_IsStillProcessed()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
+            afterLoadBeforeEmbed: AddTestObjectToGameScreen);
+
+        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        var loadScreenResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Screens\\GameScreen",
+            ScreenSave = screen,
+        });
+        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
+
+        var editModeResponse = await game.Send(new SetEditMode
+        {
+            IsInEditMode = true,
+            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        });
+        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
+        await Task.Delay(1000);
+
+        // Deliberately no SetBorderlessDto here - EmbeddedWindowLogic.IsEmbedded stays false, matching a
+        // standalone (non-Glue-embedded) run where Game.IsActive is the real, meaningful focus signal.
+        // Regression guard: the #2154 fix must not block clicks in this mode.
+        var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
+            new SimulateClickSelectRespectingActivityGateDto
+            {
+                ObjectName = "TestObjectA",
+                AdditiveModifierDown = false,
+            });
+
+        clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
+        clickResponse.Data.WasProcessed.ShouldBeTrue(
+            "a non-embedded (standalone) game window should still process clicks normally");
+        clickResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectA" });
+    }
+
+    static async Task AddTestObjectToGameScreen()
+    {
+        var gameScreen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        var nos = new NamedObjectSave();
+        nos.SetDefaults();
+        nos.InstanceName = "TestObjectA";
+        nos.SourceType = SourceType.FlatRedBallType;
+        nos.SourceClassType = "FlatRedBall.Math.Geometry.AxisAlignedRectangle";
+
+        await GlueCommands.Self.GluxCommands.AddNamedObjectToAsync(
+            nos, gameScreen, listToAddTo: null, selectNewNos: false,
+            performSaveAndGenerateCode: true, updateUi: false);
+    }
+}


### PR DESCRIPTION
Closes #2154.

`EditingManager.IsGameOrGlueActive` OR'd `IsEmbeddedInActiveGlue` (a real foreground-window check) with `FlatRedBallServices.Game.IsActive`. In embedded Edit Mode the game window is reparented into Glue (`SetParent`) and never receives normal `WM_ACTIVATE`/deactivate notifications, so `Game.IsActive` gets stuck `true` and permanently masks the correct check - clicks/selection kept working even with Glue in the background. Fix: when embedded, `IsEmbeddedInActiveGlue` is the sole determinant; the `Game.IsActive` fallback only applies to non-embedded (standalone) runs, where it's still reliable.

## Tests

`EditModeActivityGateTests` (new) drives `EditingManager.SimulateClickSelectRespectingActivityGateForTesting` - a new test-only entry point that respects `IsGameOrGlueActive`, unlike the existing `SimulateClickSelectForTesting` which deliberately bypasses it. `SetBorderlessDto{IsBorderless=true}` is the real DTO Glue sends to mark the window embedded; no real Glue.exe process runs in the test, so `IsEmbeddedInActiveGlue` is deterministically false there.

- `ClickWhileEmbeddedAndNotForegroundGlue_IsIgnored` - red before the fix, green after.
- `ClickWhileNotEmbedded_IsStillProcessed` - regression guard for standalone (non-Glue-embedded) runs.

Full non-BuildSmoke suite (727 tests) green from a clean build.

Manual test: not needed - covered by the tests above, which exercise the real production DTO wiring end to end.
