### PR TITLE
Extend orphaned-csproj-entry reconciliation to Gum Forms-generated files

### DIFF
--- a/FRBDK/Glue/Glue/IO/ProjectLoader.cs
+++ b/FRBDK/Glue/Glue/IO/ProjectLoader.cs
@@ -455,7 +455,9 @@ namespace FlatRedBall.Glue.IO
         /// referenced in the .csproj, producing CS2001 the next time the project builds. Codegen above has
         /// just run, so any file a live element still owns has been (re)created - anything still missing
         /// and unclaimed by a current element is a leftover from an incomplete cleanup, not a fresh
-        /// checkout waiting on codegen.
+        /// checkout waiting on codegen. Also covers Gum Forms-generated files (GitHub issue #2185), whose
+        /// ownership GumPlugin reports back through the plugin call below since core Glue has no ownership
+        /// model for Gum elements.
         /// </summary>
         static void RemoveOrphanedGeneratedCsprojEntries()
         {
@@ -468,7 +470,10 @@ namespace FlatRedBall.Glue.IO
             var allElements = ObjectFinder.Self.GlueProject.Screens.Cast<GlueElement>()
                 .Concat(ObjectFinder.Self.GlueProject.Entities);
 
-            var removed = mainProject.RemoveOrphanedGeneratedCompileItems(allElements);
+            var formsOwnedRelativePaths =
+                PluginManager.CallPluginMethod("Gum Plugin", "GetFormsGeneratedRelativePaths") as IEnumerable<string>;
+
+            var removed = mainProject.RemoveOrphanedGeneratedCompileItems(allElements, formsOwnedRelativePaths);
 
             if (removed.Count > 0)
             {

--- a/FRBDK/Glue/Glue/VSHelpers/OrphanedGeneratedCompileItemFinder.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/OrphanedGeneratedCompileItemFinder.cs
@@ -27,12 +27,14 @@ namespace FlatRedBall.Glue.VSHelpers
     public static class OrphanedGeneratedCompileItemFinder
     {
         /// <summary>
-        /// Top-level folders a Screen/Entity's owned generated files can ever live under - see
-        /// <see cref="FlatRedBall.Glue.Elements.DeletionPlanner.GetOwnedGeneratedRelativePaths"/> (element
-        /// names are always "Screens\..."/"Entities\...", and factories always live under "Factories\").
-        /// Reconciliation is scoped to only these folders - see GitHub issue #2170 - because the ownership
-        /// model only understands Screen/Entity ownership: a ".Generated.cs" written by some other generator
-        /// into any other folder (e.g. Performance\PoolList.Generated.cs, written once by
+        /// Top-level folders a Screen/Entity's or a Gum element's owned generated files can ever live under -
+        /// see <see cref="FlatRedBall.Glue.Elements.DeletionPlanner.GetOwnedGeneratedRelativePaths"/> (element
+        /// names are always "Screens\..."/"Entities\...", factories always live under "Factories\", and Gum
+        /// Forms code always lives under "Forms\" - see GumPlugin's
+        /// CodeGeneratorManager.GetFormsGeneratedRelativePaths, GitHub issue #2185). Reconciliation is scoped
+        /// to only these folders - see GitHub issue #2170 - because the
+        /// ownership model doesn't understand every generator's output: a ".Generated.cs" written by some
+        /// other generator into any other folder (e.g. Performance\PoolList.Generated.cs, written once by
         /// FactoryElementCodeGenerator.AddGeneratedPerformanceTypes) will never appear "owned" and would
         /// otherwise look orphaned - and get removed - on any load where its backing file happens to be
         /// missing when this check runs.
@@ -42,6 +44,7 @@ namespace FlatRedBall.Glue.VSHelpers
             "Screens",
             "Entities",
             "Factories",
+            "Forms",
         };
 
         public static bool IsGlueGeneratedFileName(string fileName)

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -1242,19 +1242,26 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
         /// <summary>
         /// Removes &lt;Compile Include&gt; entries for Glue-generated files (".Generated.cs",
-        /// ".Generated.Event.cs", factories) whose backing file no longer exists on disk and which no
-        /// element in <paramref name="ownerElements"/> currently owns - see GitHub issue #2103. Run at
+        /// ".Generated.Event.cs", factories, Gum Forms code) whose backing file no longer exists on disk and
+        /// which no element in <paramref name="ownerElements"/> or path in
+        /// <paramref name="additionalOwnedRelativePaths"/> currently owns - see GitHub issue #2103. Run at
         /// project load, after codegen has had a chance to (re)create any file a live element still owns,
         /// so "missing on disk" plus "unowned" together are a safe signal the entry is a leftover from a
         /// delete/rename that didn't clean up the csproj (a merge, a manual edit, an older Glue version).
         /// Never touches wildcard or conditional (platform-specific) entries, or hand-authored files - only
-        /// Glue's own generated-file naming is a candidate. Also scoped to only the Screens/Entities/Factories
-        /// folders a Screen/Entity's generated files can ever live under - see GitHub issue #2170; the
-        /// ownership model only understands Screen/Entity ownership, so a ".Generated.cs" some other generator
-        /// wrote elsewhere (e.g. Performance/PoolList.Generated.cs) would always look orphaned to it. Returns
-        /// the removed entries' Include values.
+        /// Glue's own generated-file naming is a candidate. Also scoped to only the
+        /// Screens/Entities/Factories/Forms folders those generated files can ever live under - see GitHub
+        /// issue #2170; the <paramref name="ownerElements"/> ownership model only understands Screen/Entity
+        /// ownership, so a ".Generated.cs" some other generator wrote elsewhere (e.g.
+        /// Performance/PoolList.Generated.cs) would always look orphaned to it.
+        /// <paramref name="additionalOwnedRelativePaths"/> exists for ownership sources outside that model -
+        /// currently just GumPlugin's Forms-generated paths, since Forms files are owned by Gum elements in
+        /// the .gumx, not by any GlueElement (GitHub issue #2185). Returns the removed entries' Include
+        /// values.
         /// </summary>
-        public List<string> RemoveOrphanedGeneratedCompileItems(IEnumerable<GlueElement> ownerElements)
+        public List<string> RemoveOrphanedGeneratedCompileItems(
+            IEnumerable<GlueElement> ownerElements,
+            IEnumerable<string> additionalOwnedRelativePaths = null)
         {
             var ownedRelativePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var element in ownerElements ?? Enumerable.Empty<GlueElement>())
@@ -1263,6 +1270,11 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 {
                     ownedRelativePaths.Add(relativePath.Replace('/', '\\'));
                 }
+            }
+
+            foreach (var relativePath in additionalOwnedRelativePaths ?? Enumerable.Empty<string>())
+            {
+                ownedRelativePaths.Add(relativePath.Replace('/', '\\'));
             }
 
             var candidates = EvaluatedItems

--- a/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/MainGumPlugin.cs
@@ -262,6 +262,11 @@ public class MainGumPlugin : PluginBase
 
     public bool HasGum() => AppState.Self.GumProjectSave != null;
 
+    // Called via PluginManager.CallPluginMethod("Gum Plugin", "GetFormsGeneratedRelativePaths") - see
+    // ProjectLoader.RemoveOrphanedGeneratedCsprojEntries (GitHub issue #2185).
+    public List<string> GetFormsGeneratedRelativePaths() =>
+        CodeGeneratorManager.Self.GetFormsGeneratedRelativePaths().ToList();
+
     private void HandleFileRemoved(GlueElement container, ReferencedFileSave file)
     {
         if (file.Name.EndsWith(".gumx"))

--- a/FRBDK/Glue/GumPlugin/GumPlugin/Managers/CodeGeneratorManager.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/Managers/CodeGeneratorManager.cs
@@ -70,21 +70,43 @@ public class CodeGeneratorManager : Singleton<CodeGeneratorManager>
     public FilePath CustomRuntimeCodeLocationFor(ElementSave gumElement) => GumRuntimesFolder + gumElement.Name + "Runtime.cs";
     public FilePath GeneratedRuntimeCodeLocationFor(ElementSave gumElement) =>
         GumRuntimesFolder + gumElement.Name + "Runtime.Generated.cs";
-    public FilePath CustomFormsCodeLocationFor(ElementSave gumElement)
-    {
-        var subfolder = gumElement is Gum.DataTypes.ScreenSave ? "Screens/"
-        : gumElement is ComponentSave ? "Components/"
-        : "Standard/";
-        return FormsFolder + subfolder + gumElement.Name + "Forms.cs";
-    }
-
-    public FilePath GeneratedFormsCodeLocationFor(ElementSave gumElement)
-    {
-        var subfolder = gumElement is Gum.DataTypes.ScreenSave ? "Screens/"
+    static string FormsSubfolderFor(ElementSave gumElement) =>
+        gumElement is Gum.DataTypes.ScreenSave ? "Screens/"
         : gumElement is ComponentSave ? "Components/"
         : "Standard/";
 
-        return FormsFolder + subfolder + gumElement.Name + "Forms.Generated.cs";
+    public FilePath CustomFormsCodeLocationFor(ElementSave gumElement) =>
+        FormsFolder + FormsSubfolderFor(gumElement) + gumElement.Name + "Forms.cs";
+
+    public FilePath GeneratedFormsCodeLocationFor(ElementSave gumElement) =>
+        FormsFolder + FormsSubfolderFor(gumElement) + gumElement.Name + "Forms.Generated.cs";
+
+    /// <summary>
+    /// The "Forms/..." relative paths every current Screen/Component in the loaded Gum project owns for its
+    /// generated Forms code - used by Glue's load-time orphaned-csproj-entry reconciliation (GitHub issue
+    /// #2185) so a Forms-generated file that hasn't been regenerated yet isn't mistaken for an orphan.
+    /// Yielded unconditionally (not gated on whether that element's generated Forms code is actually
+    /// non-empty) - same tolerance <see cref="FlatRedBall.Glue.Elements.DeletionPlanner.GetOwnedGeneratedRelativePaths"/>
+    /// already applies to Screen/Entity factory paths, since over-claiming ownership only risks leaving a
+    /// stray csproj entry in place, never deleting a file that's still owned.
+    /// </summary>
+    public IEnumerable<string> GetFormsGeneratedRelativePaths()
+    {
+        var gumProject = ObjectFinder.Self.GumProjectSave;
+        if (gumProject == null)
+        {
+            yield break;
+        }
+
+        foreach (var screen in gumProject.Screens)
+        {
+            yield return "Forms/" + FormsSubfolderFor(screen) + screen.Name + "Forms.Generated.cs";
+        }
+
+        foreach (var component in gumProject.Components)
+        {
+            yield return "Forms/" + FormsSubfolderFor(component) + component.Name + "Forms.Generated.cs";
+        }
     }
 
     FilePath GumBehaviorsFolder => GumRuntimesFolder + @"Behaviors\";

--- a/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/FormsGeneratedRelativePathsTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GumPlugin/FormsGeneratedRelativePathsTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using Gum.DataTypes;
+using GumPlugin.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GumPluginTests;
+
+/// <summary>
+/// GitHub issue #2185: Glue's load-time orphaned-csproj-entry reconciliation needs to know which
+/// "Forms/...Forms.Generated.cs" paths the currently-loaded Gum project still owns, since that ownership
+/// isn't expressible through the Screen/Entity model core Glue already understands. These pin
+/// <see cref="CodeGeneratorManager.GetFormsGeneratedRelativePaths"/> - the source GumPlugin reports that
+/// ownership from - independent of the plugin-call plumbing that reaches it.
+/// </summary>
+public class FormsGeneratedRelativePathsTests : IDisposable
+{
+    readonly GumProjectSave _originalGumProjectSave;
+
+    public FormsGeneratedRelativePathsTests()
+    {
+        _originalGumProjectSave = Gum.Managers.ObjectFinder.Self.GumProjectSave;
+    }
+
+    public void Dispose()
+    {
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = _originalGumProjectSave;
+    }
+
+    [Fact]
+    public void GetFormsGeneratedRelativePaths_ShouldReturnEmpty_WhenNoGumProjectIsLoaded()
+    {
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = null;
+
+        var result = CodeGeneratorManager.Self.GetFormsGeneratedRelativePaths().ToList();
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetFormsGeneratedRelativePaths_ShouldReturnPathFor_EachScreenAndComponent()
+    {
+        var gumProject = new GumProjectSave();
+        gumProject.Screens.Add(new ScreenSave { Name = "WrapUpScreenGum" });
+        gumProject.Components.Add(new ComponentSave { Name = "EndgameDemo" });
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = gumProject;
+
+        var result = CodeGeneratorManager.Self.GetFormsGeneratedRelativePaths().ToList();
+
+        result.ShouldBe(new[]
+        {
+            "Forms/Screens/WrapUpScreenGumForms.Generated.cs",
+            "Forms/Components/EndgameDemoForms.Generated.cs",
+        }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void GetFormsGeneratedRelativePaths_ShouldPreserveNestedComponentSubfolders()
+    {
+        // Matches the real-world repro from issue #2185: a component nested under a subfolder in the
+        // .gumx (Components/Elements/SummaryColumn) generates to Forms/Components/Elements/SummaryColumnForms.Generated.cs.
+        var gumProject = new GumProjectSave();
+        gumProject.Components.Add(new ComponentSave { Name = "Elements/SummaryColumn" });
+        Gum.Managers.ObjectFinder.Self.GumProjectSave = gumProject;
+
+        var result = CodeGeneratorManager.Self.GetFormsGeneratedRelativePaths().ToList();
+
+        result.ShouldBe(new[] { "Forms/Components/Elements/SummaryColumnForms.Generated.cs" });
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/OrphanedGeneratedCompileItemReconciliationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/OrphanedGeneratedCompileItemReconciliationTests.cs
@@ -13,8 +13,8 @@ namespace GlueUnitTests.Projects;
 /// its ".Generated.cs" still referenced in the .csproj, producing CS2001 on the next build. These pin
 /// <see cref="VisualStudioProject.RemoveOrphanedGeneratedCompileItems"/> - the load-time reconciliation
 /// pass - against a real, MSBuild-backed project (via <see cref="TestVisualStudioProjectFactory"/>), no
-/// full Glue bootstrap needed since the method only takes an explicit element list and touches the project
-/// it's called on.
+/// full Glue bootstrap needed since the method only takes an explicit element list (plus, as of GitHub
+/// issue #2185, an explicit extra-owned-paths list for Forms code) and touches the project it's called on.
 /// </summary>
 public class OrphanedGeneratedCompileItemReconciliationTests
 {
@@ -170,6 +170,51 @@ public class OrphanedGeneratedCompileItemReconciliationTests
                 .ShouldBeTrue();
             project.IsFilePartOfProject(@"Performance\IEntityFactory.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline)
                 .ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldKeep_FormsEntryOwnedViaAdditionalOwnedRelativePaths_EvenThoughFileIsMissing()
+    {
+        // GitHub issue #2185: Forms\...Forms.Generated.cs is owned by a Gum element, not any GlueElement, so
+        // its ownership arrives through additionalOwnedRelativePaths (what GumPlugin reports) instead of
+        // ownerElements.
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            project.AddCodeBuildItem(@"Forms\Components\EndgameDemoForms.Generated.cs");
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(
+                new List<GlueElement>(),
+                new List<string> { "Forms/Components/EndgameDemoForms.Generated.cs" });
+
+            removed.ShouldBeEmpty();
+            project.IsFilePartOfProject(@"Forms\Components\EndgameDemoForms.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline)
+                .ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RemoveOrphanedGeneratedCompileItems_ShouldRemove_OrphanedFormsEntry_WhenNotInAdditionalOwnedRelativePaths()
+    {
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var directory);
+        try
+        {
+            project.AddCodeBuildItem(@"Forms\Screens\WrapUpScreenGumForms.Generated.cs");
+
+            var removed = project.RemoveOrphanedGeneratedCompileItems(new List<GlueElement>(), new List<string>());
+
+            removed.ShouldBe(new[] { @"Forms\Screens\WrapUpScreenGumForms.Generated.cs" });
+            project.IsFilePartOfProject(@"Forms\Screens\WrapUpScreenGumForms.Generated.cs", BuildItemMembershipType.CompileOrContentPipeline)
+                .ShouldBeFalse();
         }
         finally
         {

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/OrphanedGeneratedCompileItemFinderTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/OrphanedGeneratedCompileItemFinderTests.cs
@@ -10,8 +10,8 @@ namespace GlueUnitTests.VSHelpers;
 /// its ".Generated.cs" (or similar) still referenced in the .csproj, producing CS2001 on the next build.
 /// These pin the pure decision logic - which candidate &lt;Compile Include&gt; entries are safe to treat as
 /// orphaned - independent of any real project or Glue bootstrap. Also covers GitHub issue #2170: candidates
-/// are scoped to the Screens/Entities/Factories folders, since the ownership model only understands
-/// Screen/Entity ownership.
+/// are scoped to the Screens/Entities/Factories/Forms folders, since the ownership model only understands
+/// Screen/Entity ownership plus (as of GitHub issue #2185) whatever GumPlugin reports owning Forms code.
 /// </summary>
 public class OrphanedGeneratedCompileItemFinderTests
 {
@@ -88,6 +88,17 @@ public class OrphanedGeneratedCompileItemFinderTests
         var result = Find(items);
 
         result.ShouldBe(new[] { @"Factories\MyEntityFactory.Generated.cs" });
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldRemove_OrphanedFormsGeneratedCs()
+    {
+        // GitHub issue #2185: Forms\...Forms.Generated.cs is scoped in the same way as Screens/Entities/Factories.
+        var items = new[] { Item(@"Forms\Screens\WrapUpScreenGumForms.Generated.cs") };
+
+        var result = Find(items);
+
+        result.ShouldBe(new[] { @"Forms\Screens\WrapUpScreenGumForms.Generated.cs" });
     }
 
     [Fact]
@@ -197,6 +208,20 @@ public class OrphanedGeneratedCompileItemFinderTests
         var items = new[] { Item(include) };
 
         var result = Find(items);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindOrphanedIncludes_ShouldKeep_FormsGeneratedCsOwnedByALiveGumElement_EvenIfMissingOnDisk()
+    {
+        // GitHub issue #2185: a fresh checkout where Forms\...Forms.Generated.cs is gitignored and hasn't
+        // been regenerated yet, but the owning Gum element (reported by GumPlugin, not any GlueElement) is
+        // still live - the entry must survive, same tolerance as Screens/Entities.
+        var include = @"Forms\Components\EndgameDemoForms.Generated.cs";
+        var items = new[] { Item(include) };
+
+        var result = Find(items, ownedRelativePaths: new HashSet<string> { include });
 
         result.ShouldBeEmpty();
     }


### PR DESCRIPTION
## Summary
Glue's load-time orphaned-`<Compile Include>` reconciliation (#2103, scoped down in #2170) only treated Screens/Entities/Factories as folders where a missing `.Generated.cs` is safe to remove. `Forms\` (Gum Forms-generated code) wasn't included, so a missing/stale Forms.Generated.cs entry produced CS2001 instead of being cleaned up.

- `CodeGeneratorManager.GetFormsGeneratedRelativePaths()` (GumPlugin) reports the Forms-generated paths owned by the currently-loaded Gum project's Screens/Components.
- `MainGumPlugin.GetFormsGeneratedRelativePaths()` exposes it for `PluginManager.CallPluginMethod("Gum Plugin", ...)`, since core Glue has no ownership model for Gum elements.
- `ProjectLoader.RemoveOrphanedGeneratedCsprojEntries` unions that into the reconciliation pass alongside Screen/Entity ownership.
- `"Forms"` added to `OrphanedGeneratedCompileItemFinder.ElementOwnedGeneratedFolders`.
- `VisualStudioProject.RemoveOrphanedGeneratedCompileItems` gets a new optional `additionalOwnedRelativePaths` param for ownership sources outside the GlueElement model.

Manual test: not needed - codegen-plumbing-only change, fully covered by unit tests plus a from-scratch build/test run (775/775 non-BuildSmoke tests green).

## Test plan
- [x] `OrphanedGeneratedCompileItemFinderTests` - new Forms-folder positive/negative cases
- [x] `OrphanedGeneratedCompileItemReconciliationTests` - new `additionalOwnedRelativePaths` end-to-end cases
- [x] `FormsGeneratedRelativePathsTests` (new) - `CodeGeneratorManager.GetFormsGeneratedRelativePaths` path building, including nested component subfolders
- [x] Full `--filter "Category!=BuildSmoke"` suite green from a clean build (775/775)

Fixes #2185

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01U4fUr9cKNiL2qfqJo9Htku
