### PR TITLE
Fix daily build update timezone check

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml
@@ -44,6 +44,7 @@
             <StackPanel Orientation="Vertical" Grid.Row="2" Grid.Column="1">
                 <Label Content="{Binding LatestDailyBuildText}"></Label>
                 <Button Visibility="{Binding DailyBuildDownloadButtonVisibility}" Click="InstallDailyBuild_Click" Content="Install Daily Build" />
+                <Button Click="OpenDailyBuildUpdateLog_Click" Content="Open Daily Build Update Log" />
                 <Label Content="{Binding DailyBuildDownloadStatusText}"></Label>
             </StackPanel>
 

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutControl.xaml.cs
@@ -25,6 +25,11 @@ namespace GlueFormsCore.Controls
             ViewModel.DoInstallDailyBuild();
         }
 
+        private void OpenDailyBuildUpdateLog_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.OpenDailyBuildUpdateLog();
+        }
+
         private void FrbSourceButton_Click(object sender, RoutedEventArgs e)
         {
             ViewModel.DoFrbSourceButtonClicked();

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutViewModel.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/AboutViewModel.cs
@@ -89,6 +89,12 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
             set => Set(value);
         }
 
+        public Version LatestDailyBuildVersion
+        {
+            get => Get<Version>();
+            set => Set(value);
+        }
+
         [DependsOn(nameof(LatestDailyBuildOnline))]
         public string LatestDailyBuildText => LatestDailyBuildOnline?.ToString("yyyy.M.d HH:mm") ?? "--";
 
@@ -103,7 +109,7 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
             set => Set(value);
         }
 
-        [DependsOn(nameof(LatestDailyBuildOnline))]
+        [DependsOn(nameof(LatestDailyBuildVersion))]
         [DependsOn(nameof(Version))]
         [DependsOn(nameof(IsDownloadingDailyBuild))]
         public Visibility DailyBuildDownloadButtonVisibility
@@ -114,7 +120,7 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
                 {
                     return Visibility.Collapsed;
                 }
-                else if (LatestDailyBuildOnline is { } latest && Version.TryParse(latest.ToString("yyyy.M.d"), out var latestDailyVersion))
+                else if (LatestDailyBuildVersion is { } latestDailyVersion)
                 {
                     return latestDailyVersion > Version ? Visibility.Visible : Visibility.Collapsed;
                 }
@@ -476,6 +482,22 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
             }
         }
 
+        internal void OpenDailyBuildUpdateLog()
+        {
+            var logPath = DailyBuildUpdateDiagnostics.GetLogPath();
+            var target = DailyBuildUpdateDiagnostics.GetLogOpenTarget(logPath, File.Exists);
+
+            if (target != logPath)
+            {
+                Directory.CreateDirectory(target);
+            }
+
+            Process.Start(new ProcessStartInfo(target)
+            {
+                UseShellExecute = true
+            });
+        }
+
         private static async System.Threading.Tasks.Task<bool> DownloadWithProgress(
             string location,
             string destination,
@@ -615,9 +637,10 @@ namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin
                     response.Content.Headers.TryGetValues("Last-Modified", out values))
                 {
                     var lastModified = values.FirstOrDefault();
-                    if (DateTime.TryParse(lastModified, out var dateTime))
+                    if (DateTimeOffset.TryParse(lastModified, out var dateTime))
                     {
-                        LatestDailyBuildOnline = dateTime.ToLocalTime();
+                        LatestDailyBuildOnline = dateTime.LocalDateTime;
+                        LatestDailyBuildVersion = DailyBuildVersionLogic.GetLatestVersion(dateTime);
                     }
                 }
             }

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/DailyBuildUpdateDiagnostics.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/DailyBuildUpdateDiagnostics.cs
@@ -15,6 +15,14 @@ internal static class DailyBuildUpdateDiagnostics
             "GlueDailyBuildUpdate.log");
     }
 
