### PR TITLE
Fix Glue project-load crashes: wildcard parallel deadlock + Tiled tsx errors

### DIFF
--- a/FRBDK/Glue/Glue/Managers/WildcardReferencedFileSaveLogic.cs
+++ b/FRBDK/Glue/Glue/Managers/WildcardReferencedFileSaveLogic.cs
@@ -74,6 +74,11 @@ public class WildcardReferencedFileSaveLogic
         }
 
         ConcurrentBag<ReferencedFileSave> newRfses = new();
+        // Errors are buffered rather than reported with GlueCommands.Self.PrintError from inside the
+        // Parallel.ForEach body: PrintError synchronously marshals onto the UI thread, and this method
+        // runs on the UI thread itself (synchronously, during project load), so a worker thread's
+        // PrintError call would deadlock waiting for a UI thread that's blocked waiting on this loop.
+        ConcurrentBag<string> errors = new();
 
         //foreach (var wildcardRfs in wildcardRfses)
         Parallel.ForEach(wildcardRfses, wildcardRfs =>
@@ -87,7 +92,7 @@ public class WildcardReferencedFileSaveLogic
             }
             catch (DirectoryNotFoundException ex)
             {
-                GlueCommands.Self.PrintError($"Error processing wildcard pattern {wildcardRfs.Name}:\n{ex}");
+                errors.Add($"Error processing wildcard pattern {wildcardRfs.Name}:\n{ex}");
             }
 
             foreach (var filePathForPossibleRfs in files)
@@ -102,6 +107,11 @@ public class WildcardReferencedFileSaveLogic
                 }
             }
         });
+
+        foreach (var error in errors)
+        {
+            _glueCommands.PrintError(error);
+        }
 
         // Parallelization causes files to arrive at the list at random times causing sort changes
         // every time startup is run and this causing noise in GlobalContent.Generated.cs.

--- a/FRBDK/Glue/Glue/Tiled/TiledCache.cs
+++ b/FRBDK/Glue/Glue/Tiled/TiledCache.cs
@@ -116,29 +116,42 @@ namespace FlatRedBall.Glue.Tiled
 
             List<string> tmxErrors = new List<string>();
 
