### PR TITLE
Fix ArgumentOutOfRangeException moving the last/first polygon point

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/PointEditingPlugin/PointEditControl.xaml.cs
+++ b/FRBDK/Glue/OfficialPlugins/PointEditingPlugin/PointEditControl.xaml.cs
@@ -252,21 +252,9 @@ namespace OfficialPlugins.PointEditingPlugin
             ListBox.SelectedIndex = ListBox.Items.Count - 1;
         }
 
-        private void MovePointUp(object sender, RoutedEventArgs e)
-        {
-            var oldSelectedIndex = ViewModel.SelectedIndex;
-            var newSelectedIndex = ViewModel.SelectedIndex - 1;
-            ViewModel.Points.Move(oldSelectedIndex, newSelectedIndex);
-            ViewModel.SelectedIndex = newSelectedIndex;
-        }
+        private void MovePointUp(object sender, RoutedEventArgs e) => ViewModel.MoveSelectedPointUp();
 
-        private void MovePointDown(object sender, RoutedEventArgs e)
-        {
-            var oldSelectedIndex = ViewModel.SelectedIndex;
-            var newSelectedIndex = ViewModel.SelectedIndex + 1;
-            ViewModel.Points.Move(oldSelectedIndex, newSelectedIndex);
-            ViewModel.SelectedIndex = newSelectedIndex;
-        }
+        private void MovePointDown(object sender, RoutedEventArgs e) => ViewModel.MoveSelectedPointDown();
 
         private void ResizePolygon(object sender, RoutedEventArgs e)
         {

--- a/FRBDK/Glue/OfficialPlugins/PointEditingPlugin/PointEditingViewModel.cs
+++ b/FRBDK/Glue/OfficialPlugins/PointEditingPlugin/PointEditingViewModel.cs
@@ -35,5 +35,27 @@ namespace OfficialPlugins.PointEditingPlugin
         public bool IsMoveDownEnabled => SelectedIndex < Points.Count - 1;
 
         public PointEditingViewModel() => Points = new ObservableCollection<Vector2>();
+
+        public void MoveSelectedPointUp()
+        {
+            if (IsMoveUpEnabled)
+            {
+                var oldSelectedIndex = SelectedIndex;
+                var newSelectedIndex = SelectedIndex - 1;
+                Points.Move(oldSelectedIndex, newSelectedIndex);
+                SelectedIndex = newSelectedIndex;
+            }
+        }
+
+        public void MoveSelectedPointDown()
+        {
+            if (IsMoveDownEnabled)
+            {
+                var oldSelectedIndex = SelectedIndex;
+                var newSelectedIndex = SelectedIndex + 1;
+                Points.Move(oldSelectedIndex, newSelectedIndex);
+                SelectedIndex = newSelectedIndex;
+            }
+        }
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/PointEditingPlugin/PointEditingViewModelTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/PointEditingPlugin/PointEditingViewModelTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.Xna.Framework;
+using OfficialPlugins.PointEditingPlugin;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.PointEditingPlugin;
+
+/// <summary>
+/// Moving the last point down (or the first point up) used to call ObservableCollection.Move
+/// unconditionally, which throws ArgumentOutOfRangeException and crashes Glue. See GitHub issue #2189.
+/// </summary>
+public class PointEditingViewModelTests
+{
+    [Fact]
+    public void MoveSelectedPointDown_WhenSelectedIsLastPoint_ShouldNotThrowAndShouldNotChangePoints()
+    {
+        var viewModel = new PointEditingViewModel();
+        viewModel.Points.Add(new Vector2(0, 0));
+        viewModel.Points.Add(new Vector2(1, 1));
+        viewModel.Points.Add(new Vector2(2, 2));
+        viewModel.SelectedIndex = 2;
+
+        Should.NotThrow(() => viewModel.MoveSelectedPointDown());
+
+        viewModel.Points.ShouldBe(new[] { new Vector2(0, 0), new Vector2(1, 1), new Vector2(2, 2) });
+        viewModel.SelectedIndex.ShouldBe(2);
+    }
+
+    [Fact]
+    public void MoveSelectedPointUp_WhenSelectedIsFirstPoint_ShouldNotThrowAndShouldNotChangePoints()
+    {
+        var viewModel = new PointEditingViewModel();
+        viewModel.Points.Add(new Vector2(0, 0));
+        viewModel.Points.Add(new Vector2(1, 1));
+        viewModel.Points.Add(new Vector2(2, 2));
+        viewModel.SelectedIndex = 0;
+
+        Should.NotThrow(() => viewModel.MoveSelectedPointUp());
+
+        viewModel.Points.ShouldBe(new[] { new Vector2(0, 0), new Vector2(1, 1), new Vector2(2, 2) });
+        viewModel.SelectedIndex.ShouldBe(0);
+    }
+
+    [Fact]
+    public void MoveSelectedPointDown_WhenSelectedIsNotLast_ShouldMovePointAndUpdateSelectedIndex()
+    {
+        var viewModel = new PointEditingViewModel();
+        viewModel.Points.Add(new Vector2(0, 0));
+        viewModel.Points.Add(new Vector2(1, 1));
+        viewModel.Points.Add(new Vector2(2, 2));
+        viewModel.SelectedIndex = 0;
+
+        viewModel.MoveSelectedPointDown();
+
+        viewModel.Points.ShouldBe(new[] { new Vector2(1, 1), new Vector2(0, 0), new Vector2(2, 2) });
+        viewModel.SelectedIndex.ShouldBe(1);
+    }
+
+    [Fact]
+    public void MoveSelectedPointUp_WhenSelectedIsNotFirst_ShouldMovePointAndUpdateSelectedIndex()
+    {
+        var viewModel = new PointEditingViewModel();
+        viewModel.Points.Add(new Vector2(0, 0));
+        viewModel.Points.Add(new Vector2(1, 1));
+        viewModel.Points.Add(new Vector2(2, 2));
+        viewModel.SelectedIndex = 2;
+
+        viewModel.MoveSelectedPointUp();
+
+        viewModel.Points.ShouldBe(new[] { new Vector2(0, 0), new Vector2(2, 2), new Vector2(1, 1) });
+        viewModel.SelectedIndex.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
Fixes #2189.

`MovePointUp`/`MovePointDown` called `ObservableCollection<Vector2>.Move` unconditionally. The buttons are already disabled via `IsMoveUpEnabled`/`IsMoveDownEnabled` bindings when the selection is at an end, but the click handlers didn't guard against being invoked anyway, so the crash was reachable regardless of the button's visual state.

Moved the move logic into `PointEditingViewModel.MoveSelectedPointUp/Down`, guarded by the same enabled checks, and made the code-behind handlers call those. This also makes the logic unit-testable outside WPF.

Manual test: not needed — covered by the new unit tests (`PointEditingViewModelTests`), which reproduce the exact crash (verified red against the unguarded logic) and pass green with the fix.
