### PR TITLE
Fix Glue play button building/running FRB2 Common instead of Desktop launcher

### DIFF
--- a/FRBDK/Glue/CompilerPlugin/Managers/Compiler.cs
+++ b/FRBDK/Glue/CompilerPlugin/Managers/Compiler.cs
@@ -178,7 +178,12 @@ namespace CompilerPlugin.Managers
                 //}
 
                 //do we actually want to do this ?
-                var projectFileName = GlueState.Self.CurrentMainProject?.FullFileName;
+                // FRB2 games are split into Common (what Glue edits, and has no OutputType of its
+                // own) and a launcher like Desktop that actually builds/runs the game (#2188) -
+                // build the launcher when one is found, which pulls Common in as its own
+                // ProjectReference dependency.
+                var launcherProjectFileName = GlueState.Self.CurrentFrb2LauncherProjectFileName;
+                var projectFileName = launcherProjectFileName ?? GlueState.Self.CurrentMainProject?.FullFileName;
 
 
                 if (shouldCompile && projectFileName != null)
@@ -230,7 +235,6 @@ namespace CompilerPlugin.Managers
                             string startOutput = "Build started at " + DateTime.Now.ToLongTimeString();
                             string endOutput = "Build succeeded";
 
-                            var outputDirectory = GlueState.Self.CurrentMainProject.GetOutputDirectory();
                             // For info on parameters:
                             // https://msdn.microsoft.com/en-us/library/ms164311.aspx?f=255&MSPPError=-2147217396
                             // \m uses multiple cores
@@ -241,10 +245,22 @@ namespace CompilerPlugin.Managers
 
                                 $"/p:XNAContentPipelineTargetPlatform=\"Windows\" " +
                                 $"/p:XNAContentPipelineTargetProfile=\"HiDef\" " +
-                                $"/p:OutDir=\"{outputDirectory}\" " +
                                 "/m " +
                                 "/nologo " +
                                 "/verbosity:minimal";
+
+                            if (launcherProjectFileName == null)
+                            {
+                                // Building Common directly (FRB1, or an FRB2 project without a
+                                // resolvable launcher) - pin OutDir so the output lands exactly where
+                                // Runner expects it.
+                                var outputDirectory = GlueState.Self.CurrentMainProject.GetOutputDirectory();
+                                arguments += $" /p:OutDir=\"{outputDirectory}\"";
+                            }
+                            // else: building the FRB2 launcher - let it and the Common project it
+                            // references each build to their own default output directories, same as
+                            // `dotnet build` would. Forcing a single OutDir here would collide the two
+                            // projects' outputs together.
 
                             if (printMsBuildCommand)
                             {

--- a/FRBDK/Glue/CompilerPlugin/Managers/Runner.cs
+++ b/FRBDK/Glue/CompilerPlugin/Managers/Runner.cs
@@ -265,7 +265,7 @@ namespace CompilerPlugin.Managers
                 .OrderBy(item => item.ProcessName)
                 .ToArray();
 
-            var projectName = GlueState.Self.CurrentMainProject?.ExecutableName?.ToLowerInvariant();
+            var projectName = GetExecutableName(_compilerViewModel.Configuration)?.ToLowerInvariant();
 
             var found = processes
                 .Where(item => item.ProcessName.ToLowerInvariant() == projectName &&
@@ -458,14 +458,29 @@ namespace CompilerPlugin.Managers
             {
                 return null;
             }
-            else
-            {
-                var executableName = project.ExecutableName;
-                var outputDirectory = project.GetOutputDirectory();
-                var exeLocation = outputDirectory + executableName + ".exe";
 
-                return exeLocation;
+            var launcherProjectFileName = GlueState.Self.CurrentFrb2LauncherProjectFileName;
+            if (launcherProjectFileName != null)
+            {
+                // FRB2: Common (CurrentMainProject) has no OutputType of its own - the launcher
+                // (e.g. Desktop) is what actually builds and runs the game (#2188).
+                return Frb2LauncherProjectInfo.TryGet(launcherProjectFileName.FullPath, configuration)?.ExeLocation;
             }
+
+            var executableName = project.ExecutableName;
+            var outputDirectory = project.GetOutputDirectory();
+            return outputDirectory + executableName + ".exe";
+        }
+
+        private static string GetExecutableName(string configuration)
+        {
+            var launcherProjectFileName = GlueState.Self.CurrentFrb2LauncherProjectFileName;
+            if (launcherProjectFileName != null)
+            {
+                return Frb2LauncherProjectInfo.TryGet(launcherProjectFileName.FullPath, configuration)?.ExecutableName;
+            }
+
+            return GlueState.Self.CurrentMainProject?.ExecutableName;
         }
 
         private async Task<ToolsUtilities.GeneralResponse<Process>> StartProcess(bool preventFocus, string runArguments, string exeLocation)

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueState.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/GlueState.cs
@@ -346,12 +346,58 @@ namespace FlatRedBall.Glue.Plugins.ExportedImplementations
                 {
                     CurrentCodeProjectFileName = value.FullFileName;
                 }
+                // Invalidate - Runner re-reads this every few seconds while polling for the game
+                // process, so it can't re-walk the solution and every referenced .csproj each time.
+                _currentFrb2LauncherProjectFileNameCache = null;
+                _hasCachedCurrentFrb2LauncherProjectFileName = false;
             }
         }
 
         public VisualStudioProject CurrentMainContentProject { get { return ProjectManager.ContentProject; } }
 
         public FilePath CurrentSlnFileName => SlnFileForProject(CurrentMainProject);
