### PR TITLE
Stop AddGeneratedPerformanceTypes writing into FRB2 projects

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/FactoryPlugin/FactoryElementCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/FactoryPlugin/FactoryElementCodeGenerator.cs
@@ -383,6 +383,16 @@ namespace FlatRedBall.Glue.Plugins.EmbeddedPlugins.FactoryPlugin
 
         public static void AddGeneratedPerformanceTypes()
         {
+            // GitHub issue #2169: an FRB2 project owns its own .csproj and generated code
+            // (CodeWritePolicy.WritesCodeForCurrentProject is false), so this must not write the
+            // Performance/*.Generated.cs files or add them as Compile items - the same seam
+            // SaveIfDiffers already suppresses on, but UpdateFileMembershipInProject below has no such
+            // check, so it was still adding a Compile item pointing at a file that was never written.
+            if (!CodeWritePolicy.WritesCodeForCurrentProject)
+            {
+                return;
+            }
+
             // May 23, 2024
             // PoolList is part
             // of FRB and also generated

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/FileCommands.cs
@@ -583,7 +583,7 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
                         FilePath absoluteExe = TryToGetFilePathFromExtension(textExtension);
                         if ((absoluteExe != "") && absoluteExe?.Exists() == true)
                         {
-                            Process.Start(new ProcessStartInfo(absoluteExe.FullPath, fileName));
+                            Process.Start(CreateResolvedAppStartInfo(absoluteExe.FullPath, fileName));
                             return;
                         }
 
@@ -663,6 +663,22 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces
             UseShellExecute = true,
             Verb = "openas"
         };
+
+        /// <summary>
+        /// GitHub issue #2176: builds the launch info for opening <paramref name="fileName"/> in a
+        /// resolved-by-extension app (e.g. Gum.exe for .gumx). Uses ArgumentList rather than the
+        /// ProcessStartInfo(fileName, arguments) two-arg constructor, which passes arguments as a raw
+        /// unquoted command-line string - a fileName containing a space (a "Vic Personal"-style user
+        /// profile folder) then splits into two argv tokens on the child process's side, which for Gum
+        /// surfaced as it trying to resolve the second token as a path relative to its own exe
+        /// directory. ArgumentList quotes/escapes each entry correctly regardless of content.
+        /// </summary>
+        internal static ProcessStartInfo CreateResolvedAppStartInfo(string exeFileName, string fileName)
+        {
+            var startInfo = new ProcessStartInfo(exeFileName);
+            startInfo.ArgumentList.Add(fileName);
+            return startInfo;
+        }
 
         private FilePath TryToGetFilePathFromExtension(string textExtension)
         {

--- a/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionCheck.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionCheck.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.VSHelpers.Projects;
 using Gum.DataTypes;
 using GumPlugin.Managers;
 
@@ -40,6 +41,18 @@ namespace GumPlugin.ErrorReporting
             var gumProject = AppState.Self.GumProjectSave;
             if (gumProject == null ||
                 gumProject.Version < (int)GumProjectSave.GumxVersions.ShapeVariableExpansion)
+            {
+                return true;
+            }
+
+            // GitHub issue #2172: this check only knows how to find an FRB1-shaped engine reference
+            // (a committed GumCore.*.dll, or a FlatRedBall.GumCore.* NuGet package) that can drift
+            // behind the gumx format it's stamped against. FRB2 has no such reference to go stale -
+            // its engine comes from either a Directory.Packages.props-pinned NuGet package or a live
+            // source ProjectReference, both always current with the rest of the engine - so there is
+            // nothing for this check to catch there, and DetectedRuntimeSyntaxVersion's FRB1-only name
+            // lists made it misfire as "not present" on every FRB2 project regardless.
+            if (GlueState.Self.CurrentMainProject is Frb2Project)
             {
                 return true;
             }

--- a/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/FileCommandsTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/FileCommandsTests.cs
@@ -18,4 +18,20 @@ public class FileCommandsTests
         startInfo.UseShellExecute.ShouldBeTrue();
         startInfo.FileName.ShouldBe(@"E:\Content\ResonatorAnimation.achx");
     }
+
+    // GitHub issue #2176: a user profile folder containing a space (e.g. "Vic Personal") broke
+    // "open in Gum" because the file path was passed via ProcessStartInfo's raw Arguments string,
+    // which splits on whitespace before the child process ever sees it.
+    [Fact]
+    public void CreateResolvedAppStartInfo_KeepsFileNameAsOneArgument_EvenWithSpaces()
+    {
+        var startInfo = FileCommands.CreateResolvedAppStartInfo(
+            @"C:\Users\Vic Personal\Documents\GitHub\Gum\Gum\bin\Debug\Gum.exe",
+            @"C:\Users\Vic Personal\Documents\FlatRedBallProjects\FRB_2_10\FRB_2_10.Common\Content\FrbEditor\GumProject\GumProject.gumx");
+
+        startInfo.FileName.ShouldBe(@"C:\Users\Vic Personal\Documents\GitHub\Gum\Gum\bin\Debug\Gum.exe");
+        startInfo.ArgumentList.Count.ShouldBe(1);
+        startInfo.ArgumentList[0].ShouldBe(
+            @"C:\Users\Vic Personal\Documents\FlatRedBallProjects\FRB_2_10\FRB_2_10.Common\Content\FrbEditor\GumProject\GumProject.gumx");
+    }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeRuntimeVersionCheckTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeRuntimeVersionCheckTests.cs
@@ -2,10 +2,12 @@ using System;
 using System.IO;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.VSHelpers.Projects;
 using Gum.DataTypes;
 using GlueUnitTests.Tasks;
 using GlueUnitTests.TestSupport;
 using GumPlugin.ErrorReporting;
