### PR TITLE
FRB2: strip dead default GameScreen.cs, always update dotnet-new template

### DIFF
--- a/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2Game1InitializeUpdater.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2Game1InitializeUpdater.cs
@@ -23,6 +23,15 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             @"FlatRedBallService\.Default\.Initialize\s*<\s*GameScreen\s*>\s*\(\s*this\s*\)\s*;",
             RegexOptions.Compiled);
 
+        /// <summary>
+        /// The template's only using of the namespace GameScreen.cs lived in - there solely to bring
+        /// GameScreen into scope for the call <see cref="DefaultInitializeCall"/> matches. Once that
+        /// call is rewritten (and <c>ProjectCreationHelper.RemoveFrb2DefaultGameScreen</c> has deleted
+        /// Screens/GameScreen.cs itself, at this same first-load moment), the using is dead.
+        /// </summary>
+        static readonly Regex ScreensNamespaceUsing = new Regex(
+            @"^[ \t]*using\s+[\w.]+\.Screens\s*;\s*\r?\n", RegexOptions.Compiled | RegexOptions.Multiline);
+
         /// <param name="game1FilePath">Full path to Game1.cs.</param>
         /// <param name="glueProjectContentRelativePath">
         /// The .gluj's path relative to the content root, e.g. "Content/FrbEditor/MyGame.Common.gluj".
@@ -44,6 +53,8 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
             var updated = DefaultInitializeCall.Replace(contents,
                 $"FlatRedBallService.Default.Initialize(this, \"{glueProjectContentRelativePath}\");");
+
+            updated = ScreensNamespaceUsing.Replace(updated, "", 1);
 
             File.WriteAllText(game1FilePath, updated);
 