+
+        bool _hasCachedCurrentFrb2LauncherProjectFileName;
+        FilePath _currentFrb2LauncherProjectFileNameCache;
+
+        /// <summary>
+        /// The FRB2 launcher project (Desktop today) that actually builds/runs
+        /// <see cref="CurrentMainProject"/> - Glue edits Common, but Common alone has no
+        /// <c>OutputType</c> and nothing to run (#2188). Null for non-FRB2 projects, or when the
+        /// launcher can't be found or is ambiguous - see
+        /// <see cref="VSHelpers.ProjectFileResolver.FindFrb2LauncherProject"/>.
+        /// </summary>
+        /// <remarks>
+        /// Cached per <see cref="CurrentMainProject"/>: Runner polls this every few seconds while
+        /// watching for the game process, and re-parsing the solution plus every referenced .csproj
+        /// that often would be wasteful disk I/O for a value that cannot change without a project
+        /// reload.
+        /// </remarks>
+        public FilePath CurrentFrb2LauncherProjectFileName
+        {
+            get
+            {
+                if (_hasCachedCurrentFrb2LauncherProjectFileName)
+                {
+                    return _currentFrb2LauncherProjectFileNameCache;
+                }
+
+                FilePath result = null;
+
+                if (CurrentMainProject is Frb2Project && CurrentSlnFileName != null)
+                {
+                    var launcherPath = VSHelpers.ProjectFileResolver.FindFrb2LauncherProject(
+                        CurrentSlnFileName.FullPath, CurrentMainProject.FullFileName.FullPath);
+
+                    result = launcherPath == null ? null : new FilePath(launcherPath);
+                }
+
+                _currentFrb2LauncherProjectFileNameCache = result;
+                _hasCachedCurrentFrb2LauncherProjectFileName = true;
+
+                return result;
+            }
+        }
 
         public FilePath SlnFileForProject(VisualStudioProject vsproject)
         {

--- a/FRBDK/Glue/Glue/VSHelpers/ProjectFileResolver.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/ProjectFileResolver.cs
@@ -110,6 +110,30 @@ namespace FlatRedBall.Glue.VSHelpers
                 : null;
         }
 
