### PR TITLE
Show FRB/Gum source-linked repo status in About tab

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml
@@ -26,6 +26,8 @@
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
             </Grid.RowDefinitions>
 
             <Label Content="FlatRedBall Editor Version" />
@@ -57,7 +59,17 @@
             <Label Grid.Row="6" Content="DLL version" />
             <Label Grid.Row="6" Grid.Column="1" Content="{Binding DllSyntaxVersionToShow}" />
 
+            <Label Grid.Row="7" Content="FlatRedBall Source" Visibility="{Binding FrbSourceRowVisibility}" />
+            <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.Column="1" Visibility="{Binding FrbSourceRowVisibility}">
+                <Label Content="{Binding FrbSourceStatusText}" />
+                <Button Content="{Binding FrbSourceButtonText}" IsEnabled="{Binding IsFrbSourceButtonEnabled}" Click="FrbSourceButton_Click" Margin="5,0,0,0" />
+            </StackPanel>
 
+            <Label Grid.Row="8" Content="Gum Source" Visibility="{Binding GumSourceRowVisibility}" />
+            <StackPanel Orientation="Horizontal" Grid.Row="8" Grid.Column="1" Visibility="{Binding GumSourceRowVisibility}">
+                <Label Content="{Binding GumSourceStatusText}" />
+                <Button Content="{Binding GumSourceButtonText}" IsEnabled="{Binding IsGumSourceButtonEnabled}" Click="GumSourceButton_Click" Margin="5,0,0,0" />
+            </StackPanel>
 
         </Grid>
     </Grid>

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml.cs
@@ -24,5 +24,15 @@ namespace GlueFormsCore.Controls
         {
             ViewModel.DoInstallDailyBuild();
         }
