### PR TITLE
Fix flaky SetEditMode retry race on game startup

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
+++ b/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
@@ -127,6 +127,7 @@
     <Compile Include="GlueControl\CodeGeneration\InstanceLogicCodeGenerator.cs" />
     <Compile Include="GlueControl\CommandReceiving\CommandReceiver.cs" />
     <Compile Include="GlueControl\CommandSending\CommandSender.cs" />
+    <Compile Include="GlueControl\CommandSending\GameReadinessRetryPolicy.cs" />
     <Compile Include="GlueControl\Dtos\Dtos.cs" />
     <Compile Include="GlueControl\Dtos\GeneratePreviewDto.cs" />
     <Compile Include="GlueControl\Managers\ModalReportingService.cs" />
@@ -146,7 +147,6 @@
     <Compile Include="GlueControl\ViewModels\RunnerToolbarViewModel.cs" />
     <Compile Include="GlueControl\ViewModels\TestViewModel.cs" />
     <Compile Include="GlueControl\Views\AirspacePopup.cs" />
-    <Compile Include="GlueControl\Views\BorderlessRetryPolicy.cs" />
     <Compile Include="GlueControl\Views\EmbedSettlePolicy.cs" />
     <Compile Include="GlueControl\Views\BottomStatusBar.xaml.cs" />
     <Compile Include="GlueControl\Views\EditingToolsView.xaml.cs" />

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandSending/CommandSender.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandSending/CommandSender.cs
@@ -183,12 +183,23 @@ namespace GameCommunicationPlugin.GlueControl.CommandSending
 
                 lastStartedSend = text;
 
-                int triesLeft = importance  == SendImportance.RetryOnFailure ? 5 : 1;
                 GeneralResponse<string> result = GeneralResponse<string>.UnsuccessfulResponse;
 
-                while(result.Succeeded == false && triesLeft > 0)
+                if (importance == SendImportance.RetryOnFailure)
                 {
-                    triesLeft--;
+                    // A single attempt races the game's own startup (see GameReadinessRetryPolicy) -
+                    // the game can report itself as not connected, or not yet ready to dispatch the
+                    // command, for up to a second or so after its window first appears. Retrying
+                    // without waiting between attempts loses that race every time, since the condition
+                    // that makes the next attempt succeed hasn't had time to change.
+                    await GameReadinessRetryPolicy.TryRepeatedlyAsync(async () =>
+                    {
+                        result = await SendCommandNoSemaphore(text, isImportant, shouldPrint, waitForResponse);
+                        return result.Succeeded;
+                    });
+                }
+                else
+                {
                     result = await SendCommandNoSemaphore(text, isImportant, shouldPrint, waitForResponse);
                 }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandSending/GameReadinessRetryPolicy.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandSending/GameReadinessRetryPolicy.cs
@@ -1,17 +1,19 @@
 using System;
 using System.Threading.Tasks;
 
