### PR TITLE
Add ApplyPhysics delegate for platformer collision relationships

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/FlatRedBallServices.cs
@@ -118,7 +118,7 @@ namespace FlatRedBall
         public int Version;
     }
 
-    [SyntaxVersion(Version=69)]
+    [SyntaxVersion(Version=70)]
     public static partial class FlatRedBallServices
     {
         internal static SingleThreadSynchronizationContext singleThreadSynchronizationContext;

--- a/Engines/FlatRedBallXNA/FlatRedBall/Math/Collision/CollisionRelationship.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Math/Collision/CollisionRelationship.cs
@@ -904,6 +904,10 @@ namespace FlatRedBall.Math.Collision
     {
         public Func<First, Second, bool> CollisionFunction { get; set; }
 
+        // Used by platformer collision relationships to decide, per collision, whether physics should be
+        // applied. Null (the default) means physics is always applied - unchanged from prior behavior.
+        public Func<First, Second, bool> ApplyPhysics { get; set; }
+
         public Action<First, Second> CollisionOccurred;
 
 
@@ -955,6 +959,10 @@ namespace FlatRedBall.Math.Collision
         PositionedObjectList<SecondCollidableT> list;
 
         public Func<First, SecondCollidableT, bool> CollisionFunction { get; set; }
+
+        // Used by platformer collision relationships to decide, per collision, whether physics should be
+        // applied. Null (the default) means physics is always applied - unchanged from prior behavior.
+        public Func<First, SecondCollidableT, bool> ApplyPhysics { get; set; }
 
         public override object FirstAsObject => singleObject;
         public override object SecondAsObject => list;
@@ -1024,6 +1032,10 @@ namespace FlatRedBall.Math.Collision
         Second singleObject;
 
         public Func<FirstCollidableT, Second, bool> CollisionFunction { get; set; }
+
+        // Used by platformer collision relationships to decide, per collision, whether physics should be
+        // applied. Null (the default) means physics is always applied - unchanged from prior behavior.
+        public Func<FirstCollidableT, Second, bool> ApplyPhysics { get; set; }
 
         public override object FirstAsObject => list;
 
@@ -1954,6 +1966,10 @@ namespace FlatRedBall.Math.Collision
         public LoopDirection LoopDirection { get; set; }
 
         public Func<FirstCollidableT, SecondCollidableT, bool> CollisionFunction { get; set; }
+
+        // Used by platformer collision relationships to decide, per collision, whether physics should be
+        // applied. Null (the default) means physics is always applied - unchanged from prior behavior.
+        public Func<FirstCollidableT, SecondCollidableT, bool> ApplyPhysics { get; set; }
 
         public Action<FirstCollidableT, SecondCollidableT> CollisionOccurred;
 

--- a/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
+++ b/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
@@ -213,6 +213,13 @@ namespace FlatRedBall.Glue.SaveClasses
             // reference away from).
             AnimationChainListHasReplaceValues = 69,
 
+            // August 25, 2026 - Platformer collision relationships (PlatformerSolidCollision/
+            // PlatformerCloudCollision) generate a CollisionFunction that references the relationship's
+            // new ApplyPhysics delegate (Func<First,Second,bool>), letting user code decide per-collision
+            // whether platformer physics is applied. Gated because ApplyPhysics is a new engine-side
+            // property on the Delegate*Relationship classes.
+            PlatformerCollisionSupportsApplyPhysicsDelegate = 70,
+
             // Stop! If adding an entry here, modify SyntaxVersionAttribute on FlatRedBallServices
             // and LatestVersion down below
             // and update the docs
@@ -222,7 +229,7 @@ namespace FlatRedBall.Glue.SaveClasses
 
         #region Versions
 
-        public const int LatestVersion = (int)GluxVersions.AnimationChainListHasReplaceValues;
+        public const int LatestVersion = (int)GluxVersions.PlatformerCollisionSupportsApplyPhysicsDelegate;
 
         public int FileVersion { get; set; }
 

--- a/FRBDK/Glue/OfficialPlugins/CollisionPlugin/CodeGenerators/CollisionCodeGenerator.cs
+++ b/FRBDK/Glue/OfficialPlugins/CollisionPlugin/CodeGenerators/CollisionCodeGenerator.cs
@@ -534,11 +534,19 @@ namespace OfficialPlugins.CollisionPlugin
             var isCloud = (collisionType == CollisionType.PlatformerCloudCollision).ToString().ToLowerInvariant();
             string whatToCollideAgainst = "second";
 
+            // temp.ApplyPhysics lets game code decide, per collision, whether platformer physics is applied;
+            // unset (the default) falls back to physics always being applied, same as before this existed.
+            var supportsApplyPhysicsDelegate = GlueState.Self.CurrentGlueProject.FileVersion >=
+                (int)GlueProjectSave.GluxVersions.PlatformerCollisionSupportsApplyPhysicsDelegate;
+            var applyPhysicsArg = supportsApplyPhysicsDelegate
+                ? ", temp.ApplyPhysics == null ? (System.Func<bool>)null : (System.Func<bool>)(() => temp.ApplyPhysics(first, second))"
+                : "";
+
             if (!isFirstList && isSecondList)
             {
                 if (collisionType == CollisionType.PlatformerCloudCollision || collisionType == CollisionType.PlatformerSolidCollision)
                 {
-                    block.Line($"return first.CollideAgainst({whatToCollideAgainst}, {isCloud});");
+                    block.Line($"return first.CollideAgainst({whatToCollideAgainst}, {isCloud}{applyPhysicsArg});");
                 }
                 else
                 {
@@ -546,11 +554,11 @@ namespace OfficialPlugins.CollisionPlugin
                     if (firstSubCollision == null)
                     {
                         // it's an icollidable probably
-                        block.Line($"return first.CollideAgainst({whatToCollideAgainst}.Collision, {isCloud});");
+                        block.Line($"return first.CollideAgainst({whatToCollideAgainst}.Collision, {isCloud}{applyPhysicsArg});");
                     }
                     else
                     {
-                        block.Line($"return first.CollideAgainst({whatToCollideAgainst}.Collision, first.{firstSubCollision}, {isCloud});");
+                        block.Line($"return first.CollideAgainst({whatToCollideAgainst}.Collision, first.{firstSubCollision}, {isCloud}{applyPhysicsArg});");
                     }
 
                 }
@@ -560,12 +568,12 @@ namespace OfficialPlugins.CollisionPlugin
                 if (firstSubCollision == null)
                 {
                     // assume it's a shape collection
-                    block.Line($"return first.CollideAgainst({whatToCollideAgainst}, {isCloud});");
+                    block.Line($"return first.CollideAgainst({whatToCollideAgainst}, {isCloud}{applyPhysicsArg});");
                 }
                 else
                 {
                     // assume it's a shape collection
-                    block.Line($"return first.CollideAgainst({whatToCollideAgainst}, first.{firstSubCollision}, {isCloud});");
+                    block.Line($"return first.CollideAgainst({whatToCollideAgainst}, first.{firstSubCollision}, {isCloud}{applyPhysicsArg});");
                 }
             }
 

--- a/FRBDK/Glue/OfficialPlugins/CollisionPlugin/CodeGenerators/CollisionCodeGenerator.cs
+++ b/FRBDK/Glue/OfficialPlugins/CollisionPlugin/CodeGenerators/CollisionCodeGenerator.cs
@@ -534,13 +534,30 @@ namespace OfficialPlugins.CollisionPlugin
             var isCloud = (collisionType == CollisionType.PlatformerCloudCollision).ToString().ToLowerInvariant();
             string whatToCollideAgainst = "second";
 
-            // temp.ApplyPhysics lets game code decide, per collision, whether platformer physics is applied;
-            // unset (the default) falls back to physics always being applied, same as before this existed.
+            // The "Automatically Apply Physics" checkbox (ArePhysicsAppliedAutomatically) previously did
+            // nothing for platformer relationships - it's only consulted by DoCollisionPhysicsInner, which
+            // Delegate*Relationship (what platformer uses) never calls. temp.ApplyPhysics additionally lets
+            // game code decide per-collision. Neither referenced (old behavior: physics always applied)
+            // unless the project's FileVersion supports it.
+            var supportsManualPhysics = GlueState.Self.CurrentGlueProject.FileVersion >=
+                (int)GlueProjectSave.GluxVersions.CollisionRelationshipManualPhysics;
             var supportsApplyPhysicsDelegate = GlueState.Self.CurrentGlueProject.FileVersion >=
                 (int)GlueProjectSave.GluxVersions.PlatformerCollisionSupportsApplyPhysicsDelegate;
-            var applyPhysicsArg = supportsApplyPhysicsDelegate
-                ? ", temp.ApplyPhysics == null ? (System.Func<bool>)null : (System.Func<bool>)(() => temp.ApplyPhysics(first, second))"
-                : "";
+
+            var applyPhysicsArg = "";
+            if (supportsManualPhysics || supportsApplyPhysicsDelegate)
+            {
+                var conditions = new List<string>();
+                if (supportsManualPhysics)
+                {
+                    conditions.Add("temp.ArePhysicsAppliedAutomatically");
+                }
+                if (supportsApplyPhysicsDelegate)
+                {
+                    conditions.Add("(temp.ApplyPhysics == null || temp.ApplyPhysics(first, second))");
+                }
+                applyPhysicsArg = $", () => {string.Join(" && ", conditions)}";
+            }
 
             if (!isFirstList && isSecondList)
             {

--- a/FRBDK/Glue/PlatformerPlugin/CodeGenerators/EntityCodeGenerator.cs
+++ b/FRBDK/Glue/PlatformerPlugin/CodeGenerators/EntityCodeGenerator.cs
@@ -804,14 +804,14 @@ namespace FlatRedBall.PlatformerPlugin.Generators
         /// <summary>
         /// Performs a standard solid collision against an ICollidable.
         /// </summary>
-        public bool CollideAgainst(FlatRedBall.Math.Geometry.ICollidable collidable, bool isCloudCollision = false)
+        public bool CollideAgainst(FlatRedBall.Math.Geometry.ICollidable collidable, bool isCloudCollision = false, System.Func<bool> shouldApplyPhysics = null)
         {
-            return CollideAgainst(collidable.Collision, isCloudCollision);
+            return CollideAgainst(collidable.Collision, isCloudCollision, shouldApplyPhysics);
         }
 
-        public bool CollideAgainst(FlatRedBall.Math.Geometry.ICollidable collidable, FlatRedBall.Math.Geometry.AxisAlignedRectangle thisSubcollision, bool isCloudCollision = false)
+        public bool CollideAgainst(FlatRedBall.Math.Geometry.ICollidable collidable, FlatRedBall.Math.Geometry.AxisAlignedRectangle thisSubcollision, bool isCloudCollision = false, System.Func<bool> shouldApplyPhysics = null)
         {
-            return CollideAgainst(collidable.Collision, thisSubcollision, isCloudCollision);
+            return CollideAgainst(collidable.Collision, thisSubcollision, isCloudCollision, shouldApplyPhysics);
         }
 
         /// <summary>
@@ -837,7 +837,7 @@ namespace FlatRedBall.PlatformerPlugin.Generators
         /// </summary>
         /// <param name=""shapeCollection"">The ShapeCollection to collide against.</param>
         /// <param name=""isCloudCollision"">Whether to perform solid or cloud collisions.</param>
-        public bool CollideAgainst(FlatRedBall.Math.Geometry.ShapeCollection shapeCollection, bool isCloudCollision)
+        public bool CollideAgainst(FlatRedBall.Math.Geometry.ShapeCollection shapeCollection, bool isCloudCollision, System.Func<bool> shouldApplyPhysics = null)
         {
             return CollideAgainst(() =>
             {
@@ -848,11 +848,11 @@ namespace FlatRedBall.PlatformerPlugin.Generators
                 if (shapeCollection.LastCollisionPolygons.Count > 0) lastCollided = shapeCollection.LastCollisionPolygons[0];
                 // do we care about other shapes?
                 return (collided, lastCollided);
-            }, isCloudCollision);
+            }, isCloudCollision, shouldApplyPhysics: shouldApplyPhysics);
         }
 
 
-        public bool CollideAgainst(FlatRedBall.Math.Geometry.ShapeCollection shapeCollection, FlatRedBall.Math.Geometry.AxisAlignedRectangle thisRect, bool isCloudCollision)
+        public bool CollideAgainst(FlatRedBall.Math.Geometry.ShapeCollection shapeCollection, FlatRedBall.Math.Geometry.AxisAlignedRectangle thisRect, bool isCloudCollision, System.Func<bool> shouldApplyPhysics = null)
         {
             return CollideAgainst(() =>
             {
@@ -863,7 +863,7 @@ namespace FlatRedBall.PlatformerPlugin.Generators
                 if (shapeCollection.LastCollisionPolygons.Count > 0) lastCollided = shapeCollection.LastCollisionPolygons[0];
                 // do we care about other shapes?
                 return (collided, lastCollided);
-            }, isCloudCollision);
+            }, isCloudCollision, shouldApplyPhysics: shouldApplyPhysics);
         }
 
         /// <summary>
