### PR TITLE
Fix embedded click-select passing through to overlapping windows

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -654,6 +654,30 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     }
     #endregion
 
+    #region TestComputeCursorOverOwnWindowDto
+
+    /// <summary>
+    /// Test-only (issue #2205): drives GlueControl.Editing.EmbeddedWindowLogic.ComputeCursorOverOwnWindow
+    /// (Embedded) with synthetic Win32-call outcomes instead of a real ClientToScreen/WindowFromPoint
+    /// round trip against a real overlapping window - moving the real OS cursor precisely enough for that
+    /// turned out to be unreliable on multi-monitor setups (see issue #2205 discussion), so this pins the
+    /// decision logic (fails closed on ClientToScreen failure, fails closed on no window found, true/false
+    /// on owner PID match) directly instead.
+    /// </summary>
+    public class TestComputeCursorOverOwnWindowDto
+    {
+        public bool ClientToScreenSucceeded { get; set; }
+        public bool TopmostWindowFound { get; set; }
+        public uint TopmostWindowOwnerPid { get; set; }
+        public uint ThisProcessId { get; set; }
+    }
+
+    public class TestComputeCursorOverOwnWindowResponse
+    {
+        public bool Result { get; set; }
+    }
+    #endregion
+
     #region ForceGameResolution
     public class ForceGameResolution
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -1685,6 +1685,18 @@ namespace GlueControl
 
         #endregion
 
+        #region TestComputeCursorOverOwnWindowDto
+
+        private static TestComputeCursorOverOwnWindowResponse HandleDto(TestComputeCursorOverOwnWindowDto dto)
+        {
+            var topmostWindowAtCursor = dto.TopmostWindowFound ? new IntPtr(1) : IntPtr.Zero;
+            var result = EmbeddedWindowLogic.ComputeCursorOverOwnWindow(
+                dto.ClientToScreenSucceeded, topmostWindowAtCursor, dto.TopmostWindowOwnerPid, dto.ThisProcessId);
+            return new TestComputeCursorOverOwnWindowResponse { Result = result };
+        }
+
+        #endregion
+
         #region ForceGameResolution
 
         private static void HandleDto(ForceGameResolution dto)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -639,6 +639,30 @@ namespace GlueControl.Dtos
     }
     #endregion
 
+    #region TestComputeCursorOverOwnWindowDto
+
+    /// <summary>
+    /// Test-only (issue #2205): drives GlueControl.Editing.EmbeddedWindowLogic.ComputeCursorOverOwnWindow
+    /// with synthetic Win32-call outcomes instead of a real ClientToScreen/WindowFromPoint round trip
+    /// against a real overlapping window - moving the real OS cursor precisely enough for that turned out
+    /// to be unreliable on multi-monitor setups (see issue #2205 discussion), so this pins the decision
+    /// logic (fails closed on ClientToScreen failure, fails closed on no window found, true/false on owner
+    /// PID match) directly instead.
+    /// </summary>
+    public class TestComputeCursorOverOwnWindowDto
+    {
+        public bool ClientToScreenSucceeded { get; set; }
+        public bool TopmostWindowFound { get; set; }
+        public uint TopmostWindowOwnerPid { get; set; }
+        public uint ThisProcessId { get; set; }
+    }
+
+    public class TestComputeCursorOverOwnWindowResponse
+    {
+        public bool Result { get; set; }
+    }
+    #endregion
+
     #region ForceGameResolution
     public class ForceGameResolution
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -1653,20 +1653,91 @@ namespace GlueControl.Editing
             // clicks were silently dropped. A follow-up attempt using WindowFromPoint at the raw cursor
             // position failed too - GetCursorPos() itself returned false with Win32 error 87
             // (ERROR_INVALID_PARAMETER) on that machine, so the OS focus/cursor APIs are evidently