-            Parallel.ForEach(tmxFiles, fileName =>
+            // Loading the full TMX cache should not require every referenced tsx to actually exist on disk -
+            // a missing/broken tileset reference is reported per-file below, not an uncaught exception. This
+            // matches every other production TiledMapSave.FromFile call site (TmxCreationManager,
+            // FileReferenceManager, TmxCodeGenerator), which all set this false around the call.
+            var oldShouldLoadValuesFromSource = Tileset.ShouldLoadValuesFromSource;
+            Tileset.ShouldLoadValuesFromSource = false;
+            try
             {
-                if (!CachedTiledMapSaves.ContainsKey(fileName) && fileName.Exists())
+                Parallel.ForEach(tmxFiles, fileName =>
                 {
-                    TiledMapSave tms = null;
-
-                    try
+                    if (!CachedTiledMapSaves.ContainsKey(fileName) && fileName.Exists())
                     {
-                        tms = TiledMapSave.FromFile(fileName.FullPath);
-                    }
-                    catch (Exception e) 
-                    {
-                        tmxErrors.Add($"Could not load TMX file {fileName} because of error: {e.ToString()}");
-                    }
-                    if(tms != null)
-                    {
-                        CachedTiledMapSave cachedTiledMapSave = CreateCachedTiledMapSave(fileName, tms);
+                        TiledMapSave tms = null;
 
-                        dictionary[fileName] = cachedTiledMapSave;
-                    }
+                        try
+                        {
+                            tms = TiledMapSave.FromFile(fileName.FullPath);
+                        }
+                        catch (Exception e)
+                        {
+                            tmxErrors.Add($"Could not load TMX file {fileName} because of error: {e.ToString()}");
+                        }
+                        if(tms != null)
+                        {
+                            CachedTiledMapSave cachedTiledMapSave = CreateCachedTiledMapSave(fileName, tms);
 
-                }
-            });
+                            dictionary[fileName] = cachedTiledMapSave;
+                        }
+
+                    }
+                });
+            }
+            finally
+            {
+                Tileset.ShouldLoadValuesFromSource = oldShouldLoadValuesFromSource;
+            }
 
             foreach (var error in tmxErrors)
             {
@@ -200,7 +213,16 @@ namespace FlatRedBall.Glue.Tiled
             {
                 if (filePath.Exists())
                 {
-                    tms = TiledMapSave.FromFile(filePath.FullPath);
+                    var oldShouldLoadValuesFromSource = Tileset.ShouldLoadValuesFromSource;
+                    Tileset.ShouldLoadValuesFromSource = false;
+                    try
+                    {
+                        tms = TiledMapSave.FromFile(filePath.FullPath);
+                    }
+                    finally
+                    {
+                        Tileset.ShouldLoadValuesFromSource = oldShouldLoadValuesFromSource;
+                    }
 
                     CachedTiledMapSaves[filePath] = CreateCachedTiledMapSave(filePath, tms);
                 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/Managers/WildcardReferencedFileSaveLogicTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Managers/WildcardReferencedFileSaveLogicTests.cs
@@ -1,11 +1,15 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FlatRedBall.Glue.Managers;
 using FlatRedBall.Glue.Plugins.ExportedInterfaces;
 using FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.IO;
 using Moq;
 using Shouldly;
 
@@ -54,5 +58,52 @@ public class WildcardReferencedFileSaveLogicTests
         _sut.IsMatch("c:/Content/Images/**/*.*", "c:/Content/Images/Subfolder/hero.png").ShouldBeTrue();
         _sut.IsMatch("c:/Content/Images/**/*.*", "c:/Content/Images/hero.achx").ShouldBeTrue();
         _sut.IsMatch("c:/Content/Images/**/*.*", "c:/Content/Images/Subfolder/hero.achx").ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// GitHub issue: LoadWildcardReferencedFiles used to report a missing wildcard folder by calling
+    /// GlueCommands.Self.PrintError from inside the Parallel.ForEach body. PrintError marshals onto the
+    /// UI thread, and this method itself runs synchronously on the UI thread during project load - so a
+    /// worker thread hitting that catch block deadlocked waiting for a UI thread that was blocked waiting
+    /// on the very same Parallel.ForEach to finish. This pins that every error is now reported from the
+    /// calling thread only after the loop has fully completed, never from a worker thread mid-loop.
+    /// </summary>
+    [Fact]
+    public void LoadWildcardReferencedFiles_ShouldReportErrors_OnlyFromCallingThread_AfterLoopCompletes()
+    {
+        var callingThreadId = Environment.CurrentManagedThreadId;
+        var reportingThreadIds = new ConcurrentBag<int>();
+
+        _glueCommands
+            .Setup(gc => gc.PrintError(It.IsAny<string>()))
+            .Callback<string>(_ => reportingThreadIds.Add(Environment.CurrentManagedThreadId));
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "WildcardDeadlockTest_" + Guid.NewGuid());
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            var glujPath = new FilePath(Path.Combine(tempDirectory, "Project.gluj"));
+
+            var glueProjectSave = new GlueProjectSave();
+            // Enough wildcard entries, each pointing at a folder that does not exist under Content/, that
+            // Parallel.ForEach genuinely spreads the DirectoryNotFoundException-throwing work across
+            // multiple thread-pool workers rather than running it all inline on the calling thread.
+            for (var i = 0; i < 20; i++)
+            {
+                glueProjectSave.GlobalFiles.Add(new ReferencedFileSave
+                {
+                    Name = $"MissingFolder{i}/**/*.png"
+                });
+            }
+
+            _sut.LoadWildcardReferencedFiles(glujPath, glueProjectSave);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, true);
+        }
+
+        reportingThreadIds.ShouldNotBeEmpty();
+        reportingThreadIds.ShouldAllBe(id => id == callingThreadId);
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/Tiled/MapTilesetTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Tiled/MapTilesetTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using System.Linq;
+using FlatRedBall.IO;
+using Shouldly;
+using TMXGlueLib;
+using Xunit;
+
+namespace GlueUnitTests.Tiled;
+
+/// <summary>
+/// A TMX can reference several tilesets. Previously, one tileset's tsx being missing threw
+/// FileNotFoundException out of TiledMapSave.FromFile entirely - aborting the whole map's load/codegen,
+/// including everything tied to the other, still-valid tilesets. Tileset.ShouldThrowOnMissingSource lets a
+/// caller (TmxCodeGenerator) opt out of that: the broken tileset degrades to its default (empty)
+/// Tiles/Images and the rest of the map loads normally.
+/// </summary>
+public class MapTilesetTests
+{
+    [Fact]
+    public void FromFile_ShouldNotThrow_AndShouldStillLoadOtherTilesets_WhenOneTilesetTsxIsMissing_AndShouldThrowOnMissingSourceIsFalse()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "MapTilesetMissingTsxTest_" + Guid.NewGuid());
+        Directory.CreateDirectory(tempDirectory);
+
+        var originalRelativeDirectory = FileManager.RelativeDirectory;
+        var originalShouldLoadValuesFromSource = Tileset.ShouldLoadValuesFromSource;
+        var originalShouldThrowOnMissingSource = Tileset.ShouldThrowOnMissingSource;
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDirectory, "Valid.tsx"),
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<tileset name=\"Valid\" tilewidth=\"16\" tileheight=\"16\" tilecount=\"1\" columns=\"1\">\n" +
+                " <image source=\"valid.png\" width=\"16\" height=\"16\"/>\n" +
+                "</tileset>");
+
+            var tmxPath = Path.Combine(tempDirectory, "Map.tmx");
+            File.WriteAllText(tmxPath,
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<map version=\"1.4\" tiledversion=\"1.4.3\" orientation=\"orthogonal\" renderorder=\"right-down\" " +
+                "width=\"1\" height=\"1\" tilewidth=\"16\" tileheight=\"16\" infinite=\"0\" nextlayerid=\"1\" nextobjectid=\"1\">\n" +
+                " <tileset firstgid=\"1\" source=\"Valid.tsx\"/>\n" +
+                " <tileset firstgid=\"2\" source=\"DoesNotExist.tsx\"/>\n" +
+                "</map>");
+
+            FileManager.RelativeDirectory = tempDirectory + "\\";
+            Tileset.ShouldLoadValuesFromSource = true;
+            Tileset.ShouldThrowOnMissingSource = false;
+
+            TiledMapSave tms = null;
+            var exception = Record.Exception(() => tms = TiledMapSave.FromFile(tmxPath));
+
+            exception.ShouldBeNull();
+            tms.ShouldNotBeNull();
+            tms.Tilesets.Count.ShouldBe(2);
+
+            var validTileset = tms.Tilesets.Single(t => t.Source.Contains("Valid"));
+            validTileset.Images.ShouldNotBeNull();
+            validTileset.Images.Length.ShouldBe(1, "the valid tileset should have loaded fully despite the other tileset's missing tsx");
+
+            var brokenTileset = tms.Tilesets.Single(t => t.Source.Contains("DoesNotExist"));
+            brokenTileset.Tiles.ShouldBeEmpty("the broken tileset should have degraded to its default rather than throwing");
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = originalRelativeDirectory;
+            Tileset.ShouldLoadValuesFromSource = originalShouldLoadValuesFromSource;
+            Tileset.ShouldThrowOnMissingSource = originalShouldThrowOnMissingSource;
+            Directory.Delete(tempDirectory, true);
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Tiled/TiledCacheTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Tiled/TiledCacheTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.Tiled;
+using FlatRedBall.IO;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using TMXGlueLib;
+using Xunit;
+
+namespace GlueUnitTests.Tiled;
+
+/// <summary>
+/// TiledMapSave.FromFile eagerly loads every referenced tileset's tsx file by default
+/// (Tileset.ShouldLoadValuesFromSource == true), which throws FileNotFoundException the moment a TMX
+/// references a tsx that does not exist on disk - a real, unremarkable situation (a moved/renamed/deleted
+/// shared tileset) that Glue needs to tolerate while loading a project, not crash on. Every other
+/// production TiledMapSave.FromFile call site (TmxCreationManager, FileReferenceManager, TmxCodeGenerator)
+/// sets Tileset.ShouldLoadValuesFromSource = false around the call; TiledCache's two call sites
+/// (RefreshCache, GetTiledMap) were the one place that didn't.
+/// </summary>
+public class TiledCacheTests
+{
+    public TiledCacheTests() => GlueTestBootstrap.EnsureInitialized();
+
+    [Fact]
+    public void GetTiledMap_ShouldNotThrow_WhenReferencedTilesetTsxIsMissing()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "TiledCacheMissingTsxTest_" + Guid.NewGuid());
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            var tmxPath = Path.Combine(tempDirectory, "Map.tmx");
+            File.WriteAllText(tmxPath,
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<map version=\"1.4\" tiledversion=\"1.4.3\" orientation=\"orthogonal\" renderorder=\"right-down\" " +
+                "width=\"1\" height=\"1\" tilewidth=\"16\" tileheight=\"16\" infinite=\"0\" nextlayerid=\"1\" nextobjectid=\"1\">\n" +
+                " <tileset firstgid=\"1\" source=\"DoesNotExist.tsx\"/>\n" +
+                "</map>");
+
+            var sut = new TiledCache();
+
+            var exception = Record.Exception(() => sut.GetTiledMap(new FilePath(tmxPath)));
+
+            exception.ShouldBeNull();
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, true);
+        }
+    }
+}

