### PR TITLE
Clamp new-project FileVersion to the referenced engine dll's syntax version

### DIFF
--- a/FRBDK/Glue/Glue/IO/ProjectLoader.cs
+++ b/FRBDK/Glue/Glue/IO/ProjectLoader.cs
@@ -172,7 +172,8 @@ namespace FlatRedBall.Glue.IO
                 {
                     ProjectManager.GlueProjectSave = new GlueProjectSave();
 
-                    ProjectManager.GlueProjectSave.FileVersion = GlueProjectSave.LatestVersion;
+                    ProjectManager.GlueProjectSave.FileVersion =
+                        GlueProjectSave.GetFileVersionForNewProject(GlueState.Self.EngineDllSyntaxVersion);
 
                     // After assigning the file version the glue project may change version, so try to update it:
                     glueProjectFile = GlueState.Self.GlueProjectFileName;

--- a/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
+++ b/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
@@ -226,6 +226,16 @@ namespace FlatRedBall.Glue.SaveClasses
 
         public int FileVersion { get; set; }
 
+        // Clamps to the referenced engine dll's syntax version when it's older than LatestVersion.
+        public static int GetFileVersionForNewProject(int? engineDllSyntaxVersion)
+        {
+            if (engineDllSyntaxVersion.HasValue && engineDllSyntaxVersion.Value < LatestVersion)
+            {
+                return engineDllSyntaxVersion.Value;
+            }
+            return LatestVersion;
+        }
+
         #endregion
 
         #region Camera Fields

--- a/FRBDK/Glue/Tests/GlueUnitTests/SaveClasses/GlueProjectSaveNewProjectVersionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/SaveClasses/GlueProjectSaveNewProjectVersionTests.cs
@@ -1,0 +1,38 @@
+using FlatRedBall.Glue.SaveClasses;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.SaveClasses;
+
+public class GlueProjectSaveNewProjectVersionTests
+{
+    [Fact]
+    public void GetFileVersionForNewProject_ShouldReturnLatestVersion_WhenEngineDllSyntaxVersionIsUnknown()
+    {
+        // Reproduces the "could not determine engine dll syntax version" case (no FlatRedBall
+        // PackageReference resolved yet) - fall back to Glue's own latest version.
+        GlueProjectSave.GetFileVersionForNewProject(engineDllSyntaxVersion: null)
+            .ShouldBe(GlueProjectSave.LatestVersion);
+    }
+
+    [Fact]
+    public void GetFileVersionForNewProject_ShouldReturnEngineDllSyntaxVersion_WhenLowerThanLatestVersion()
+    {
+        // Reproduces #2163: a new project's referenced FlatRedBall NuGet package (e.g. one grabbed
+        // before a newer Glue's NuGet packages were published) supports an older syntax version than
+        // Glue itself. The new project's FileVersion should not outrun what its own engine dll supports.
+        var engineDllSyntaxVersion = GlueProjectSave.LatestVersion - 1;
+
+        GlueProjectSave.GetFileVersionForNewProject(engineDllSyntaxVersion)
+            .ShouldBe(engineDllSyntaxVersion);
+    }
+
+    [Fact]
+    public void GetFileVersionForNewProject_ShouldReturnLatestVersion_WhenEngineDllSyntaxVersionIsHigherOrEqual()
+    {
+        var engineDllSyntaxVersion = GlueProjectSave.LatestVersion + 1;
+
+        GlueProjectSave.GetFileVersionForNewProject(engineDllSyntaxVersion)
+            .ShouldBe(GlueProjectSave.LatestVersion);
+    }
+}


### PR DESCRIPTION
## Summary

A new `.gluj` was always stamped with `GlueProjectSave.LatestVersion`, even when the referenced FlatRedBall NuGet package (e.g. grabbed before a newer Glue's packages were published) only supports an older syntax version - producing a `FileVersion` mismatch error before the project ever builds.

New projects now clamp `FileVersion` to `min(LatestVersion, EngineDllSyntaxVersion)` via `GlueProjectSave.GetFileVersionForNewProject`, called from `ProjectLoader.LoadProject` on the first-time-creation path only. Loading an *existing* project is unaffected - `FileVersion` still comes straight from the file, so a user who manually raises it still hits the existing mismatch error.

Fixes #2163

## Test plan

- [x] `GlueProjectSaveNewProjectVersionTests` (new) - unit tests for `GetFileVersionForNewProject`: unknown dll version falls back to latest, dll version lower than latest wins, dll version higher-or-equal falls back to latest
- [x] Full `GlueUnitTests` suite (`Category!=BuildSmoke`), clean rebuild: 732/732 passed
- Manual test: not needed - the change is a single value computation covered by unit tests; no UI/runtime path involved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rnz6AiTtVKNTHfxr2nrEmj
