### PR TITLE
Drop the ".Common" suffix from FRB2 .gluj file names

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueState.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueState.cs
@@ -409,11 +409,20 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations
                         return withoutExtension + extension;
                     }
 
+                    var nameOnly = FileManager.RemovePath(withoutExtension.FullPath);
+
+                    // FRB2's Common project is named "<ProjectName>.Common.csproj" (paralleling
+                    // .Desktop/.Android/...), but there's only one .gluj for the whole game, so drop
+                    // the suffix rather than naming it "<ProjectName>.Common.gluj".
+                    if (CurrentMainProject is Frb2Project && nameOnly.EndsWith(".Common"))
+                    {
+                        nameOnly = nameOnly.Substring(0, nameOnly.Length - ".Common".Length);
+                    }
+
                     // Same file name, different folder - see ProjectBase.GlueProjectSubdirectory. The
                     // Screens/Entities JSON follows automatically: every writer derives its directory
                     // from this path.
-                    return CurrentMainProject.Directory + subdirectory +
-                        FileManager.RemovePath(withoutExtension.FullPath) + extension;
+                    return CurrentMainProject.Directory + subdirectory + nameOnly + extension;
                 }
             }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectLoadTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectLoadTests.cs
@@ -48,8 +48,9 @@ public class Frb2ProjectLoadTests
 
         Assert.IsType<Frb2Project>(GlueState.Self.CurrentMainProject);
         Assert.True(File.Exists(Path.Combine(
-                Path.GetDirectoryName(commonCsproj)!, "Content", "FrbEditor", ProjectName + ".Common.gluj")),
-            "The .gluj should land under the Common project's Content/FrbEditor/.");
+                Path.GetDirectoryName(commonCsproj)!, "Content", "FrbEditor", ProjectName + ".gluj")),
+            "The .gluj should land under the Common project's Content/FrbEditor/, named after the " +
+            "game rather than carrying the Common project's own \".Common\" suffix.");
 
         // Same contract as a source-referencing FRB2 game: no generated code anywhere.
         Assert.Empty(Directory.GetFiles(temp.Root, "*.cs", SearchOption.AllDirectories)


### PR DESCRIPTION
## Summary
FRB2's Common project is named `<ProjectName>.Common.csproj` (paralleling `.Desktop`/`.Android`/...). `GlueState.GlueProjectFileName` named the `.gluj` after the owning csproj verbatim, so a template-created FRB2 project got `<ProjectName>.Common.gluj` under `Content/FrbEditor/` - wordy, and confusing since there's only one `.gluj` per game. Strips the `.Common` suffix, scoped to `Frb2Project` only.

## Test plan
- [x] `dotnet test` full non-BuildSmoke suite: 752/752 passed
- [x] Updated `Frb2ProjectLoadTests.LoadingATemplateCreatedFrb2Project_IsRecognisedAndWritesNoCode` to assert the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1jRpQknCBc3C1PShkynZU