### PR TITLE
Support mouse-drag value scrubbing on PathInstance X/Y/Angle fields

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/OfficialPlugins.csproj
+++ b/FRBDK/Glue/OfficialPlugins/OfficialPlugins.csproj
@@ -148,6 +148,7 @@
     <ProjectReference Include="..\..\AchxToSpineAtlas\SpineAtlasLibrary\SpineAtlasLibrary.csproj" />
     <ProjectReference Include="..\..\Localization\Localization.csproj" />
     <ProjectReference Include="..\PluginLibraries\PluginLibraries.csproj" />
+    <ProjectReference Include="..\..\..\..\Gum\WpfDataUi\WpfDataUi.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FRBDK/Glue/OfficialPlugins/PathPlugin/Views/PathSegmentView.xaml
+++ b/FRBDK/Glue/OfficialPlugins/PathPlugin/Views/PathSegmentView.xaml
@@ -23,7 +23,7 @@
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
                 <ColumnDefinition></ColumnDefinition>
             </Grid.ColumnDefinitions>
-            <TextBlock VerticalAlignment="Center" Margin="0,0,3,0">X:</TextBlock>
+            <TextBlock x:Name="XLabel" VerticalAlignment="Center" Margin="0,0,3,0" Cursor="SizeWE" MouseDown="Label_MouseDown" MouseMove="Label_MouseMove" MouseUp="Label_MouseUp">X:</TextBlock>
             <TextBox x:Name="XTextBox" Grid.Column="1" Text="{Binding X}"  GotFocus="TextBox_GotFocus" KeyUp="TextBox_KeyEnterUpdate" MouseWheel="TextBox_MouseWheel"></TextBox>
         </Grid>
         <Grid Grid.Column="2" Margin="14,0,0,0">
@@ -31,7 +31,7 @@
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
                 <ColumnDefinition></ColumnDefinition>
             </Grid.ColumnDefinitions>
-            <TextBlock  VerticalAlignment="Center"  Margin="0,0,3,0">Y:</TextBlock>
+            <TextBlock x:Name="YLabel" VerticalAlignment="Center"  Margin="0,0,3,0" Cursor="SizeWE" MouseDown="Label_MouseDown" MouseMove="Label_MouseMove" MouseUp="Label_MouseUp">Y:</TextBlock>
             <TextBox x:Name="YTextBox" Grid.Column="1" Text="{Binding Y}" GotFocus="TextBox_GotFocus" KeyUp="TextBox_KeyEnterUpdate"  MouseWheel="TextBox_MouseWheel"></TextBox>
         </Grid>
         <Grid Grid.Column="3" Margin="14,0,0,0" Visibility="{Binding AngleVisibility}">
@@ -39,7 +39,7 @@
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
                 <ColumnDefinition></ColumnDefinition>
             </Grid.ColumnDefinitions>
-            <TextBlock  VerticalAlignment="Center" Margin="0,0,3,0" Text="Angle:" />
+            <TextBlock x:Name="AngleLabel" VerticalAlignment="Center" Margin="0,0,3,0" Text="Angle:" Cursor="SizeWE" MouseDown="Label_MouseDown" MouseMove="Label_MouseMove" MouseUp="Label_MouseUp" />
             <TextBox x:Name="AngleTextBox" Grid.Column="1" Text="{Binding Angle}" GotFocus="TextBox_GotFocus" KeyUp="TextBox_KeyEnterUpdate"  MouseWheel="TextBox_MouseWheel"></TextBox>
         </Grid>
 

