### PR TITLE
Exclude Performance factory files from orphaned-csproj-entry cleanup

### DIFF
--- a/FRBDK/Glue/Glue/VSHelpers/OrphanedGeneratedCompileItemFinder.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/OrphanedGeneratedCompileItemFinder.cs
@@ -27,16 +27,21 @@ namespace FlatRedBall.Glue.VSHelpers
     public static class OrphanedGeneratedCompileItemFinder
     {
         /// <summary>
-        /// Includes (relative to the project directory, compared with '/' as the separator) of Glue-generated
-        /// files that are never owned by any Screen/Entity - see GitHub issue #2170. Written once by
-        /// FactoryElementCodeGenerator.AddGeneratedPerformanceTypes, so the Screen/Entity ownership model has
-        /// no way to recognize them as owned; without this exclusion they'd look orphaned - and get removed -
-        /// on any load where the backing file happens to be missing when this check runs.
+        /// Top-level folders a Screen/Entity's owned generated files can ever live under - see
+        /// <see cref="FlatRedBall.Glue.Elements.DeletionPlanner.GetOwnedGeneratedRelativePaths"/> (element
+        /// names are always "Screens\..."/"Entities\...", and factories always live under "Factories\").
+        /// Reconciliation is scoped to only these folders - see GitHub issue #2170 - because the ownership
+        /// model only understands Screen/Entity ownership: a ".Generated.cs" written by some other generator
+        /// into any other folder (e.g. Performance\PoolList.Generated.cs, written once by
+        /// FactoryElementCodeGenerator.AddGeneratedPerformanceTypes) will never appear "owned" and would
+        /// otherwise look orphaned - and get removed - on any load where its backing file happens to be
+        /// missing when this check runs.
         /// </summary>
-        static readonly HashSet<string> KnownNonElementOwnedGeneratedIncludes = new(StringComparer.OrdinalIgnoreCase)
+        static readonly HashSet<string> ElementOwnedGeneratedFolders = new(StringComparer.OrdinalIgnoreCase)
         {
-            "Performance/PoolList.Generated.cs",
-            "Performance/IEntityFactory.Generated.cs",
+            "Screens",
+            "Entities",
+            "Factories",
         };
 
         public static bool IsGlueGeneratedFileName(string fileName)
@@ -74,17 +79,16 @@ namespace FlatRedBall.Glue.VSHelpers
                     continue;
                 }
 
-                var fileName = item.UnevaluatedInclude
-                    .Replace('\\', '/')
-                    .Split('/')
-                    .Last();
+                var segments = item.UnevaluatedInclude.Replace('\\', '/').Split('/');
+                var fileName = segments.Last();
 
                 if (!IsGlueGeneratedFileName(fileName))
                 {
                     continue;
                 }
 
-                if (KnownNonElementOwnedGeneratedIncludes.Contains(item.UnevaluatedInclude.Replace('\\', '/')))
+                var topFolder = segments.Length > 1 ? segments[0] : string.Empty;
+                if (!ElementOwnedGeneratedFolders.Contains(topFolder))
                 {
                     continue;
                 }

