### PR TITLE
Fix Sprite.Animate skipped in Component state codegen below GumNineSliceHasAnimate

### DIFF
--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/NineSliceCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/NineSliceCodeGenerator.cs
@@ -118,4 +118,22 @@ public class NineSliceCodeGenerator
             variablesToIgnore.Add("IsTilingMiddleSections");
         }
     }
+
+    // Mirrors AddTypeSpecificVariableNamesToSkipForProperties above, but for the state pipeline
+    // (StateCodeGenerator). "Animate" must be skipped here PER-TYPE, keyed on "NineSlice" specifically -
+    // not as a global variable-name skip - because Sprite has its own, much older "Animate" variable
+    // (SpriteCodeGenerator/Sprite.gutx) that is unrelated to NineSlice's and must never be gated by
+    // GumNineSliceHasAnimate. A global skip previously suppressed Sprite's Animate state assignment too,
+    // for any Sprite instance nested inside a Component, on any project below that version.
+    internal void AddTypeSpecificVariableNamesToSkipForStates(Dictionary<string, List<string>> typeSpecificVariableNamesToSkipForStates)
+    {
+        var variablesToSkip = new List<string>();
+
+        if (!HasNineSliceAnimate)
+        {
+            variablesToSkip.Add("Animate");
+        }
+
+        typeSpecificVariableNamesToSkipForStates["NineSlice"] = variablesToSkip;
+    }
 }

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.cs
@@ -27,6 +27,7 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
     public static Dictionary<string, string> VariableNamesToReplaceForStates = new Dictionary<string, string>();
     private TextCodeGenerator _textCodeGenerator;
     private ContainerCodeGenerator _containerCodeGenerator;
+    private NineSliceCodeGenerator _nineSliceCodeGenerator;
 
     #endregion
 
@@ -59,10 +60,11 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         VariableNamesToReplaceForStates.Add("Height Units", "HeightUnits");
     }
 
-    public void Initialize(TextCodeGenerator textCodeGenerator, ContainerCodeGenerator containerCodeGenerator)
+    public void Initialize(TextCodeGenerator textCodeGenerator, ContainerCodeGenerator containerCodeGenerator, NineSliceCodeGenerator nineSliceCodeGenerator)
     {
         _textCodeGenerator = textCodeGenerator;
         _containerCodeGenerator = containerCodeGenerator;
+        _nineSliceCodeGenerator = nineSliceCodeGenerator;
     }
 
     public StateCodeGenerator()
@@ -120,6 +122,7 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
         //mVariableNamesToSkipForStates.Add("State");
 
         _containerCodeGenerator.AddTypeSpecificVariableNamesToSkipForStates(typeSpecificVariableNamesToSkipForStates);
+        _nineSliceCodeGenerator.AddTypeSpecificVariableNamesToSkipForStates(typeSpecificVariableNamesToSkipForStates);
 
         // Mirrors the property-pipeline exclusion in StandardsCodeGenerator.RefreshVariableNamesToSkipForProperties -
         // Gum's "Rectangle"/"Circle" standard elements now define a fill/stroke/gradient/dropshadow/blend
@@ -220,17 +223,12 @@ public partial class StateCodeGenerator : Singleton<StateCodeGenerator>
             Skip("IsTilingMiddleSections");
         }
 
-        // Mirrors the property-pipeline gate in NineSliceCodeGenerator.HasNineSliceAnimate. "Animate"
-        // only exists on NineSlice, so a global skip here is fine (same precedent as StackSpacing/
-        // IsTilingMiddleSections above) - older projects don't have a NineSlice with this variable.
-        if (version >= (int)GluxVersions.GumNineSliceHasAnimate)
-        {
-            Include("Animate");
-        }
-        else
-        {
-            Skip("Animate");
-        }
+        // NOT a global skip: unlike StackSpacing/IsTilingMiddleSections above, "Animate" is not unique to
+        // NineSlice - Sprite has had its own, much older "Animate" variable since long before
+        // GumNineSliceHasAnimate existed (SpriteCodeGenerator/Sprite.gutx). Gating the name globally here
+        // silently suppressed Sprite's Animate state assignment too, for any Sprite instance nested inside
+        // a Component, below this version. The NineSlice-only version gate now lives in
+        // NineSliceCodeGenerator.AddTypeSpecificVariableNamesToSkipForStates instead.
 
         if (version >= (int)GluxVersions.GumTextHasIsBold)
         {

--- a/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
@@ -114,7 +114,7 @@ public class MainGumPlugin : PluginBase
             containerCodeGenerator,
             nineSliceCodeGenerator,
             polygonCodeGenerator);
-        StateCodeGenerator.Self.Initialize(textCodeGenerator, containerCodeGenerator);
+        StateCodeGenerator.Self.Initialize(textCodeGenerator, containerCodeGenerator, nineSliceCodeGenerator);
     }
 
     private void AssignEvents()

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumStandardElementCodegenSweepTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/GumStandardElementCodegenSweepTests.cs
@@ -258,6 +258,57 @@ public class GumStandardElementCodegenSweepTests : IDisposable
     }
 
     [Fact]
