### PR TITLE
Skip RectangleFillStrokeRuntimeVersionCheck for FRB2 projects

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionCheck.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/ErrorReporting/RectangleFillStrokeRuntimeVersionCheck.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.VSHelpers.Projects;
 using Gum.DataTypes;
 using GumPlugin.Managers;
 
@@ -40,6 +41,18 @@ namespace GumPlugin.ErrorReporting
             var gumProject = AppState.Self.GumProjectSave;
             if (gumProject == null ||
                 gumProject.Version < (int)GumProjectSave.GumxVersions.ShapeVariableExpansion)
+            {
+                return true;
+            }
+
+            // GitHub issue #2172: this check only knows how to find an FRB1-shaped engine reference
+            // (a committed GumCore.*.dll, or a FlatRedBall.GumCore.* NuGet package) that can drift
+            // behind the gumx format it's stamped against. FRB2 has no such reference to go stale -
+            // its engine comes from either a Directory.Packages.props-pinned NuGet package or a live
+            // source ProjectReference, both always current with the rest of the engine - so there is
+            // nothing for this check to catch there, and DetectedRuntimeSyntaxVersion's FRB1-only name
+            // lists made it misfire as "not present" on every FRB2 project regardless.
+            if (GlueState.Self.CurrentMainProject is Frb2Project)
             {
                 return true;
             }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeRuntimeVersionCheckTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/RectangleFillStrokeRuntimeVersionCheckTests.cs
@@ -2,10 +2,12 @@ using System;
 using System.IO;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.VSHelpers.Projects;
 using Gum.DataTypes;
 using GlueUnitTests.Tasks;
 using GlueUnitTests.TestSupport;
 using GumPlugin.ErrorReporting;
+using Microsoft.Build.Evaluation;
 using Shouldly;
 using Xunit;
 
@@ -101,6 +103,23 @@ public class RectangleFillStrokeRuntimeVersionCheckTests : IDisposable
 
         RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed().ShouldBeFalse();
         RectangleFillStrokeRuntimeVersionCheck.DetectedRuntimeSyntaxVersion().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetIfCurrentlyFixed_V3GumProject_Frb2Project_IsFixed_RegardlessOfReferences()
+    {
+        // GitHub issue #2172: FRB2 has no committed GumCore.*.dll to go stale, so this check does not
+        // apply to it at all - without the Frb2Project early-out, DetectedRuntimeSyntaxVersion's
+        // FRB1-only name lists never resolve an FRB2 engine reference, so this fired on every FRB2
+        // project the moment its gumx hit version 3+ (the default for any project saved by current
+        // Gum tooling).
+        SetGumProjectVersion((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        AddStaleDllReference();
+
+        var csprojPath = GlueState.Self.CurrentMainProject.FullFileName.FullPath;
+        GlueState.Self.CurrentMainProject = new Frb2Project(new Project(csprojPath, null, null, new ProjectCollection()));
+
+        RectangleFillStrokeRuntimeVersionCheck.GetIfCurrentlyFixed().ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #2172

## Summary
Adding a Gum object to an FRB2 project always tripped the "gumx version 3+ ... but the referenced Gum runtime assembly declares GumSyntaxVersion not present" error in Glue's error list, even on a perfectly healthy project.

`RectangleFillStrokeRuntimeVersionCheck.DetectedRuntimeSyntaxVersion` only recognizes FRB1-shaped engine references: `GumCore.*` DLL hint paths and `FlatRedBall.GumCore.*` NuGet packages. An FRB2 project references the engine as `FlatRedBall2`/`FlatRedBall2.MonoGame` (or a `ProjectReference` to `FlatRedBall2.csproj`), matching none of those names, so detection always returned null. The `IsFrbSourceLinked()` fallback is also FRB1-only. So the check could never come back "fixed" for FRB2, and fired the moment the gumx hit version 3+ - which happens automatically since current Gum tooling saves at v4.

It's also the wrong check to even run for FRB2: the risk it exists to catch (a stale, independently-committed `GumCore.*.dll` binary drifting behind the gumx format) is an FRB1-only shape. FRB2's engine reference is either a `Directory.Packages.props`-pinned NuGet package or a live source `ProjectReference`, either way always current with the rest of the engine.

Fix: skip the check entirely for `Frb2Project`.

## Test plan
- [x] New unit test `GetIfCurrentlyFixed_V3GumProject_Frb2Project_IsFixed_RegardlessOfReferences`, confirmed Red without the fix and Green with it.
- [x] Full non-BuildSmoke suite: 740 passed, clean build.
- [ ] Manual: open an FRB2 project with a v3+ gumx in Glue, confirm this error no longer appears in the error list.