### PR TITLE
Glue: add opt-in MSBuild Server setting to speed up edit-mode build/run

### DIFF
--- a/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
+++ b/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
@@ -61,6 +61,26 @@ namespace CompilerPlugin
             _compiler.BuildSettingsUser = BuildSettingsUser;
             _compilerViewModel.HasLoadedGlux = true;
             _compilerViewModel.HasDoneNugetRestore = false;
+
+            if (_compiler.ShouldWarmUpMsBuildServer)
+            {
+                _ = WarmUpMsBuildServerAsync();
+            }
+        }
+
+        private async Task WarmUpMsBuildServerAsync()
+        {
+            var result = await _compiler.Compile(
+                (value) => HandleOutput(value),
+                (value) => ReactToPluginEvent("Compiler_Output_Error", value),
+                !_compilerViewModel.HasDoneNugetRestore,
+                _compilerViewModel.Configuration,
+                _compilerViewModel.IsPrintMsBuildCommandChecked);
+
+            if (result.Succeeded)
+            {
+                _compilerViewModel.HasDoneNugetRestore = true;
+            }
         }
 
         private void HandleGluxUnLoaded()

--- a/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
+++ b/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
@@ -1,4 +1,5 @@
-﻿using FlatRedBall.Glue.Plugins;
+﻿using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins;
 using FlatRedBall.Glue.Plugins.Interfaces;
 using System;
 using System.ComponentModel.Composition;
@@ -64,8 +65,17 @@ namespace CompilerPlugin
 
             if (_compiler.ShouldWarmUpMsBuildServer)
             {
-                _ = WarmUpMsBuildServerAsync();
+                QueueMsBuildServerWarmUp();
             }
+        }
+
+        // Runs as a real TaskManager task (not a bare fire-and-forget Task) so it occupies the FIFO
+        // queue and shows up in "Tasks remaining" - the whole point of warming up is user-visible,
+        // background work, not something that should look like nothing is happening.
+        private void QueueMsBuildServerWarmUp()
+        {
+            _ = TaskManager.Self.AddAsync(WarmUpMsBuildServerAsync, "Warming up MSBuild Server",
+                TaskExecutionPreference.Fifo, doOnUiThread: true);
         }
 
         private async Task WarmUpMsBuildServerAsync()
@@ -222,6 +232,7 @@ namespace CompilerPlugin
                 var view = new BuildSettingsWindow();
                 view.DataContext = viewModel;
                 viewModel.SetFrom(BuildSettingsUser);
+                var wasUsingMsBuildServer = BuildSettingsUser.UseMsBuildServer;
 
                 var results = view.ShowDialog();
 
@@ -231,6 +242,11 @@ namespace CompilerPlugin
                     viewModel.ApplyTo(BuildSettingsUser);
 
                     SaveBuildSettings();
+
+                    if (Compiler.ShouldWarmUpOnSettingsChange(wasUsingMsBuildServer, BuildSettingsUser.UseMsBuildServer))
+                    {
+                        QueueMsBuildServerWarmUp();
+                    }
                 }
             };
         }

--- a/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
+++ b/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
@@ -119,6 +119,15 @@ namespace CompilerPlugin
             }
         }
 
+        private void SaveBuildSettings()
+        {
+            GlueCommands.Self.TryMultipleTimes(() =>
+            {
+                var textToSave = JsonConvert.SerializeObject(BuildSettingsUser);
+                System.IO.File.WriteAllText(BuildSettingsUserFilePath.FullPath, textToSave);
+            });
+        }
+
         #endregion
 
         #region Private Methods
@@ -221,11 +230,7 @@ namespace CompilerPlugin
                     // apply VM:
                     viewModel.ApplyTo(BuildSettingsUser);
 
-                    GlueCommands.Self.TryMultipleTimes(() =>
-                    {
-                        var textToSave = JsonConvert.SerializeObject(BuildSettingsUser);
-                        System.IO.File.WriteAllText(BuildSettingsUserFilePath.FullPath, textToSave);
-                    });
+                    SaveBuildSettings();
                 }
             };
         }

