### PR TITLE
Move LiveGameProcess's EditorTest1 window off-screen

### DIFF
--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
@@ -32,6 +32,14 @@ namespace GlueUnitTests.TestSupport;
 /// </summary>
 internal sealed class LiveGameProcess : IDisposable
 {
+    /// <summary>
+    /// Set to "1" on the launched process's environment - read by <c>EditorTest1.Game1.Initialize</c> right
+    /// after <c>FlatRedBallServices.InitializeFlatRedBall</c> creates the real (still hidden) SDL window, to
+    /// position it off the combined virtual desktop before it's ever shown. See that call site's comment for
+    /// why this is the only point where setting <c>Window.Position</c> actually sticks.
+    /// </summary>
+    internal const string OffscreenWindowEnvironmentVariable = "FRB_LIVE_GAME_TEST_OFFSCREEN";
+
     readonly TempDir project;
     readonly System.Diagnostics.Process process;
     readonly GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager;
@@ -141,6 +149,7 @@ internal sealed class LiveGameProcess : IDisposable
                     RedirectStandardOutput = true,
                 }
             };
+            process.StartInfo.Environment[OffscreenWindowEnvironmentVariable] = "1";
             // Async, event-based capture rather than ReadToEnd(): this process is long-lived (killed by
             // Dispose, not naturally exiting), so a blocking read would never return - see NestedDotnetCli's
             // doc comment for the same deadlock shape with dotnet build's child MSBuild nodes. This is what

--- a/Samples/EditorTest1/EditorTest1/Game1.cs
+++ b/Samples/EditorTest1/EditorTest1/Game1.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 using FlatRedBall;
 using FlatRedBall.Graphics;
@@ -54,6 +55,21 @@ namespace EditorTest1
 
             FlatRedBallServices.InitializeFlatRedBall(this, graphics);
 
+            // Set by LiveGameProcess (GlueUnitTests) before launching this exe repeatedly to drive live-edit
+            // tests. The window is still hidden here - MonoGame's SdlGameWindow.CreateWindow (invoked as
+            // part of InitializeFlatRedBall's resolution setup, above) destroys and recreates the SDL
+            // window centered but hidden; nothing calls Sdl.Window.Show until Game.Run()'s loop actually
+            // starts, after Initialize()/LoadContent() finish - so repositioning it here moves it off the
+            // combined virtual desktop before it's ever painted. Setting Window.Position any earlier (e.g.
+            // in Program.cs before Run()) does not work: that CreateWindow() call above would destroy the
+            // already-positioned window and recreate a fresh centered one, discarding it.
+            if (Environment.GetEnvironmentVariable("FRB_LIVE_GAME_TEST_OFFSCREEN") == "1")
+            {
+                var offscreenX = NativeMethods.GetSystemMetrics(NativeMethods.SM_XVIRTUALSCREEN)
+                    + NativeMethods.GetSystemMetrics(NativeMethods.SM_CXVIRTUALSCREEN);
+                Window.Position = new Point(offscreenX, Window.Position.Y);
+            }
+
             GeneratedInitialize();
 
             base.Initialize();
@@ -79,6 +95,15 @@ namespace EditorTest1
             GeneratedDraw(gameTime);
 
             base.Draw(gameTime);
+        }
+
+        static class NativeMethods
+        {
+            public const int SM_XVIRTUALSCREEN = 76;
+            public const int SM_CXVIRTUALSCREEN = 78;
+
+            [DllImport("user32.dll")]
+            public static extern int GetSystemMetrics(int nIndex);
         }
     }
 }


### PR DESCRIPTION
## Summary
`LiveGameProcess` (the test harness driving live-edit tests against a real, running EditorTest1 process) was launching the game window dead-center on screen every run, stealing focus repeatedly during local test runs.

Positioning had to happen inside `EditorTest1.Game1.Initialize()`, right after `FlatRedBallServices.InitializeFlatRedBall(...)`, not in `Program.cs` before `Run()`: MonoGame's SDL window is destroyed and recreated (centered, hidden) during that call, so any earlier position gets discarded. The window stays hidden until `Game.Run()`'s loop starts, so positioning it there is before the first paint - no visible flash.

Gated behind an env var (`FRB_LIVE_GAME_TEST_OFFSCREEN`) `LiveGameProcess` sets on the launched process, so this has zero effect on a normal manual EditorTest1 launch.

## Test plan
- [x] `dotnet test --filter "Category=LiveGame"` - 19/19 passing (includes 2 new tests that landed via a rebase onto `NetStandard` mid-PR)
- [x] Manually watched several repeated runs - window no longer flashes on screen

Manual test: not needed beyond the above - test-infra-only change, no product code touched.
