### PR TITLE
Glue: defer MSBuild server startup until build

### DIFF
--- a/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
+++ b/FRBDK/Glue/CompilerPlugin/CompilerPlugin.cs
@@ -1,5 +1,4 @@
-﻿using FlatRedBall.Glue.Managers;
-using FlatRedBall.Glue.Plugins;
+﻿using FlatRedBall.Glue.Plugins;
 using FlatRedBall.Glue.Plugins.Interfaces;
 using System;
 using System.ComponentModel.Composition;
@@ -62,35 +61,6 @@ namespace CompilerPlugin
             _compiler.BuildSettingsUser = BuildSettingsUser;
             _compilerViewModel.HasLoadedGlux = true;
             _compilerViewModel.HasDoneNugetRestore = false;
-
-            if (_compiler.ShouldWarmUpMsBuildServer)
-            {
-                QueueMsBuildServerWarmUp();
-            }
-        }
-
-        // Runs as a real TaskManager task (not a bare fire-and-forget Task) so it occupies the FIFO
-        // queue and shows up in "Tasks remaining" - the whole point of warming up is user-visible,
-        // background work, not something that should look like nothing is happening.
-        private void QueueMsBuildServerWarmUp()
-        {
-            _ = TaskManager.Self.AddAsync(WarmUpMsBuildServerAsync, "Warming up MSBuild Server",
-                TaskExecutionPreference.Fifo, doOnUiThread: true);
-        }
-
-        private async Task WarmUpMsBuildServerAsync()
-        {
-            var result = await _compiler.Compile(
-                (value) => HandleOutput(value),
-                (value) => ReactToPluginEvent("Compiler_Output_Error", value),
-                !_compilerViewModel.HasDoneNugetRestore,
-                _compilerViewModel.Configuration,
-                _compilerViewModel.IsPrintMsBuildCommandChecked);
-
-            if (result.Succeeded)
-            {
-                _compilerViewModel.HasDoneNugetRestore = true;
-            }
         }
 
         private void HandleGluxUnLoaded()
@@ -232,7 +202,6 @@ namespace CompilerPlugin
                 var view = new BuildSettingsWindow();
                 view.DataContext = viewModel;
                 viewModel.SetFrom(BuildSettingsUser);
-                var wasUsingMsBuildServer = BuildSettingsUser.UseMsBuildServer;
 
                 var results = view.ShowDialog();
 
@@ -242,11 +211,6 @@ namespace CompilerPlugin
                     viewModel.ApplyTo(BuildSettingsUser);
 
                     SaveBuildSettings();
-
-                    if (Compiler.ShouldWarmUpOnSettingsChange(wasUsingMsBuildServer, BuildSettingsUser.UseMsBuildServer))
-                    {
-                        QueueMsBuildServerWarmUp();
-                    }
                 }
             };
         }

--- a/FRBDK/Glue/CompilerPlugin/Managers/Compiler.cs
+++ b/FRBDK/Glue/CompilerPlugin/Managers/Compiler.cs
@@ -97,16 +97,6 @@ namespace CompilerPlugin.Managers
 
         public BuildSettingsUser BuildSettingsUser { get; set; }
 
-        // Gates the background warm-up build fired on project load (CompilerPlugin.HandleGluxLoaded) -
-        // only worth doing when the setting that makes MSBuild Server actually get used is on.
-        public bool ShouldWarmUpMsBuildServer => BuildSettingsUser?.UseMsBuildServer == true;
-
-        // Gates the background warm-up build fired when the Build Settings dialog is closed
-        // (CompilerPlugin's MSBuildSettingsClicked handler) - only worth doing on the OFF -> ON
-        // transition, not every OK click while it's already on (or off).
-        internal static bool ShouldWarmUpOnSettingsChange(bool wasUsingMsBuildServer, bool isUsingMsBuildServerNow) =>
-            !wasUsingMsBuildServer && isUsingMsBuildServerNow;
-
         FilePath msBuildLocation;
         private CompilerViewModel _compilerViewModel;
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/CompilerMsBuildServerTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CompilerPlugin/CompilerMsBuildServerTests.cs
@@ -54,24 +54,5 @@ namespace GlueUnitTests.CompilerPlugin
             process.StartInfo.EnvironmentVariables.ContainsKey("DOTNET_CLI_USE_MSBUILD_SERVER").ShouldBeFalse();
         }
 
-        [Fact]
-        public void ShouldWarmUpMsBuildServer_ReflectsBuildSettingsUser()
-        {
-            CreateCompiler(useMsBuildServer: true).ShouldWarmUpMsBuildServer.ShouldBeTrue();
-            CreateCompiler(useMsBuildServer: false).ShouldWarmUpMsBuildServer.ShouldBeFalse();
-            CreateCompiler(useMsBuildServer: null).ShouldWarmUpMsBuildServer.ShouldBeFalse();
-        }
-
-        [Theory]
-        [InlineData(false, true, true)]   // turning it on mid-session should warm up
-        [InlineData(true, true, false)]   // already on, OK clicked again - don't refire
-        [InlineData(true, false, false)]  // turning it off - nothing to warm up
-        [InlineData(false, false, false)] // stayed off
-        public void ShouldWarmUpOnSettingsChange_OnlyFiresOnOffToOnTransition(
-            bool wasUsingMsBuildServer, bool isUsingMsBuildServerNow, bool expected)
-        {
-            Compiler.ShouldWarmUpOnSettingsChange(wasUsingMsBuildServer, isUsingMsBuildServerNow)
-                .ShouldBe(expected);
-        }
     }
 }


### PR DESCRIPTION
Removes eager MSBuild-server warm-up builds from project load and from enabling the setting. Normal restore and build processes continue to opt into the server, so a compatible running server is reused when the user builds or presses Play. Tests: CompilerMsBuildServerTests (3 passed).