--- a/FRBDK/Glue/NpcWpfLib/Managers/DotnetNewService.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/DotnetNewService.cs
@@ -14,8 +14,8 @@ namespace Npc.Managers;
 public interface IDotnetNewService
 {
     /// <summary>
-    /// Installs <paramref name="templatePackageId"/> if the CLI does not already have it, then runs the
-    /// template into <paramref name="outputDirectory"/>.
+    /// Installs/updates <paramref name="templatePackageId"/> to whatever the latest published version
+    /// is, then runs the template into <paramref name="outputDirectory"/>.
     /// </summary>
     Task<GeneralResponse> CreateProjectAsync(
         string templatePackageId, string templateShortName, string projectName, string outputDirectory);
@@ -28,20 +28,18 @@ public class DotnetNewService : IDotnetNewService
     public async Task<GeneralResponse> CreateProjectAsync(
         string templatePackageId, string templateShortName, string projectName, string outputDirectory)
     {
-        var probe = await RunAsync($"new {templateShortName} --help");
+        // Always install rather than probing "is it already there" first: `dotnet new install` on an
+        // already-installed package checks nuget and updates to the latest version, but skipping it
+        // once any version was ever installed meant Glue kept silently reusing whatever stale template
+        // (and stale engine version it referenced) happened to be cached locally.
+        var install = await RunAsync($"new install {templatePackageId}");
 
-        if (probe.ExitCode != 0)
+        if (install.ExitCode != 0)
         {
-            // Not installed, or no SDK at all - the install attempt below distinguishes them.
-            var install = await RunAsync($"new install {templatePackageId}");
-
-            if (install.ExitCode != 0)
-            {
-                return GeneralResponse.UnsuccessfulWith(
-                    $"Could not install the {templatePackageId} template package. FlatRedBall 2 projects " +
-                    $"are created by the dotnet CLI, so the .NET SDK has to be installed and on the PATH, " +
-                    $"and this first install needs internet access.\n\n{install.Output}");
-            }
+            return GeneralResponse.UnsuccessfulWith(
+                $"Could not install the {templatePackageId} template package. FlatRedBall 2 projects " +
+                $"are created by the dotnet CLI, so the .NET SDK has to be installed and on the PATH, " +
+                $"and this needs internet access.\n\n{install.Output}");
         }
 
         var create = await RunAsync(

--- a/FRBDK/Glue/NpcWpfLib/Managers/ProjectCreationHelper.cs
+++ b/FRBDK/Glue/NpcWpfLib/Managers/ProjectCreationHelper.cs
@@ -229,6 +229,8 @@ public static class ProjectCreationHelper
             return false;
         }
 
+        RemoveFrb2DefaultGameScreen(templateInfo, viewModel.ProjectName, unpackDirectory);
+
         if (viewModel.OpenSlnFolderAfterCreation)
         {
             System.Diagnostics.Process.Start(
@@ -238,6 +240,39 @@ public static class ProjectCreationHelper
         System.Console.Out.WriteLine(unpackDirectory);
 
         return true;
+    }
+
+    /// <summary>
+    /// FlatRedBall 2's nuget-packaged template id - the one explicit signal this is really the FRB2
+    /// template and not some other, currently-hypothetical dotnet-new-based entry that might get added
+    /// to <see cref="Npc.Data.EmptyTemplates"/> later. Deliberately not inferred from
+    /// "this is the only DotnetNewProjectInfo today".
+    /// </summary>
+    const string Frb2TemplatePackageId = "FlatRedBall2.Templates";
+
+    /// <summary>
+    /// The frb2-desktop template ships a hardcoded Screens/GameScreen.cs "Hello from FlatRedBall 2"
+    /// starter screen so a bare `dotnet new` + F5 shows something before Glue is ever involved. Once
+    /// Glue opens the project, Game1.cs is rewritten to load Glue's .gluj instead of that class (see
+    /// Frb2Game1InitializeUpdater), so the file becomes dead code from that point on. Strip it here so a
+    /// project made through Glue doesn't carry it - and only this one file: no other Screens/ content,
+    /// no wildcard, no folder deletion.
+    /// </summary>
+    static void RemoveFrb2DefaultGameScreen(DotnetNewProjectInfo templateInfo, string projectName, string unpackDirectory)
+    {
+        if (templateInfo.TemplatePackageId != Frb2TemplatePackageId)
+        {
+            return;
+        }
+
+        var openedProject = GetProjectToOpen(templateInfo, projectName, unpackDirectory);
+        var gameScreenPath = Path.Combine(
+            Path.GetDirectoryName(openedProject) ?? unpackDirectory, "Screens", "GameScreen.cs");
+
+        if (File.Exists(gameScreenPath))
+        {
+            File.Delete(gameScreenPath);
+        }
     }
 
     /// <summary>

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/DotnetNewProjectCreationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/DotnetNewProjectCreationTests.cs
@@ -121,6 +121,32 @@ public class DotnetNewProjectCreationTests : IDisposable
     }
 
     [Fact]
+    public async Task CreatingAnFrb2Project_RemovesTheTemplatesDefaultGameScreen()
+    {
+        // The template ships Screens/GameScreen.cs (a "Hello from FlatRedBall 2" starter screen) under
+        // the .Common project so a bare `dotnet new` + F5 shows something. Once Glue rewrites Game1.cs
+        // to load the .gluj instead, that class is never referenced again - a Glue-made project should
+        // not carry it.
+        _service.OnCreate = (name, directory) =>
+        {
+            var commonDirectory = Path.Combine(directory, name + ".Common");
+            Directory.CreateDirectory(Path.Combine(commonDirectory, "Screens"));
+            File.WriteAllText(Path.Combine(commonDirectory, name + ".Common.csproj"), "<Project />");
+            File.WriteAllText(Path.Combine(commonDirectory, "Screens", "GameScreen.cs"), "// starter screen");
+            File.WriteAllText(Path.Combine(commonDirectory, "Game1.cs"), "// Game1");
+        };
+
+        await ProjectCreationHelper.MakeNewProject(MakeViewModel("StripMe"));
+
+        var commonDirectory = Path.Combine(_service.Calls[0].OutputDirectory, "StripMe.Common");
+        File.Exists(Path.Combine(commonDirectory, "Screens", "GameScreen.cs")).ShouldBeFalse();
+
+        // Nothing else the template wrote should be touched.
+        File.Exists(Path.Combine(commonDirectory, "Game1.cs")).ShouldBeTrue();
+        File.Exists(Path.Combine(commonDirectory, "StripMe.Common.csproj")).ShouldBeTrue();
+    }
+
+    [Fact]
     public void GlueIsToldToOpenTheCommonProject_NotTheLauncher()
     {
         // `dotnet new frb2-desktop` produces two projects and only .Common is the game.

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2Game1InitializeUpdaterTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2Game1InitializeUpdaterTests.cs
@@ -27,6 +27,29 @@ public class Frb2Game1InitializeUpdaterTests
     }
 
     [Fact]
+    public void TryUpdateGame1ToLoadGlueProject_RemovesTheNowDeadScreensUsing()
+    {
+        // Repro: a real Glue-made project (FRB_2_15) still had `using FRB_2_15.Screens;` after
+        // Screens/GameScreen.cs was deleted and the Initialize call rewritten - that using existed
+        // solely to bring GameScreen into scope for the call this method rewrites.
+        using var temp = new TempDir("Frb2Game1UpdaterUsing_");
+        var game1Path = Path.Combine(temp.Root, "Game1.cs");
+        File.WriteAllText(game1Path,
+            "using Microsoft.Xna.Framework;\n" +
+            Frb2ProjectFixture.ScreensNamespaceUsing("MyGame") + "\n\n" +
+            "namespace MyGame;\npublic class Game1\n{\n    void Initialize()\n    {\n        " +
+            Frb2ProjectFixture.DefaultInitializeCall + "\n    }\n}\n");
+
+        Frb2Game1InitializeUpdater.TryUpdateGame1ToLoadGlueProject(
+            game1Path, "Content/FrbEditor/MyGame.gluj");
+
+        var contents = File.ReadAllText(game1Path);
+        Assert.DoesNotContain(Frb2ProjectFixture.ScreensNamespaceUsing("MyGame"), contents);
+        // Unrelated usings are untouched - only the exact `using <namespace>.Screens;` line goes.
+        Assert.Contains("using Microsoft.Xna.Framework;", contents);
+    }
+
+    [Fact]
     public void TryUpdateGame1ToLoadGlueProject_WithoutTheDefaultCall_LeavesTheFileAloneAndReturnsFalse()
     {
         using var temp = new TempDir("Frb2Game1UpdaterNoMatch_");

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectLoadTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectLoadTests.cs
@@ -390,6 +390,11 @@ public class Frb2ProjectLoadTests
         Assert.Contains(
             $"FlatRedBallService.Default.Initialize(this, \"Content/FrbEditor/{ProjectName}.gluj\");",
             game1Contents);
+
+        // Screens/GameScreen.cs is gone (deleted at project creation, not by this rewrite - see
+        // ProjectCreationHelperTests), so the using that only existed to bring GameScreen into scope
+        // must go too, or it's a dangling reference to a namespace with nothing left in it.
+        Assert.DoesNotContain(Frb2ProjectFixture.ScreensNamespaceUsing(ProjectName), game1Contents);
     }
 
     [StaFact]

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/Frb2ProjectFixture.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/Frb2ProjectFixture.cs
@@ -25,8 +25,15 @@ internal static class Frb2ProjectFixture
     /// </summary>
     public const string DefaultInitializeCall = "FlatRedBallService.Default.Initialize<GameScreen>(this);";
 
+    /// <summary>
+    /// The template's using for the namespace Screens/GameScreen.cs lives in - there solely to bring
+    /// GameScreen into scope for <see cref="DefaultInitializeCall"/>, and dead once that call and the
+    /// file are both gone.
+    /// </summary>
+    public static string ScreensNamespaceUsing(string projectName) => $"using {projectName}.Screens;";
+
     static string Game1Contents(string projectName) =>
-        "namespace " + projectName + ";\npublic class Game1\n{\n    void Initialize()\n    {\n        " +
+        ScreensNamespaceUsing(projectName) + "\n\nnamespace " + projectName + ";\npublic class Game1\n{\n    void Initialize()\n    {\n        " +
         DefaultInitializeCall + "\n    }\n}\n";
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Delete the frb2-desktop template's hardcoded `Screens/GameScreen.cs` (and its now-dangling `using`) once Glue rewrites `Game1.cs` to load the `.gluj` - the file is dead code past that point.
- `DotnetNewService` now always runs `dotnet new install` before creating a project, instead of probing "is it already installed" first - the probe skipped the update-to-latest check once any version was ever cached locally, silently pinning stale templates/engine versions.

## Test plan
- [x] `dotnet test "Glue with All.sln" --filter FullyQualifiedName~Frb2ProjectLoadTests|FullyQualifiedName~Frb2Game1InitializeUpdaterTests|FullyQualifiedName~DotnetNewProjectCreationTests` - 27/27 passed