### PR TITLE
Fix Edit Mode mouse interaction broken when game is embedded in Glue

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -583,6 +583,23 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     }
     #endregion
 
+    #region SetEmbeddedFocusTestOverrideDto
+
+    /// <summary>
+    /// Test-only (issue #2183): forces GlueControl.Editing.EmbeddedWindowLogic.IsParentGlueFocused
+    /// (Embedded) to a synthetic result instead of inspecting real OS focus/process state, which the
+    /// LiveGameProcess harness can't fake (no real "GlueFormsCore" process, no way to move real OS
+    /// foreground). Send with ClearOverride=true to go back to the real (production) check.
+    /// </summary>
+    public class SetEmbeddedFocusTestOverrideDto
+    {
+        public bool ClearOverride { get; set; }
+        public bool GlueProcessExists { get; set; }
+        public bool ForegroundMatchesGlueMainWindow { get; set; }
+        public bool ForegroundOwnedByThisGame { get; set; }
+    }
+    #endregion
+
     #region ForceGameResolution
     public class ForceGameResolution
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -1640,6 +1640,17 @@ namespace GlueControl
 
         #endregion
 
+        #region SetEmbeddedFocusTestOverrideDto
+
+        private static void HandleDto(SetEmbeddedFocusTestOverrideDto dto)
+        {
+            EmbeddedWindowLogic.TestOverride = dto.ClearOverride
+                ? ((bool, bool, bool)?)null
+                : (dto.GlueProcessExists, dto.ForegroundMatchesGlueMainWindow, dto.ForegroundOwnedByThisGame);
+        }
+
+        #endregion
+
         #region ForceGameResolution
 
         private static void HandleDto(ForceGameResolution dto)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -568,6 +568,23 @@ namespace GlueControl.Dtos
     }
     #endregion
 
+    #region SetEmbeddedFocusTestOverrideDto
+
+    /// <summary>
+    /// Test-only (issue #2183): forces GlueControl.Editing.EmbeddedWindowLogic.IsParentGlueFocused to a
+    /// synthetic result instead of inspecting real OS focus/process state, which the LiveGameProcess
+    /// harness can't fake (no real "GlueFormsCore" process, no way to move real OS foreground). Send
+    /// with ClearOverride=true to go back to the real (production) check.
+    /// </summary>
+    public class SetEmbeddedFocusTestOverrideDto
+    {
+        public bool ClearOverride { get; set; }
+        public bool GlueProcessExists { get; set; }
+        public bool ForegroundMatchesGlueMainWindow { get; set; }
+        public bool ForegroundOwnedByThisGame { get; set; }
+    }
+    #endregion
+
     #region ForceGameResolution
     public class ForceGameResolution
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -1492,28 +1492,69 @@ namespace GlueControl.Editing
         static System.Diagnostics.Process glueProcess;
         public static bool IsGlueShowingModalWindow { get; set; }
 
