### PR TITLE
Cap the About tab logo so it can't scale up indefinitely

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml
@@ -11,7 +11,7 @@
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition></RowDefinition>
         </Grid.RowDefinitions>
-        <Image Source="/Content/logo-512.png" Margin="15"></Image>
+        <Image Source="/Content/logo-512.png" Margin="15" MaxWidth="200" MaxHeight="200" HorizontalAlignment="Center"></Image>
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"></ColumnDefinition>


### PR DESCRIPTION
Fixes #2162.

The About tab's logo `Image` had no size cap, and `Stretch="Uniform"` (the
default) scales to fill whatever width its container gets. Since About docks
to the right panel by default and that panel's width is a plain pixel
`GridLength` with no upper bound, dragging the Left/Center splitter far
enough grows the panel - and the logo with it - without limit.

Fix: cap the logo at 200x200 and center it, so it no longer tracks the
panel's width at all.

Repro'd by editing `RightTabWidthPixels` in `settings.xml` to a large value
and reopening the About tab - confirmed the logo ballooned on old code and
stays capped with the fix.

Manual test: needed (WPF layout change, not something a unit test can pin -
see the `glue-manual-repro`/testability-gate reasoning). Steps:
1. Open Help > About.
2. Drag the splitter between the Center and Right panels far to the left.
3. Logo should stay capped at its normal size instead of growing.