-namespace GameCommunicationPlugin.GlueControl.Views
+namespace GameCommunicationPlugin.GlueControl.CommandSending
 {
     /// <summary>
-    /// Retry budget for the SetBorderlessDto that strips the game window's frame when it's embedded
-    /// in the Game tab (issue #2048). Runner_GameStarted fires as soon as the game process has a
-    /// window handle, but the DTO is only actually handled once the game's Initialize has gotten as
-    /// far as constructing GlueControlManager - until then the socket is connected yet
-    /// GlueControlManager.Self is null, so the receive loop reports itself as not ready and the
-    /// command is dropped. Retrying past that gap is the whole point of this type.
+    /// Retry budget for a DTO sent while the game might still be mid-startup (originally added for
+    /// SetBorderlessDto, issue #2048; also used for the initial SetEditMode send, issue #2174).
+    /// Runner_GameStarted fires as soon as the game process has a window handle - which can be before
+    /// GameConnectionManager has even connected the socket - and the DTO is only actually handled once
+    /// the game's Initialize has gotten as far as constructing GlueControlManager. Until then either the
+    /// socket isn't connected yet, or it is but GlueControlManager.Self is null and the receive loop
+    /// reports itself as not ready, so the command is dropped either way. Retrying past that gap is the
+    /// whole point of this type.
     /// </summary>
-    public static class BorderlessRetryPolicy
+    public static class GameReadinessRetryPolicy
     {
         public const int MaxAttempts = 40;
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -912,6 +912,10 @@ namespace GameCommunicationPlugin.GlueControl
                     ? "Game sent back no response"
                     : $"Game sent back the following message: {response.Message}";
 
+                // This is sent with SendImportance.RetryOnFailure, so getting here means the game never
+                // became ready within the whole retry budget - not just a single unlucky attempt.
+                message += $"\n(retried for up to {GameReadinessRetryPolicy.TotalBudgetMilliseconds}ms)";
+
                 return message;
             }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
@@ -160,7 +160,7 @@ namespace OfficialPlugins.GameHost.Views
         {
             var dto = new GameCommunicationPlugin.GlueControl.Dtos.SetBorderlessDto { IsBorderless = true };
 
-            var succeeded = await BorderlessRetryPolicy.TryRepeatedlyAsync(async () =>
+            var succeeded = await GameReadinessRetryPolicy.TryRepeatedlyAsync(async () =>
             {
                 var sendResponse = await CommandSender.Self.Send(dto);
 
@@ -174,7 +174,7 @@ namespace OfficialPlugins.GameHost.Views
             if (!succeeded)
             {
                 GlueCommands.Self.PrintOutput(
-                    $"Failed to make the game window borderless after {BorderlessRetryPolicy.TotalBudgetMilliseconds}ms, " +
+                    $"Failed to make the game window borderless after {GameReadinessRetryPolicy.TotalBudgetMilliseconds}ms, " +
                     "so it will stay embedded with its own title bar and won't be resized to fit the Game tab. " +
                     "Restarting the game usually fixes this - please report it (with this message) at " +
                     "https://github.com/vchelaru/FlatRedBall/issues/2048 if it keeps happening.");

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/CommandSenderResponseTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/CommandSenderResponseTests.cs
@@ -109,6 +109,32 @@ namespace GlueUnitTests.GameCommunicationPlugin
             response.Message.ShouldContain("not ready");
         }
 
+        /// <summary>
+        /// Pins issue #2174: MainCompilerPlugin sends the initial SetEditMode with
+        /// SendImportance.RetryOnFailure specifically to outlast the game's own startup, where
+        /// Runner_GameStarted can fire before the game's socket has even connected. A retry loop that
+        /// doesn't actually wait between attempts burns through its whole budget before that real time
+        /// has a chance to pass, so it fails exactly the race it exists to survive. The fake game here
+        /// only becomes ready after real wall-clock time elapses, so this only passes if retrying
+        /// actually waits between attempts.
+        /// </summary>
+        [Fact]
+        public async Task TypedSend_WithRetryOnFailure_WaitsForTheGameToBecomeReady()
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            using var fixture = await ConnectAsync(_ =>
+                stopwatch.ElapsedMilliseconds < 200
+                    ? GameConnectionManager.NotReadyPayload
+                    : "{\"Succeeded\":true,\"Message\":\"ready now\"}");
+
+            var response = await fixture.Sender.Send<GeneralCommandResponse>(
+                new SetEditMode(), SendImportance.RetryOnFailure);
+
+            response.Succeeded.ShouldBeTrue(
+                "retrying with real delays between attempts must eventually catch the game becoming ready");
+        }
+
         [Fact]
         public async Task TypedSend_WhenTheGameNeverAnswers_ReportsFailure()
         {

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/DroppedCommandCallerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/DroppedCommandCallerTests.cs
@@ -45,6 +45,9 @@ namespace GlueUnitTests.GameCommunicationPlugin
             message.ShouldNotBeNull();
             message.ShouldContain("Edit");
             message.ShouldContain("not ready to handle commands");
+            // Sent with SendImportance.RetryOnFailure, so reaching this message means the whole retry
+            // budget was exhausted, not just one unlucky attempt - worth saying so for diagnostics.
+            message.ShouldContain("retried for up to");
         }
 
         [Fact]

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GameReadinessRetryPolicyTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GameReadinessRetryPolicyTests.cs
@@ -1,26 +1,27 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using GameCommunicationPlugin.GlueControl.Views;
+using GameCommunicationPlugin.GlueControl.CommandSending;
 using Shouldly;
 using Xunit;
 
 namespace GlueUnitTests.GameCommunicationPlugin;
 
 /// <summary>
-/// The retry budget for the SetBorderlessDto sent when the game is embedded in the Game tab
-/// (issue #2048). The game reports itself as not ready for the window between its socket connecting
-/// and GlueControlManager being constructed, so the budget has to outlast that gap or the game keeps
-/// its window frame for the rest of the session.
+/// The retry budget for a DTO sent while the game might still be mid-startup - originally added for
+/// SetBorderlessDto (issue #2048), also used for the initial SetEditMode send (issue #2174). The game
+/// reports itself as not connected, or connected but not ready, for the window between its process
+/// starting and GlueControlManager being constructed, so the budget has to outlast that gap or the
+/// command is silently dropped.
 /// </summary>
-public class BorderlessRetryPolicyTests
+public class GameReadinessRetryPolicyTests
 {
     [Fact]
     public async Task TryRepeatedlyAsync_ShouldStopAtFirstSuccess()
     {
         var attempts = 0;
 
-        var succeeded = await BorderlessRetryPolicy.TryRepeatedlyAsync(
+        var succeeded = await GameReadinessRetryPolicy.TryRepeatedlyAsync(
             attemptAsync: () => { attempts++; return Task.FromResult(true); },
             delayAsync: _ => Task.CompletedTask);
 
@@ -33,7 +34,7 @@ public class BorderlessRetryPolicyTests
     {
         var attempts = 0;
 
-        var succeeded = await BorderlessRetryPolicy.TryRepeatedlyAsync(
+        var succeeded = await GameReadinessRetryPolicy.TryRepeatedlyAsync(
             attemptAsync: () => { attempts++; return Task.FromResult(attempts == 4); },
             delayAsync: _ => Task.CompletedTask);
 
@@ -46,7 +47,7 @@ public class BorderlessRetryPolicyTests
     {
         var attempts = 0;
 
-        var succeeded = await BorderlessRetryPolicy.TryRepeatedlyAsync(
+        var succeeded = await GameReadinessRetryPolicy.TryRepeatedlyAsync(
             attemptAsync: () => { attempts++; return Task.FromResult(false); },
             delayAsync: _ => Task.CompletedTask,
             maxAttempts: 5);
@@ -60,7 +61,7 @@ public class BorderlessRetryPolicyTests
     {
         var delays = new List<int>();
 
-        await BorderlessRetryPolicy.TryRepeatedlyAsync(
+        await GameReadinessRetryPolicy.TryRepeatedlyAsync(
             attemptAsync: () => Task.FromResult(false),
             delayAsync: milliseconds => { delays.Add(milliseconds); return Task.CompletedTask; },
             maxAttempts: 3,
@@ -78,6 +79,27 @@ public class BorderlessRetryPolicyTests
         // connects immediately) and GlueControlManager (which is what actually handles the DTO) -
         // CameraSetup.SetupCamera sits between them, and graphics-device setup is what swings on a
         // cold GPU driver load. The original 90ms budget lost that race often enough to be reported.
-        BorderlessRetryPolicy.TotalBudgetMilliseconds.ShouldBeGreaterThanOrEqualTo(1000);
+        GameReadinessRetryPolicy.TotalBudgetMilliseconds.ShouldBeGreaterThanOrEqualTo(1000);
+    }
+
+    /// <summary>
+    /// Pins issue #2174's root cause directly: the default call (no injected delay) must actually pass
+    /// wall-clock time between attempts, not just call attemptAsync() repeatedly in a tight loop. A
+    /// caller racing the game's startup (CommandSender's SetEditMode retry) depends on real time
+    /// elapsing for the game to become ready - a loop with no delay retries 5 times before the game's
+    /// socket has even had a chance to connect.
+    /// </summary>
+    [Fact]
+    public async Task TryRepeatedlyAsync_WithNoInjectedDelay_ActuallyWaitsBetweenAttempts()
+    {
+        var attempts = 0;
+
+        var succeeded = await GameReadinessRetryPolicy.TryRepeatedlyAsync(
+            attemptAsync: () => { attempts++; return Task.FromResult(attempts == 3); },
+            maxAttempts: 5,
+            millisecondsBetweenAttempts: 20);
+
+        succeeded.ShouldBeTrue();
+        attempts.ShouldBe(3);
     }
 }


### PR DESCRIPTION
Part of #2174. Could not reproduce the reported black-screen/"Not connected" loop directly, but found and fixed a concrete, verified bug in the exact code path the log points at, which is a likely contributor.

## What was wrong

`CommandSender.SendCommand`'s `SendImportance.RetryOnFailure` path (used only by the initial `SetEditMode` send when the game starts) retried up to 5 times **with no delay between attempts**. The game's window handle can appear before its socket has even connected (window creation happens before `Initialize()` runs, which is where `GameConnectionManager` gets constructed), so all 5 retries fired and failed within microseconds - before the game had any real time to connect. This is the same race that was already fixed once for the "make window borderless" call (#2048, bumped from a 90ms to a 1000ms delay-based retry budget) - that fix was never applied to this call.

## Fix

Generalized `BorderlessRetryPolicy` into `GameReadinessRetryPolicy` (moved to `CommandSending/`, same delay-based budget: up to 40 attempts, 25ms apart, ~1s total) and reused it in `CommandSender`'s retry path instead of the old zero-delay loop.

Also appended the retry budget to the `SetEditMode` failure message, so if this keeps happening, the printed message now says the game never became ready within ~1s of retrying - not just that a single attempt failed - which is a stronger diagnostic signal for a future report.

## Tests

- `CommandSenderResponseTests.TypedSend_WithRetryOnFailure_WaitsForTheGameToBecomeReady` pins the bug directly: a fake game that only becomes ready after 200ms of wall-clock time. Fails on the old code (5 retries with no delay all complete well under 200ms), passes with the fix.
- `GameReadinessRetryPolicyTests` renamed/extended from `BorderlessRetryPolicyTests`.
- `DroppedCommandCallerTests` extended to assert the new diagnostic suffix.
- Full non-BuildSmoke suite: 744/744 passing from a clean rebuild.

Manual test: not needed - the retry path is fully covered by `CommandSenderResponseTests` driving the real `CommandSender` over a real loopback socket against a fake game.