-            // unreliable here in more than one way, not just GetForegroundWindow(). FlatRedBall.Input.Mouse
-            // already tracks the cursor's game-window-relative position through MonoGame's own input
-            // pipeline (not these Win32 calls) for entirely unrelated purposes elsewhere in this class -
-            // IsInGameWindow() is a pure bounds check against that position, explicitly documented as valid
-            // "even if the game window does not have focus." Reusing it here sidesteps the unreliable APIs
-            // entirely instead of chasing another one. Only probed as a last resort (like
-            // foregroundOwnedByThisGame above), not as a blanket "foreground is unknown -> assume focused" -
-            // that was tried first and a regression test
-            // (ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored) caught that it could also
-            // mask a genuine focus loss to an unrelated window (re-opening #2154).
-            var cursorOverOwnWindow = glueProcessExists && !foregroundMatchesGlueMainWindow && !foregroundOwnedByThisGame
-                && FlatRedBall.Input.InputManager.Mouse.IsInGameWindow();
+            // unreliable here in more than one way, not just GetForegroundWindow(). The fix that shipped
+            // used FlatRedBall.Input.Mouse.IsInGameWindow() instead - a pure bounds check against the
+            // client-relative position MonoGame's own input pipeline already tracks (not these Win32
+            // calls), valid "even if the game window does not have focus."
+            //
+            // Follow-up (#2205 continued): a bounds check alone can't detect occlusion. If another real
+            // window is drawn on top of the embedded game at the cursor's position (dragged over it, or
+            // any overlapping window), IsInGameWindow() still says "inside my bounds" - it has no Z-order
+            // awareness - so the game kept reporting clicks/hovers meant for the window on top of it.
+            // Fixed by adding a topmost check: convert the already-reliable client-relative mouse position
+            // to screen coordinates via ClientToScreen on our OWN window handle (not GetCursorPos, which
+            // is the API that failed above), then WindowFromPoint at that screen position to find out who
+            // is ACTUALLY topmost there. Deliberately fails CLOSED (cursorOverOwnWindow stays false) if
+            // ClientToScreen fails or WindowFromPoint resolves to nothing/another process - same "when in
+            // doubt, block" philosophy as #2154. Only probed as a last resort (like foregroundOwnedByThisGame
+            // above), not as a blanket "foreground is unknown -> assume focused" - that was tried first and
+            // a regression test (ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored) caught
+            // that it could also mask a genuine focus loss to an unrelated window (re-opening #2154).
+            // Not gated on glueProcessExists here (unlike the two checks above) - ComputeIsFocused already
+            // requires it independently for the final gate result, so gating it here too would only be a
+            // micro-optimization (skip the Win32 calls when Glue clearly isn't running at all).
+            var cursorOverOwnWindow = false;
+            if (!foregroundMatchesGlueMainWindow && !foregroundOwnedByThisGame)
+            {
+                var diagnostics = ComputeCursorOverOwnWindowDiagnostics();
+                cursorOverOwnWindow = diagnostics.mouseInGameWindow && ComputeCursorOverOwnWindow(
+                    diagnostics.clientToScreenSucceeded, diagnostics.topmostWindowAtCursor,
+                    diagnostics.topmostWindowOwnerPid, diagnostics.thisProcessId);
+            }
 
             return (glueProcessExists, foregroundMatchesGlueMainWindow, foregroundOwnedByThisGame, cursorOverOwnWindow);