+using Microsoft.Build.Evaluation;
 using Shouldly;
 using Xunit;
 
@@ -101,6 +103,23 @@ public class RectangleFillStrokeRuntimeVersionCheckTests : IDisposable
 
         RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed().ShouldBeFalse();
         RectangleFillStrokeRuntimeVersionCheck.DetectedRuntimeSyntaxVersion().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetIfCurrentlyFixed_V3GumProject_Frb2Project_IsFixed_RegardlessOfReferences()
+    {
+        // GitHub issue #2172: FRB2 has no committed GumCore.*.dll to go stale, so this check does not
+        // apply to it at all - without the Frb2Project early-out, DetectedRuntimeSyntaxVersion's
+        // FRB1-only name lists never resolve an FRB2 engine reference, so this fired on every FRB2
+        // project the moment its gumx hit version 3+ (the default for any project saved by current
+        // Gum tooling).
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        AddStaleDllReference();
+
+        var csprojPath = GlueState.Self.CurrentMainProject.FullFileName.FullPath;
+        GlueState.Self.CurrentMainProject = new Frb2Project(new Project(csprojPath, null, null, new ProjectCollection()));
+
+        RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed().ShouldBeTrue();
     }
 
     [Fact]

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.EmbeddedPlugins.FactoryPlugin;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.Plugins.ExportedImplementations.CommandInterfaces;
 using FlatRedBall.Glue.SaveClasses;
@@ -426,6 +427,25 @@ public class Frb2CodeGenerationSuppressionTests : IDisposable
 
         Assert.False(didWrite);
         Assert.False(File.Exists(codeFile));
+    }
+
+    [Fact]
+    public void AddGeneratedPerformanceTypes_DoesNothing_WhenTheProjectIsFrb2()
+    {
+        // GitHub issue #2169: these files were never owned by a Screen/Entity, so once they were added
+        // to an FRB2 project's in-memory Compile items, GitHub issue #2103's orphan-cleanup treated them
+        // as leftovers and removed them again on the next load - noisy and pointless, since an FRB2
+        // project shouldn't have had them in the first place.
+        GlueState.Self.CurrentMainProject = CreateProject(p => new Frb2Project(p), "Frb2Game");
+
+        FactoryElementCodeGenerator.AddGeneratedPerformanceTypes();
+
+        Assert.False(File.Exists(Path.Combine(_directory, "Performance", "PoolList.Generated.cs")));
+        Assert.False(File.Exists(Path.Combine(_directory, "Performance", "IEntityFactory.Generated.cs")));
+        Assert.False(GlueState.Self.CurrentMainProject.IsFilePartOfProject(
+            Path.Combine(_directory, "Performance", "PoolList.Generated.cs"), BuildItemMembershipType.Any));
+        Assert.False(GlueState.Self.CurrentMainProject.IsFilePartOfProject(
+            Path.Combine(_directory, "Performance", "IEntityFactory.Generated.cs"), BuildItemMembershipType.Any));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #2169

## Summary
Opening an FRB2 project (or triggering a reload, e.g. adding a Gum object) had Glue add `Content\FrbEditor\Performance\PoolList.Generated.cs` and `IEntityFactory.Generated.cs` as `<Compile>` items to the game's own .csproj, even though FRB2 owns its .csproj and generated code.

`FactoryElementCodeGenerator.AddGeneratedPerformanceTypes` ran unconditionally on load. `SaveIfDiffers` already suppresses the actual file write for FRB2 via `CodeWritePolicy`, but `UpdateFileMembershipInProject` had no such check, so it kept adding a Compile item pointing at a file that was never written - which #2103's orphan-cleanup then flagged as an orphan and removed on the next load (the noisy "Removed orphaned csproj entry" log lines).

Fix: gate the whole method on `CodeWritePolicy.WritesCodeForCurrentProject`.

Follow-up (`Performance/*.Generated.cs` shouldn't be swept by the orphan-cleanup on FRB1 either, since it isn't Screen/Entity-owned) tracked separately in #2170.

## Test plan
- [x] New unit test `AddGeneratedPerformanceTypes_DoesNothing_WhenTheProjectIsFrb2`, confirmed Red without the fix (NRE reaching into project membership for an FRB2 project) and Green with it.
- [x] Full non-BuildSmoke suite: 740 passed, clean build.
- [x] Manual: open an FRB2 project's `.Common` project in Glue, add a Gum object, confirm no `Removed orphaned csproj entry` log lines and no Performance files added to the .csproj.