@@ -874,7 +874,8 @@ namespace FlatRedBall.PlatformerPlugin.Generators
         /// </summary>
         /// <param name=""collisionFunction"">The collision function to execute.</param>
         /// <param name=""isCloudCollision"">Whether to perform cloud collision (only check when moving down)</param>
-        public bool CollideAgainst(System.Func<(bool, PositionedObject)> collisionFunction, bool isCloudCollision, string objectName = null)
+        /// <param name=""shouldApplyPhysics"">Optional. If provided and a collision occurs, this is called to decide whether physics (reposition, landing, grounded state) is applied for that collision. If null, physics is always applied on collision.</param>
+        public bool CollideAgainst(System.Func<(bool, PositionedObject)> collisionFunction, bool isCloudCollision, string objectName = null, System.Func<bool> shouldApplyPhysics = null)
         {
             Microsoft.Xna.Framework.Vector3 positionBeforeCollision = this.Position;
             Microsoft.Xna.Framework.Vector3 velocityBeforeCollision = this.Velocity;
@@ -966,6 +967,11 @@ namespace FlatRedBall.PlatformerPlugin.Generators
 
                             shouldApplyCollision = yReposition < (-thisYDistanceMovedThisFrame + otherYDistanceMovedThisFrame);
                         }
+                    }
+
+                    if (shouldApplyCollision && shouldApplyPhysics != null)
+                    {
+                        shouldApplyCollision = shouldApplyPhysics();
                     }
 
                     if (shouldApplyCollision)