--- a/FRBDK/Glue/CompilerPlugin/Managers/Compiler.cs
+++ b/FRBDK/Glue/CompilerPlugin/Managers/Compiler.cs
@@ -97,6 +97,10 @@ namespace CompilerPlugin.Managers
 
         public BuildSettingsUser BuildSettingsUser { get; set; }
 
+        // Gates the background warm-up build fired on project load (CompilerPlugin.HandleGluxLoaded) -
+        // only worth doing when the setting that makes MSBuild Server actually get used is on.
+        public bool ShouldWarmUpMsBuildServer => BuildSettingsUser?.UseMsBuildServer == true;
+
         FilePath msBuildLocation;
         private CompilerViewModel _compilerViewModel;
 
@@ -470,7 +474,9 @@ namespace CompilerPlugin.Managers
         }
 
 
-        private static Process CreateProcess(string executable, string arguments)
+        // internal (not private) so GlueUnitTests can pin the env var behavior below without spawning
+        // a real process - CreateProcess only builds the ProcessStartInfo, it never calls Start().
+        internal Process CreateProcess(string executable, string arguments)
         {
             Process process = new Process();
 
@@ -482,6 +488,12 @@ namespace CompilerPlugin.Managers
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.CreateNoWindow = true;
 
+            if (BuildSettingsUser?.UseMsBuildServer == true)
+            {
+                // Scoped to this child process's environment block only - does not affect Glue's own
+                // process, sibling processes, or any other tool's `dotnet`/`msbuild` invocations.
+                process.StartInfo.EnvironmentVariables["DOTNET_CLI_USE_MSBUILD_SERVER"] = "1";
+            }
 
             return process;
         }

--- a/FRBDK/Glue/CompilerPlugin/Managers/Compiler.cs
+++ b/FRBDK/Glue/CompilerPlugin/Managers/Compiler.cs
@@ -101,6 +101,12 @@ namespace CompilerPlugin.Managers
         // only worth doing when the setting that makes MSBuild Server actually get used is on.
         public bool ShouldWarmUpMsBuildServer => BuildSettingsUser?.UseMsBuildServer == true;
 
+        // Gates the background warm-up build fired when the Build Settings dialog is closed
+        // (CompilerPlugin's MSBuildSettingsClicked handler) - only worth doing on the OFF -> ON
+        // transition, not every OK click while it's already on (or off).
+        internal static bool ShouldWarmUpOnSettingsChange(bool wasUsingMsBuildServer, bool isUsingMsBuildServerNow) =>
+            !wasUsingMsBuildServer && isUsingMsBuildServerNow;
+
         FilePath msBuildLocation;
         private CompilerViewModel _compilerViewModel;
 

--- a/FRBDK/Glue/CompilerPlugin/Models/BuildSettingsUser.cs
+++ b/FRBDK/Glue/CompilerPlugin/Models/BuildSettingsUser.cs
@@ -7,5 +7,7 @@ namespace CompilerPlugin.Models
     public class BuildSettingsUser
     {
         public string CustomMsBuildLocation { get; set; }
+
+        public bool UseMsBuildServer { get; set; }
     }
 }

--- a/FRBDK/Glue/CompilerPlugin/ViewModels/BuildSettingsWindowViewModel.cs
+++ b/FRBDK/Glue/CompilerPlugin/ViewModels/BuildSettingsWindowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using FlatRedBall.Glue.MVVM;
+using CompilerLibrary.ViewModels;
 using CompilerPlugin.Models;
 using System;
 using System.Collections.Generic;
@@ -20,16 +21,27 @@ namespace CompilerPlugin.ViewModels
             set => Set(value);
         }
 