+
+        private void FrbSourceButton_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.DoFrbSourceButtonClicked();
+        }
+
+        private void GumSourceButton_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.DoGumSourceButtonClicked();
+        }
     }
 }

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutViewModel.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutViewModel.cs
@@ -17,6 +17,14 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
 {
     public class AboutViewModel : ViewModel
     {
+        public AboutViewModel()
+        {
+            // Get<Visibility>() otherwise defaults to Visibility.Visible (enum value 0), which would
+            // show an empty source-status row before InitializeSourceStatus ever runs.
+            FrbSourceRowVisibility = Visibility.Collapsed;
+            GumSourceRowVisibility = Visibility.Collapsed;
+        }
+
         public string CopyrightText
         {
             get => Get<string>();
@@ -156,6 +164,161 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
             get => Get<string>();
             set => Set(value);
         }
+
+        #region Source Repo Status (FRB/Gum)
+
+        string _frbSourceRoot;
+        string _gumSourceRoot;
+
+        public Visibility FrbSourceRowVisibility
+        {
+            get => Get<Visibility>();
+            set => Set(value);
+        }
+
+        public Visibility GumSourceRowVisibility
+        {
+            get => Get<Visibility>();
+            set => Set(value);
+        }
+
+        public string FrbSourceStatusText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string GumSourceStatusText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string FrbSourceButtonText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string GumSourceButtonText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public bool IsFrbSourceButtonEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool IsGumSourceButtonEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        /// <summary>
+        /// Kicks off the initial FRB/Gum source-status check. Intended to be called once, the first
+        /// time the About tab is shown for a source-linked project - subsequent re-checks go through
+        /// the per-row Refresh/Pull Latest button instead.
+        /// </summary>
+        internal void InitializeSourceStatus(string frbSourceRoot, string gumSourceRoot)
+        {
+            _frbSourceRoot = frbSourceRoot;
+            _gumSourceRoot = gumSourceRoot;
+
+            FrbSourceRowVisibility = frbSourceRoot != null ? Visibility.Visible : Visibility.Collapsed;
+            GumSourceRowVisibility = gumSourceRoot != null ? Visibility.Visible : Visibility.Collapsed;
+
+            if (frbSourceRoot != null)
+            {
+                _ = RefreshSourceStatusAsync(isFrb: true);
+            }
+
+            if (gumSourceRoot != null)
+            {
+                _ = RefreshSourceStatusAsync(isFrb: false);
+            }
+        }
+
+        internal async void DoFrbSourceButtonClicked() => await HandleSourceButtonClickedAsync(isFrb: true);
+
+        internal async void DoGumSourceButtonClicked() => await HandleSourceButtonClickedAsync(isFrb: false);
+
+        async System.Threading.Tasks.Task HandleSourceButtonClickedAsync(bool isFrb)
+        {
+            if ((isFrb ? FrbSourceButtonText : GumSourceButtonText) == "Pull Latest")
+            {
+                await PullSourceAsync(isFrb);
+            }
+            else
+            {
+                await RefreshSourceStatusAsync(isFrb);
+            }
+        }
+
+        async System.Threading.Tasks.Task RefreshSourceStatusAsync(bool isFrb)
+        {
+            var root = isFrb ? _frbSourceRoot : _gumSourceRoot;
+
+            SetSourceButtonEnabled(isFrb, false);
+            SetSourceStatusText(isFrb, "Checking...");
+
+            var result = await GitRepoStatusChecker.CheckStatusAsync(root);
+
+            if (!result.Succeeded)
+            {
+                SetSourceStatusText(isFrb, $"Unable to check ({result.ErrorMessage})");
+                SetSourceButtonText(isFrb, "Refresh");
+            }
+            else if (result.CommitsBehind == 0)
+            {
+                SetSourceStatusText(isFrb, "Up to date");
+                SetSourceButtonText(isFrb, "Refresh");
+            }
+            else
+            {
+                SetSourceStatusText(isFrb, result.CommitsBehind == 1 ? "1 commit behind" : $"{result.CommitsBehind} commits behind");
+                SetSourceButtonText(isFrb, "Pull Latest");
+            }
+
+            SetSourceButtonEnabled(isFrb, true);
+        }
+
+        async System.Threading.Tasks.Task PullSourceAsync(bool isFrb)
+        {
+            var root = isFrb ? _frbSourceRoot : _gumSourceRoot;
+
+            SetSourceButtonEnabled(isFrb, false);
+            SetSourceStatusText(isFrb, "Pulling...");
+
+            var result = await GitRepoStatusChecker.PullAsync(root);
+
+            if (!result.Succeeded)
+            {
+                GlueCommands.Self.DialogCommands.ShowMessageBox($"Failed to pull latest:\n{result.ErrorMessage}");
+            }
+
+            await RefreshSourceStatusAsync(isFrb);
+        }
+
+        void SetSourceStatusText(bool isFrb, string text)
+        {
+            if (isFrb) FrbSourceStatusText = text; else GumSourceStatusText = text;
+        }
+
+        void SetSourceButtonText(bool isFrb, string text)
+        {
+            if (isFrb) FrbSourceButtonText = text; else GumSourceButtonText = text;
+        }
+
+        void SetSourceButtonEnabled(bool isFrb, bool enabled)
+        {
+            if (isFrb) IsFrbSourceButtonEnabled = enabled; else IsGumSourceButtonEnabled = enabled;
+        }
+
+        #endregion
 
         internal async void DoInstallUpdate()
         {

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutViewModel.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutViewModel.cs
@@ -219,9 +219,9 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
         }
 
         /// <summary>
-        /// Kicks off the initial FRB/Gum source-status check. Intended to be called once, the first
-        /// time the About tab is shown for a source-linked project - subsequent re-checks go through
-        /// the per-row Refresh/Pull Latest button instead.
+        /// Kicks off an FRB/Gum source-status check. Called every time the About tab is shown; the
+        /// per-row Refresh/Pull Latest button lets the user re-check again without closing and
+        /// reopening the tab.
         /// </summary>
         internal void InitializeSourceStatus(string frbSourceRoot, string gumSourceRoot)
         {

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/GitRepoStatusChecker.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/GitRepoStatusChecker.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
+{
+    internal readonly struct GitStatusResult
+    {
+        public bool Succeeded { get; }
+        public int CommitsBehind { get; }
+        public string ErrorMessage { get; }
+
+        public GitStatusResult(bool succeeded, int commitsBehind, string errorMessage)
+        {
+            Succeeded = succeeded;
+            CommitsBehind = commitsBehind;
+            ErrorMessage = errorMessage;
+        }
+    }
+
+    internal readonly struct GitPullResult
+    {
+        public bool Succeeded { get; }
+        public string ErrorMessage { get; }
+
+        public GitPullResult(bool succeeded, string errorMessage)
+        {
+            Succeeded = succeeded;
+            ErrorMessage = errorMessage;
+        }
+    }
+
+    /// <summary>
+    /// Shells out to the git CLI to check whether a source-linked repo checkout is behind its
+    /// upstream branch, and to fast-forward it. Uses <c>@{u}</c> (the current branch's configured
+    /// upstream) rather than a hardcoded branch name, since FRB1/Gum default to NetStandard while
+    /// FRB2 defaults to main.
+    /// </summary>
+    internal static class GitRepoStatusChecker
+    {
+        public static async Task<GitStatusResult> CheckStatusAsync(string repoDirectory)
+        {
+            var fetch = await RunGitAsync(repoDirectory, "fetch");
+            if (fetch.ExitCode != 0)
+            {
+                return new GitStatusResult(false, 0, FirstNonEmpty(fetch.StdErr, "git fetch failed"));
+            }
+
+            var revList = await RunGitAsync(repoDirectory, "rev-list --count HEAD..@{u}");
+            if (revList.ExitCode != 0)
+            {
+                return new GitStatusResult(false, 0, FirstNonEmpty(revList.StdErr, "Could not determine upstream branch"));
+            }
+
+            if (!int.TryParse(revList.StdOut.Trim(), out var commitsBehind))
+            {
+                return new GitStatusResult(false, 0, "Unexpected git output");
+            }
+
+            return new GitStatusResult(true, commitsBehind, null);
+        }
+
+        public static async Task<GitPullResult> PullAsync(string repoDirectory)
+        {
+            var pull = await RunGitAsync(repoDirectory, "pull --ff-only");
+            return pull.ExitCode == 0
+                ? new GitPullResult(true, null)
+                : new GitPullResult(false, FirstNonEmpty(pull.StdErr, "git pull --ff-only failed"));
+        }
+
+        static string FirstNonEmpty(string value, string fallback) =>
+            string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+
+        static async Task<(int ExitCode, string StdOut, string StdErr)> RunGitAsync(string workingDirectory, string arguments)
+        {
+            var startInfo = new ProcessStartInfo("git", arguments)
+            {
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            try
+            {
+                using var process = new Process { StartInfo = startInfo };
+                process.Start();
+
+                var stdOutTask = process.StandardOutput.ReadToEndAsync();
+                var stdErrTask = process.StandardError.ReadToEndAsync();
+                await Task.WhenAll(stdOutTask, stdErrTask, process.WaitForExitAsync());
+
+                return (process.ExitCode, await stdOutTask, await stdErrTask);
+            }
+            catch (Exception ex)
+            {
+                return (-1, string.Empty, ex.Message);
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/MainAboutPlugin.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/MainAboutPlugin.cs
@@ -2,6 +2,7 @@
 using FlatRedBall.Glue.Plugins.EmbeddedPlugins;
 using FlatRedBall.Glue.Plugins.ExportedImplementations;
 using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.VSHelpers.Projects;
 using FlatRedBall.IO;
 using GlueFormsCore.Controls;
 using Microsoft.Build.Evaluation;
@@ -24,6 +25,7 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
     {
         PluginTab tab;
         AboutViewModel aboutViewModel;
+        bool hasCheckedSourceStatus;
 
         public override void StartUp()
         {
@@ -59,9 +61,42 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
                 tab = CreateTab(view, "About");
             }
             RefreshAboutViewModel(GlueState.Self.CurrentGlueProject);
+            CheckSourceStatusIfFirstShow();
 
             tab.Show();
             tab.Focus();
+        }
+
+        private void CheckSourceStatusIfFirstShow()
+        {
+            if (hasCheckedSourceStatus)
+            {
+                return;
+            }
+
+            var mainProject = GlueState.Self.CurrentMainProject;
+
+            string frbRoot = null;
+            string gumRoot = null;
+
+            if (mainProject is Frb2Project frb2Project)
+            {
+                SourceRepoLocator.TryGetFrb2SourceRoot(frb2Project, out frbRoot);
+            }
+            else if (mainProject != null)
+            {
+                SourceRepoLocator.TryGetFrb1SourceRoots(mainProject, out frbRoot, out gumRoot);
+            }
+
+            if (frbRoot == null)
+            {
+                // No project loaded yet, or not linked to source - nothing to check yet. Leave
+                // hasCheckedSourceStatus false so this runs again next time the tab is shown.
+                return;
+            }
+
+            hasCheckedSourceStatus = true;
+            aboutViewModel.InitializeSourceStatus(frbRoot, gumRoot);
         }
 
         private void RefreshAboutViewModel(GlueProjectSave glueProject)

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/MainAboutPlugin.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/MainAboutPlugin.cs
@@ -25,7 +25,6 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
     {
         PluginTab tab;
         AboutViewModel aboutViewModel;
-        bool hasCheckedSourceStatus;
 
         public override void StartUp()
         {
@@ -61,19 +60,19 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
                 tab = CreateTab(view, "About");
             }
             RefreshAboutViewModel(GlueState.Self.CurrentGlueProject);
-            CheckSourceStatusIfFirstShow();
+            CheckSourceStatus();
 
             tab.Show();
             tab.Focus();
         }
 
-        private void CheckSourceStatusIfFirstShow()
+        /// <summary>
+        /// Re-checks FRB/Gum source status against the current project every time the About tab is
+        /// shown (not on the passive project-load refresh in StartUp) - the row's Refresh/Pull Latest
+        /// button exists for re-checking without closing and reopening the tab, not as the only trigger.
+        /// </summary>
+        private void CheckSourceStatus()
         {
-            if (hasCheckedSourceStatus)
-            {
-                return;
-            }
-
             var mainProject = GlueState.Self.CurrentMainProject;
 
             string frbRoot = null;
@@ -88,14 +87,6 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
                 SourceRepoLocator.TryGetFrb1SourceRoots(mainProject, out frbRoot, out gumRoot);
             }
 
-            if (frbRoot == null)
-            {
-                // No project loaded yet, or not linked to source - nothing to check yet. Leave
-                // hasCheckedSourceStatus false so this runs again next time the tab is shown.
-                return;
-            }
-
-            hasCheckedSourceStatus = true;
             aboutViewModel.InitializeSourceStatus(frbRoot, gumRoot);
         }
 

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/SourceRepoLocator.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/SourceRepoLocator.cs
@@ -1,0 +1,98 @@
+using FlatRedBall.Glue.VSHelpers.Projects;
+using System;
+using System.IO;
+
+namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
+{
+    /// <summary>
+    /// Resolves the absolute folder of the FRB/Gum source repos a loaded game project is linked
+    /// against, by finding the project's evaluated ProjectReference to a known engine csproj and
+    /// stripping off the known relative suffix.
+    /// </summary>
+    /// <remarks>
+    /// This mirrors <c>OfficialPlugins\FrbSourcePlugin\Managers\AddSourceManager</c>'s and
+    /// <c>Frb2AddSourceManager</c>'s relative-path lists rather than reusing them: Glue.csproj can't
+    /// reference OfficialPlugins.csproj (the dependency runs the other way, through PluginLibraries).
+    /// </remarks>
+    internal static class SourceRepoLocator
+    {
+        static readonly (string FrbRelative, string GumRelative)[] Frb1EngineRelativePaths = new[]
+        {
+            (@"Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj", @"GumCore\GumCoreXnaPc\GumCore.DesktopGlNet6\GumCore.DesktopGlNet6.csproj"),
+            (@"Engines\FlatRedBallXNA\FlatRedBall.FNA\FlatRedBall.FNA.csproj", @"GumCore\GumCoreXnaPc\GumCore.FNA\GumCore.FNA.csproj"),
+            (@"Engines\FlatRedBallXNA\KniWeb\FlatRedBallKniWeb.csproj", @"GumCore\GumCoreXnaPc\GumCore.Kni.Web\GumCore.Kni.Web.csproj"),
+            (@"Engines\FlatRedBallXNA\FlatRedBallAndroid\FlatRedBallAndroid.csproj", @"GumCore\GumCoreXnaPc\GumCoreAndroid\GumCoreAndroid.csproj"),
+            (@"Engines\FlatRedBallXNA\FlatRedBalliOS\FlatRedBalliOS.csproj", @"GumCore\GumCoreXnaPc\GumCoreiOS\GumCoreiOS.csproj"),
+        };
+
+        const string Frb2EngineRelativePath = @"src\FlatRedBall2.csproj";
+
+        public static bool TryGetFrb1SourceRoots(VisualStudioProject project, out string frbRoot, out string gumRoot)
+        {
+            frbRoot = null;
+            gumRoot = null;
+
+            var projectDirectory = project.FullFileName.GetDirectoryContainingThis().FullPath;
+
+            foreach (var item in project.EvaluatedItems)
+            {
+                if (item.ItemType != "ProjectReference")
+                {
+                    continue;
+                }
+
+                var fullPath = ResolveFullPath(projectDirectory, item.EvaluatedInclude);
+
+                foreach (var (frbRelative, gumRelative) in Frb1EngineRelativePaths)
+                {
+                    if (frbRoot == null && EndsWithPath(fullPath, frbRelative))
+                    {
+                        frbRoot = fullPath.Substring(0, fullPath.Length - frbRelative.Length).TrimEnd('\\', '/');
+                    }
+                    if (gumRoot == null && EndsWithPath(fullPath, gumRelative))
+                    {
+                        gumRoot = fullPath.Substring(0, fullPath.Length - gumRelative.Length).TrimEnd('\\', '/');
+                    }
+                }
+            }
+
+            return frbRoot != null;
+        }
+
+        public static bool TryGetFrb2SourceRoot(VisualStudioProject project, out string frbRoot)
+        {
+            frbRoot = null;
+
+            var projectDirectory = project.FullFileName.GetDirectoryContainingThis().FullPath;
+
+            foreach (var item in project.EvaluatedItems)
+            {
+                if (item.ItemType != "ProjectReference")
+                {
+                    continue;
+                }
+
+                var fullPath = ResolveFullPath(projectDirectory, item.EvaluatedInclude);
+
+                if (EndsWithPath(fullPath, Frb2EngineRelativePath))
+                {
+                    frbRoot = fullPath.Substring(0, fullPath.Length - Frb2EngineRelativePath.Length).TrimEnd('\\', '/');
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static string ResolveFullPath(string projectDirectory, string evaluatedInclude)
+        {
+            var combined = Path.IsPathRooted(evaluatedInclude)
+                ? evaluatedInclude
+                : Path.Combine(projectDirectory, evaluatedInclude);
+            return Path.GetFullPath(combined);
+        }
+
+        static bool EndsWithPath(string fullPath, string relativeSuffix) =>
+            fullPath.EndsWith(relativeSuffix, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/AboutPlugin/SourceRepoLocatorTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/AboutPlugin/SourceRepoLocatorTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+
+namespace GlueUnitTests.AboutPlugin;
+
+public class SourceRepoLocatorTests : IDisposable
+{
+    private readonly string _directory;
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.ClassLibraryProject _project;
+
+    public SourceRepoLocatorTests()
+    {
+        _project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _directory);
+    }
+
+    public void Dispose() => Directory.Delete(_directory, recursive: true);
+
+    [Fact]
+    public void TryGetFrb1SourceRoots_ShouldReturnFalse_WhenProjectHasNoEngineProjectReference()
+    {
+        SourceRepoLocator.TryGetFrb1SourceRoots(_project, out var frbRoot, out var gumRoot).ShouldBeFalse();
+        frbRoot.ShouldBeNull();
+        gumRoot.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryGetFrb1SourceRoots_ShouldResolveBothRoots_WhenProjectReferencesFrbAndGumEngineProjects()
+    {
+        AddProjectReference(@"..\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj");
+        AddProjectReference(@"..\GumCore\GumCoreXnaPc\GumCore.DesktopGlNet6\GumCore.DesktopGlNet6.csproj");
+
+        var expectedRoot = Directory.GetParent(_directory).FullName;
+
+        SourceRepoLocator.TryGetFrb1SourceRoots(_project, out var frbRoot, out var gumRoot).ShouldBeTrue();
+        frbRoot.ShouldBe(expectedRoot);
+        gumRoot.ShouldBe(expectedRoot);
+    }
+
+    [Fact]
+    public void TryGetFrb2SourceRoot_ShouldReturnFalse_WhenProjectHasNoEngineProjectReference()
+    {
+        SourceRepoLocator.TryGetFrb2SourceRoot(_project, out var frbRoot).ShouldBeFalse();
+        frbRoot.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryGetFrb2SourceRoot_ShouldResolveRoot_WhenProjectReferencesFlatRedBall2Engine()
+    {
+        AddProjectReference(@"..\src\FlatRedBall2.csproj");
+
+        var expectedRoot = Directory.GetParent(_directory).FullName;
+
+        SourceRepoLocator.TryGetFrb2SourceRoot(_project, out var frbRoot).ShouldBeTrue();
+        frbRoot.ShouldBe(expectedRoot);
+    }
+
+    private void AddProjectReference(string relativePath)
+    {
+        _project.Project.AddItem("ProjectReference", relativePath);
+        _project.Project.MarkDirty();
+        _project.Project.ReevaluateIfNecessary();
+    }
+}


### PR DESCRIPTION
## Summary
- Help->About now shows an "FlatRedBall Source" row and a "Gum Source" row (Gum only for FRB1) when the loaded project is linked to source, each with an up-to-date/N-commits-behind status and a button that pulls (`git pull --ff-only`) when behind or re-checks (`git fetch` + `rev-list` against `@{u}`) when up to date.
- The check runs once, the first time the tab is shown for a source-linked project; the row's button is the only way to re-check afterward.
- Repo roots are resolved from the project's evaluated `ProjectReference` paths directly in `Glue.csproj` (not reused from `FrbSourcePlugin`'s `AddSourceManager`), since `Glue.csproj` can't reference `OfficialPlugins.csproj` (the dependency runs the other way, through `PluginLibraries`).

## Test plan
- [x] `SourceRepoLocatorTests` (4 new unit tests) cover FRB1 root resolution (both FRB + Gum), FRB2 root resolution, and the no-match case.
- [x] `Glue.csproj` builds clean.
- [x] Manual: open a project linked to FRB1 source, confirm both rows appear with correct status and that Pull Latest / Refresh work; open an FRB2 project linked to source, confirm only the FlatRedBall row appears; open an unlinked project, confirm neither row appears.