@@ -1128,12 +1134,12 @@ namespace FlatRedBall.PlatformerPlugin.Generators
             return (didCollideInternal, null);
         }
 
-        public bool CollideAgainst(FlatRedBall.TileCollisions.TileShapeCollection shapeCollection, bool isCloudCollision = false)
+        public bool CollideAgainst(FlatRedBall.TileCollisions.TileShapeCollection shapeCollection, bool isCloudCollision = false, System.Func<bool> shouldApplyPhysics = null)
         {
             var positionBefore = this.Position;
             var velocityBefore = this.Velocity;
 
-            var collided = CollideAgainst(() => DoCollisionWithShapeCollectionConsideringCornerLanding(shapeCollection, isCloudCollision), isCloudCollision, shapeCollection.Name);
+            var collided = CollideAgainst(() => DoCollisionWithShapeCollectionConsideringCornerLanding(shapeCollection, isCloudCollision), isCloudCollision, shapeCollection.Name, shouldApplyPhysics);
 
             if(collided)
             {
@@ -1256,13 +1262,13 @@ namespace FlatRedBall.PlatformerPlugin.Generators
         }
 
 
-        public bool CollideAgainst(FlatRedBall.TileCollisions.TileShapeCollection shapeCollection, FlatRedBall.Math.Geometry.AxisAlignedRectangle thisCollision, bool isCloudCollision = false)
+        public bool CollideAgainst(FlatRedBall.TileCollisions.TileShapeCollection shapeCollection, FlatRedBall.Math.Geometry.AxisAlignedRectangle thisCollision, bool isCloudCollision = false, System.Func<bool> shouldApplyPhysics = null)
         {
             return CollideAgainst(() =>
             {
                 var didCollide = shapeCollection.CollideAgainstSolid(thisCollision);
                 return (didCollide, null);
-            }, isCloudCollision, shapeCollection.Name);
+            }, isCloudCollision, shapeCollection.Name, shouldApplyPhysics);
         }
 
 ");