+        // Backed by CompilerViewModel.Self rather than BuildSettingsUser - this setting is session-only
+        // (not persisted to BuildSettings.user.json), same as before it moved into this dialog from the
+        // Build tab's toolbar.
+        public bool IsPrintMsBuildCommandChecked
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
         public void SetFrom(BuildSettingsUser buildSettingsUser)
         {
             CustomMsBuildLocation = buildSettingsUser.CustomMsBuildLocation;
             UseMsBuildServer = buildSettingsUser.UseMsBuildServer;
+            IsPrintMsBuildCommandChecked = CompilerViewModel.Self.IsPrintMsBuildCommandChecked;
         }
 
         public void ApplyTo(BuildSettingsUser buildSettingsUser)
         {
             buildSettingsUser.CustomMsBuildLocation = CustomMsBuildLocation;
             buildSettingsUser.UseMsBuildServer = UseMsBuildServer;
+            CompilerViewModel.Self.IsPrintMsBuildCommandChecked = IsPrintMsBuildCommandChecked;
         }
     }
 }

--- a/FRBDK/Glue/CompilerPlugin/ViewModels/BuildSettingsWindowViewModel.cs
+++ b/FRBDK/Glue/CompilerPlugin/ViewModels/BuildSettingsWindowViewModel.cs
@@ -14,14 +14,22 @@ namespace CompilerPlugin.ViewModels
             set => Set(value);
         }
 
+        public bool UseMsBuildServer
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
         public void SetFrom(BuildSettingsUser buildSettingsUser)
         {
             CustomMsBuildLocation = buildSettingsUser.CustomMsBuildLocation;
+            UseMsBuildServer = buildSettingsUser.UseMsBuildServer;
         }
 
         public void ApplyTo(BuildSettingsUser buildSettingsUser)
         {
             buildSettingsUser.CustomMsBuildLocation = CustomMsBuildLocation;
+            buildSettingsUser.UseMsBuildServer = UseMsBuildServer;
         }
     }
 }

--- a/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml
+++ b/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml
@@ -24,7 +24,6 @@
                 Visibility="{Binding WhileStoppedViewVisibility}"
                 BuildClicked="HandleCompileClick"
                 PackageClicked="WhileStoppedView_PackageClicked"
-                MSBuildSettingsClicked="HandleMSBuildSettingsClicked"
                 >
             </views:WhileStoppedView>
 
@@ -43,6 +42,14 @@
                     </TextBlock>
                 </CheckBox.ToolTip>
             </CheckBox>
+
+            <Button VerticalAlignment="Center" Margin="12,0,0,0" Click="HandleMSBuildSettingsButtonClick"
+                    Content="{materialDesign:PackIcon Cog}" Style="{DynamicResource ToolIcon}"
+                    Visibility="{Binding WhileStoppedViewVisibility}">
+                <Button.ToolTip>
+                    <TextBlock>Build Settings</TextBlock>
+                </Button.ToolTip>
+            </Button>
 
         </WrapPanel>
 

--- a/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml.cs
+++ b/FRBDK/Glue/CompilerPlugin/Views/BuildTabView.xaml.cs
@@ -88,7 +88,7 @@ namespace CompilerPlugin.Views
             RunClicked?.Invoke(this, null);
         }
 
-        private void HandleMSBuildSettingsClicked()
+        private void HandleMSBuildSettingsButtonClick(object sender, RoutedEventArgs e)
         {
             MSBuildSettingsClicked?.Invoke();
         }

--- a/FRBDK/Glue/CompilerPlugin/Views/WhileStoppedView.xaml
+++ b/FRBDK/Glue/CompilerPlugin/Views/WhileStoppedView.xaml
@@ -28,11 +28,8 @@
         </ToolTip>
       </Button.ToolTip>
     </Button>
-    <ComboBox IsEditable="True" Margin="4,0" Width="150" 
+    <ComboBox IsEditable="True" Margin="4,0" Width="150"
                   ItemsSource="{Binding AvailableConfigurations}"
                  Text="{Binding Configuration}"></ComboBox>
