### PR TITLE
Fix InvalidOperationException live-editing a Text's Font to <NONE>

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/VariableAssignmentLogic.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/VariableAssignmentLogic.cs
@@ -1303,7 +1303,9 @@ namespace GlueControl.Editing
             }
             else if (type == typeof(FlatRedBall.Graphics.BitmapFont).ToString() || type == "BitmapFont")
             {
-                if (variableValue == null)
+                // Glue's UI sends the sentinel string "<NONE>" (not a CLR/JSON null) when a Font selection
+                // is cleared, so it must be treated the same as variableValue == null here.
+                if (variableValue == null || variableValue == "<NONE>")
                 {
                     convertedValue = FlatRedBall.Graphics.TextManager.DefaultFont;
                 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableAssignmentLogicEnumConversionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableAssignmentLogicEnumConversionTests.cs
@@ -144,6 +144,31 @@ public class VariableAssignmentLogicEnumConversionTests : IDisposable
         output.ShouldContain("ALL_OK");
     }
 
+    // Issue #2161: live-editing a FlatRedBall Text's BitmapFont-typed Font variable to <NONE> (Glue's
+    // sentinel string for "no file selected") throws InvalidOperationException. ConvertStringToType's
+    // BitmapFont case only recognized a literal null VariableValue, not the "<NONE>" sentinel string Glue's
+    // UI sends when a font selection is cleared, so the raw "<NONE>" string reached LateBinder.SetValue
+    // unconverted.
+    [Fact]
+    public void LiveEditingBitmapFontVariable_ShouldConvertNoneSentinel_NotThrowInvalidOperationException()
+    {
+        EmbeddedCodeManager.EmbedAll(fullyGenerate: true);
+        GlueCallsCodeGenerator.GenerateAll();
+
+        var generatedDirectory = Path.Combine(_tempProjectDirectory, "GlueControl");
+        var repoRoot = FindRepoRoot();
+        var scratchDirectory = Path.Combine(_tempProjectDirectory, "BitmapFontNoneScratch");
+        WriteScratchProject(scratchDirectory, repoRoot, generatedDirectory);
+        WriteBitmapFontNoneProgram(scratchDirectory);
+
+        var (exitCode, output) = NestedDotnetCli.Run($"run --project \"{scratchDirectory}\" -c Debug");
+
+        exitCode.ShouldBe(0,
+            "Live-editing a FlatRedBall Text's Font variable to <NONE> did not convert cleanly:" +
+            Environment.NewLine + output);
+        output.ShouldContain("ALL_OK");
+    }
+
     private static void WriteScratchProject(string scratchDirectory, string repoRoot, string generatedDirectory)
     {
         Directory.CreateDirectory(scratchDirectory);
@@ -509,6 +534,63 @@ public class VariableAssignmentLogicEnumConversionTests : IDisposable
                 var parsedFloat = VariableAssignmentLogic.ConvertStringToType(
                     "float?", "12.5", isState: false, out _);
                 Check("float? \"12.5\" (existing behavior)", parsedFloat, 12.5f);
+
+                if (failureCount == 0)
+                {
+                    Console.WriteLine("ALL_OK");
+                    Environment.Exit(0);
+                }
+                else
+                {
+                    Environment.Exit(1);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("FAIL: unhandled exception: " + ex);
+                Environment.Exit(1);
+            }
+            """);
+    }
+
+    private static void WriteBitmapFontNoneProgram(string scratchDirectory)
+    {
+        File.WriteAllText(Path.Combine(scratchDirectory, "Program.cs"), """
+            using System;
+            using GlueControl.Editing;
+
+            int failureCount = 0;
+
+            void Check(string label, bool condition, string detail)
+            {
+                if (condition)
+                {
+                    Console.WriteLine($"OK: {label}");
+                }
+                else
+                {
+                    Console.WriteLine($"FAIL: {label} - {detail}");
+                    failureCount++;
+                }
+            }
+
+            try
+            {
+                // Issue #2161 repro: Glue sends the literal string "<NONE>" (not a JSON/CLR null) as
+                // VariableValue when a BitmapFont-typed variable (e.g. a Text's Font) is cleared in the UI.
+                var convertedFont = VariableAssignmentLogic.ConvertStringToType(
+                    "BitmapFont", "<NONE>", isState: false, out _);
+                Check("BitmapFont \"<NONE>\" is not left as the unconverted string",
+                    !(convertedFont is string),
+                    $"got back the raw string \"{convertedFont}\" instead of a converted value");
+
+                // Closes the loop against the exact call path a live game hits: apply the converted value
+                // onto a real FlatRedBall.Graphics.Text's real Font property the same way Screen.ApplyVariable
+                // does, via FlatRedBall's reflection-based LateBinder - this is what actually threw
+                // InvalidOperationException in the original bug report.
+                var text = new FlatRedBall.Graphics.Text();
+                FlatRedBall.Instructions.Reflection.LateBinder.SetValueStatic(text, "Font", convertedFont);
+                Console.WriteLine("OK: LateBinder.SetValueStatic applied Font without throwing");
 
                 if (failureCount == 0)
                 {


### PR DESCRIPTION
## Summary
- Live-editing a `FlatRedBall.Graphics.Text`'s `Font` variable to `<NONE>` in Glue threw `InvalidOperationException` in the running game, because `VariableAssignmentLogic.ConvertStringToType`'s `BitmapFont` case only recognized a literal `null` `VariableValue`, not Glue's `<NONE>` sentinel string.
- Now treats `<NONE>` the same as `null` for `BitmapFont`, converting to `TextManager.DefaultFont`.

Closes #2161

## Test plan
- [x] Added `LiveEditingBitmapFontVariable_ShouldConvertNoneSentinel_NotThrowInvalidOperationException`, following the existing `ConvertStringToType` regression pattern in this file (#1978/#2141/#2151) — watched it fail with the exact reported exception before the fix, pass after.
- [x] Full `VariableAssignmentLogicEnumConversionTests` class: 4/4 passed.

Manual test: not needed — covered by the unit test above, which exercises the real generated code against the real engine assemblies.