--- a/FRBDK/Glue/Tests/GlueUnitTests/CollisionPlugin/PlatformerCollisionApplyPhysicsDelegateTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CollisionPlugin/PlatformerCollisionApplyPhysicsDelegateTests.cs
@@ -116,11 +116,17 @@ public class PlatformerCollisionApplyPhysicsDelegateTests : IDisposable
         CollisionCodeGenerator.GenerateInitializeCodeFor(gameScreen, relationshipNos, codeBlock);
         var generatedCode = codeBlock.ToString();
 
+        generatedCode.ShouldContain("temp.ArePhysicsAppliedAutomatically");
         generatedCode.ShouldContain("temp.ApplyPhysics");
     }
 
+    // The "Automatically Apply Physics" checkbox (ArePhysicsAppliedAutomatically) previously did nothing
+    // for platformer relationships: DelegateCollisionRelationship's DoCollisions() never calls
+    // DoCollisionPhysicsInner, the only place that property was consulted. Projects on this version (but
+    // below the newer ApplyPhysics-delegate gate) now get the checkbox honored, without needing the
+    // delegate feature from #942.
     [Fact]
-    public async Task GenerateInitializeCodeFor_ShouldFallBackToAlwaysApplyingPhysics_WhenFileVersionPredatesTheDelegate()
+    public async Task GenerateInitializeCodeFor_ShouldHonorAutomaticallyApplyPhysicsCheckbox_WhenFileVersionSupportsManualPhysicsButPredatesTheDelegate()
     {
         var (gameScreen, relationshipNos) = await CreatePlatformerSolidCollisionRelationship();
 
@@ -130,6 +136,22 @@ public class PlatformerCollisionApplyPhysicsDelegateTests : IDisposable
         CollisionCodeGenerator.GenerateInitializeCodeFor(gameScreen, relationshipNos, codeBlock);
         var generatedCode = codeBlock.ToString();
 
+        generatedCode.ShouldContain("temp.ArePhysicsAppliedAutomatically");
+        generatedCode.ShouldNotContain("ApplyPhysics");
+    }
+
+    [Fact]
+    public async Task GenerateInitializeCodeFor_ShouldFallBackToAlwaysApplyingPhysics_WhenFileVersionPredatesManualPhysics()
+    {
+        var (gameScreen, relationshipNos) = await CreatePlatformerSolidCollisionRelationship();
+
+        ObjectFinder.Self.GlueProject.FileVersion = (int)GlueProjectSave.GluxVersions.CollisionRelationshipManualPhysics - 1;
+
+        var codeBlock = new CodeBlockBase();
+        CollisionCodeGenerator.GenerateInitializeCodeFor(gameScreen, relationshipNos, codeBlock);
+        var generatedCode = codeBlock.ToString();
+
+        generatedCode.ShouldNotContain("ArePhysicsAppliedAutomatically");
         generatedCode.ShouldNotContain("ApplyPhysics");
         generatedCode.ShouldContain("first.CollideAgainst(second, false);");
     }

