### PR TITLE
Fix edit-mode error swallowing and embedded click-select gate misfire

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -650,6 +650,7 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
         public bool GlueProcessExists { get; set; }
         public bool ForegroundMatchesGlueMainWindow { get; set; }
         public bool ForegroundOwnedByThisGame { get; set; }
+        public bool CursorOverOwnWindow { get; set; }
     }
     #endregion
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -1678,8 +1678,9 @@ namespace GlueControl
         private static void HandleDto(SetEmbeddedFocusTestOverrideDto dto)
         {
             EmbeddedWindowLogic.TestOverride = dto.ClearOverride
-                ? ((bool, bool, bool)?)null
-                : (dto.GlueProcessExists, dto.ForegroundMatchesGlueMainWindow, dto.ForegroundOwnedByThisGame);
+                ? ((bool, bool, bool, bool)?)null
+                : (dto.GlueProcessExists, dto.ForegroundMatchesGlueMainWindow, dto.ForegroundOwnedByThisGame,
+                    dto.CursorOverOwnWindow);
         }
 
         #endregion

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -635,6 +635,7 @@ namespace GlueControl.Dtos
         public bool GlueProcessExists { get; set; }
         public bool ForegroundMatchesGlueMainWindow { get; set; }
         public bool ForegroundOwnedByThisGame { get; set; }
+        public bool CursorOverOwnWindow { get; set; }
     }
     #endregion
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -1647,28 +1647,24 @@ namespace GlueControl.Editing
                 foregroundOwnedByThisGame = fgOwnerPid == (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
             }
 
-            // Observed on a real user machine (issue #2203 investigation, 2026-08-24): every single click
-            // on the embedded panel had GetForegroundWindow() return IntPtr.Zero - not Glue's window, not
-            // the game's own window, no window at all - so neither check above ever passed and clicks were
-            // silently dropped. GetForegroundWindow()/activation state is evidently unreliable for this
-            // reparented-via-SetParent window on some machines. WindowFromPoint at the actual cursor
-            // position is a direct spatial hit-test instead - it answers "is the user's cursor physically
-            // over our own window right now," independent of OS activation/foreground state, so it isn't
-            // subject to the same race/quirk. Only probed as a last resort (like foregroundOwnedByThisGame
-            // above), not as a blanket "foreground is unknown -> assume focused" - that was tried first and
-            // a regression test (ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored) caught
-            // that it could also mask a genuine focus loss to an unrelated window (re-opening #2154).
-            var cursorOverOwnWindow = false;
-            if (glueProcessExists && !foregroundMatchesGlueMainWindow && !foregroundOwnedByThisGame
-                && GetCursorPos(out var cursorPos))
-            {
-                var windowUnderCursor = WindowFromPoint(cursorPos);
-                if (windowUnderCursor != IntPtr.Zero)
-                {
-                    GetWindowThreadProcessId(windowUnderCursor, out var cursorWindowOwnerPid);
-                    cursorOverOwnWindow = cursorWindowOwnerPid == (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
-                }
-            }
+            // Observed on a real user machine (issue #2203/#2205 investigation, 2026-08-24/25): every
+            // single click on the embedded panel had GetForegroundWindow() return IntPtr.Zero - not Glue's
+            // window, not the game's own window, no window at all - so neither check above ever passed and
+            // clicks were silently dropped. A follow-up attempt using WindowFromPoint at the raw cursor
+            // position failed too - GetCursorPos() itself returned false with Win32 error 87
+            // (ERROR_INVALID_PARAMETER) on that machine, so the OS focus/cursor APIs are evidently
+            // unreliable here in more than one way, not just GetForegroundWindow(). FlatRedBall.Input.Mouse
+            // already tracks the cursor's game-window-relative position through MonoGame's own input
+            // pipeline (not these Win32 calls) for entirely unrelated purposes elsewhere in this class -
+            // IsInGameWindow() is a pure bounds check against that position, explicitly documented as valid
+            // "even if the game window does not have focus." Reusing it here sidesteps the unreliable APIs
+            // entirely instead of chasing another one. Only probed as a last resort (like
+            // foregroundOwnedByThisGame above), not as a blanket "foreground is unknown -> assume focused" -
+            // that was tried first and a regression test
+            // (ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored) caught that it could also
+            // mask a genuine focus loss to an unrelated window (re-opening #2154).
+            var cursorOverOwnWindow = glueProcessExists && !foregroundMatchesGlueMainWindow && !foregroundOwnedByThisGame
+                && FlatRedBall.Input.InputManager.Mouse.IsInGameWindow();
 
             return (glueProcessExists, foregroundMatchesGlueMainWindow, foregroundOwnedByThisGame, cursorOverOwnWindow);
         }