+        /// <summary>
+        /// The FRB2 launcher project (Desktop today) that plays <paramref name="frb2GameCsprojPath"/>,
+        /// found among everything <paramref name="solutionFileName"/> references. Null when the game
+        /// project isn't FRB2, nothing in the solution references it, or more than one thing does -
+        /// see <see cref="Frb2ProjectDetector.FindFrb2LauncherProjectFor"/>.
+        /// </summary>
+        public static string FindFrb2LauncherProject(string solutionFileName, string frb2GameCsprojPath)
+        {
+            if (string.IsNullOrEmpty(solutionFileName) || string.IsNullOrEmpty(frb2GameCsprojPath))
+            {
+                return null;
+            }
+
+            var solution = VSSolution.FromFile(solutionFileName);
+            var solutionDirectory = FileManager.GetDirectory(solutionFileName);
+
+            var candidates = solution.ReferencedProjects
+                .Where(item => FileManager.GetExtension(item.Name) == "csproj")
+                .Select(item => AbsolutePathOf(item.Name, solutionDirectory))
+                .Where(item => item != null);
+
+            return Frb2ProjectDetector.FindFrb2LauncherProjectFor(frb2GameCsprojPath, candidates);
+        }
+
         static string ResolveFromSolution(string solutionFileName)
         {
             var solution = VSSolution.FromFile(solutionFileName);

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2LauncherProjectInfo.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2LauncherProjectInfo.cs
@@ -1,0 +1,85 @@
+using FlatRedBall.IO;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace FlatRedBall.Glue.VSHelpers.Projects
+{
+    /// <summary>
+    /// Where an FRB2 launcher project (e.g. Desktop) puts its build output, computed without an
+    /// MSBuild evaluation - the launcher is never loaded into Glue as a <see cref="ProjectBase"/>,
+    /// so there is no <see cref="VisualStudioProject"/> to ask.
+    /// </summary>
+    public readonly struct Frb2LauncherOutputInfo
+    {
+        public Frb2LauncherOutputInfo(string executableName, string exeLocation)
+        {
+            ExecutableName = executableName;
+            ExeLocation = exeLocation;
+        }
+
+        public string ExecutableName { get; }
+        public string ExeLocation { get; }
+    }
+
+    /// <summary>
+    /// Reads an FRB2 launcher's own output directory and executable name straight from its
+    /// .csproj's literal &lt;TargetFramework&gt;/&lt;AssemblyName&gt; elements, the same way
+    /// <see cref="Frb2ProjectDetector"/> avoids a real MSBuild evaluation.
+    /// </summary>
+    public static class Frb2LauncherProjectInfo
+    {
+        /// <summary>
+        /// Null when the launcher can't be read, is multi-targeted (&lt;TargetFrameworks&gt;), or
+        /// customizes &lt;OutputPath&gt; - guessing wrong there would send Runner looking in the
+        /// wrong place instead of correctly reporting "could not find game .exe".
+        /// </summary>
+        public static Frb2LauncherOutputInfo? TryGet(string launcherCsprojPath, string configuration)
+        {
+            if (string.IsNullOrEmpty(launcherCsprojPath) || !System.IO.File.Exists(launcherCsprojPath))
+            {
+                return null;
+            }
+
+            var properties = ReadTopLevelProperties(launcherCsprojPath);
+
+            if (properties == null ||
+                properties.ContainsKey("TargetFrameworks") ||
+                properties.ContainsKey("OutputPath") ||
+                !properties.TryGetValue("TargetFramework", out var targetFramework) ||
+                string.IsNullOrEmpty(targetFramework))
+            {
+                return null;
+            }
+
+            var executableName = properties.TryGetValue("AssemblyName", out var assemblyName) && !string.IsNullOrEmpty(assemblyName)
+                ? assemblyName
+                : FileManager.RemoveExtension(FileManager.RemovePath(launcherCsprojPath));
+
+            var directory = FileManager.GetDirectory(launcherCsprojPath);
+            var outputDirectory = $"{directory}bin/{configuration}/{targetFramework}/";
+            var exeLocation = outputDirectory + executableName + ".exe";
+
+            return new Frb2LauncherOutputInfo(executableName, exeLocation);
+        }
+
+        // Later PropertyGroups win, matching MSBuild's own document-order evaluation - a project that
+        // sets the same property twice means the second one.
+        static Dictionary<string, string> ReadTopLevelProperties(string csprojPath)
+        {
+            try
+            {
+                return XDocument.Load(csprojPath)
+                    .Descendants()
+                    .Where(element => element.Parent?.Name.LocalName == "PropertyGroup")
+                    .GroupBy(element => element.Name.LocalName, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(group => group.Key, group => group.Last().Value, StringComparer.OrdinalIgnoreCase);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2ProjectDetector.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/Frb2ProjectDetector.cs
@@ -132,6 +132,89 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             return null;
         }
 
+        /// <summary>
+        /// The project among <paramref name="candidateCsprojPaths"/> that launches the FRB2 game at
+        /// <paramref name="frb2GameCsprojPath"/> - the one that references it directly and builds an
+        /// executable. `dotnet new frb2-desktop` names this MyGame.Desktop; MyGame.Common has no
+        /// <c>OutputType</c> of its own and nothing to run, which is why pressing Play on it alone
+        /// silently builds a DLL and never launches anything (#2188).
+        /// </summary>
+        /// <remarks>
+        /// One hop only, matching <see cref="FindFrb2GameProjectFor"/>: a launcher referencing the
+        /// game through an intermediate project is not a shape the template produces. Ambiguous when
+        /// more than one candidate qualifies - there is no way to guess which platform the user wants
+        /// to run, so the caller gets null rather than a wrong guess.
+        /// </remarks>
+        public static string FindFrb2LauncherProjectFor(string frb2GameCsprojPath, IEnumerable<string> candidateCsprojPaths)
+        {
+            if (string.IsNullOrEmpty(frb2GameCsprojPath) || !File.Exists(frb2GameCsprojPath) || candidateCsprojPaths == null)
+            {
+                return null;
+            }
+
+            var gameFullPath = Path.GetFullPath(frb2GameCsprojPath);
+
+            var launchers = candidateCsprojPaths
+                .Where(path => !string.IsNullOrEmpty(path) && File.Exists(path))
+                .Select(Path.GetFullPath)
+                .Where(path => !string.Equals(path, gameFullPath, StringComparison.OrdinalIgnoreCase))
+                .Where(path => IsExecutableReferencing(path, gameFullPath))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            return launchers.Length == 1 ? launchers[0] : null;
+        }
+
+        static bool IsExecutableReferencing(string csprojPath, string gameFullPath)
+        {
+            var items = ReadProjectItems(csprojPath);
+
+            var directory = Path.GetDirectoryName(csprojPath);
+
+            var referencesGame = items
+                .Where(item => item.ItemType == "ProjectReference" && !string.IsNullOrEmpty(item.Include))
+                .Any(item => ResolvesToGame(directory, item.Include, gameFullPath));
+
+            if (!referencesGame)
+            {
+                return false;
+            }
+
+            var outputType = ReadOutputType(csprojPath);
+
+            return string.Equals(outputType, "Exe", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(outputType, "WinExe", StringComparison.OrdinalIgnoreCase);
+        }
+
+        static bool ResolvesToGame(string directory, string include, string gameFullPath)
+        {
+            try
+            {
+                var resolved = Path.GetFullPath(
+                    Path.Combine(directory, include.Replace('\\', Path.DirectorySeparatorChar)));
+                return string.Equals(resolved, gameFullPath, StringComparison.OrdinalIgnoreCase);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        static string ReadOutputType(string csprojPath)
+        {
+            try
+            {
+                return System.Xml.Linq.XDocument.Load(csprojPath)
+                    .Descendants()
+                    .FirstOrDefault(element => element.Name.LocalName == "OutputType")
+                    ?.Value;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
         static IEnumerable<ProjectItemInfo> ReadProjectItems(string csprojPath)
         {
             try

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2LauncherProjectDetectorTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2LauncherProjectDetectorTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// `dotnet new frb2-desktop` produces MyGame.Common (what Glue edits, with no OutputType of its
+/// own) and MyGame.Desktop (the runnable launcher). Pressing Play used to build/run Common, which
+/// has no .exe to launch - so the button silently did nothing (#2188). This is what finds the
+/// launcher given the game project Glue actually has loaded.
+/// </summary>
+public class Frb2LauncherProjectDetectorTests : IDisposable
+{
+    readonly string _root;
+
+    public Frb2LauncherProjectDetectorTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "Frb2Launcher_" + Guid.NewGuid());
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    string WriteProject(string name, string itemGroupXml, string outputType = null)
+    {
+        var directory = Path.Combine(_root, name);
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, name + ".csproj");
+        var outputTypeXml = outputType == null ? "" : $"    <OutputType>{outputType}</OutputType>\n";
+        File.WriteAllText(path, $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+{outputTypeXml}  </PropertyGroup>
+  <ItemGroup>
+{itemGroupXml}
+  </ItemGroup>
+</Project>");
+        return path;
+    }
+
+    string WriteCommon() =>
+        WriteProject("MyGame.Common", @"    <PackageReference Include=""FlatRedBall2.MonoGame"" Version=""*-*"" />");
+
+    string WriteDesktopLauncher() =>
+        WriteProject("MyGame.Desktop",
+            @"    <PackageReference Include=""MonoGame.Framework.DesktopGL"" Version=""3.8.4.1"" />
+    <ProjectReference Include=""..\MyGame.Common\MyGame.Common.csproj"" />",
+            outputType: "WinExe");
+
+    [Fact]
+    public void ReferencingProjectWithExeOutputType_IsFoundAsTheLauncher()
+    {
+        var common = WriteCommon();
+        var desktop = WriteDesktopLauncher();
+
+        var found = Frb2ProjectDetector.FindFrb2LauncherProjectFor(common, new[] { common, desktop });
+
+        Assert.Equal(Path.GetFullPath(desktop), found);
+    }
+
+    [Fact]
+    public void ReferencingProjectWithoutExeOutputType_IsNotALauncher()
+    {
+        // A plain ProjectReference back to Common - e.g. a future test/tools project - is not
+        // something Glue should ever try to run.
+        var common = WriteCommon();
+        var libraryReferencingCommon = WriteProject("MyGame.Tests",
+            @"    <ProjectReference Include=""..\MyGame.Common\MyGame.Common.csproj"" />");
+
+        var found = Frb2ProjectDetector.FindFrb2LauncherProjectFor(
+            common, new[] { common, libraryReferencingCommon });
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void ExecutableProjectNotReferencingTheGame_IsNotALauncher()
+    {
+        var common = WriteCommon();
+        var unrelatedExe = WriteProject("SomeOtherTool", "", outputType: "Exe");
+
+        var found = Frb2ProjectDetector.FindFrb2LauncherProjectFor(common, new[] { common, unrelatedExe });
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void TwoCandidateLaunchers_ResolvesToNothingRatherThanGuessing()
+    {
+        var common = WriteCommon();
+        var desktop = WriteDesktopLauncher();
+        var android = WriteProject("MyGame.Android",
+            @"    <ProjectReference Include=""..\MyGame.Common\MyGame.Common.csproj"" />",
+            outputType: "Exe");
+
+        var found = Frb2ProjectDetector.FindFrb2LauncherProjectFor(
+            common, new[] { common, desktop, android });
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void TheGameProjectItself_IsNeverReturnedAsItsOwnLauncher()
+    {
+        var common = WriteCommon();
+
+        var found = Frb2ProjectDetector.FindFrb2LauncherProjectFor(common, new[] { common });
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void NoCandidates_ResolvesToNull()
+    {
+        var common = WriteCommon();
+
+        Assert.Null(Frb2ProjectDetector.FindFrb2LauncherProjectFor(common, Array.Empty<string>()));
+        Assert.Null(Frb2ProjectDetector.FindFrb2LauncherProjectFor(common, null));
+    }
+
+    [Fact]
+    public void MissingGameProject_ResolvesToNullRatherThanThrowing()
+    {
+        var desktop = WriteDesktopLauncher();
+
+        Assert.Null(Frb2ProjectDetector.FindFrb2LauncherProjectFor(
+            Path.Combine(_root, "Nope", "Nope.csproj"), new[] { desktop }));
+        Assert.Null(Frb2ProjectDetector.FindFrb2LauncherProjectFor(null, new[] { desktop }));
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2LauncherProjectInfoTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2LauncherProjectInfoTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// <see cref="Frb2LauncherProjectInfo"/> tells Runner where an FRB2 launcher's own build output
+/// lands, without an MSBuild evaluation - so Runner can find MyGame.Desktop.exe instead of trying
+/// (and failing) to run MyGame.Common, which has no OutputType of its own (#2188).
+/// </summary>
+public class Frb2LauncherProjectInfoTests : IDisposable
+{
+    readonly string _root;
+
+    public Frb2LauncherProjectInfoTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "Frb2LauncherInfo_" + Guid.NewGuid());
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    string WriteCsproj(string propertyGroupXml)
+    {
+        var path = Path.Combine(_root, "MyGame.Desktop.csproj");
+        File.WriteAllText(path, $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+{propertyGroupXml}
+  </PropertyGroup>
+</Project>");
+        return path;
+    }
+
+    [Fact]
+    public void DefaultAssemblyName_FallsBackToTheProjectFileName()
+    {
+        var csproj = WriteCsproj("    <TargetFramework>net8.0</TargetFramework>");
+
+        var info = Frb2LauncherProjectInfo.TryGet(csproj, "Debug");
+
+        Assert.NotNull(info);
+        Assert.Equal("MyGame.Desktop", info.Value.ExecutableName);
+        Assert.Equal(
+            Path.Combine(_root, "bin", "Debug", "net8.0", "MyGame.Desktop.exe").Replace('\\', '/'),
+            info.Value.ExeLocation.Replace('\\', '/'));
+    }
+
+    [Fact]
+    public void ExplicitAssemblyName_IsUsedForBothTheExeNameAndProcessName()
+    {
+        var csproj = WriteCsproj(
+            "    <TargetFramework>net8.0</TargetFramework>\n    <AssemblyName>MyGame</AssemblyName>");
+
+        var info = Frb2LauncherProjectInfo.TryGet(csproj, "Debug");
+
+        Assert.NotNull(info);
+        Assert.Equal("MyGame", info.Value.ExecutableName);
+        Assert.EndsWith("MyGame.exe", info.Value.ExeLocation);
+    }
+
+    [Fact]
+    public void ConfigurationIsHonored_UnlikeTheCommonProjectPath()
+    {
+        var csproj = WriteCsproj("    <TargetFramework>net8.0</TargetFramework>");
+
+        var info = Frb2LauncherProjectInfo.TryGet(csproj, "Release");
+
+        Assert.NotNull(info);
+        Assert.Contains("/Release/", info.Value.ExeLocation.Replace('\\', '/'));
+    }
+
+    [Fact]
+    public void MultiTargetedProject_ResolvesToNull()
+    {
+        // Which folder wins depends on which TFM built (and ran) last - not worth guessing.
+        var csproj = WriteCsproj("    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>");
+
+        Assert.Null(Frb2LauncherProjectInfo.TryGet(csproj, "Debug"));
+    }
+
+    [Fact]
+    public void CustomOutputPath_ResolvesToNullRatherThanGuessingWrong()
+    {
+        var csproj = WriteCsproj(
+            "    <TargetFramework>net8.0</TargetFramework>\n    <OutputPath>CustomOut\\</OutputPath>");
+
+        Assert.Null(Frb2LauncherProjectInfo.TryGet(csproj, "Debug"));
+    }
+
+    [Fact]
+    public void MissingProject_ResolvesToNullRatherThanThrowing()
+    {
+        Assert.Null(Frb2LauncherProjectInfo.TryGet(
+            Path.Combine(_root, "Nope.csproj"), "Debug"));
+        Assert.Null(Frb2LauncherProjectInfo.TryGet(null, "Debug"));
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectLoadTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2ProjectLoadTests.cs
@@ -81,6 +81,39 @@ public class Frb2ProjectLoadTests
     }
 
     [StaFact]
+    public async Task LoadingATemplateCreatedFrb2Project_ResolvesTheDesktopLauncher()
+    {
+        // Runner/Compiler build and run GlueState.Self.CurrentFrb2LauncherProjectFileName instead of
+        // the loaded Common project - Common has no OutputType of its own, so pressing Play used to
+        // build a DLL and never launch anything (#2188).
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2LauncherResolve_");
+        var commonCsproj = WriteTemplateShapedFrb2Project(temp.Root);
+
+        await GoldProject.LoadInGlueAsync(commonCsproj);
+
+        var launcher = GlueState.Self.CurrentFrb2LauncherProjectFileName;
+
+        Assert.NotNull(launcher);
+        Assert.Equal(ProjectName + ".Desktop.csproj", Path.GetFileName(launcher.FullPath));
+    }
+
+    [StaFact]
+    public async Task LoadingASingleProjectFrb2Game_HasNoLauncherToResolve()
+    {
+        // The source-linked, single-project layout Frb2ProjectFixture.Write produces has nothing
+        // separate to build/run - CurrentMainProject itself is the runnable project, so there is no
+        // launcher redirect to make.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2LauncherNone_");
+        await GoldProject.LoadInGlueAsync(WriteFrb2Project(temp.Root));
+
+        Assert.Null(GlueState.Self.CurrentFrb2LauncherProjectFileName);
+    }
+
+    [StaFact]
     public async Task LoadingAnFrb2Project_CreatesTheGluj_AndWritesNothingElse()
     {
         // The full game-project plugin set, not just the embedded ones: which plugins are registered is


### PR DESCRIPTION
Closes #2188

FRB2 games split into `<Name>.Common` (what Glue loads/edits, no `OutputType` of its own) and a
platform launcher like `<Name>.Desktop` (the runnable project, referencing Common). Runner/Compiler
always built and ran `GlueState.Self.CurrentMainProject` directly, which is Common — so pressing
Play built a DLL with nothing to launch.

Resolves the launcher from the loaded solution (one hop, unambiguous only) and builds/runs it
instead when found; Common still builds transitively via its `ProjectReference`. Falls back to the
previous single-project behavior for FRB1 and for an FRB2 project with no resolvable launcher.

## Test plan
- [x] Unit tests: `Frb2LauncherProjectDetectorTests`, `Frb2LauncherProjectInfoTests`, plus new
      `Frb2ProjectLoadTests` coverage resolving the launcher via a real `GoldProject.LoadInGlueAsync`
      load — 135 tests passing in the FRB2/Runner/resolver area.
- [x] Manual: opened `FRB_2_15.Common.csproj` (real `dotnet new frb2-desktop`-shaped project) in
      Glue, pressed Play — both `.Common` and `.Desktop` build, and the game window launches.