--- a/FRBDK/Glue/Tests/GlueUnitTests/CollisionPlugin/PlatformerCollisionApplyPhysicsDelegateTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CollisionPlugin/PlatformerCollisionApplyPhysicsDelegateTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using GlueUnitTests.Tasks;
+using OfficialPlugins.CollisionPlugin;
+using OfficialPlugins.CollisionPlugin.ViewModels;
+using OfficialPlugins.Wizard.Managers;
+using OfficialPlugins.Wizard.Models;
+using Shouldly;
+
+namespace GlueUnitTests.CollisionPlugin;
+
+// GitHub issue #942: platformer collision relationships (PlatformerSolidCollision/
+// PlatformerCloudCollision) always apply physics whenever a collision is detected - there was no way
+// for game code to say "this collision happened, but don't apply physics this time". The fix adds
+// ApplyPhysics (a Func<First,Second,bool>) to the engine's Delegate*Relationship classes used by
+// platformer relationships; CollisionCodeGenerator.GenerateInitializeCodeFor now wires the generated
+// CollisionFunction to consult it when set, falling back to always applying physics (the pre-#942
+// behavior, and what every project below the new GluxVersions gate still gets) when it's left null.
+//
+// This pins CollisionCodeGenerator.GenerateInitializeCodeFor - the same static method used both as
+// AssetTypeInfoManager's ConstructorFunc and directly here - against a real PlatformerSolidCollision
+// NamedObjectSave whose FirstCollisionName/SecondCollisionName resolve against real NamedObjectSaves
+// in a real GameScreen (produced by WizardProjectLogic.HandleAddGameScreen, same real production path
+// FixNamedObjectCollisionTypeTests/CollisionAssetTypeRegistrationTests use), asserting on the
+// generated code text rather than on runtime behavior (which needs a compiled/running game, out of
+// reach for a Glue-side unit test).
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class PlatformerCollisionApplyPhysicsDelegateTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _originalRelativeDirectory;
+    private readonly bool _originalSynchronousMode;
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly string _tempProjectDirectory;
+
+    public PlatformerCollisionApplyPhysicsDelegateTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        GlueTestBootstrap.EnsureCollisionPluginAssetTypesRegistered();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+        FlatRedBall.IO.FileManager.RelativeDirectory = _tempProjectDirectory + "\\";
+
+        TaskManager.SynchronousMode = true;
+        TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    private async Task<(FlatRedBall.Glue.SaveClasses.ScreenSave gameScreen, NamedObjectSave relationshipNos)> CreatePlatformerSolidCollisionRelationship()
+    {
+        var vm = new WizardViewModel { AddGameScreen = true, AddSolidCollision = true };
+        var (gameScreen, solidCollisionNos, _) = await WizardProjectLogic.HandleAddGameScreen(vm);
+
+        // Stand-in for the player entity: any object type with a resolvable SourceClassType works here
+        // since we're only pinning generated *text*, not compiling/running the result.
+        var playerNos = new NamedObjectSave();
+        playerNos.SetDefaults();
+        playerNos.InstanceName = "Player";
+        playerNos.SourceType = SourceType.FlatRedBallType;
+        playerNos.SourceClassType = "FlatRedBall.Sprite";
+        gameScreen.NamedObjects.Add(playerNos);
+
+        var relationshipNos = new NamedObjectSave();
+        relationshipNos.SetDefaults();
+        relationshipNos.InstanceName = "PlayerVsSolidCollision";
+        relationshipNos.SourceType = SourceType.FlatRedBallType;
+        relationshipNos.Properties.SetValue(nameof(CollisionRelationshipViewModel.FirstCollisionName), playerNos.InstanceName);
+        relationshipNos.Properties.SetValue(nameof(CollisionRelationshipViewModel.SecondCollisionName), solidCollisionNos.InstanceName);
+        relationshipNos.Properties.SetValue(nameof(CollisionRelationshipViewModel.CollisionType), (int)OfficialPlugins.CollisionPlugin.ViewModels.CollisionType.PlatformerSolidCollision);
+
+        return (gameScreen, relationshipNos);
+    }
+
+    [Fact]
+    public async Task GenerateInitializeCodeFor_ShouldReferenceApplyPhysicsDelegate_WhenFileVersionSupportsIt()
+    {
+        var (gameScreen, relationshipNos) = await CreatePlatformerSolidCollisionRelationship();
+
+        ObjectFinder.Self.GlueProject.FileVersion = (int)GlueProjectSave.GluxVersions.PlatformerCollisionSupportsApplyPhysicsDelegate;
+
+        var codeBlock = new CodeBlockBase();
+        CollisionCodeGenerator.GenerateInitializeCodeFor(gameScreen, relationshipNos, codeBlock);
+        var generatedCode = codeBlock.ToString();
+
+        generatedCode.ShouldContain("temp.ApplyPhysics");
+    }
+
+    [Fact]
+    public async Task GenerateInitializeCodeFor_ShouldFallBackToAlwaysApplyingPhysics_WhenFileVersionPredatesTheDelegate()
+    {
+        var (gameScreen, relationshipNos) = await CreatePlatformerSolidCollisionRelationship();
+
+        ObjectFinder.Self.GlueProject.FileVersion = (int)GlueProjectSave.GluxVersions.PlatformerCollisionSupportsApplyPhysicsDelegate - 1;
+
+        var codeBlock = new CodeBlockBase();
+        CollisionCodeGenerator.GenerateInitializeCodeFor(gameScreen, relationshipNos, codeBlock);
+        var generatedCode = codeBlock.ToString();
+
+        generatedCode.ShouldNotContain("ApplyPhysics");
+        generatedCode.ShouldContain("first.CollideAgainst(second, false);");
+    }
+
+    private class InlineUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public Task Invoke(Func<Task> func) => func();
+        public Task<T> Invoke<T>(Func<Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+}