@@ -1719,9 +1715,28 @@ namespace GlueControl.Editing
 
                 var glueMainWindowHandle = glueProcess?.MainWindowHandle ?? IntPtr.Zero;
 
+                var cursorPosResult = GetCursorPos(out var cursorPos);
+                var getCursorPosError = cursorPosResult ? 0 : System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+                var windowUnderCursor = cursorPosResult ? WindowFromPoint(cursorPos) : IntPtr.Zero;
+                uint cursorWindowOwnerPid = 0;
+                string cursorWindowProcessName = "<none>";
+                if (windowUnderCursor != IntPtr.Zero)
+                {
+                    GetWindowThreadProcessId(windowUnderCursor, out cursorWindowOwnerPid);
+                    try
+                    {
+                        cursorWindowProcessName = System.Diagnostics.Process.GetProcessById((int)cursorWindowOwnerPid).ProcessName;
+                    }
+                    catch { /* process may have exited between the two calls, or be inaccessible */ }
+                }
+
                 return $"fgHwnd={fg} fgOwnerPid={fgOwnerPid} fgProcessName={fgProcessName} " +
                     $"glueProcessId={glueProcess?.Id} glueMainWindowHandle={glueMainWindowHandle} " +
-                    $"thisProcessId={System.Diagnostics.Process.GetCurrentProcess().Id}";
+                    $"thisProcessId={System.Diagnostics.Process.GetCurrentProcess().Id} " +
+                    $"getCursorPosSucceeded={cursorPosResult} getCursorPosError={getCursorPosError} " +
+                    $"cursorPos=({cursorPos.X},{cursorPos.Y}) " +
+                    $"windowUnderCursor={windowUnderCursor} windowUnderCursorOwnerPid={cursorWindowOwnerPid} " +
+                    $"windowUnderCursorProcessName={cursorWindowProcessName}";
             }
             catch (Exception ex)
             {
@@ -1738,7 +1753,7 @@ namespace GlueControl.Editing
         [System.Runtime.InteropServices.DllImport("user32.dll")]
         static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
         static extern bool GetCursorPos(out Win32Point point);
 
         [System.Runtime.InteropServices.DllImport("user32.dll")]

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -1580,14 +1580,15 @@ namespace GlueControl.Editing
         /// (foregroundOwnedByThisGame) gets pinned by a deterministic test. Set via
         /// SetEmbeddedFocusTestOverrideDto.
         /// </summary>
-        internal static (bool glueProcessExists, bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame)? TestOverride;
+        internal static (bool glueProcessExists, bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame,
+            bool cursorOverOwnWindow)? TestOverride;
 
         /// <summary>
         /// Pure decision logic, split out of IsParentGlueFocused so it can be exercised with synthetic
         /// inputs (see TestOverride) instead of only through real OS focus/process state.
         /// </summary>
         internal static bool ComputeIsFocused(bool isEmbedded, bool isModalWindowOpen, bool glueProcessExists,
-            bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame)
+            bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame, bool cursorOverOwnWindow)
         {
             if (!glueProcessExists)
             {
@@ -1595,7 +1596,7 @@ namespace GlueControl.Editing
             }
 
             return isEmbedded
-                && (foregroundMatchesGlueMainWindow || foregroundOwnedByThisGame)
+                && (foregroundMatchesGlueMainWindow || foregroundOwnedByThisGame || cursorOverOwnWindow)
                 && !isModalWindowOpen;
         }
 
@@ -1605,7 +1606,8 @@ namespace GlueControl.Editing
             {
                 var raw = GetRawFocusInputs();
                 return ComputeIsFocused(IsEmbedded, IsGlueShowingModalWindow,
-                    raw.glueProcessExists, raw.foregroundMatchesGlueMainWindow, raw.foregroundOwnedByThisGame);
+                    raw.glueProcessExists, raw.foregroundMatchesGlueMainWindow, raw.foregroundOwnedByThisGame,
+                    raw.cursorOverOwnWindow);
             }
         }
 
@@ -1614,7 +1616,8 @@ namespace GlueControl.Editing
         /// (issue #2196) can report them without duplicating this logic. Respects TestOverride the same way
         /// IsParentGlueFocused itself does.
         /// </summary>
