### PR TITLE
Guard shared-static content reload against unloading an already-unloaded asset

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Content/ContentManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Content/ContentManager.cs
@@ -1021,8 +1021,15 @@ namespace FlatRedBall.Content
 				}
 				else
 				{
-					throw new ArgumentException("The content manager " + mName + " does not contain the argument " +
-						"assetToUnload, or the file has been loaded from XNB and cannot be unloaded without disposing the content manager.  " +
+					string assetIdentifier = typeof(T).Name;
+					if (assetToUnload is Microsoft.Xna.Framework.Graphics.GraphicsResource graphicsResource &&
+						!string.IsNullOrEmpty(graphicsResource.Name))
+					{
+						assetIdentifier += " \"" + graphicsResource.Name + "\"";
+					}
+
+					throw new ArgumentException("The content manager " + mName + " does not contain the " +
+						assetIdentifier + " passed as assetToUnload, or the file has been loaded from XNB and cannot be unloaded without disposing the content manager.  " +
 						"Check the " +
 						"contentManagerName and verify that it is a contentManager that has loaded this asset.");
 				}

--- a/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
@@ -1041,10 +1041,17 @@ namespace FlatRedBall.Glue.CodeGeneration
                     var newlyLoadedVariable = $"newlyLoaded{instanceName}";
 
                     codeBlock.Line($"var cm = FlatRedBall.FlatRedBallServices.GetContentManagerByName(\"Global\");");
-                    codeBlock.Line($"cm.UnloadAsset({instanceName});");
+                    // A shared-static file is often reloaded through more than one static field pointing at
+                    // the same underlying disposable (one per Entity that declares it shared-static, plus
+                    // GlobalContent's own field) - whichever reload runs first already unloads/disposes it,
+                    // so every later one finds it no longer tracked and UnloadAsset throws ArgumentException.
+                    // Guard with IsAssetLoadedByReference instead of assuming this is the only holder.
+                    codeBlock.If($"cm.IsAssetLoadedByReference({instanceName})")
+                        .Line($"cm.UnloadAsset({instanceName});");
                     codeBlock.Line($"var {newlyLoadedVariable} = FlatRedBall.FlatRedBallServices.Load<FlatRedBall.Graphics.Animation.AnimationChainList>(\"{fileToLoad}\");");
                     codeBlock.Line($"{instanceName}.ReplaceValues({newlyLoadedVariable});");
-                    codeBlock.Line($"cm.UnloadAsset({newlyLoadedVariable});");
+                    codeBlock.If($"cm.IsAssetLoadedByReference({newlyLoadedVariable})")
+                        .Line($"cm.UnloadAsset({newlyLoadedVariable});");
                     codeBlock.Line($"cm.AddDisposable(\"{fileToLoad}\", {instanceName});");
                 }
                 else if (ati?.CustomReloadFunc != null)
@@ -1151,7 +1158,12 @@ namespace FlatRedBall.Glue.CodeGeneration
                             var innerBlock = codeBlock.Block();
 
                             innerBlock.Line("var cm = FlatRedBall.FlatRedBallServices.GetContentManagerByName(\"Global\");");