-    <CheckBox VerticalAlignment="Center" VerticalContentAlignment="Center" IsChecked="{Binding IsPrintMsBuildCommandChecked}" Content="Print MSBuild Command" Margin="4,0"></CheckBox>
-    <Button VerticalAlignment="Top" Height="24" Click="MSBuildSettingsButtonClicked" Margin="4,0" Content="{materialDesign:PackIcon Cog}" Style="{DynamicResource ToolIcon}">
-    </Button>
   </StackPanel>
 </UserControl>

--- a/FRBDK/Glue/CompilerPlugin/Views/WhileStoppedView.xaml.cs
+++ b/FRBDK/Glue/CompilerPlugin/Views/WhileStoppedView.xaml.cs
@@ -23,7 +23,6 @@ namespace CompilerPlugin.Views
         public event Action BuildClicked;
         public event Action PackageClicked;
         //public event Action BuildContentClicked;
-        public event Action MSBuildSettingsClicked;
 
         public WhileStoppedView()
         {
@@ -33,16 +32,6 @@ namespace CompilerPlugin.Views
         private void HandleCompileClick(object sender, RoutedEventArgs e)
         {
             BuildClicked?.Invoke();
-        }
-
-        private void MSBuildSettingsButtonClicked(object sender, RenderingEventArgs e)
-        {
-            MSBuildSettingsClicked?.Invoke();
-        }
-
-        private void MSBuildSettingsButtonClicked(object sender, RoutedEventArgs e)
-        {
-            MSBuildSettingsClicked?.Invoke();
         }
 
         private void HandlePackageClicked(object sender, RoutedEventArgs e)

--- a/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/BuildSettingsWindowViewModelTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/BuildSettingsWindowViewModelTests.cs
@@ -1,17 +1,33 @@
+using CompilerLibrary.ViewModels;
 using CompilerPlugin.Models;
 using CompilerPlugin.ViewModels;
 using Shouldly;
+using System;
 using Xunit;
 
 namespace GlueUnitTests.CompilerPlugin
 {
     /// <summary>
-    /// Covers issue #2200: the "Use MSBuild Server" checkbox must round-trip through
-    /// BuildSettingsUser (the JSON persisted to BuildSettings.user.json) same as the existing
-    /// CustomMsBuildLocation setting.
+    /// Covers issue #2200: the "Use MSBuild Server" and "Print MSBuild Command" settings, both shown
+    /// in the Build Settings dialog behind the Build tab's gear icon, must round-trip correctly even
+    /// though they're backed by different stores - UseMsBuildServer by BuildSettingsUser (persisted to
+    /// BuildSettings.user.json), IsPrintMsBuildCommandChecked by CompilerViewModel.Self (session-only,
+    /// same as before it moved into this dialog from the Build tab's toolbar).
     /// </summary>
-    public class BuildSettingsWindowViewModelTests
+    public class BuildSettingsWindowViewModelTests : IDisposable
     {
+        readonly bool _originalIsPrintMsBuildCommandChecked;
+
+        public BuildSettingsWindowViewModelTests()
+        {
+            _originalIsPrintMsBuildCommandChecked = CompilerViewModel.Self.IsPrintMsBuildCommandChecked;
+        }
+
+        public void Dispose()
+        {
+            CompilerViewModel.Self.IsPrintMsBuildCommandChecked = _originalIsPrintMsBuildCommandChecked;
+        }
+
         [Fact]
         public void SetFrom_ThenApplyTo_RoundTripsUseMsBuildServer()
         {
@@ -26,6 +42,22 @@ namespace GlueUnitTests.CompilerPlugin
             viewModel.ApplyTo(target);
 
             target.UseMsBuildServer.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void SetFrom_ThenApplyTo_RoundTripsIsPrintMsBuildCommandChecked()
+        {
+            CompilerViewModel.Self.IsPrintMsBuildCommandChecked = true;
+            var viewModel = new BuildSettingsWindowViewModel();
+
+            viewModel.SetFrom(new BuildSettingsUser());
+
+            viewModel.IsPrintMsBuildCommandChecked.ShouldBeTrue();
+
+            viewModel.IsPrintMsBuildCommandChecked = false;
+            viewModel.ApplyTo(new BuildSettingsUser());
+
+            CompilerViewModel.Self.IsPrintMsBuildCommandChecked.ShouldBeFalse();
         }
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/BuildSettingsWindowViewModelTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/BuildSettingsWindowViewModelTests.cs
@@ -1,0 +1,31 @@
+using CompilerPlugin.Models;
+using CompilerPlugin.ViewModels;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.CompilerPlugin
+{
+    /// <summary>
+    /// Covers issue #2200: the "Use MSBuild Server" checkbox must round-trip through
+    /// BuildSettingsUser (the JSON persisted to BuildSettings.user.json) same as the existing
+    /// CustomMsBuildLocation setting.
+    /// </summary>
+    public class BuildSettingsWindowViewModelTests
+    {
+        [Fact]
+        public void SetFrom_ThenApplyTo_RoundTripsUseMsBuildServer()
+        {
+            var source = new BuildSettingsUser { UseMsBuildServer = true };
+            var viewModel = new BuildSettingsWindowViewModel();
+
+            viewModel.SetFrom(source);
+
+            viewModel.UseMsBuildServer.ShouldBeTrue();
+
+            var target = new BuildSettingsUser { UseMsBuildServer = false };
+            viewModel.ApplyTo(target);
+
+            target.UseMsBuildServer.ShouldBeTrue();
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/CompilerMsBuildServerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/CompilerMsBuildServerTests.cs
@@ -1,0 +1,65 @@
+using CompilerLibrary.ViewModels;
+using CompilerPlugin.Managers;
+using CompilerPlugin.Models;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.CompilerPlugin
+{
+    /// <summary>
+    /// Covers issue #2200: an opt-in "Use MSBuild Server" setting that sets
+    /// DOTNET_CLI_USE_MSBUILD_SERVER on the environment of the restore/build processes Glue spawns,
+    /// scoped to that child process only (CreateProcess never calls Start(), so this pins the
+    /// ProcessStartInfo it builds without launching a real process).
+    /// </summary>
+    public class CompilerMsBuildServerTests
+    {
+        static Compiler CreateCompiler(bool? useMsBuildServer)
+        {
+            var compiler = new Compiler(CompilerViewModel.Self);
+            if (useMsBuildServer.HasValue)
+            {
+                compiler.BuildSettingsUser = new BuildSettingsUser { UseMsBuildServer = useMsBuildServer.Value };
+            }
+            return compiler;
+        }
+
+        [Fact]
+        public void CreateProcess_WhenUseMsBuildServerIsTrue_SetsEnvironmentVariable()
+        {
+            var compiler = CreateCompiler(useMsBuildServer: true);
+
+            var process = compiler.CreateProcess("dotnet", "msbuild");
+
+            process.StartInfo.EnvironmentVariables["DOTNET_CLI_USE_MSBUILD_SERVER"].ShouldBe("1");
+        }
+
+        [Fact]
+        public void CreateProcess_WhenUseMsBuildServerIsFalse_DoesNotSetEnvironmentVariable()
+        {
+            var compiler = CreateCompiler(useMsBuildServer: false);
+
+            var process = compiler.CreateProcess("dotnet", "msbuild");
+
+            process.StartInfo.EnvironmentVariables.ContainsKey("DOTNET_CLI_USE_MSBUILD_SERVER").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void CreateProcess_WhenBuildSettingsUserIsNull_DoesNotSetEnvironmentVariable()
+        {
+            var compiler = CreateCompiler(useMsBuildServer: null);
+
+            var process = compiler.CreateProcess("dotnet", "msbuild");
+
+            process.StartInfo.EnvironmentVariables.ContainsKey("DOTNET_CLI_USE_MSBUILD_SERVER").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ShouldWarmUpMsBuildServer_ReflectsBuildSettingsUser()
+        {
+            CreateCompiler(useMsBuildServer: true).ShouldWarmUpMsBuildServer.ShouldBeTrue();
+            CreateCompiler(useMsBuildServer: false).ShouldWarmUpMsBuildServer.ShouldBeFalse();
+            CreateCompiler(useMsBuildServer: null).ShouldWarmUpMsBuildServer.ShouldBeFalse();
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/CompilerMsBuildServerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/CompilerMsBuildServerTests.cs
@@ -61,5 +61,17 @@ namespace GlueUnitTests.CompilerPlugin
             CreateCompiler(useMsBuildServer: false).ShouldWarmUpMsBuildServer.ShouldBeFalse();
             CreateCompiler(useMsBuildServer: null).ShouldWarmUpMsBuildServer.ShouldBeFalse();
         }
+
+        [Theory]
+        [InlineData(false, true, true)]   // turning it on mid-session should warm up
+        [InlineData(true, true, false)]   // already on, OK clicked again - don't refire
+        [InlineData(true, false, false)]  // turning it off - nothing to warm up
+        [InlineData(false, false, false)] // stayed off
+        public void ShouldWarmUpOnSettingsChange_OnlyFiresOnOffToOnTransition(
+            bool wasUsingMsBuildServer, bool isUsingMsBuildServerNow, bool expected)
+        {
+            Compiler.ShouldWarmUpOnSettingsChange(wasUsingMsBuildServer, isUsingMsBuildServerNow)
+                .ShouldBe(expected);
+        }
     }
 }


### PR DESCRIPTION
Closes #2200.

Adds an opt-in "Use MSBuild Server" checkbox to the Build Settings dialog (`BuildSettingsWindowViewModel`/`BuildSettingsUser`, persisted to `BuildSettings.user.json`). Reachable from the gear icon at the far right of the Build tab's toolbar (only visible while nothing is compiling/running). "Print MSBuild Command" moved into this same dialog from the toolbar, to keep the toolbar itself uncluttered.

When "Use MSBuild Server" is checked:
- `DOTNET_CLI_USE_MSBUILD_SERVER=1` is set on the environment of the restore/build processes Glue spawns (`Compiler.CreateProcess`) - scoped to that child process's environment block only, no effect on other tools/processes.
- A background warm-up build fires as a real `TaskManager` task (Fifo) on project load (`CompilerPlugin.HandleGluxLoaded`), and again immediately if the checkbox is toggled OFF -> ON mid-session, so the MSBuild Server node is already warm by the time the user hits Play. Runs through `TaskManager` (not a bare fire-and-forget `Task`) so it occupies the task queue and shows up in "Tasks remaining" - visible proof to the user that something is happening.

Default is off.

## Test plan
- Unit tests added: `CompilerMsBuildServerTests` (env var set/unset on the spawned `ProcessStartInfo` based on the setting, without spawning a real process) and `BuildSettingsWindowViewModelTests` (both settings round-trip correctly - one through `BuildSettingsUser`, one through `CompilerViewModel.Self`).
- Manual test: needed (UI + real build timing).
  1. Open `FRBDK/Glue/Glue with All.sln` in this worktree.
  2. Run Glue, open a project. On the Build tab, stop any running game so the toolbar is visible, then click the gear icon at the far right.
  3. Check "Use MSBuild Server", click OK. The "Tasks remaining" counter should tick up by one right away (the warm-up build queued from the OFF -> ON toggle) and the Build tab should show a build running.
  4. Reload the project (or restart Glue and reopen it) - a build should start automatically in the Build tab shortly after load, again visible in "Tasks remaining".
  5. Click Play - the first build after that warm-up should already be fast (comparable to a second build in the same session today), not the slow first-build timing.