--- a/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/CodeGeneration/TmxCodeGenerator.cs
+++ b/FRBDK/Glue/TileGraphicsPlugin/TileGraphicsPlugin/CodeGeneration/TmxCodeGenerator.cs
@@ -61,9 +61,15 @@ namespace TileGraphicsPlugin.CodeGeneration
             if(absoluteFile.Exists())
             {
                 var oldShouldLoadFromSource = Tileset.ShouldLoadValuesFromSource;
+                var oldShouldThrowOnMissingSource = Tileset.ShouldThrowOnMissingSource;
                 //Tileset.ShouldLoadValuesFromSource = false;
                 // we need this to be true so we get the tileset info:
                 Tileset.ShouldLoadValuesFromSource = true;
+                // A map can reference several tilesets - one having a moved/deleted shared tsx shouldn't
+                // abort field generation for objects tied to the other, still-valid tilesets. Only the
+                // affected Tileset degrades to its default (empty) Tiles/Images; TiledMapSave.FromFile
+                // still returns normally.
+                Tileset.ShouldThrowOnMissingSource = false;
 
                 try
                 {
@@ -88,7 +94,10 @@ namespace TileGraphicsPlugin.CodeGeneration
                                     else
                                     {
                                         var tileset = tiledMapSave.Tilesets.FirstOrDefault(possibleTileset => possibleTileset.Firstgid <= item.gid);
-                                        var foundTile = tileset?.Tiles.First(tile => tile.id + tileset.Firstgid == item.gid);
+                                        // FirstOrDefault, not First: a tileset that failed to load (missing tsx)
+                                        // has no Tiles, and even a loaded tileset may have no <tile> entry for
+                                        // this gid - either way that's "no class for this object", not a crash.
+                                        var foundTile = tileset?.Tiles.FirstOrDefault(tile => tile.id + tileset.Firstgid == item.gid);
                                         className = foundTile?.Class;
                                     }
                                     var entity = ObjectFinder.Self.GetEntitySaveUnqualified(className);
@@ -107,7 +116,11 @@ namespace TileGraphicsPlugin.CodeGeneration
                 {
                     // do nothing - this will be handled elsewhere by the file tracking error system
                 }
-                Tileset.ShouldLoadValuesFromSource = oldShouldLoadFromSource;
+                finally
+                {
+                    Tileset.ShouldLoadValuesFromSource = oldShouldLoadFromSource;
+                    Tileset.ShouldThrowOnMissingSource = oldShouldThrowOnMissingSource;
+                }
             }
         }
 