+        }
+
+        /// <summary>
+        /// Runs the raw Win32 half of the occlusion check (issue #2205 follow-up: client-relative mouse
+        /// position -> screen coordinates -> topmost window there), separated from ComputeCursorOverOwnWindow's
+        /// pure decision logic below so each half stays simple. Only reaches the actual Win32 calls when
+        /// FlatRedBall.Input.Mouse.IsInGameWindow() is true.
+        /// </summary>
+        internal static (bool mouseInGameWindow, int mouseX, int mouseY, bool clientToScreenSucceeded,
+            IntPtr topmostWindowAtCursor, uint topmostWindowOwnerPid, uint thisProcessId) ComputeCursorOverOwnWindowDiagnostics()
+        {
+            var mouseInGameWindow = FlatRedBall.Input.InputManager.Mouse.IsInGameWindow();
+            var mouseX = FlatRedBall.Input.InputManager.Mouse.X;
+            var mouseY = FlatRedBall.Input.InputManager.Mouse.Y;
+            var thisProcessId = (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
+
+            var clientToScreenSucceeded = false;
+            var topmostWindowAtCursor = IntPtr.Zero;
+            uint topmostWindowOwnerPid = 0;
+
+            if (mouseInGameWindow)
+            {
+                var gameWindowHandle = FlatRedBallServices.Game.Window.Handle;
+                var clientPoint = new Win32Point { X = mouseX, Y = mouseY };
+                clientToScreenSucceeded = ClientToScreen(gameWindowHandle, ref clientPoint);
+                topmostWindowAtCursor = clientToScreenSucceeded ? WindowFromPoint(clientPoint) : IntPtr.Zero;
+                if (topmostWindowAtCursor != IntPtr.Zero)
+                {
+                    GetWindowThreadProcessId(topmostWindowAtCursor, out topmostWindowOwnerPid);
+                }
+            }
+
+            return (mouseInGameWindow, mouseX, mouseY, clientToScreenSucceeded, topmostWindowAtCursor,
+                topmostWindowOwnerPid, thisProcessId);
+        }
+
+        /// <summary>
+        /// Pure decision logic behind the occlusion check in GetRawFocusInputs, split out of the raw Win32
+        /// orchestration above (ComputeCursorOverOwnWindowDiagnostics) the same way ComputeIsFocused is
+        /// split from GetRawFocusInputs. Only called after the cursor is already confirmed within our own
+        /// window's bounds (FlatRedBall.Input.Mouse.IsInGameWindow()); this is specifically the
+        /// topmost/occlusion half. Fails closed (false) whenever the outcome can't be positively confirmed,
+        /// matching #2154's "when in doubt, block" philosophy - a missing/ambiguous signal must never be
+        /// read as "we're on top."
+        /// </summary>
+        internal static bool ComputeCursorOverOwnWindow(bool clientToScreenSucceeded, IntPtr topmostWindowAtCursor,
+            uint topmostWindowOwnerPid, uint thisProcessId)
+        {
+            if (!clientToScreenSucceeded || topmostWindowAtCursor == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            return topmostWindowOwnerPid == thisProcessId;
         }
 
         /// <summary>
@@ -1759,11 +1830,15 @@ namespace GlueControl.Editing
         [System.Runtime.InteropServices.DllImport("user32.dll")]
         static extern IntPtr WindowFromPoint(Win32Point point);
 
+        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+        static extern bool ClientToScreen(IntPtr hWnd, ref Win32Point point);
+
 #else
         static IntPtr GetForegroundWindow() => IntPtr.Zero;
         static uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId) { processId = 0; return 0; }
         static bool GetCursorPos(out Win32Point point) { point = default; return false; }
         static IntPtr WindowFromPoint(Win32Point point) => IntPtr.Zero;
+        static bool ClientToScreen(IntPtr hWnd, ref Win32Point point) => false;
 
 #endif
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
@@ -570,6 +570,75 @@ public class EditModeActivityGateTests
         }
     }
 