+        /// <summary>
+        /// Test-only: when set, IsParentGlueFocused uses these values instead of calling
+        /// GetForegroundWindow()/GetWindowThreadProcessId() and inspecting a real "GlueFormsCore"
+        /// process. There's no way to spin up a real Glue process (or fake OS focus/window ownership)
+        /// from the LiveGameProcess test harness, so this is how issue #2183's fix
+        /// (foregroundOwnedByThisGame) gets pinned by a deterministic test. Set via
+        /// SetEmbeddedFocusTestOverrideDto.
+        /// </summary>
+        internal static (bool glueProcessExists, bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame)? TestOverride;
+
+        /// <summary>
+        /// Pure decision logic, split out of IsParentGlueFocused so it can be exercised with synthetic
+        /// inputs (see TestOverride) instead of only through real OS focus/process state.
+        /// </summary>
+        internal static bool ComputeIsFocused(bool isEmbedded, bool isModalWindowOpen, bool glueProcessExists,
+            bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame)
+        {
+            if (!glueProcessExists)
+            {
+                return false;
+            }
+
+            return isEmbedded
+                && (foregroundMatchesGlueMainWindow || foregroundOwnedByThisGame)
+                && !isModalWindowOpen;
+        }
+
         public static bool IsParentGlueFocused
         {
             get
             {
+                if (TestOverride is { } testOverride)
+                {
+                    return ComputeIsFocused(IsEmbedded, IsGlueShowingModalWindow,
+                        testOverride.glueProcessExists, testOverride.foregroundMatchesGlueMainWindow,
+                        testOverride.foregroundOwnedByThisGame);
+                }
+
                 if (DateTime.Now - lastUpdate > TimeSpan.FromSeconds(5))
                 {
                     lastUpdate = DateTime.Now;
                     RefreshGlueProcess();
                 }
 
-                if (glueProcess == null)
+                var glueProcessExists = glueProcess != null;
+                var fg = GetForegroundWindow();
+                var foregroundMatchesGlueMainWindow = glueProcessExists && glueProcess.MainWindowHandle == fg;
+
+                // The embedded game window is reparented into Glue via a raw SetParent (no WS_CHILD style
+                // fixup), so Windows still lets it take OS foreground/activation on its own when clicked -
+                // GetForegroundWindow() then returns the game's own window, not Glue's. When embedded,
+                // that IS Glue's UI from the user's perspective, so treat it as focused too (issue #2183 -
+                // this was masked for years by the old `|| Game.IsActive` fallback that #2154's fix
+                // removed).
+                var foregroundOwnedByThisGame = false;
+                if (glueProcessExists && !foregroundMatchesGlueMainWindow)
                 {
-                    return false;
-                }
-                else
-                {
-                    return IsEmbedded
-                        && glueProcess?.MainWindowHandle == GetForegroundWindow()
-                        && !IsGlueShowingModalWindow
-                        ;
+                    GetWindowThreadProcessId(fg, out var fgOwnerPid);
+                    foregroundOwnedByThisGame = fgOwnerPid == (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
                 }
 
+                return ComputeIsFocused(IsEmbedded, IsGlueShowingModalWindow, glueProcessExists,
+                    foregroundMatchesGlueMainWindow, foregroundOwnedByThisGame);
             }
         }
 
@@ -1523,8 +1564,12 @@ namespace GlueControl.Editing
         [System.Runtime.InteropServices.DllImport("user32.dll")]
         static extern IntPtr GetForegroundWindow();
 
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
 #else
         static IntPtr GetForegroundWindow() => IntPtr.Zero;
+        static uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId) { processId = 0; return 0; }
 
 
 #endif

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
@@ -121,6 +121,128 @@ public class EditModeActivityGateTests
         clickResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectA" });
     }
 