### PR DESCRIPTION
Closes #942.

Platformer collision relationships (`PlatformerSolidCollision`/`PlatformerCloudCollision`) always applied physics (reposition, landing, grounded state) whenever a collision was detected, with no way for game code to opt out per-collision.

## Change

- Engine: `DelegateCollisionRelationship<,>` and its list variants (`Delegate{Single,List}Vs{Single,List}Relationship`) gain `ApplyPhysics` (`Func<First,Second,bool>`). Null (default) = always apply physics, same as before.
- Platformer entity's generated `CollideAgainst` overloads gain an optional `shouldApplyPhysics` hook threaded down to the point where physics is applied; unset behaves exactly as before.
- `CollisionCodeGenerator.GeneratePlatformerCollision` wires the generated `CollisionFunction` to call the relationship's `ApplyPhysics` when the project's `FileVersion` supports it (new `GluxVersions.PlatformerCollisionSupportsApplyPhysicsDelegate = 70`), falling back to the old unconditional call otherwise.

Gated because the generated code now references `ApplyPhysics`, a new engine-side property - a project referencing an older FlatRedBall build wouldn't have it.

## Testing

- `PlatformerCollisionApplyPhysicsDelegateTests` (new): pins generated-code text for both above/below the version gate. Verified red against the pre-fix codegen, green after.
- `GoldProjectCompileTests.FormsSampleProject_WithAddedPlatformerEntity_LoadInGlue_ThenBuild_ShouldSucceed`: real end-to-end compile of the edited `CollideAgainst` overloads against the real engine - passed.
- Full `GlueUnitTests.CollisionPlugin` namespace (18 tests): passed.

Manual test: not needed - covered by the gold-project real compile test above plus the codegen-text unit tests; no UI surface changed (no new checkbox/property exposed in Glue yet, this is the engine+codegen plumbing the delegate needs).