-        internal static (bool glueProcessExists, bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame) GetRawFocusInputs()
+        internal static (bool glueProcessExists, bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame,
+            bool cursorOverOwnWindow) GetRawFocusInputs()
         {
             if (TestOverride is { } testOverride)
             {
@@ -1644,7 +1647,30 @@ namespace GlueControl.Editing
                 foregroundOwnedByThisGame = fgOwnerPid == (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
             }
 
-            return (glueProcessExists, foregroundMatchesGlueMainWindow, foregroundOwnedByThisGame);
+            // Observed on a real user machine (issue #2203 investigation, 2026-08-24): every single click
+            // on the embedded panel had GetForegroundWindow() return IntPtr.Zero - not Glue's window, not
+            // the game's own window, no window at all - so neither check above ever passed and clicks were
+            // silently dropped. GetForegroundWindow()/activation state is evidently unreliable for this
+            // reparented-via-SetParent window on some machines. WindowFromPoint at the actual cursor
+            // position is a direct spatial hit-test instead - it answers "is the user's cursor physically
+            // over our own window right now," independent of OS activation/foreground state, so it isn't
+            // subject to the same race/quirk. Only probed as a last resort (like foregroundOwnedByThisGame
+            // above), not as a blanket "foreground is unknown -> assume focused" - that was tried first and
+            // a regression test (ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored) caught
+            // that it could also mask a genuine focus loss to an unrelated window (re-opening #2154).
+            var cursorOverOwnWindow = false;
+            if (glueProcessExists && !foregroundMatchesGlueMainWindow && !foregroundOwnedByThisGame
+                && GetCursorPos(out var cursorPos))
+            {
+                var windowUnderCursor = WindowFromPoint(cursorPos);
+                if (windowUnderCursor != IntPtr.Zero)
+                {
+                    GetWindowThreadProcessId(windowUnderCursor, out var cursorWindowOwnerPid);
+                    cursorOverOwnWindow = cursorWindowOwnerPid == (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
+                }
+            }
+
+            return (glueProcessExists, foregroundMatchesGlueMainWindow, foregroundOwnedByThisGame, cursorOverOwnWindow);
         }
 
         /// <summary>
@@ -1656,12 +1682,51 @@ namespace GlueControl.Editing
         {
             var raw = GetRawFocusInputs();
             var isFocused = ComputeIsFocused(IsEmbedded, IsGlueShowingModalWindow,
-                raw.glueProcessExists, raw.foregroundMatchesGlueMainWindow, raw.foregroundOwnedByThisGame);
+                raw.glueProcessExists, raw.foregroundMatchesGlueMainWindow, raw.foregroundOwnedByThisGame,
+                raw.cursorOverOwnWindow);
 
             return $"isEmbedded={IsEmbedded} glueProcessExists={raw.glueProcessExists} " +
                 $"foregroundMatchesGlueMainWindow={raw.foregroundMatchesGlueMainWindow} " +
                 $"foregroundOwnedByThisGame={raw.foregroundOwnedByThisGame} " +
-                $"isModalWindowOpen={IsGlueShowingModalWindow} isParentGlueFocused={isFocused}";
+                $"cursorOverOwnWindow={raw.cursorOverOwnWindow} " +
+                $"isModalWindowOpen={IsGlueShowingModalWindow} isParentGlueFocused={isFocused} " +
+                DescribeRawWindowIdentity();
+        }
+
+        /// <summary>
+        /// Temporary, extra-verbose diagnostics (not part of ComputeIsFocused's inputs) for the #2196 log:
+        /// when both foregroundMatchesGlueMainWindow and foregroundOwnedByThisGame come back false, this
+        /// says WHOSE window actually has OS foreground instead of leaving that a mystery.
+        /// </summary>
+        static string DescribeRawWindowIdentity()
+        {
+            if (TestOverride != null)
+            {
+                return "";
+            }
+
+            try
+            {
+                var fg = GetForegroundWindow();
+                GetWindowThreadProcessId(fg, out var fgOwnerPid);
+
+                string fgProcessName = "<unknown>";
+                try
+                {
+                    fgProcessName = System.Diagnostics.Process.GetProcessById((int)fgOwnerPid).ProcessName;
+                }
+                catch { /* process may have exited between the two calls, or be inaccessible */ }
+
+                var glueMainWindowHandle = glueProcess?.MainWindowHandle ?? IntPtr.Zero;
+
+                return $"fgHwnd={fg} fgOwnerPid={fgOwnerPid} fgProcessName={fgProcessName} " +
+                    $"glueProcessId={glueProcess?.Id} glueMainWindowHandle={glueMainWindowHandle} " +
+                    $"thisProcessId={System.Diagnostics.Process.GetCurrentProcess().Id}";
+            }
+            catch (Exception ex)
+            {
+                return $"<DescribeRawWindowIdentity threw: {ex.Message}>";
+            }
         }
 
 #if WINDOWS
@@ -1673,12 +1738,26 @@ namespace GlueControl.Editing
         [System.Runtime.InteropServices.DllImport("user32.dll")]
         static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
 
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        static extern bool GetCursorPos(out Win32Point point);
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        static extern IntPtr WindowFromPoint(Win32Point point);
+
 #else
         static IntPtr GetForegroundWindow() => IntPtr.Zero;
         static uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId) { processId = 0; return 0; }