@@ -298,9 +311,15 @@ namespace TileGraphicsPlugin.CodeGeneration
             if (absoluteFile.Exists())
             {
                 var oldShouldLoadFromSource = Tileset.ShouldLoadValuesFromSource;
+                var oldShouldThrowOnMissingSource = Tileset.ShouldThrowOnMissingSource;
                 //Tileset.ShouldLoadValuesFromSource = false;
                 // we need this to be true so we get the tileset info:
                 Tileset.ShouldLoadValuesFromSource = true;
+                // A map can reference several tilesets - one having a moved/deleted shared tsx shouldn't
+                // abort field generation for objects tied to the other, still-valid tilesets. Only the
+                // affected Tileset degrades to its default (empty) Tiles/Images; TiledMapSave.FromFile
+                // still returns normally.
+                Tileset.ShouldThrowOnMissingSource = false;
 
                 try
                 {
@@ -323,10 +342,13 @@ namespace TileGraphicsPlugin.CodeGeneration
                                     }
                                     else
                                     {
-                                        var tileset = tiledMapSave.Tilesets.First(possibleTileset => possibleTileset.Firstgid <= item.gid);
-                                        var foundTile = tileset.Tiles.First(tile => tile.id + tileset.Firstgid == item.gid);
+                                        var tileset = tiledMapSave.Tilesets.FirstOrDefault(possibleTileset => possibleTileset.Firstgid <= item.gid);
+                                        // FirstOrDefault, not First: a tileset that failed to load (missing tsx)
+                                        // has no Tiles, and even a loaded tileset may have no <tile> entry for
+                                        // this gid - either way that's "no class for this object", not a crash.
+                                        var foundTile = tileset?.Tiles.FirstOrDefault(tile => tile.id + tileset.Firstgid == item.gid);
 
-                                        className = foundTile.Class;
+                                        className = foundTile?.Class;
                                     }
                                     var entity = ObjectFinder.Self.GetEntitySaveUnqualified(className);
 
@@ -345,7 +367,11 @@ namespace TileGraphicsPlugin.CodeGeneration
                 {
                     // do nothing - this will be handled elsewhere by the file tracking error system
                 }
-                Tileset.ShouldLoadValuesFromSource = oldShouldLoadFromSource;
+                finally
+                {
+                    Tileset.ShouldLoadValuesFromSource = oldShouldLoadFromSource;
+                    Tileset.ShouldThrowOnMissingSource = oldShouldThrowOnMissingSource;
+                }
 
             }
         }