-                            innerBlock.Line($"cm.UnloadAsset({referencedFile.GetInstanceName()});");
+                            // See the matching guard/comment in GetReload's AnimationChainList branch above -
+                            // a shared-static file can be reloaded through more than one static field pointing
+                            // at the same underlying disposable, and whichever reload runs first already
+                            // unloads it, leaving every later one's UnloadAsset call throwing ArgumentException.
+                            innerBlock.If($"cm.IsAssetLoadedByReference({referencedFile.GetInstanceName()})")
+                                .Line($"cm.UnloadAsset({referencedFile.GetInstanceName()});");
 
                             string code =
                                 $"{referencedFile.GetInstanceName()} = " +

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/SharedStaticTextureReloadCodegenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/SharedStaticTextureReloadCodegenTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.CodeGeneration;
+using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using Xunit;
+
+namespace GlueUnitTests.GlueControlTests;
+
+// Reproduces the crash reported against CrankyChibiCthulhu (the same project
+// GlobalContentReloadIdentifierTests's SelectGlobalReferencedFile test is modeled on): a texture shared
+// across many Entities via IsSharedStatic (ChibiCthulhuTiles.png, referenced by Bullet, Checkpoint,
+// DestructibleObstacle, Door, Enemy, ... and GlobalContent itself). Each of those holders is a distinct
+// static field, but they all point at the same underlying Texture2D instance loaded from disk.
+//
+// GetReload's generated MaintainInstance reload does `cm.UnloadAsset(instanceName)` unconditionally before
+// loading a replacement. When the file changes on disk, Glue tells every holder to reload in turn - the
+// first one to run successfully unloads/disposes the shared texture, so every later holder's UnloadAsset
+// call finds it no longer tracked and throws ArgumentException ("does not contain the argument
+// assetToUnload, or the file has been loaded from XNB..."). That exception aborts the reload for every
+// holder still queued behind the one that already succeeded - including GlobalContent's own field, which
+// is what brand-new entities (e.g. a boss spawned after the edit) read their texture reference from at
+// construction time. The abandoned field still points at the disposed texture, so a freshly spawned
+// Sprite crashes with ObjectDisposedException the next time it's drawn - far from this reload code, and
+// with no indication a reload ever ran into trouble.
+public class SharedStaticTextureReloadCodegenTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _tempProjectDirectory;
+
+    public SharedStaticTextureReloadCodegenTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave
+        {
+            FileVersion = GlueProjectSave.LatestVersion,
+        };
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    [Fact]
+    public void GetReload_ForSharedStaticTexture_GuardsUnloadAssetAgainstAlreadyUnloadedInstance()
+    {
+        var rfs = new ReferencedFileSave
+        {
+            Name = "GlobalContent/ChibiCthulhuTiles.png",
+            LoadedAtRuntime = true,
+            IsSharedStatic = true,
+        };
+
+        var codeBlock = new CodeBlockBase();
+        ReferencedFileSaveCodeGenerator.GetReload(rfs, container: null, codeBlock, LoadType.MaintainInstance);
+        var generatedCode = codeBlock.ToString();
+
+        // Sanity check this test actually exercises the Texture2D reload branch (ReplaceTexture is only
+        // emitted there) rather than silently falling through to a no-op because the ati failed to resolve.
+        Assert.Contains("FlatRedBallServices.ReplaceTexture", generatedCode);
+
+        // Before the fix, this was an unconditional "cm.UnloadAsset(ChibiCthulhuTiles);" - fine the first
+        // time any holder of the shared texture reloads it, but every later holder's call throws
+        // ArgumentException once the first one has already unloaded/disposed it.
+        Assert.Contains("if (cm.IsAssetLoadedByReference(ChibiCthulhuTiles))", generatedCode);
+    }
+}


### PR DESCRIPTION
## Summary
Second, independent bug behind the same crash #2211 partially fixed. #2211 fixed a cross-thread race in `HandleDto(ForceReloadFileDto)`; this fixes a separate bug in the same reload machinery, still reproducible per the latest user report (`GlobalContent.Reload` throwing `ArgumentException` from `ContentManager.UnloadAsset`, immediately followed by `ObjectDisposedException` in `RenderBreak`).

- A texture/AnimationChainList shared across many Entities via `IsSharedStatic` (e.g. a tileset atlas) has one static field **per holder** - each Entity plus `GlobalContent` itself - all pointing at the same underlying disposable. The generated reload always did `cm.UnloadAsset(instanceName)` unconditionally. The first holder to reload disposes the shared asset; every later holder's `UnloadAsset` call then finds it no longer tracked and throws, aborting that holder's reload - including `GlobalContent`'s own field. A freshly constructed object reading its texture from `GlobalContent`'s now-abandoned, still-pointing-at-disposed field crashes on next `Draw()`, far from the actual bug.
- Fix: guard every generated `UnloadAsset` call with `IsAssetLoadedByReference` (same guard already used in `FlatRedBallServices.ReplaceFromFileTexture2D`) so a holder that finds the asset already gone just skips disposal and proceeds to load+reassign+`ReplaceTexture`.
- Also improved `ContentManager.UnloadAsset`'s `ArgumentException` message to name the actual asset's type (and `GraphicsResource.Name` when set) instead of the literal parameter name `"assetToUnload"` - flagged by the user as unhelpful for debugging.

## Test plan
- Added `SharedStaticTextureReloadCodegenTests`, reproducing the exact CrankyChibiCthulhu shape (texture shared across many Entities) - asserts the generated `Reload` code guards `UnloadAsset`. Verified it fails against the old codegen and passes against the fix.
- Built the DesktopGL engine project standalone to confirm the `ContentManager.cs` message change compiles clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01PBvCUmjXQwYT4c2qghKVYP