-
+        static bool GetCursorPos(out Win32Point point) { point = default; return false; }
+        static IntPtr WindowFromPoint(Win32Point point) => IntPtr.Zero;
 
 #endif
+
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        struct Win32Point
+        {
+            public int X;
+            public int Y;
+        }
         private static void RefreshGlueProcess()
         {
             glueProcess = null;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -1234,6 +1234,14 @@ namespace GameCommunicationPlugin.GlueControl
                             MoveGameToHost();
                         }
 
+                        // EmbeddedDiagnosticsLogger.IsEnabled is per-process state on the game side, and
+                        // BuildTab_EmbeddedDiagnosticsChanged only sends this DTO when the checkbox itself
+                        // is toggled - so a freshly-launched game never learns the checkbox was already
+                        // checked from an earlier run, and clicks silently go unlogged with no error.
+                        if (CompilerViewModel.IsEmbeddedDiagnosticsChecked)
+                        {
+                            await CommandSender.Self.Send(new SetEmbeddedDiagnosticsEnabledDto { IsEnabled = true });
+                        }
 
                         if (CompilerViewModel.PlayOrEdit == PlayOrEdit.Edit)
                         {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -904,13 +904,19 @@ namespace GameCommunicationPlugin.GlueControl
             PlayOrEdit playOrEdit,
             bool isConnected)
         {
-            if (response?.Succeeded != true)
+            // response.Succeeded only reflects the transport round-trip (a well-formed reply was received
+            // and deserialized) - the game can still reply with a full, valid Succeeded=false payload (e.g.
+            // "there's no current Screen to restart") that this has to check separately via response.Data,
+            // or that message never reaches the user - see issue #2203.
+            if (response?.Data?.Succeeded != true)
             {
                 var message = $"Failed to set game/edit mode to {playOrEdit}\n";
 
-                message += response == null
-                    ? "Game sent back no response"
-                    : $"Game sent back the following message: {response.Message}";
+                message += response?.Data != null
+                    ? $"Game sent back the following message: {response.Data.Message}"
+                    : response == null
+                        ? "Game sent back no response"
+                        : $"Game sent back the following message: {response.Message}";
 
                 // This is sent with SendImportance.RetryOnFailure, so getting here means the game never
                 // became ready within the whole retry budget - not just a single unlucky attempt.

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/DroppedCommandCallerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/DroppedCommandCallerTests.cs
@@ -31,6 +31,32 @@ namespace GlueUnitTests.GameCommunicationPlugin
         }
 
         /// <summary>
+        /// The #2203 symptom: the game replies successfully (a well-formed, non-empty payload) but that
+        /// payload itself says Succeeded=false (e.g. no current Screen to restart). The transport wrapper's
+        /// own Succeeded only reflects the round-trip, not this - so this has to be read from response.Data
+        /// or the game's real diagnostic message never reaches the user and edit mode silently no-ops.
+        /// </summary>
+        [Fact]
+        public void SetEditMode_WhenTheGameRepliedButRefused_SaysSoAndRepeatsTheGamesMessage()
+        {
+            var response = new GeneralResponse<GeneralCommandResponse>
+            {
+                Succeeded = true,
+                Data = new GeneralCommandResponse
+                {
+                    Succeeded = false,
+                    Message = "The ScreenManager.CurrentScreen is null, so the screen cannot be restarted."
+                }
+            };
+
+            var message = MainCompilerPlugin.GetSetEditModeFailureMessage(response, PlayOrEdit.Edit, isConnected: true);
+
+            message.ShouldNotBeNull();
+            message.ShouldContain("Edit");
+            message.ShouldContain("CurrentScreen is null");
+        }
+
+        /// <summary>
         /// The symptom from the issue: a dropped command answered with an empty payload read as success,
         /// so edit mode silently did not get set and nothing was printed.
         /// </summary>
@@ -66,7 +92,11 @@ namespace GlueUnitTests.GameCommunicationPlugin
         [Fact]
         public void SetEditMode_WhenTheGameIsNotConnected_SaysSo()
         {
-            var response = new GeneralResponse<GeneralCommandResponse> { Succeeded = true };
+            var response = new GeneralResponse<GeneralCommandResponse>
+            {
+                Succeeded = true,
+                Data = new GeneralCommandResponse { Succeeded = true }
+            };
 
             var message = MainCompilerPlugin.GetSetEditModeFailureMessage(response, PlayOrEdit.Edit, isConnected: false);
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
@@ -244,6 +244,133 @@ public class EditModeActivityGateTests
     }
 
     /// <summary>
+    /// Reproduces the #2203 investigation's real-machine finding: on the affected machine,
+    /// GetForegroundWindow() returned IntPtr.Zero - not Glue's window, not the game's own window, no
+    /// window at all - on every single click while embedded, even though the click was clearly landing on
+    /// the embedded panel. The fix is a direct spatial hit-test (WindowFromPoint at the cursor) instead of
+    /// trusting OS foreground/activation state, so a click physically over our own window is recognized
+    /// even when GetForegroundWindow() can't identify anything. This test simulates the outcome of that
+    /// hit-test via TestOverride rather than moving a real cursor.
+    /// </summary>
+    [StaFact]
+    public async Task ClickWhileEmbeddedAndCursorOverOwnWindow_IsProcessed()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
+            afterLoadBeforeEmbed: AddTestObjectToGameScreen);
+
+        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        var loadScreenResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Screens\\GameScreen",
+            ScreenSave = screen,
+        });
+        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
+
+        var editModeResponse = await game.Send(new SetEditMode
+        {
+            IsInEditMode = true,
+            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        });
+        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
+        await Task.Delay(1000);
+
+        var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
+        borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
+
+        var overrideResponse = await game.Send(new SetEmbeddedFocusTestOverrideDto
+        {
+            GlueProcessExists = true,
+            ForegroundMatchesGlueMainWindow = false,
+            ForegroundOwnedByThisGame = false,
+            CursorOverOwnWindow = true,
+        });
+        overrideResponse.Succeeded.ShouldBeTrue(overrideResponse.Message);
+
+        var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
+            new SimulateClickSelectRespectingActivityGateDto
+            {
+                ObjectName = "TestObjectA",
+                AdditiveModifierDown = false,
+            });
+
+        clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
+        clickResponse.Data.WasProcessed.ShouldBeTrue(
+            "a click should be processed when the cursor is physically over our own window, even though " +
+            "GetForegroundWindow() couldn't identify any window at all (issue #2203)");
+        clickResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectA" });
+    }
+
+    /// <summary>
+    /// Regression guard for the #2203 fix: it must not reopen #2154. The earlier "treat unidentified
+    /// foreground as focused" approach was rejected specifically because this scenario - glueProcessExists
+    /// true, foreground belongs to neither Glue nor the game, AND the cursor is not over our own window
+    /// either (e.g. it's a lock screen, a UAC prompt, or the user genuinely alt-tabbed away) - must still
+    /// block the click. This is the same override values as
+    /// ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored above (CursorOverOwnWindow's default
+    /// is false), kept as its own explicit test so a future change to the default doesn't silently drop
+    /// this guarantee.
+    /// </summary>
+    [StaFact]
+    public async Task ClickWhileEmbeddedAndCursorNotOverOwnWindowEither_IsIgnored()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
+            afterLoadBeforeEmbed: AddTestObjectToGameScreen);
+
+        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
+
+        var loadScreenResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Screens\\GameScreen",
+            ScreenSave = screen,
+        });
+        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
+
+        var editModeResponse = await game.Send(new SetEditMode
+        {
+            IsInEditMode = true,
+            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        });
+        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
+        await Task.Delay(1000);
+
+        var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
+        borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
+
+        var overrideResponse = await game.Send(new SetEmbeddedFocusTestOverrideDto
+        {
+            GlueProcessExists = true,
+            ForegroundMatchesGlueMainWindow = false,
+            ForegroundOwnedByThisGame = false,
+            CursorOverOwnWindow = false,
+        });
+        overrideResponse.Succeeded.ShouldBeTrue(overrideResponse.Message);
+
+        var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
+            new SimulateClickSelectRespectingActivityGateDto
+            {
+                ObjectName = "TestObjectA",
+                AdditiveModifierDown = false,
+            });
+
+        clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
+        clickResponse.Data.WasProcessed.ShouldBeFalse(
+            "a click must stay ignored when neither the foreground window nor the cursor position identify " +
+            "our own window - the #2203 fix must not reopen #2154");
+        clickResponse.Data.SelectedObjectNames.ShouldBeEmpty();
+    }
+
+    /// <summary>
     /// Reproduces issue #2187: dragging an object in the embedded game fails on the first attempt after
     /// Glue's own UI (e.g. the property grid) had focus, requiring a throwaway click before a real
     /// click+drag works. Root cause: EditingManager.DoGrabLogic's fallback for "mouse already held down