--- a/Tiled/TMXGlueLib/MapTileset.cs
+++ b/Tiled/TMXGlueLib/MapTileset.cs
@@ -78,6 +78,15 @@ namespace TMXGlueLib
 
         public static bool ShouldLoadValuesFromSource = true;
 
+        /// <summary>
+        /// Whether a missing/unreadable shared tsx file should throw a FileNotFoundException (the default,
+        /// existing behavior - some callers want to surface this as a real error) or be tolerated by leaving
+        /// this one Tileset's values (Tiles, Images, etc.) at their defaults and continuing. Only consulted
+        /// when <see cref="ShouldLoadValuesFromSource"/> is true - unlike that flag, this does not skip
+        /// loading every tileset, only degrades the specific one whose source could not be found.
+        /// </summary>
+        public static bool ShouldThrowOnMissingSource = true;
+
         [XmlAttribute("source")]
         public string Source
         {
@@ -323,8 +332,15 @@ namespace TMXGlueLib
                 }
                 catch (FileNotFoundException)
                 {
+                    if (!ShouldThrowOnMissingSource)
+                    {
+                        // Leave this Tileset's values (Tiles, Images, etc.) at their defaults and move on -
+                        // one map can reference several tilesets, and a caller that opted into this should
+                        // still get everything from the tilesets that did load.
+                        return;
+                    }
 
-                    string message = "Could not find the shared tsx file \n" + fileAttemptedToLoad + 
+                    string message = "Could not find the shared tsx file \n" + fileAttemptedToLoad +
                         "\nIf this is a relative file name, then the loader will use " +
                         "the FileManager's RelativeDirectory to make the file absolute.  Therefore, be sure to set the FileManger's RelativeDirectory to the file represented by " +
                         "this fileset before setting this property if setting this property manually.\n\nIf you are loading this TMX in a tool and you do not want to recursively" +


### PR DESCRIPTION
## Summary
- Fix a UI-thread self-deadlock in `WildcardReferencedFileSaveLogic.LoadWildcardReferencedFiles`: a `Parallel.ForEach` worker hitting a missing wildcard folder called `PrintError`, which synchronously marshals onto the UI thread - but the UI thread was itself blocked waiting on the same loop.
- Fix `TiledCache.RefreshCache`/`GetTiledMap` throwing `FileNotFoundException` when a TMX references a moved/deleted shared tsx, unlike every other production `TiledMapSave.FromFile` call site.
- Fix `TmxCodeGenerator` so one broken tileset reference no longer aborts field generation for a whole TMX's other, valid tilesets (`Tileset.ShouldThrowOnMissingSource`, new opt-in flag; default preserves existing behavior for callers like `FileReferenceManager` that want the failure reported).

## Test plan
- [x] Added/updated regression tests for all three fixes (`WildcardReferencedFileSaveLogicTests`, `TiledCacheTests`, `MapTilesetTests`); confirmed each fails against the pre-fix code and passes against the fix.
- [x] Full `GlueUnitTests` suite (`Category!=BuildSmoke`) green from a clean build: 761/761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMLx2VYEzMa9HsezB5oP3C