+    /// <summary>
+    /// Pins EmbeddedWindowLogic.ComputeCursorOverOwnWindow's decision table directly, via synthetic Win32-
+    /// call outcomes (TestComputeCursorOverOwnWindowDto) rather than a real ClientToScreen/WindowFromPoint
+    /// round trip against a real overlapping window - moving the real OS cursor precisely enough for that
+    /// proved unreliable on a multi-monitor dev machine (issue #2205 discussion), so this is the regression
+    /// coverage that actually shipped for the occlusion fix instead. One process, four cases: covers both
+    /// fail-closed paths (no ClientToScreen result, no window found at the cursor) and both PID-match
+    /// outcomes (occluded by another window vs. genuinely on top).
+    /// </summary>
+    [StaFact]
+    public async Task ComputeCursorOverOwnWindow_DecisionTable()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe");
+
+        var clientToScreenFailed = await game.Send<TestComputeCursorOverOwnWindowResponse>(
+            new TestComputeCursorOverOwnWindowDto
+            {
+                ClientToScreenSucceeded = false,
+                TopmostWindowFound = true,
+                TopmostWindowOwnerPid = 123,
+                ThisProcessId = 123,
+            });
+        clientToScreenFailed.Succeeded.ShouldBeTrue(clientToScreenFailed.Message);
+        clientToScreenFailed.Data.Result.ShouldBeFalse(
+            "a failed ClientToScreen call must fail closed even if the (unusable) window/PID inputs would otherwise match");
+
+        var noWindowFound = await game.Send<TestComputeCursorOverOwnWindowResponse>(
+            new TestComputeCursorOverOwnWindowDto
+            {
+                ClientToScreenSucceeded = true,
+                TopmostWindowFound = false,
+                TopmostWindowOwnerPid = 123,
+                ThisProcessId = 123,
+            });
+        noWindowFound.Succeeded.ShouldBeTrue(noWindowFound.Message);
+        noWindowFound.Data.Result.ShouldBeFalse(
+            "no window found at the cursor position (e.g. the desktop background) must fail closed");
+
+        var occludedByAnotherProcess = await game.Send<TestComputeCursorOverOwnWindowResponse>(
+            new TestComputeCursorOverOwnWindowDto
+            {
+                ClientToScreenSucceeded = true,
+                TopmostWindowFound = true,
+                TopmostWindowOwnerPid = 456,
+                ThisProcessId = 123,
+            });
+        occludedByAnotherProcess.Succeeded.ShouldBeTrue(occludedByAnotherProcess.Message);
+        occludedByAnotherProcess.Data.Result.ShouldBeFalse(
+            "a real window belonging to a different process is topmost at the cursor - this is the exact " +
+            "occlusion scenario from the #2205 follow-up report and must not be detected as our own window");
+
+        var genuinelyOnTop = await game.Send<TestComputeCursorOverOwnWindowResponse>(
+            new TestComputeCursorOverOwnWindowDto
+            {
+                ClientToScreenSucceeded = true,
+                TopmostWindowFound = true,
+                TopmostWindowOwnerPid = 123,
+                ThisProcessId = 123,
+            });
+        genuinelyOnTop.Succeeded.ShouldBeTrue(genuinelyOnTop.Message);
+        genuinelyOnTop.Data.Result.ShouldBeTrue(
+            "the topmost window at the cursor belongs to our own process - nothing is occluding us");
+    }
+
     static async Task AddTestObjectToGameScreen()
     {
         var gameScreen = ObjectFinder.Self.GetScreenSave("GameScreen");


### PR DESCRIPTION
Follow-up to #2205: a window overlapping the embedded game panel still had its clicks/hovers reported by the game underneath it.

## Root cause

The #2205 fix (`FlatRedBall.Input.Mouse.IsInGameWindow()`) is a pure client-rectangle bounds check with no Z-order awareness - it can't tell "cursor is within my bounds" apart from "cursor is within my bounds AND another window is drawn on top of me there."

## Fix

Added a topmost/occlusion check: convert the client-relative mouse position to screen coordinates via `ClientToScreen` on the game's own window handle, then `WindowFromPoint` at that screen position to find out who is actually topmost there. Fails closed if `ClientToScreen` fails or `WindowFromPoint` resolves to nothing/another process, matching #2154's "when in doubt, block" philosophy.

The decision logic (`EmbeddedWindowLogic.ComputeCursorOverOwnWindow`) is split from the raw Win32 orchestration, mirroring `ComputeIsFocused`'s existing split.

Closes #2214

## Test plan

- `ComputeCursorOverOwnWindow_DecisionTable` - pins the full decision table (fails closed on no `ClientToScreen` result, fails closed on no window found, both PID-match outcomes) via a synthetic-input test DTO (`TestComputeCursorOverOwnWindowDto`), same pattern as the existing `SetEmbeddedFocusTestOverrideDto`-driven tests.
  - A real end-to-end test that moves the actual OS cursor to verify against a real overlapping window was attempted first, but `Mouse.SetScreenPosition`'s X coordinate proved unreliable on a multi-monitor dev machine (Y worked, X consistently landed wrong) - a separate, pre-existing limitation unrelated to this fix.
- All existing #2154/#2183/#2187/#2196/#2205 focus-gate tests still pass (9/9 `EditModeActivityGateTests`).
- Compiles inside a real game project (this file is `<Compile Remove>`d from `GameCommunicationPlugin.csproj`, only compiles via `EmbedAll`).
- Manually verified working against the real reported project.