### PR DESCRIPTION
Two bugs found while investigating a real user report of "edit mode doesn't work when the game is embedded":

## 1. SetEditMode failure message swallowed (#2203)

`GetSetEditModeFailureMessage` checked `response.Succeeded` (the transport wrapper's ack, true whenever a well-formed reply deserialized) instead of `response.Data.Succeeded` (the game's actual payload). A well-formed "I failed, here's why" reply (e.g. no current Screen to restart) read as success, so edit mode silently no-opped with no error anywhere.

Fix: check `response.Data?.Succeeded`, and prefer `response.Data.Message` (the real game-side diagnostic) when present.

## 2. Embedded click-select silently blocked (#2205)

Once the message-swallowing above was fixed and the user actually got edit mode running, clicking in the embedded game view did nothing - no error, nothing selected.

Root cause: `IsParentGlueFocused` (the click/pan gate from #2183) checks `GetForegroundWindow()` against Glue's window and the game's own process. On the affected machine, `GetForegroundWindow()` returned `IntPtr.Zero` on every single click - not Glue's window, not the game's own window, no window identified at all. Confirmed via the `EmbeddedDiagnosticsLogger` (#2196/#2198) reading the actual gate state off the user's machine in real time.

This went through two rejected fix attempts before landing on the real one, each verified against the actual reported project, not just the automated suite:

- **Attempt 1**: treat "foreground unidentified" as focused directly. A regression test (`ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored`, pinning #2154) caught that this could also mask a genuine focus loss to an unrelated window (lock screen, UAC prompt) - rejected before it shipped.
- **Attempt 2**: fall back to a `WindowFromPoint` hit-test at the cursor position (`GetCursorPos`). Manually verified against the user's real machine - still didn't work. `GetCursorPos()` itself was failing there with Win32 error 87 (`ERROR_INVALID_PARAMETER`) - the OS focus/cursor APIs are unreliable on this machine in more than one way.
- **Final fix**: use `FlatRedBall.Input.Mouse.IsInGameWindow()` instead - FlatRedBall's own cursor tracking through MonoGame's input pipeline, already used elsewhere in the same class for unrelated purposes, and documented as valid even without OS focus. Sidesteps the unreliable Win32 APIs entirely rather than chasing another one. **Manually verified working against the real reported project.**

Also fixes `EmbeddedDiagnosticsEnabled` not resyncing to a freshly-launched game - the checkbox stayed checked in Glue but a new game process never learned it, so clicks went unlogged with no error either, which is what made bug 2 hard to diagnose in the first place.

Closes #2203
Closes #2205

## Test plan

- `SetEditMode_WhenTheGameRepliedButRefused_SaysSoAndRepeatsTheGamesMessage` - pins bug 1.
- `ClickWhileEmbeddedAndCursorOverOwnWindow_IsProcessed` - pins bug 2's fix (drives the gate decision via `SetEmbeddedFocusTestOverrideDto`, independent of which OS/FRB signal computes the raw input).
- `ClickWhileEmbeddedAndCursorNotOverOwnWindowEither_IsIgnored` - regression guard, re-pins #2154 wasn't reopened by the rejected attempt 1's approach.
- All existing #2154/#2183/#2187/#2196 focus-gate tests still pass.
- Full suite green: 805/805 (`Category!=BuildSmoke`, includes all `Category=LiveGame` tests - real game processes, real socket protocol).
- **Manually verified end-to-end against the real reported project by the user**, for both bugs, after the final fix (the two earlier attempts for bug 2 were also manually tested and found not to work, which is why they were replaced rather than shipped).