+    /// <summary>
+    /// Reproduces issue #2183: the #2154 fix above made IsGameOrGlueActive depend solely on
+    /// IsParentGlueFocused (GetForegroundWindow() == glueProcess.MainWindowHandle) while embedded. But
+    /// the embedded game window is reparented via a raw SetParent with no WS_CHILD style fixup
+    /// (GameHostView.xaml.cs::EmbedHwnd), so Windows still lets it take OS foreground on its own when
+    /// clicked - GetForegroundWindow() then returns the game's own window, not Glue's. That made
+    /// click-select, deselect, and middle-mouse camera pan all silently stop working while embedded,
+    /// since they're all gated behind IsGameOrGlueActive. SetEmbeddedFocusTestOverrideDto simulates that
+    /// exact OS state (foreground owned by the game itself, not matching Glue's main window) since the
+    /// LiveGameProcess harness can't fake real OS focus/window ownership.
+    /// </summary>
+    [StaFact]
+    public async Task ClickWhileEmbeddedAndForegroundOwnedByGameItself_IsProcessed()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
+            afterLoadBeforeEmbed: AddTestObjectToGameScreen);
+
+        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        var loadScreenResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Screens\\GameScreen",
+            ScreenSave = screen,
+        });
+        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
+
+        var editModeResponse = await game.Send(new SetEditMode
+        {
+            IsInEditMode = true,
+            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        });
+        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
+        await Task.Delay(1000);
+
+        var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
+        borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
+
+        // Simulates the real embedded state: a real Glue process exists, but OS foreground is owned by
+        // the game's own reparented window instead of matching Glue's MainWindowHandle.
+        var overrideResponse = await game.Send(new SetEmbeddedFocusTestOverrideDto
+        {
+            GlueProcessExists = true,
+            ForegroundMatchesGlueMainWindow = false,
+            ForegroundOwnedByThisGame = true,
+        });
+        overrideResponse.Succeeded.ShouldBeTrue(overrideResponse.Message);
+
+        var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
+            new SimulateClickSelectRespectingActivityGateDto
+            {
+                ObjectName = "TestObjectA",
+                AdditiveModifierDown = false,
+            });
+
+        clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
+        clickResponse.Data.WasProcessed.ShouldBeTrue(
+            "a click on the embedded game panel should be processed even though OS foreground is owned " +
+            "by the game's own reparented window rather than exactly matching Glue's MainWindowHandle (issue #2183)");
+        clickResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectA" });
+    }
+
+    /// <summary>
+    /// Regression guard for the #2183 fix: it must not reopen #2154. When some unrelated window (neither
+    /// Glue's nor the embedded game's own) is truly in the foreground, clicks must stay ignored.
+    /// </summary>
+    [StaFact]
+    public async Task ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
+            afterLoadBeforeEmbed: AddTestObjectToGameScreen);
+
+        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        var loadScreenResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Screens\\GameScreen",
+            ScreenSave = screen,
+        });
+        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
+
+        var editModeResponse = await game.Send(new SetEditMode
+        {
+            IsInEditMode = true,
+            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        });
+        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
+        await Task.Delay(1000);
+
+        var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
+        borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
+
+        var overrideResponse = await game.Send(new SetEmbeddedFocusTestOverrideDto
+        {
+            GlueProcessExists = true,
+            ForegroundMatchesGlueMainWindow = false,
+            ForegroundOwnedByThisGame = false,
+        });
+        overrideResponse.Succeeded.ShouldBeTrue(overrideResponse.Message);
+
+        var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
+            new SimulateClickSelectRespectingActivityGateDto
+            {
+                ObjectName = "TestObjectA",
+                AdditiveModifierDown = false,
+            });
+
+        clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
+        clickResponse.Data.WasProcessed.ShouldBeFalse(
+            "a click should still be ignored when OS foreground belongs to neither Glue nor the embedded game (issue #2154 must stay fixed)");
+        clickResponse.Data.SelectedObjectNames.ShouldBeEmpty();
+    }
+
     static async Task AddTestObjectToGameScreen()
     {
         var gameScreen = ObjectFinder.Self.GetScreenSave("GameScreen");


### PR DESCRIPTION
Fixes #2183.

## Root cause
PR #2158 (fix for #2154) made `IsGameOrGlueActive` depend solely on `IsParentGlueFocused` while embedded, which requires `GetForegroundWindow() == glueProcess.MainWindowHandle`. But the embedded game window is reparented into Glue via a raw `SetParent` (`GameHostView.xaml.cs::EmbedHwnd`) with no `WS_CHILD` style fixup, so Windows still lets it take OS foreground/activation on its own when clicked - `GetForegroundWindow()` then returns the game's own window, not Glue's.

Confirmed via temporary logging: while interacting with the embedded panel, the gate was false almost the entire time. Since click-select, deselect, and middle-mouse camera pan are all gated behind `IsGameOrGlueActive`, all three silently broke. Marker-driven dragging of an already-selected object kept working (not gated), and in-game Gum UI kept working (not part of this gate at all) - which is what made the regression look like a "weird mix" rather than a total break.

The old `|| Game.IsActive` fallback, removed by #2158, had been masking this pre-existing `SetParent` gap for years.

## Fix
Treat "OS foreground window is owned by the embedded game's own process" as equivalent to "Glue is focused" when embedded - that's exactly the state while a user is legitimately interacting with the embedded panel, and it still correctly blocks the #2154 case (some unrelated window truly covering everything).

## Testing
`IsParentGlueFocused` only exists compiled into a real running game process (never Glue itself), and the `LiveGameProcess` test harness can't spin up a real `GlueFormsCore` process or fake real OS focus - so this adds `SetEmbeddedFocusTestOverrideDto`, a test-only DTO that forces the decision inputs deterministically. Two new tests in `EditModeActivityGateTests.cs`:
- `ClickWhileEmbeddedAndForegroundOwnedByGameItself_IsProcessed` - the regression case, fails without the fix (verified Red before Green).
- `ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored` - guards that #2154 stays fixed.

Full `Category!=BuildSmoke` suite (768 tests) is green.

Manual test: not needed for the fix logic itself (fully covered by the new unit tests), but worth a real embedded Glue session to confirm the on-screen feel now matches - happy to do that pass if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