+    public void GenerateEverythingFor_ComponentWithSpriteInstance_BelowNineSliceAnimateGate_ShouldStillAssignSpriteAnimate()
+    {
+        // The bug the two NineSlice tests above didn't catch: the "Animate" skip that fixed NineSlice's
+        // state pipeline (RefreshVariableNamesToSkipBasedOnGlueVersion) was added as a GLOBAL skip keyed
+        // only on the variable name "Animate" - but Sprite has its own, much older "Animate" variable
+        // (SpriteCodeGenerator/Sprite.gutx) that has nothing to do with NineSlice's newer one. Below
+        // GluxVersions.GumNineSliceHasAnimate, that global skip silently suppressed Sprite's "Animate"
+        // state assignment too - for a Sprite *instance nested inside a Component* specifically (a
+        // top-level Screen object's Default state is applied through a different, non-codegen'd
+        // reflection path, so it was unaffected - see the gum-integration skill). Real-world symptom: a
+        // HealthSprite.Animate=true set in a component's Default state never reached the generated code,
+        // so the sprite's AnimationChainLogic.Animate stayed at its default (false) and the .achx
+        // animation never played, even though the identical Sprite worked fine as a top-level Screen
+        // object.
+        FlatRedBall.Glue.Elements.ObjectFinder.Self.GlueProject.FileVersion = 0;
+        GlueTestBootstrap.EnsureGumPluginStandardElementsInitialized();
+        GlueTestBootstrap.EnsureGumPluginCodeGeneratorsInitialized();
+
+        var gumProject = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+
+        var containerStandard = new StandardElementSave { Name = "Container" };
+        containerStandard.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("Container"));
+        gumProject.StandardElements.Add(containerStandard);
+
+        var spriteStandard = new StandardElementSave { Name = "Sprite" };
+        spriteStandard.Initialize(Gum.Managers.StandardElementsManager.Self.GetDefaultStateFor("Sprite"));
+        gumProject.StandardElements.Add(spriteStandard);
+
+        var component = new ComponentSave { Name = "PlayerStatus", BaseType = "Container" };
+        component.Instances.Add(new InstanceSave { Name = "HealthSprite", BaseType = "Sprite" });
+
+        var defaultState = new Gum.DataTypes.Variables.StateSave { Name = "Default" };
+        component.States.Add(defaultState);
+        defaultState.Variables.Add(new Gum.DataTypes.Variables.VariableSave
+        {
+            SetsValue = true,
+            Name = "HealthSprite.Animate",
+            Type = "bool",
+            Value = true
+        });
+
+        component.Initialize(defaultState);
+        gumProject.Components.Add(component);
+
+        var generatedSource = GueDerivingClassCodeGenerator.Self.GenerateCodeFor(component);
+
+        generatedSource.ShouldNotBeNullOrWhiteSpace();
+        generatedSource.ShouldContain("HealthSprite.Animate = true;");
+    }
+
+    [Fact]
     public void GenerateStandardElementSaveCodeFor_Sprite_BelowRenderTargetTextureSourceGate_ShouldNotGenerateIt()
     {
         // Below GluxVersions.GumHasIRenderTargetTextureReferencer, SpriteCodeGenerator itself generates

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -607,7 +607,7 @@ internal static class GlueTestBootstrap
                     containerCodeGenerator,
                     nineSliceCodeGenerator,
                     polygonCodeGenerator);
-                GumPlugin.CodeGeneration.StateCodeGenerator.Self.Initialize(textCodeGenerator, containerCodeGenerator);
+                GumPlugin.CodeGeneration.StateCodeGenerator.Self.Initialize(textCodeGenerator, containerCodeGenerator, nineSliceCodeGenerator);
             }
         }
 


### PR DESCRIPTION
## Summary
- A Sprite instance's `Animate=true` set in a Component's Default state was silently never applied when the project's `.gluj` `FileVersion` is below `GluxVersions.GumNineSliceHasAnimate` (64). Root cause: `StateCodeGenerator.RefreshVariableNamesToSkipBasedOnGlueVersion` gated the variable name `"Animate"` **globally**, added to fix NineSlice's own (newer) `Animate` variable - but Sprite has had its own, much older `Animate` variable since long before that gate existed, and the global skip silently swept it up too.
- Symptom: a Sprite nested inside a Component never animates its `.achx` chain at runtime (the sprite's `AnimationChainLogic.Animate` stays at its default `false`), while the identical Sprite as a top-level Screen object works fine (a Screen's own Default state is applied through a different, non-codegen'd path, so it was never affected).
- Fix: move the gate to a NineSlice-only, per-type skip (`NineSliceCodeGenerator.AddTypeSpecificVariableNamesToSkipForStates`), mirroring the pattern already used for the property pipeline and for `Container`.

## Test plan
- [x] Added `GenerateEverythingFor_ComponentWithSpriteInstance_BelowNineSliceAnimateGate_ShouldStillAssignSpriteAnimate` - fails against the old code (missing `HealthSprite.Animate = true;` in generated output), passes after the fix.
- [x] Existing `GenerateStandardElementSaveCodeFor_NineSlice_BelowAnimateGate_...` / `AtAnimateGate_...` tests still pass - NineSlice's own gate is unchanged.
- [x] Full `GumPlugin` test namespace (67 tests) passes.
- [x] Full non-BuildSmoke suite (759 tests) passes on a from-scratch rebuild.

Manual test: not needed - covered by the new unit test plus the unaffected NineSlice pin tests; this is codegen-plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWgpy3s3DXhjJ8TLVYZXEX