--- a/FRBDK/Glue/OfficialPlugins/PathPlugin/Views/PathSegmentView.xaml.cs
+++ b/FRBDK/Glue/OfficialPlugins/PathPlugin/Views/PathSegmentView.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using WpfDataUi.Controls;
 
 namespace OfficialPlugins.PathPlugin.Views
 {
@@ -94,5 +95,79 @@ namespace OfficialPlugins.PathPlugin.Views
         {
             ViewModel?.HandleTextBoxFocus();
         }
+
+        #region Label Dragging
+
+        double? dragStartX;
+        double dragUnroundedValue;
+        TextBlock draggingLabel;
+
+        private void Label_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (ViewModel == null) return;
+
+            draggingLabel = (TextBlock)sender;
+            dragStartX = e.GetPosition(this).X;
+            dragUnroundedValue = GetDraggedValue(draggingLabel);
+
+            Mouse.Capture(draggingLabel);
+        }
+
+        private void Label_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (dragStartX == null || draggingLabel == null) return;
+
+            if (e.LeftButton != MouseButtonState.Pressed)
+            {
+                if (Mouse.Captured == draggingLabel)
+                {
+                    Mouse.Capture(null);
+                }
+                return;
+            }
+
+            var newX = e.GetPosition(this).X;
+            var pixelDifference = newX - dragStartX.Value;
+            dragStartX = newX;
+
+            if (pixelDifference == 0) return;
+
+            dragUnroundedValue += pixelDifference;
+            var newValue = SnapDraggedValue(dragUnroundedValue);
+            SetDraggedValue(draggingLabel, newValue);
+        }
+
+        private void Label_MouseUp(object sender, MouseButtonEventArgs e)
+        {
+            draggingLabel = null;
+            dragStartX = null;
+            if (Mouse.Captured == sender)
+            {
+                Mouse.Capture(null);
+            }
+        }
+
+        double GetDraggedValue(TextBlock label)
+        {
+            if (Equals(label, XLabel)) return ViewModel.X;
+            if (Equals(label, YLabel)) return ViewModel.Y;
+            return ViewModel.Angle;
+        }
+
+        void SetDraggedValue(TextBlock label, float value)
+        {
+            if (Equals(label, XLabel)) ViewModel.X = value;
+            else if (Equals(label, YLabel)) ViewModel.Y = value;
+            else ViewModel.Angle = value;
+        }
+
+        // Reuses WpfDataUi's own label-drag snapping so this matches the drag feel of every other
+        // numeric field in Glue (1px = 1 unit, snapped to whole numbers) rather than a hand-rolled
+        // approximation of it. Internal (not private) so GlueUnitTests can pin the snapping behavior
+        // without driving real WPF mouse events.
+        internal static float SnapDraggedValue(double unroundedValue) =>
+            (float)TextBoxDisplayLogic.SnapDraggedValue(unroundedValue, rounding: 1);
+
+        #endregion
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/PathPlugin/PathSegmentViewDragTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/PathPlugin/PathSegmentViewDragTests.cs
@@ -1,0 +1,39 @@
+using OfficialPlugins.PathPlugin.Views;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.PathPlugin;
+
+// Pins issue #2157: PathInstance's X/Y/Angle fields didn't support the click-and-drag value
+// scrubbing every other numeric field in Glue supports. PathSegmentView.SnapDraggedValue is the pure
+// snapping step the label-drag mouse handlers call on every mouse-move; it reuses WpfDataUi's own
+// TextBoxDisplayLogic.SnapDraggedValue so the drag feel matches other numeric fields exactly.
+public class PathSegmentViewDragTests
+{
+    [Fact]
+    public void SnapDraggedValue_ShouldRoundToNearestWholeNumber()
+    {
+        PathSegmentView.SnapDraggedValue(12.8).ShouldBe(13f);
+        PathSegmentView.SnapDraggedValue(-12.8).ShouldBe(-13f);
+        PathSegmentView.SnapDraggedValue(0.4).ShouldBe(0f);
+    }
+
+    [Fact]
+    public void SnapDraggedValue_ShouldReflectAccumulatedPixelDrag()
+    {
+        // Mirrors Label_MouseMove: dragUnroundedValue accumulates raw pixel deltas across moves, and
+        // is re-snapped on every tick rather than re-applying the delta on top of an already-rounded
+        // value (issue #3191 in the ported WpfDataUi logic).
+        double startingValue = 100;
+        double unrounded = startingValue;
+
+        unrounded += 3; // first move, 3px right
+        PathSegmentView.SnapDraggedValue(unrounded).ShouldBe(103f);
+
+        unrounded += 3; // second move, 3px right
+        PathSegmentView.SnapDraggedValue(unrounded).ShouldBe(106f);
+
+        unrounded -= 10; // third move, 10px left
+        PathSegmentView.SnapDraggedValue(unrounded).ShouldBe(96f);
+    }
+}


### PR DESCRIPTION
Closes #2157.

Adds click-and-drag value scrubbing to PathInstance's X/Y/Angle fields (`PathSegmentView`), matching the drag-to-adjust behavior already present on other numeric fields in Glue (via `DataUiGrid`/`WpfDataUi`).

PathInstance's editor is a hand-rolled WPF view (plain `TextBox`es bound to `PathSegmentViewModel`), not `DataUiGrid`, so the fix wires the same drag gesture directly onto its X/Y/Angle labels rather than migrating the whole editor. It reuses `WpfDataUi`'s own `TextBoxDisplayLogic.SnapDraggedValue` (added a `ProjectReference` from `OfficialPlugins.csproj` to `WpfDataUi.csproj`, same reference `Glue.csproj` already has) so the drag feel — 1px = 1 unit, snapped to whole numbers — matches every other numeric field exactly instead of a hand-rolled approximation.

## Testing
The mouse-event wiring itself isn't unit-testable, but the snapping math it calls on every drag tick is extracted into an internal static method (`PathSegmentView.SnapDraggedValue`) and pinned with a new test (`PathSegmentViewDragTests`) — watched red with the snap disabled, green with it restored. Full non-BuildSmoke suite (729 tests) passes.

## Manual test: needed
1. Open `FRBDK/Glue/Glue with All.sln` from this worktree (`C:\Users\Vic Personal\Documents\GitHub\FlatRedBall-path-drag`) in Visual Studio and run Glue.
2. Open/create a project with a `Path` object, select it, and open the Path segment editor.
3. Click and drag left/right on the "X:", "Y:", or "Angle:" label — the value should scrub up/down by whole numbers as you drag, same feel as dragging a label on other numeric Glue fields.