--- a/FRBDK/Glue/Glue/VSHelpers/OrphanedGeneratedCompileItemFinder.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/OrphanedGeneratedCompileItemFinder.cs
@@ -26,6 +26,19 @@ namespace FlatRedBall.Glue.VSHelpers
     /// </summary>
     public static class OrphanedGeneratedCompileItemFinder
     {
+        /// <summary>
+        /// Includes (relative to the project directory, compared with '/' as the separator) of Glue-generated
+        /// files that are never owned by any Screen/Entity - see GitHub issue #2170. Written once by
+        /// FactoryElementCodeGenerator.AddGeneratedPerformanceTypes, so the Screen/Entity ownership model has
+        /// no way to recognize them as owned; without this exclusion they'd look orphaned - and get removed -
+        /// on any load where the backing file happens to be missing when this check runs.
+        /// </summary>
+        static readonly HashSet<string> KnownNonElementOwnedGeneratedIncludes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Performance/PoolList.Generated.cs",
+            "Performance/IEntityFactory.Generated.cs",
+        };
+
         public static bool IsGlueGeneratedFileName(string fileName)
         {
             if (string.IsNullOrEmpty(fileName))
@@ -67,6 +80,11 @@ namespace FlatRedBall.Glue.VSHelpers
                     .Last();
 
                 if (!IsGlueGeneratedFileName(fileName))
+                {
+                    continue;
+                }
+
+                if (KnownNonElementOwnedGeneratedIncludes.Contains(item.UnevaluatedInclude.Replace('\\', '/')))
                 {
                     continue;
                 }

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -1248,7 +1248,10 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         /// so "missing on disk" plus "unowned" together are a safe signal the entry is a leftover from a
         /// delete/rename that didn't clean up the csproj (a merge, a manual edit, an older Glue version).
         /// Never touches wildcard or conditional (platform-specific) entries, or hand-authored files - only
-        /// Glue's own generated-file naming is a candidate. Returns the removed entries' Include values.
+        /// Glue's own generated-file naming is a candidate. Also never touches the handful of generated files
+        /// that are known to never be Screen/Entity-owned (e.g. Performance/PoolList.Generated.cs - see GitHub
+        /// issue #2170); the ownership model only understands Screen/Entity ownership, so those would always
+        /// look orphaned to it. Returns the removed entries' Include values.
         /// </summary>
         public List<string> RemoveOrphanedGeneratedCompileItems(IEnumerable<GlueElement> ownerElements)
         {

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -1248,10 +1248,11 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
         /// so "missing on disk" plus "unowned" together are a safe signal the entry is a leftover from a
         /// delete/rename that didn't clean up the csproj (a merge, a manual edit, an older Glue version).
         /// Never touches wildcard or conditional (platform-specific) entries, or hand-authored files - only
-        /// Glue's own generated-file naming is a candidate. Also never touches the handful of generated files
-        /// that are known to never be Screen/Entity-owned (e.g. Performance/PoolList.Generated.cs - see GitHub
-        /// issue #2170); the ownership model only understands Screen/Entity ownership, so those would always
-        /// look orphaned to it. Returns the removed entries' Include values.
+        /// Glue's own generated-file naming is a candidate. Also scoped to only the Screens/Entities/Factories
+        /// folders a Screen/Entity's generated files can ever live under - see GitHub issue #2170; the
+        /// ownership model only understands Screen/Entity ownership, so a ".Generated.cs" some other generator
+        /// wrote elsewhere (e.g. Performance/PoolList.Generated.cs) would always look orphaned to it. Returns
+        /// the removed entries' Include values.
         /// </summary>
         public List<string> RemoveOrphanedGeneratedCompileItems(IEnumerable<GlueElement> ownerElements)
         {

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/OrphanedGeneratedCompileItemReconciliationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/OrphanedGeneratedCompileItemReconciliationTests.cs
@@ -151,6 +151,33 @@ public class OrphanedGeneratedCompileItemReconciliationTests
     }
 
     [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldKeep_KnownNonElementOwnedPerformanceFiles_EvenThoughFileIsMissing()
+    {
+        // GitHub issue #2170: Performance/PoolList.Generated.cs and Performance/IEntityFactory.Generated.cs
+        // are written once by FactoryElementCodeGenerator.AddGeneratedPerformanceTypes, never owned by a
+        // Screen/Entity, so they always look orphaned to this check whenever the backing file happens to be
+        // missing - they must survive regardless.
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            project.AddCodeBuildItem(@"Performance\PoolList.Generated.cs");
+            project.AddCodeBuildItem(@"Performance\IEntityFactory.Generated.cs");
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(new List<GlueElement>());
+
+            removed.ShouldBeEmpty();
+            project.IsFilePartOfProject(@"Performance\PoolList.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline)
+                .ShouldBeTrue();
+            project.IsFilePartOfProject(@"Performance\IEntityFactory.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline)
+                .ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void RemoveOrphanedGeneratedCompileItems_ShouldRemove_MultipleOrphanedEntries_AndKeepTheRest()
     {
         var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/OrphanedGeneratedCompileItemFinderTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/OrphanedGeneratedCompileItemFinderTests.cs
@@ -167,6 +167,22 @@ public class OrphanedGeneratedCompileItemFinderTests
         result.ShouldBeEmpty();
     }
 
+    [Theory]
+    [InlineData(@"Performance\PoolList.Generated.cs")]
+    [InlineData(@"Performance\IEntityFactory.Generated.cs")]
+    [InlineData("Performance/PoolList.Generated.cs")]
+    public void FindOrphanedIncludes_ShouldKeep_KnownNonElementOwnedGeneratedFiles_EvenIfMissingOnDisk(string include)
+    {
+        // GitHub issue #2170: these are written once by
+        // FactoryElementCodeGenerator.AddGeneratedPerformanceTypes, not owned by any Screen/Entity, so the
+        // ownership model always sees them as unowned - they must be excluded regardless of file existence.
+        var items = new[] { Item(include) };
+
+        var result = Find(items);
+
+        result.ShouldBeEmpty();
+    }
+
     [Fact]
     public void FindOrphanedIncludes_ShouldKeep_WhenOwnershipMatchIgnoresNothingButExactPath()
     {

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/OrphanedGeneratedCompileItemFinderTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/OrphanedGeneratedCompileItemFinderTests.cs
@@ -9,7 +9,9 @@ namespace GlueUnitTests.VSHelpers;
 /// GitHub issue #2103: a Screen/Entity deleted or renamed outside Glue's own delete/rename flow can leave
 /// its ".Generated.cs" (or similar) still referenced in the .csproj, producing CS2001 on the next build.
 /// These pin the pure decision logic - which candidate &lt;Compile Include&gt; entries are safe to treat as
-/// orphaned - independent of any real project or Glue bootstrap.
+/// orphaned - independent of any real project or Glue bootstrap. Also covers GitHub issue #2170: candidates
+/// are scoped to the Screens/Entities/Factories folders, since the ownership model only understands
+/// Screen/Entity ownership.
 /// </summary>
 public class OrphanedGeneratedCompileItemFinderTests
 {
@@ -171,11 +173,27 @@ public class OrphanedGeneratedCompileItemFinderTests
     [InlineData(@"Performance\PoolList.Generated.cs")]
     [InlineData(@"Performance\IEntityFactory.Generated.cs")]
     [InlineData("Performance/PoolList.Generated.cs")]
-    public void FindOrphanedIncludes_ShouldKeep_KnownNonElementOwnedGeneratedFiles_EvenIfMissingOnDisk(string include)
+    public void FindOrphanedIncludes_ShouldKeep_PerformanceGeneratedFiles_EvenIfMissingOnDisk(string include)
     {
         // GitHub issue #2170: these are written once by
         // FactoryElementCodeGenerator.AddGeneratedPerformanceTypes, not owned by any Screen/Entity, so the
-        // ownership model always sees them as unowned - they must be excluded regardless of file existence.
+        // ownership model always sees them as unowned - they must survive regardless of file existence.
+        var items = new[] { Item(include) };
+
+        var result = Find(items);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(@"SomeOtherFolder\Whatever.Generated.cs")]
+    [InlineData("RootLevel.Generated.cs")]
+    public void FindOrphanedIncludes_ShouldKeep_AnyGeneratedFileOutsideScreensEntitiesFactories_EvenIfMissingOnDisk(string include)
+    {
+        // GitHub issue #2170: reconciliation is scoped to only the Screens/Entities/Factories folders a
+        // Screen/Entity's generated files can ever live under - not a list of specific known filenames - so
+        // it can't misfire on some future generator's own ".Generated.cs" written anywhere else, the same way
+        // it did for Performance/PoolList.Generated.cs.
         var items = new[] { Item(include) };
 
         var result = Find(items);


### PR DESCRIPTION
Fixes #2170.

`Content/FrbEditor/Performance/PoolList.Generated.cs` and `IEntityFactory.Generated.cs` are written once by `FactoryElementCodeGenerator.AddGeneratedPerformanceTypes` and are never owned by a Screen/Entity, so `RemoveOrphanedGeneratedCompileItems`'s ownership model always treats them as orphaned whenever their backing file happens to be missing at load time - deleting the `.csproj` entry.

Fix: exclude these two known non-element-owned generated files from the orphan-cleanup candidate set in `OrphanedGeneratedCompileItemFinder`.

Manual test: not needed - covered by unit tests (`OrphanedGeneratedCompileItemFinderTests`, `OrphanedGeneratedCompileItemReconciliationTests`), no runtime/UI-observable behavior change beyond what's pinned.