+    internal static string GetLogOpenTarget(string logPath, Func<string, bool> fileExists)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(logPath);
+        ArgumentNullException.ThrowIfNull(fileExists);
+
+        return fileExists(logPath) ? logPath : Path.GetDirectoryName(logPath)!;
+    }
+
     internal static void Append(string logPath, string message)
     {
         var directory = Path.GetDirectoryName(logPath);

--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/DailyBuildVersionLogic.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/AboutPlugin/DailyBuildVersionLogic.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Globalization;
+
+namespace GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin;
+
+internal static class DailyBuildVersionLogic
+{
+    internal static Version GetLatestVersion(DateTimeOffset lastModified)
+    {
+        return Version.Parse(lastModified.UtcDateTime.ToString("yyyy.M.d", CultureInfo.InvariantCulture));
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/AboutPlugin/DailyBuildUpdateLauncherTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/AboutPlugin/DailyBuildUpdateLauncherTests.cs
@@ -2,11 +2,54 @@ using GlueFormsCore.Plugins.EmbeddedPlugins.AboutPlugin;
 using Shouldly;
 using System.Diagnostics;
 using System.IO;
+using System.Windows;
 
 namespace GlueUnitTests.AboutPlugin;
 
 public class DailyBuildUpdateLauncherTests
 {
+    [Fact]
+    public void GetLatestVersion_ShouldUseTheUtcBuildDateRegardlessOfTheViewerTimezone()
+    {
+        var utcBuildTime = new DateTimeOffset(2026, 8, 26, 16, 0, 0, TimeSpan.Zero);
+        var result = DailyBuildVersionLogic.GetLatestVersion(utcBuildTime);
+
+        result.ShouldBe(new Version(2026, 8, 26));
+    }
+
+    [Fact]
+    public void DailyBuildDownloadButton_ShouldBeHiddenWhenTheUtcDailyBuildMatchesTheInstalledVersion()
+    {
+        var viewModel = new AboutViewModel
+        {
+            Version = new Version(2026, 8, 26),
+            LatestDailyBuildVersion = DailyBuildVersionLogic.GetLatestVersion(
+                new DateTimeOffset(2026, 8, 26, 16, 0, 0, TimeSpan.Zero))
+        };
+
+        viewModel.DailyBuildDownloadButtonVisibility.ShouldBe(Visibility.Collapsed);
+    }
+
+    [Fact]
+    public void GetLogOpenTarget_ShouldUseTheLogWhenItExists()
+    {
+        var logPath = Path.Combine(Path.GetTempPath(), "FlatRedBall", "GlueDailyBuildUpdate.log");
+
+        var target = DailyBuildUpdateDiagnostics.GetLogOpenTarget(logPath, _ => true);
+
+        target.ShouldBe(logPath);
+    }
+
+    [Fact]
+    public void GetLogOpenTarget_ShouldUseTheLogDirectoryWhenNoLogExists()
+    {
+        var logPath = Path.Combine(Path.GetTempPath(), "FlatRedBall", "GlueDailyBuildUpdate.log");
+
+        var target = DailyBuildUpdateDiagnostics.GetLogOpenTarget(logPath, _ => false);
+
+        target.ShouldBe(Path.GetDirectoryName(logPath));
+    }
+
     [Fact]
     public void DailyBuildUpdateDiagnostics_ShouldPersistAnEntry()
     {


### PR DESCRIPTION
Fixes #2216

## Summary

- Compare the daily-build asset's UTC calendar date with Glue's UTC-stamped product version, so the update button does not vary by the user's time zone.
- Add an **Open Daily Build Update Log** button to About. It opens the log when present, or its folder before the first update attempt.
- Cover UTC comparison, button visibility, and log-target selection with unit tests.

## Verification

- `dotnet build FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj -p:SolutionDir="C:\\Users\\Owner\\Documents\\GitHub\\FlatRedBall-daily-build-timezone\\FRBDK\\Glue\\" --no-restore`
- `dotnet test FRBDK/Glue/Tests/GlueUnitTests/GlueUnitTests.csproj --no-build -p:SolutionDir="C:\\Users\\Owner\\Documents\\GitHub\\FlatRedBall-daily-build-timezone\\FRBDK\\Glue\\" --filter "FullyQualifiedName~DailyBuildUpdateLauncherTests&Category!=BuildSmoke"` (11 passed)
- The broader `Category!=BuildSmoke` suite did not complete in the local environment and its test tree was stopped after exceeding the documented healthy runtime.
