### PR TITLE
Move the embedded input gate out of the game and into Glue

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
+++ b/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
@@ -130,6 +130,7 @@
     <Compile Include="GlueControl\CommandSending\GameReadinessRetryPolicy.cs" />
     <Compile Include="GlueControl\Dtos\Dtos.cs" />
     <Compile Include="GlueControl\Dtos\GeneratePreviewDto.cs" />
+    <Compile Include="GlueControl\Managers\EmbeddedInputAllowedService.cs" />
     <Compile Include="GlueControl\Managers\ModalReportingService.cs" />
     <EmbeddedResource Include="GlueControl\Embedded\CommandReplayLogic.cs" />
     <Compile Include="GlueControl\MainCompilerPlugin.cs" />

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -636,45 +636,23 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     }
     #endregion
 
-    #region SetEmbeddedFocusTestOverrideDto
+    #region SetEmbeddedInputAllowedDto
 
     /// <summary>
-    /// Test-only (issue #2183): forces GlueControl.Editing.EmbeddedWindowLogic.IsParentGlueFocused
-    /// (Embedded) to a synthetic result instead of inspecting real OS focus/process state, which the
-    /// LiveGameProcess harness can't fake (no real "GlueFormsCore" process, no way to move real OS
-    /// foreground). Send with ClearOverride=true to go back to the real (production) check.
+    /// Pushed from Glue to the embedded game whenever the answer changes: may the game act on mouse
+    /// input right now? True while the embedded game window is the topmost window under the cursor and
+    /// Glue's application is the active one.
+    ///
+    /// Glue owns this decision because Glue is a real Windows-only WPF/WinForms process where
+    /// GetForegroundWindow/GetCursorPos/WindowFromPoint actually work. The same calls inside the game
+    /// were compile-time stubs for years - GlueControl/Embedded compiles into the user's game project,
+    /// which never defines WINDOWS - which is what made issues #2183, #2205 and #2214 look like
+    /// per-machine OS flakiness. See EmbeddedInputAllowedLogic (Glue side) and EmbeddedWindowLogic
+    /// (game side).
     /// </summary>
-    public class SetEmbeddedFocusTestOverrideDto
+    public class SetEmbeddedInputAllowedDto
     {
-        public bool ClearOverride { get; set; }
-        public bool GlueProcessExists { get; set; }
-        public bool ForegroundMatchesGlueMainWindow { get; set; }
-        public bool ForegroundOwnedByThisGame { get; set; }
-        public bool CursorOverOwnWindow { get; set; }
-    }
-    #endregion
-
-    #region TestComputeCursorOverOwnWindowDto
-
-    /// <summary>
-    /// Test-only (issue #2205): drives GlueControl.Editing.EmbeddedWindowLogic.ComputeCursorOverOwnWindow
-    /// (Embedded) with synthetic Win32-call outcomes instead of a real ClientToScreen/WindowFromPoint
-    /// round trip against a real overlapping window - moving the real OS cursor precisely enough for that
-    /// turned out to be unreliable on multi-monitor setups (see issue #2205 discussion), so this pins the
-    /// decision logic (fails closed on ClientToScreen failure, fails closed on no window found, true/false
-    /// on owner PID match) directly instead.
-    /// </summary>
-    public class TestComputeCursorOverOwnWindowDto
-    {
-        public bool ClientToScreenSucceeded { get; set; }
-        public bool TopmostWindowFound { get; set; }
-        public uint TopmostWindowOwnerPid { get; set; }
-        public uint ThisProcessId { get; set; }
-    }
-
-    public class TestComputeCursorOverOwnWindowResponse
-    {
-        public bool Result { get; set; }
+        public bool IsAllowed { get; set; }
     }
     #endregion
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -1689,26 +1689,11 @@ namespace GlueControl
 
         #endregion
 
-        #region SetEmbeddedFocusTestOverrideDto
+        #region SetEmbeddedInputAllowedDto
 
-        private static void HandleDto(SetEmbeddedFocusTestOverrideDto dto)
+        private static void HandleDto(SetEmbeddedInputAllowedDto dto)
         {
-            EmbeddedWindowLogic.TestOverride = dto.ClearOverride
-                ? ((bool, bool, bool, bool)?)null
-                : (dto.GlueProcessExists, dto.ForegroundMatchesGlueMainWindow, dto.ForegroundOwnedByThisGame,
-                    dto.CursorOverOwnWindow);
-        }
-
-        #endregion
-
-        #region TestComputeCursorOverOwnWindowDto
-
-        private static TestComputeCursorOverOwnWindowResponse HandleDto(TestComputeCursorOverOwnWindowDto dto)
-        {
-            var topmostWindowAtCursor = dto.TopmostWindowFound ? new IntPtr(1) : IntPtr.Zero;
-            var result = EmbeddedWindowLogic.ComputeCursorOverOwnWindow(
-                dto.ClientToScreenSucceeded, topmostWindowAtCursor, dto.TopmostWindowOwnerPid, dto.ThisProcessId);
-            return new TestComputeCursorOverOwnWindowResponse { Result = result };
+            EmbeddedWindowLogic.IsInputAllowedFromGlue = dto.IsAllowed;
         }
 
         #endregion

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -621,45 +621,23 @@ namespace GlueControl.Dtos
     }
     #endregion
 
-    #region SetEmbeddedFocusTestOverrideDto
+    #region SetEmbeddedInputAllowedDto
 
     /// <summary>
-    /// Test-only (issue #2183): forces GlueControl.Editing.EmbeddedWindowLogic.IsParentGlueFocused to a
-    /// synthetic result instead of inspecting real OS focus/process state, which the LiveGameProcess
-    /// harness can't fake (no real "GlueFormsCore" process, no way to move real OS foreground). Send
-    /// with ClearOverride=true to go back to the real (production) check.
+    /// Pushed from Glue to the embedded game whenever the answer changes: may the game act on mouse
+    /// input right now? True while the embedded game window is the topmost window under the cursor and
+    /// Glue's application is the active one.
+    ///
+    /// Glue owns this decision because Glue is a real Windows-only WPF/WinForms process where
+    /// GetForegroundWindow/GetCursorPos/WindowFromPoint actually work. The same calls inside the game
+    /// were compile-time stubs for years - GlueControl/Embedded compiles into the user's game project,
+    /// which never defines WINDOWS - which is what made issues #2183, #2205 and #2214 look like
+    /// per-machine OS flakiness. See EmbeddedInputAllowedLogic (Glue side) and EmbeddedWindowLogic
+    /// (game side).
     /// </summary>
-    public class SetEmbeddedFocusTestOverrideDto
+    public class SetEmbeddedInputAllowedDto
     {
-        public bool ClearOverride { get; set; }
-        public bool GlueProcessExists { get; set; }
-        public bool ForegroundMatchesGlueMainWindow { get; set; }
-        public bool ForegroundOwnedByThisGame { get; set; }
-        public bool CursorOverOwnWindow { get; set; }
-    }
-    #endregion
-
-    #region TestComputeCursorOverOwnWindowDto
-
-    /// <summary>
-    /// Test-only (issue #2205): drives GlueControl.Editing.EmbeddedWindowLogic.ComputeCursorOverOwnWindow
-    /// with synthetic Win32-call outcomes instead of a real ClientToScreen/WindowFromPoint round trip
-    /// against a real overlapping window - moving the real OS cursor precisely enough for that turned out
-    /// to be unreliable on multi-monitor setups (see issue #2205 discussion), so this pins the decision
-    /// logic (fails closed on ClientToScreen failure, fails closed on no window found, true/false on owner
-    /// PID match) directly instead.
-    /// </summary>
-    public class TestComputeCursorOverOwnWindowDto
-    {
-        public bool ClientToScreenSucceeded { get; set; }
-        public bool TopmostWindowFound { get; set; }
-        public uint TopmostWindowOwnerPid { get; set; }
-        public uint ThisProcessId { get; set; }
-    }
-
-    public class TestComputeCursorOverOwnWindowResponse
-    {
-        public bool Result { get; set; }
+        public bool IsAllowed { get; set; }
     }
     #endregion
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -1562,307 +1562,56 @@ namespace GlueControl.Editing
     }
 
 
+    /// <summary>
+    /// Decides whether the embedded game should act on mouse input.
+    ///
+    /// Deliberately contains NO Win32 calls, and this is load-bearing. Everything under
+    /// GlueControl/Embedded is &lt;Compile Remove&gt;d from GameCommunicationPlugin.csproj and compiles
+    /// inside the USER'S game project instead, whose DefineConstants are MONOGAME;DESKTOP_GL;MONOGAME_381
+    /// - never WINDOWS. The `#if WINDOWS` P/Invoke block this class used to carry was therefore dead in
+    /// every real project and in the LiveGameProcess harness: GetForegroundWindow() always returned
+    /// IntPtr.Zero, ClientToScreen() always returned false, GetCursorPos() always returned false. That is
+    /// what actually broke issues #2183, #2205 and #2214 in turn, and why each one was diagnosed as "the
+    /// OS focus APIs are unreliable on that machine" - the APIs were never being called at all.
+    /// EmbeddedCodePlatformDefineTests now fails the build if a `#if WINDOWS` comes back here.
+    ///
+    /// "Is the user interacting with the embedded panel, and is anything covering it?" is answered in
+    /// Glue's own process - a genuinely Windows-only WPF/WinForms assembly where those APIs really do
+    /// work - by EmbeddedInputAllowedLogic, and pushed here as SetEmbeddedInputAllowedDto.
+    /// </summary>
     internal class EmbeddedWindowLogic
     {
-
-        static DateTime lastUpdate;
-
         public static bool IsEmbedded { get; set; }
 
-        static System.Diagnostics.Process glueProcess;
         public static bool IsGlueShowingModalWindow { get; set; }
 
         /// <summary>
-        /// Test-only: when set, IsParentGlueFocused uses these values instead of calling
-        /// GetForegroundWindow()/GetWindowThreadProcessId() and inspecting a real "GlueFormsCore"
-        /// process. There's no way to spin up a real Glue process (or fake OS focus/window ownership)
-        /// from the LiveGameProcess test harness, so this is how issue #2183's fix
-        /// (foregroundOwnedByThisGame) gets pinned by a deterministic test. Set via
-        /// SetEmbeddedFocusTestOverrideDto.
+        /// Pushed from Glue (SetEmbeddedInputAllowedDto) whenever it changes: true while the embedded
+        /// game window is the topmost window under the cursor AND Glue's application is the active one.
+        ///
+        /// This is the SLOW-changing half of the gate - it only moves when the user alt-tabs, or drags
+        /// another window over the panel. The fast-changing half (where the cursor is right now) stays
+        /// in the game as FlatRedBall.Input.Mouse.IsInGameWindow(), which is per-frame accurate and
+        /// needs no OS call, so a slightly stale push can never make a click land at wrong coordinates.
+        ///
+        /// Starts false so a game that never hears from Glue fails closed (issue #2154's "when in doubt,
+        /// block"); Glue pushes the current value as part of embedding, so there is no gap in practice.
         /// </summary>
-        internal static (bool glueProcessExists, bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame,
-            bool cursorOverOwnWindow)? TestOverride;
+        public static bool IsInputAllowedFromGlue { get; set; }
+
+        internal static bool ComputeIsFocused(bool isEmbedded, bool isModalWindowOpen, bool isInputAllowedFromGlue) =>
+            isEmbedded && isInputAllowedFromGlue && !isModalWindowOpen;
+
+        public static bool IsParentGlueFocused =>
+            ComputeIsFocused(IsEmbedded, IsGlueShowingModalWindow, IsInputAllowedFromGlue);
 
         /// <summary>
-        /// Pure decision logic, split out of IsParentGlueFocused so it can be exercised with synthetic
-        /// inputs (see TestOverride) instead of only through real OS focus/process state.
+        /// Every input to IsParentGlueFocused plus the result, for EmbeddedDiagnosticsLogger (issue
+        /// #2196) so a gate misfire can be read back from a log instead of only reproduced locally.
         /// </summary>
-        internal static bool ComputeIsFocused(bool isEmbedded, bool isModalWindowOpen, bool glueProcessExists,
-            bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame, bool cursorOverOwnWindow)
-        {
-            if (!glueProcessExists)
-            {
-                return false;
-            }
-
-            return isEmbedded
-                && (foregroundMatchesGlueMainWindow || foregroundOwnedByThisGame || cursorOverOwnWindow)
-                && !isModalWindowOpen;
-        }
-
-        public static bool IsParentGlueFocused
-        {
-            get
-            {
-                var raw = GetRawFocusInputs();
-                return ComputeIsFocused(IsEmbedded, IsGlueShowingModalWindow,
-                    raw.glueProcessExists, raw.foregroundMatchesGlueMainWindow, raw.foregroundOwnedByThisGame,
-                    raw.cursorOverOwnWindow);
-            }
-        }
-
-        /// <summary>
-        /// The raw, real OS/process inputs behind IsParentGlueFocused, split out so EmbeddedDiagnosticsLogger
-        /// (issue #2196) can report them without duplicating this logic. Respects TestOverride the same way
-        /// IsParentGlueFocused itself does.
-        /// </summary>
-        internal static (bool glueProcessExists, bool foregroundMatchesGlueMainWindow, bool foregroundOwnedByThisGame,
-            bool cursorOverOwnWindow) GetRawFocusInputs()
-        {
-            if (TestOverride is { } testOverride)
-            {
-                return testOverride;
-            }
-
-            if (DateTime.Now - lastUpdate > TimeSpan.FromSeconds(5))
-            {
-                lastUpdate = DateTime.Now;
-                RefreshGlueProcess();
-            }
-
-            var glueProcessExists = glueProcess != null;
-            var fg = GetForegroundWindow();
-            var foregroundMatchesGlueMainWindow = glueProcessExists && glueProcess.MainWindowHandle == fg;
-
-            // The embedded game window is reparented into Glue via a raw SetParent (no WS_CHILD style
-            // fixup), so Windows still lets it take OS foreground/activation on its own when clicked -
-            // GetForegroundWindow() then returns the game's own window, not Glue's. When embedded,
-            // that IS Glue's UI from the user's perspective, so treat it as focused too (issue #2183 -
-            // this was masked for years by the old `|| Game.IsActive` fallback that #2154's fix
-            // removed).
-            var foregroundOwnedByThisGame = false;
-            if (glueProcessExists && !foregroundMatchesGlueMainWindow)
-            {
-                GetWindowThreadProcessId(fg, out var fgOwnerPid);
-                foregroundOwnedByThisGame = fgOwnerPid == (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
-            }
-
-            // Observed on a real user machine (issue #2203/#2205 investigation, 2026-08-24/25): every
-            // single click on the embedded panel had GetForegroundWindow() return IntPtr.Zero - not Glue's
-            // window, not the game's own window, no window at all - so neither check above ever passed and
-            // clicks were silently dropped. A follow-up attempt using WindowFromPoint at the raw cursor
-            // position failed too - GetCursorPos() itself returned false with Win32 error 87
-            // (ERROR_INVALID_PARAMETER) on that machine, so the OS focus/cursor APIs are evidently
-            // unreliable here in more than one way, not just GetForegroundWindow(). The fix that shipped
-            // used FlatRedBall.Input.Mouse.IsInGameWindow() instead - a pure bounds check against the
-            // client-relative position MonoGame's own input pipeline already tracks (not these Win32
-            // calls), valid "even if the game window does not have focus."
-            //
-            // Follow-up (#2205 continued): a bounds check alone can't detect occlusion. If another real
-            // window is drawn on top of the embedded game at the cursor's position (dragged over it, or
-            // any overlapping window), IsInGameWindow() still says "inside my bounds" - it has no Z-order
-            // awareness - so the game kept reporting clicks/hovers meant for the window on top of it.
-            // Fixed by adding a topmost check: convert the already-reliable client-relative mouse position
-            // to screen coordinates via ClientToScreen on our OWN window handle (not GetCursorPos, which
-            // is the API that failed above), then WindowFromPoint at that screen position to find out who
-            // is ACTUALLY topmost there. Deliberately fails CLOSED (cursorOverOwnWindow stays false) if
-            // ClientToScreen fails or WindowFromPoint resolves to nothing/another process - same "when in
-            // doubt, block" philosophy as #2154. Only probed as a last resort (like foregroundOwnedByThisGame
-            // above), not as a blanket "foreground is unknown -> assume focused" - that was tried first and
-            // a regression test (ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored) caught
-            // that it could also mask a genuine focus loss to an unrelated window (re-opening #2154).
-            // Not gated on glueProcessExists here (unlike the two checks above) - ComputeIsFocused already
-            // requires it independently for the final gate result, so gating it here too would only be a
-            // micro-optimization (skip the Win32 calls when Glue clearly isn't running at all).
-            var cursorOverOwnWindow = false;
-            if (!foregroundMatchesGlueMainWindow && !foregroundOwnedByThisGame)
-            {
-                var diagnostics = ComputeCursorOverOwnWindowDiagnostics();
-                cursorOverOwnWindow = diagnostics.mouseInGameWindow && ComputeCursorOverOwnWindow(
-                    diagnostics.clientToScreenSucceeded, diagnostics.topmostWindowAtCursor,
-                    diagnostics.topmostWindowOwnerPid, diagnostics.thisProcessId);
-            }
-
-            return (glueProcessExists, foregroundMatchesGlueMainWindow, foregroundOwnedByThisGame, cursorOverOwnWindow);
-        }
-
-        /// <summary>
-        /// Runs the raw Win32 half of the occlusion check (issue #2205 follow-up: client-relative mouse
-        /// position -> screen coordinates -> topmost window there), separated from ComputeCursorOverOwnWindow's
-        /// pure decision logic below so each half stays simple. Only reaches the actual Win32 calls when
-        /// FlatRedBall.Input.Mouse.IsInGameWindow() is true.
-        /// </summary>
-        internal static (bool mouseInGameWindow, int mouseX, int mouseY, bool clientToScreenSucceeded,
-            IntPtr topmostWindowAtCursor, uint topmostWindowOwnerPid, uint thisProcessId) ComputeCursorOverOwnWindowDiagnostics()
-        {
-            var mouseInGameWindow = FlatRedBall.Input.InputManager.Mouse.IsInGameWindow();
-            var mouseX = FlatRedBall.Input.InputManager.Mouse.X;
-            var mouseY = FlatRedBall.Input.InputManager.Mouse.Y;
-            var thisProcessId = (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
-
-            var clientToScreenSucceeded = false;
-            var topmostWindowAtCursor = IntPtr.Zero;
-            uint topmostWindowOwnerPid = 0;
-
-            if (mouseInGameWindow)
-            {
-                var gameWindowHandle = FlatRedBallServices.Game.Window.Handle;
-                var clientPoint = new Win32Point { X = mouseX, Y = mouseY };
-                clientToScreenSucceeded = ClientToScreen(gameWindowHandle, ref clientPoint);
-                topmostWindowAtCursor = clientToScreenSucceeded ? WindowFromPoint(clientPoint) : IntPtr.Zero;
-                if (topmostWindowAtCursor != IntPtr.Zero)
-                {
-                    GetWindowThreadProcessId(topmostWindowAtCursor, out topmostWindowOwnerPid);
-                }
-            }
-
-            return (mouseInGameWindow, mouseX, mouseY, clientToScreenSucceeded, topmostWindowAtCursor,
-                topmostWindowOwnerPid, thisProcessId);
-        }
-
-        /// <summary>
-        /// Pure decision logic behind the occlusion check in GetRawFocusInputs, split out of the raw Win32
-        /// orchestration above (ComputeCursorOverOwnWindowDiagnostics) the same way ComputeIsFocused is
-        /// split from GetRawFocusInputs. Only called after the cursor is already confirmed within our own
-        /// window's bounds (FlatRedBall.Input.Mouse.IsInGameWindow()); this is specifically the
-        /// topmost/occlusion half. Fails closed (false) whenever the outcome can't be positively confirmed,
-        /// matching #2154's "when in doubt, block" philosophy - a missing/ambiguous signal must never be
-        /// read as "we're on top."
-        /// </summary>
-        internal static bool ComputeCursorOverOwnWindow(bool clientToScreenSucceeded, IntPtr topmostWindowAtCursor,
-            uint topmostWindowOwnerPid, uint thisProcessId)
-        {
-            if (!clientToScreenSucceeded || topmostWindowAtCursor == IntPtr.Zero)
-            {
-                return false;
-            }
-
-            return topmostWindowOwnerPid == thisProcessId;
-        }
-
-        /// <summary>
-        /// Diagnostics-only (issue #2196): every input to IsParentGlueFocused plus the result, formatted for
-        /// EmbeddedDiagnosticsLogger so a per-machine gate misfire like #2183 can be read back from a log
-        /// instead of only reproduced locally.
-        /// </summary>
-        internal static string DescribeFocusState()
-        {
-            var raw = GetRawFocusInputs();
-            var isFocused = ComputeIsFocused(IsEmbedded, IsGlueShowingModalWindow,
-                raw.glueProcessExists, raw.foregroundMatchesGlueMainWindow, raw.foregroundOwnedByThisGame,
-                raw.cursorOverOwnWindow);
-
-            return $"isEmbedded={IsEmbedded} glueProcessExists={raw.glueProcessExists} " +
-                $"foregroundMatchesGlueMainWindow={raw.foregroundMatchesGlueMainWindow} " +
-                $"foregroundOwnedByThisGame={raw.foregroundOwnedByThisGame} " +
-                $"cursorOverOwnWindow={raw.cursorOverOwnWindow} " +
-                $"isModalWindowOpen={IsGlueShowingModalWindow} isParentGlueFocused={isFocused} " +
-                DescribeRawWindowIdentity();
-        }
-
-        /// <summary>
-        /// Temporary, extra-verbose diagnostics (not part of ComputeIsFocused's inputs) for the #2196 log:
-        /// when both foregroundMatchesGlueMainWindow and foregroundOwnedByThisGame come back false, this
-        /// says WHOSE window actually has OS foreground instead of leaving that a mystery.
-        /// </summary>
-        static string DescribeRawWindowIdentity()
-        {
-            if (TestOverride != null)
-            {
-                return "";
-            }
-
-            try
-            {
-                var fg = GetForegroundWindow();
-                GetWindowThreadProcessId(fg, out var fgOwnerPid);
-
-                string fgProcessName = "<unknown>";
-                try
-                {
-                    fgProcessName = System.Diagnostics.Process.GetProcessById((int)fgOwnerPid).ProcessName;
-                }
-                catch { /* process may have exited between the two calls, or be inaccessible */ }
-
-                var glueMainWindowHandle = glueProcess?.MainWindowHandle ?? IntPtr.Zero;
-
-                var cursorPosResult = GetCursorPos(out var cursorPos);
-                var getCursorPosError = cursorPosResult ? 0 : System.Runtime.InteropServices.Marshal.GetLastWin32Error();
-                var windowUnderCursor = cursorPosResult ? WindowFromPoint(cursorPos) : IntPtr.Zero;
-                uint cursorWindowOwnerPid = 0;
-                string cursorWindowProcessName = "<none>";
-                if (windowUnderCursor != IntPtr.Zero)
-                {
-                    GetWindowThreadProcessId(windowUnderCursor, out cursorWindowOwnerPid);
-                    try
-                    {
-                        cursorWindowProcessName = System.Diagnostics.Process.GetProcessById((int)cursorWindowOwnerPid).ProcessName;
-                    }
-                    catch { /* process may have exited between the two calls, or be inaccessible */ }
-                }
-
-                return $"fgHwnd={fg} fgOwnerPid={fgOwnerPid} fgProcessName={fgProcessName} " +
-                    $"glueProcessId={glueProcess?.Id} glueMainWindowHandle={glueMainWindowHandle} " +
-                    $"thisProcessId={System.Diagnostics.Process.GetCurrentProcess().Id} " +
-                    $"getCursorPosSucceeded={cursorPosResult} getCursorPosError={getCursorPosError} " +
-                    $"cursorPos=({cursorPos.X},{cursorPos.Y}) " +
-                    $"windowUnderCursor={windowUnderCursor} windowUnderCursorOwnerPid={cursorWindowOwnerPid} " +
-                    $"windowUnderCursorProcessName={cursorWindowProcessName}";
-            }
-            catch (Exception ex)
-            {
-                return $"<DescribeRawWindowIdentity threw: {ex.Message}>";
-            }
-        }
-
-#if WINDOWS
-
-
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        static extern IntPtr GetForegroundWindow();
-
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
-
-        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
-        static extern bool GetCursorPos(out Win32Point point);
-
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        static extern IntPtr WindowFromPoint(Win32Point point);
-
-        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
-        static extern bool ClientToScreen(IntPtr hWnd, ref Win32Point point);
-
-#else
-        static IntPtr GetForegroundWindow() => IntPtr.Zero;
-        static uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId) { processId = 0; return 0; }
-        static bool GetCursorPos(out Win32Point point) { point = default; return false; }
-        static IntPtr WindowFromPoint(Win32Point point) => IntPtr.Zero;
-        static bool ClientToScreen(IntPtr hWnd, ref Win32Point point) => false;
-
-#endif
-
-        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        struct Win32Point
-        {
-            public int X;
-            public int Y;
-        }
-        private static void RefreshGlueProcess()
-        {
-            glueProcess = null;
-
-            var processes = System.Diagnostics.Process.GetProcesses();
-            // see if the foreground window is Glue:
-            foreach (var process in processes)
-            {
-                if (process.ProcessName == "GlueFormsCore")
-                {
-                    glueProcess = process;
-                    break;
-                }
-            }
-        }
+        internal static string DescribeFocusState() =>
+            $"isEmbedded={IsEmbedded} isInputAllowedFromGlue={IsInputAllowedFromGlue} " +
+            $"isModalWindowOpen={IsGlueShowingModalWindow} isParentGlueFocused={IsParentGlueFocused}";
     }
 
     /// <summary>

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -491,7 +491,12 @@ namespace GlueControl.Editing
                 }
                 else if(mouse.AnyButtonPushed())
                 {
-                    wasPushedInWindow = mouse.IsInGameWindow();
+                    // IsInGameWindow() alone is a client-bounds check with no Z-order awareness, so a
+                    // press that landed on a window sitting ON TOP of the embedded panel still counts as
+                    // "in the window" by bounds. IsGameOrGlueActive is what carries Glue's answer about
+                    // who is actually topmost there, so a gesture only counts as ours if both hold at
+                    // the moment of the press.
+                    wasPushedInWindow = mouse.IsInGameWindow() && IsGameOrGlueActive;
                 }
 
                 if (EmbeddedDiagnosticsLogger.IsEnabled)
@@ -575,12 +580,18 @@ namespace GlueControl.Editing
 
                 UpdateMarkers(didChangeItemOver);
 
-                // The measurement marker responds to right-drags, but unlike the left-button logic above
-                // it isn't inside the IsGameOrGlueActive block, and it doesn't check focus itself. Edit mode
-                // sets Cursor.RequiresGameWindowInFocus = false (the game window is reparented into Glue so it
-                // never gets normal focus), so without this check a right-drag anywhere on screen would draw
-                // the measurement overlay even with Glue behind another window.
-                if (IsGameOrGlueActive && (mouse.IsInGameWindow() || wasPushedInWindow))
+                // The measurement marker responds to right-drags and doesn't check focus itself: edit mode
+                // sets Cursor.RequiresGameWindowInFocus = false (the game window is reparented into Glue so
+                // it never gets normal focus), so Cursor.SecondaryDown stays true for the whole drag no
+                // matter what is on top. It therefore has to be gated here.
+                //
+                // Gate on where the gesture STARTED, not on where the cursor is each frame - the same
+                // push-time decision DoGrabLogic makes via ComputeShouldTreatAsPush. Re-testing per frame
+                // got this wrong in both directions: a right-drag begun on a window covering the panel
+                // started measuring the moment the drag crossed onto a visible part of the game, and a
+                // measure legitimately begun on the game stopped drawing as soon as the cursor left the
+                // window's bounds.
+                if (wasPushedInWindow)
                 {
                     UpdateMeasurementMarker();
                 }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -100,6 +100,8 @@ namespace GameCommunicationPlugin.GlueControl
 
         ModalReportingService _modalReportingService;
 
+        EmbeddedInputAllowedService _embeddedInputAllowedService;
+
         #endregion
 
         #region Startup
@@ -119,6 +121,13 @@ namespace GameCommunicationPlugin.GlueControl
             _modalReportingService = new ModalReportingService(
                 (System.ComponentModel.ISynchronizeInvoke)MainGlueWindow.Self, GlueCommands.Self.DialogCommands, CommandSender.Self);
             _modalReportingService.Initialize();
+
+            // The lambda defers reading gameHostView until the first timer tick, so this doesn't depend
+            // on CreateBuildControl having run yet.
+            _embeddedInputAllowedService = new EmbeddedInputAllowedService(
+                (System.ComponentModel.ISynchronizeInvoke)MainGlueWindow.Self, CommandSender.Self,
+                () => gameHostView?.EmbeddedGameWindowHandle ?? IntPtr.Zero);
+            _embeddedInputAllowedService.Initialize();
 
             CreateBuildControl();
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/EmbeddedInputAllowedService.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/EmbeddedInputAllowedService.cs
@@ -1,0 +1,174 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Timers;
+using GameCommunicationPlugin.GlueControl.CommandSending;
+using GameCommunicationPlugin.GlueControl.Dtos;
+
+namespace GameCommunicationPlugin.GlueControl.Managers;
+
+/// <summary>
+/// Answers "may the embedded game act on mouse input right now?" and pushes the answer to the game
+/// (<see cref="SetEmbeddedInputAllowedDto"/>) whenever it changes. Mirrors
+/// <see cref="ModalReportingService"/>: poll on a timer, send only on a change.
+///
+/// This decision used to live inside the game, where it was an OR-chain of Win32 focus guesses that
+/// grew a clause per bug report (#2183, #2205, #2214) and could never be right in both directions.
+/// Worse, all of those calls were compile-time stubs: GlueControl/Embedded compiles into the user's
+/// game project, which defines MONOGAME;DESKTOP_GL;MONOGAME_381 and never WINDOWS, so the
+/// `#if WINDOWS` P/Invokes there always returned IntPtr.Zero/false. Glue is a real Windows-only
+/// WPF/WinForms assembly, so the same APIs work here, and one precise question replaces the OR-chain:
+/// is the window the OS itself reports as topmost under the cursor our embedded game window?
+///
+/// That single check is Z-order-aware (so a window dragged over the panel blocks the game - #2154,
+/// #2214) and activation-independent (so the first click that returns focus to Glue still lands -
+/// #2183, #2187), which is exactly the pair the old heuristics kept trading against each other.
+/// </summary>
+class EmbeddedInputAllowedService
+{
+    Timer pollTimer;
+    private readonly ISynchronizeInvoke _synchronizingObject;
+    private readonly CommandSender _commandSender;
+    private readonly Func<IntPtr> _getEmbeddedGameWindowHandle;
+
+    public EmbeddedInputAllowedService(ISynchronizeInvoke synchronizingObject, CommandSender commandSender,
+        Func<IntPtr> getEmbeddedGameWindowHandle)
+    {
+        _synchronizingObject = synchronizingObject;
+        _commandSender = commandSender;
+        _getEmbeddedGameWindowHandle = getEmbeddedGameWindowHandle;
+    }
+
+    public void Initialize()
+    {
+        // Occlusion and app switching change on human timescales (dragging a window off the panel,
+        // alt-tabbing), not per-frame, so this doesn't need to keep up with the mouse. The game
+        // combines this with its own per-frame FlatRedBall.Input.Mouse.IsInGameWindow() for the
+        // cursor's actual position, so a poll interval can never misplace a click.
+        var frequency = 100; // ms
+        pollTimer = new Timer(frequency);
+        pollTimer.Elapsed += UpdateTimer;
+        pollTimer.SynchronizingObject = _synchronizingObject;
+        pollTimer.Start();
+    }
+
+    bool? lastAcknowledged = null;
+    bool isSending = false;
+
+    private async void UpdateTimer(object sender, ElapsedEventArgs e)
+    {
+        if (!_commandSender.IsConnected)
+        {
+            // A freshly launched game starts with IsInputAllowedFromGlue false and hasn't been told
+            // otherwise, so forget what the previous game was told - otherwise the first push after a
+            // restart is suppressed as "no change" and the new game's gate stays shut for good.
+            lastAcknowledged = null;
+            return;
+        }
+
+        if (isSending)
+        {
+            // A send is still in flight; skip rather than queue up. The next tick re-reads current
+            // state anyway, so nothing is lost by dropping this one.
+            return;
+        }
+
+        var isAllowed = ReadIsAllowed(_getEmbeddedGameWindowHandle());
+
+        if (lastAcknowledged == isAllowed)
+        {
+            return;
+        }
+
+        isSending = true;
+        try
+        {
+            var response = await _commandSender.Send(new SetEmbeddedInputAllowedDto
+            {
+                IsAllowed = isAllowed
+            });
+
+            // Only remember it once the game confirms it arrived. A game that is connected but not yet
+            // able to dispatch DTOs (GlueControlManager.Self still null during Game1.Initialize) answers
+            // unsuccessfully, and recording that as sent would leave the game's gate shut until the
+            // value happened to change again - the exact "clicks do nothing" symptom this replaces.
+            if (response?.Succeeded == true)
+            {
+                lastAcknowledged = isAllowed;
+            }
+        }
+        catch
+        {
+            // Game went away mid-send; the next tick re-evaluates from scratch.
+        }
+        finally
+        {
+            isSending = false;
+        }
+    }
+
+    /// <summary>
+    /// The real OS half: where is the cursor, and who owns the window actually drawn there. Split from
+    /// <see cref="ComputeIsAllowed"/> so the decision can be unit tested with synthetic inputs and this
+    /// can be tested against a real window (see EmbeddedInputAllowedServiceTests) - the previous
+    /// version of this feature had thorough tests of its decision logic and none of its Win32 calls,
+    /// which is precisely why nobody noticed the calls weren't happening.
+    /// </summary>
+    internal static bool ReadIsAllowed(IntPtr embeddedGameWindowHandle)
+    {
+        var cursorPositionKnown = GetCursorPos(out var cursorPosition);
+        var topmostWindowAtCursor = cursorPositionKnown ? WindowFromPoint(cursorPosition) : IntPtr.Zero;
+
+        var topmostBelongsToEmbeddedGame =
+            topmostWindowAtCursor != IntPtr.Zero &&
+            embeddedGameWindowHandle != IntPtr.Zero &&
+            (topmostWindowAtCursor == embeddedGameWindowHandle ||
+                IsChild(embeddedGameWindowHandle, topmostWindowAtCursor));
+
+        return ComputeIsAllowed(embeddedGameWindowHandle, cursorPositionKnown, topmostWindowAtCursor,
+            topmostBelongsToEmbeddedGame);
+    }
+
+    /// <summary>
+    /// Pure decision logic. Fails closed whenever the answer can't be positively confirmed, matching
+    /// #2154's "when in doubt, block."
+    /// </summary>
+    /// <param name="embeddedGameWindowHandle">IntPtr.Zero when no game is currently embedded.</param>
+    /// <param name="cursorPositionKnown">False when GetCursorPos failed.</param>
+    /// <param name="topmostWindowAtCursor">IntPtr.Zero when WindowFromPoint found no window there.</param>
+    /// <param name="topmostBelongsToEmbeddedGame">
+    /// Whether that topmost window is the embedded game window or a child of it. SDL/MonoGame uses a
+    /// single HWND today, but a child is still the game as far as this question goes.
+    /// </param>
+    internal static bool ComputeIsAllowed(IntPtr embeddedGameWindowHandle, bool cursorPositionKnown,
+        IntPtr topmostWindowAtCursor, bool topmostBelongsToEmbeddedGame)
+    {
+        if (embeddedGameWindowHandle == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        if (!cursorPositionKnown || topmostWindowAtCursor == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        return topmostBelongsToEmbeddedGame;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern bool GetCursorPos(out Win32Point point);
+
+    [DllImport("user32.dll")]
+    static extern IntPtr WindowFromPoint(Win32Point point);
+
+    [DllImport("user32.dll")]
+    static extern bool IsChild(IntPtr hWndParent, IntPtr hWnd);
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Win32Point
+    {
+        public int X;
+        public int Y;
+    }
+}

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Views/GameHostView.xaml.cs
@@ -243,6 +243,13 @@ namespace OfficialPlugins.GameHost.Views
             }
         }
 
+        /// <summary>
+        /// The embedded game's window handle while a game is actually embedded and running,
+        /// IntPtr.Zero otherwise. EmbeddedInputAllowedService polls this to decide whether the game
+        /// window is the topmost window under the cursor.
+        /// </summary>
+        public IntPtr EmbeddedGameWindowHandle => IsGameEmbeddedAndRunning ? gameHandle : IntPtr.Zero;
+
         private bool IsGameEmbeddedAndRunning =>
             ViewModel.IsRunning &&
             ViewModel.IsGenerateGlueControlManagerInGame1Checked &&

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbeddedCodePlatformDefineTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbeddedCodePlatformDefineTests.cs
@@ -1,0 +1,41 @@
+using System.IO;
+using System.Linq;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin;
+
+/// <summary>
+/// Everything under GlueControl/Embedded is &lt;Compile Remove&gt;d from GameCommunicationPlugin.csproj -
+/// it is copied into the user's game project and compiled there, never inside Glue. Game projects
+/// define MONOGAME;DESKTOP_GL;MONOGAME_381 (see any Samples/*/**.csproj); WINDOWS is defined by
+/// exactly one project in this repo (Tests/TestProjectDesktopNet6) and by no project a user ever
+/// gets. So a `#if WINDOWS` block in embedded code is dead in every real project - the `#else` arm
+/// is what ships - and it fails silently: it compiles, it reads as platform-guarded, and the stubs
+/// return default values that look like real answers.
+/// </summary>
+public class EmbeddedCodePlatformDefineTests
+{
+    [Fact]
+    public void EmbeddedCode_DoesNotBranchOnTheWindowsDefine()
+    {
+        var embeddedRoot = Path.Combine(RepoPaths.FrbRoot, "FRBDK", "Glue", "GameCommunicationPlugin",
+            "GlueControl", "Embedded");
+        Directory.Exists(embeddedRoot).ShouldBeTrue($"Expected embedded live-edit source at {embeddedRoot}.");
+
+        var offenders = Directory.EnumerateFiles(embeddedRoot, "*.cs", SearchOption.AllDirectories)
+            .SelectMany(file => File.ReadAllLines(file)
+                .Select((line, index) => (file, lineNumber: index + 1, text: line.Trim()))
+                .Where(x => x.text.StartsWith("#if ") || x.text.StartsWith("#elif "))
+                .Where(x => System.Text.RegularExpressions.Regex.IsMatch(x.text, @"\bWINDOWS\b")))
+            .Select(x => $"{Path.GetRelativePath(embeddedRoot, x.file)}:{x.lineNumber}: {x.text}")
+            .ToList();
+
+        offenders.ShouldBeEmpty(
+            "Embedded live-edit code is compiled inside the user's game project, which never defines " +
+            "WINDOWS - so the #else arm is what actually ships and the guarded code is dead. Use a " +
+            "runtime OS check, or move the Windows-only work into Glue itself, which really is a " +
+            "Windows-only assembly. Offenders:\n" + string.Join("\n", offenders));
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbeddedInputAllowedServiceTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbeddedInputAllowedServiceTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Threading;
+using GameCommunicationPlugin.GlueControl.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin;
+
+/// <summary>
+/// Covers the Glue-side half of the embedded input gate: EmbeddedInputAllowedService decides whether
+/// the embedded game window is the topmost window under the cursor, and pushes the answer to the game.
+///
+/// The Win32 test below matters more than the decision table. The four bug reports this feature
+/// replaced (#2183, #2205, #2214) were all the same failure: the OS calls behind the decision never
+/// ran (they were behind a `#if WINDOWS` that game projects don't define), while the decision logic
+/// itself was tested thoroughly with synthetic booleans and stayed green through every regression.
+/// Testing only the pure function reproduces exactly that blind spot, so ReadIsAllowed is exercised
+/// against a real window with the real cursor.
+/// </summary>
+public class EmbeddedInputAllowedServiceTests
+{
+    [Fact]
+    public void ComputeIsAllowed_NoEmbeddedGame_IsFalse()
+    {
+        EmbeddedInputAllowedService.ComputeIsAllowed(IntPtr.Zero, cursorPositionKnown: true,
+            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true)
+            .ShouldBeFalse("no game is embedded, so there is nothing for a click to reach");
+    }
+
+    [Fact]
+    public void ComputeIsAllowed_CursorPositionUnknown_FailsClosed()
+    {
+        EmbeddedInputAllowedService.ComputeIsAllowed(new IntPtr(1), cursorPositionKnown: false,
+            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true)
+            .ShouldBeFalse("GetCursorPos failed, so the answer can't be confirmed and must fail closed (#2154)");
+    }
+
+    [Fact]
+    public void ComputeIsAllowed_NoWindowAtCursor_FailsClosed()
+    {
+        EmbeddedInputAllowedService.ComputeIsAllowed(new IntPtr(1), cursorPositionKnown: true,
+            topmostWindowAtCursor: IntPtr.Zero, topmostBelongsToEmbeddedGame: false)
+            .ShouldBeFalse("nothing is drawn at the cursor (e.g. off-screen), so fail closed");
+    }
+
+    [Fact]
+    public void ComputeIsAllowed_AnotherWindowIsTopmost_IsFalse()
+    {
+        EmbeddedInputAllowedService.ComputeIsAllowed(new IntPtr(1), cursorPositionKnown: true,
+            topmostWindowAtCursor: new IntPtr(2), topmostBelongsToEmbeddedGame: false)
+            .ShouldBeFalse("something else is drawn over the embedded game at the cursor - the click is " +
+                "that window's, not the game's (#2154, #2214)");
+    }
+
+    [Fact]
+    public void ComputeIsAllowed_EmbeddedGameIsTopmost_IsTrue()
+    {
+        EmbeddedInputAllowedService.ComputeIsAllowed(new IntPtr(1), cursorPositionKnown: true,
+            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true)
+            .ShouldBeTrue("the game window is what the OS reports as topmost under the cursor");
+    }
+
+    [Fact]
+    public void ReadIsAllowed_NoEmbeddedGame_IsFalse() =>
+        EmbeddedInputAllowedService.ReadIsAllowed(IntPtr.Zero).ShouldBeFalse();
+
+    /// <summary>
+    /// The real thing: a real window, the real cursor, real GetCursorPos/WindowFromPoint. Proves the OS
+    /// calls actually happen and actually answer - which is the exact assurance the previous
+    /// implementation never had.
+    /// </summary>
+    [StaFact]
+    public void ReadIsAllowed_RealWindow_TracksWhetherTheCursorIsOverIt()
+    {
+        GetCursorPos(out var originalCursorPosition).ShouldBeTrue(
+            "GetCursorPos must work in Glue's own process - the whole design depends on it");
+
+        var window = new Window
+        {
+            Width = 400,
+            Height = 300,
+            Left = 100,
+            Top = 100,
+            Topmost = true,
+            ShowInTaskbar = false,
+            WindowStyle = WindowStyle.None,
+        };
+
+        try
+        {
+            window.Show();
+            PumpDispatcher();
+
+            var handle = new WindowInteropHelper(window).Handle;
+            handle.ShouldNotBe(IntPtr.Zero);
+
+            // Read the window's real screen rect rather than trusting Left/Top: those are WPF DIPs, and
+            // the cursor is positioned in physical pixels.
+            GetWindowRect(handle, out var rect).ShouldBeTrue();
+            var centerX = (rect.Left + rect.Right) / 2;
+            var centerY = (rect.Top + rect.Bottom) / 2;
+
+            SetCursorPos(centerX, centerY).ShouldBeTrue();
+            PumpDispatcher();
+
+            EmbeddedInputAllowedService.ReadIsAllowed(handle).ShouldBeTrue(
+                "the cursor is over the window and nothing covers it, so input belongs to it");
+
+            // Move the cursor off the window (its top-left corner is at least 100px in from the screen
+            // edge, so this lands outside it) and the same call must flip.
+            SetCursorPos(rect.Left - 50, rect.Top - 50).ShouldBeTrue();
+            PumpDispatcher();
+
+            EmbeddedInputAllowedService.ReadIsAllowed(handle).ShouldBeFalse(
+                "the cursor is no longer over the window, so a click there isn't the window's");
+        }
+        finally
+        {
+            SetCursorPos(originalCursorPosition.X, originalCursorPosition.Y);
+            window.Close();
+            PumpDispatcher();
+        }
+    }
+
+    static void PumpDispatcher() =>
+        Dispatcher.CurrentDispatcher.Invoke(() => { }, DispatcherPriority.ContextIdle);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern bool SetCursorPos(int x, int y);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern bool GetCursorPos(out EmbeddedInputAllowedService.Win32Point point);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern bool GetWindowRect(IntPtr hWnd, out Win32Rect rect);
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct Win32Rect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/EditModeActivityGateTests.cs
@@ -21,16 +21,19 @@ namespace GlueUnitTests.Projects;
 /// IsGameOrGlueActive first, the same gate a real click goes through in EditingManager.Activity.
 /// SetBorderlessDto{IsBorderless=true} is the exact DTO real Glue sends to mark the window embedded
 /// (CommandReceiver.HandleDto(SetBorderlessDto), GameHostView.EmbedHwnd) - it's what sets
-/// EmbeddedWindowLogic.IsEmbedded=true here, same production wiring as a real embedded session. There's
-/// no real Glue.exe (process name "GlueFormsCore") running in this test process, so
-/// EmbeddedWindowLogic.IsParentGlueFocused deterministically returns false - exactly the "window is not
-/// the foreground window" state issue #2154 reports, without needing to fake real OS focus/covering.
+/// EmbeddedWindowLogic.IsEmbedded=true here, same production wiring as a real embedded session.
+///
+/// Whether input is allowed comes from Glue as SetEmbeddedInputAllowedDto - also the real production
+/// DTO (EmbeddedInputAllowedService). The game side no longer inspects OS focus state itself, so these
+/// tests drive the gate through the same path a real session does rather than through a test-only
+/// override, and the Win32 half that decides the value is tested against a real window in
+/// EmbeddedInputAllowedServiceTests.
 /// </summary>
 [Trait("Category", "LiveGame")]
 public class EditModeActivityGateTests
 {
     [StaFact]
-    public async Task ClickWhileEmbeddedAndNotForegroundGlue_IsIgnored()
+    public async Task ClickWhileEmbeddedAndGlueHasNotReportedInputAllowed_IsIgnored()
     {
         GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
 
@@ -58,9 +61,9 @@ public class EditModeActivityGateTests
         await Task.Delay(1000);
 
         // Real Glue sends this to mark the window embedded when it reparents the game window into
-        // itself. No real Glue.exe (process name "GlueFormsCore") is running here, so
-        // EmbeddedWindowLogic.IsParentGlueFocused is false - this is the "Glue is not the foreground
-        // window" state.
+        // itself. Deliberately no SetEmbeddedInputAllowedDto after it: IsInputAllowedFromGlue starts
+        // false, so this is also the fail-closed default - a game that has been embedded but hasn't yet
+        // been told anything about the cursor must not act on clicks (issue #2154).
         var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
         borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
 
@@ -73,7 +76,8 @@ public class EditModeActivityGateTests
 
         clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
         clickResponse.Data.WasProcessed.ShouldBeFalse(
-            "a click should be ignored while the game window is embedded but Glue is not the foreground window (issue #2154)");
+            "a click should be ignored while the game is embedded but Glue hasn't reported that the game " +
+            "window is the topmost window under the cursor (issue #2154)");
         clickResponse.Data.SelectedObjectNames.ShouldBeEmpty();
     }
 
@@ -122,18 +126,17 @@ public class EditModeActivityGateTests
     }
 
     /// <summary>
-    /// Reproduces issue #2183: the #2154 fix above made IsGameOrGlueActive depend solely on
-    /// IsParentGlueFocused (GetForegroundWindow() == glueProcess.MainWindowHandle) while embedded. But
-    /// the embedded game window is reparented via a raw SetParent with no WS_CHILD style fixup
-    /// (GameHostView.xaml.cs::EmbedHwnd), so Windows still lets it take OS foreground on its own when
-    /// clicked - GetForegroundWindow() then returns the game's own window, not Glue's. That made
-    /// click-select, deselect, and middle-mouse camera pan all silently stop working while embedded,
-    /// since they're all gated behind IsGameOrGlueActive. SetEmbeddedFocusTestOverrideDto simulates that
-    /// exact OS state (foreground owned by the game itself, not matching Glue's main window) since the
-    /// LiveGameProcess harness can't fake real OS focus/window ownership.
+    /// The other side of the gate: Glue reports that the embedded game window IS the topmost window
+    /// under the cursor, so a click must land. Covers what issues #2183 (click-select, deselect and
+    /// middle-mouse pan silently dead while embedded) and #2205 (every click dropped) both reported.
+    ///
+    /// SetEmbeddedInputAllowedDto is the real production DTO - EmbeddedInputAllowedService in Glue
+    /// sends exactly this - so unlike the test-only focus override this replaces, the game side is
+    /// exercised through the same path a real session uses. The Win32 half that decides the value is
+    /// tested separately, against a real window, in EmbeddedInputAllowedServiceTests.
     /// </summary>
     [StaFact]
-    public async Task ClickWhileEmbeddedAndForegroundOwnedByGameItself_IsProcessed()
+    public async Task ClickWhileEmbeddedAndGlueReportsInputAllowed_IsProcessed()
     {
         GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
 
@@ -163,15 +166,8 @@ public class EditModeActivityGateTests
         var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
         borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
 
-        // Simulates the real embedded state: a real Glue process exists, but OS foreground is owned by
-        // the game's own reparented window instead of matching Glue's MainWindowHandle.
-        var overrideResponse = await game.Send(new SetEmbeddedFocusTestOverrideDto
-        {
-            GlueProcessExists = true,
-            ForegroundMatchesGlueMainWindow = false,
-            ForegroundOwnedByThisGame = true,
-        });
-        overrideResponse.Succeeded.ShouldBeTrue(overrideResponse.Message);
+        var inputAllowedResponse = await game.Send(new SetEmbeddedInputAllowedDto { IsAllowed = true });
+        inputAllowedResponse.Succeeded.ShouldBeTrue(inputAllowedResponse.Message);
 
         var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
             new SimulateClickSelectRespectingActivityGateDto
@@ -182,17 +178,18 @@ public class EditModeActivityGateTests
 
         clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
         clickResponse.Data.WasProcessed.ShouldBeTrue(
-            "a click on the embedded game panel should be processed even though OS foreground is owned " +
-            "by the game's own reparented window rather than exactly matching Glue's MainWindowHandle (issue #2183)");
+            "a click must be processed while Glue reports the embedded game window as topmost under the " +
+            "cursor - this is the ordinary case of a user working in the Game tab (issues #2183, #2205)");
         clickResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectA" });
     }
 
     /// <summary>
-    /// Regression guard for the #2183 fix: it must not reopen #2154. When some unrelated window (neither
-    /// Glue's nor the embedded game's own) is truly in the foreground, clicks must stay ignored.
+    /// Regression guard for issues #2154/#2214: Glue reports that something else is topmost under the
+    /// cursor - another application's window dragged over the Game tab, or Glue sitting behind another
+    /// app entirely - so the click belongs to that window and the game underneath must not act on it.
     /// </summary>
     [StaFact]
-    public async Task ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored()
+    public async Task ClickWhileEmbeddedAndGlueReportsInputBlocked_IsIgnored()
     {
         GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
 
@@ -222,13 +219,13 @@ public class EditModeActivityGateTests
         var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
         borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
 
-        var overrideResponse = await game.Send(new SetEmbeddedFocusTestOverrideDto
-        {
-            GlueProcessExists = true,
-            ForegroundMatchesGlueMainWindow = false,
-            ForegroundOwnedByThisGame = false,
-        });
-        overrideResponse.Succeeded.ShouldBeTrue(overrideResponse.Message);
+        // Explicitly allow first, so this proves the block actually closes an OPEN gate rather than
+        // passing on the fail-closed default that ClickWhileEmbeddedAndGlueHasNotReportedInputAllowed_IsIgnored covers.
+        var inputAllowedResponse = await game.Send(new SetEmbeddedInputAllowedDto { IsAllowed = true });
+        inputAllowedResponse.Succeeded.ShouldBeTrue(inputAllowedResponse.Message);
+
+        var inputBlockedResponse = await game.Send(new SetEmbeddedInputAllowedDto { IsAllowed = false });
+        inputBlockedResponse.Succeeded.ShouldBeTrue(inputBlockedResponse.Message);
 
         var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
             new SimulateClickSelectRespectingActivityGateDto
@@ -239,134 +236,8 @@ public class EditModeActivityGateTests
 
         clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
         clickResponse.Data.WasProcessed.ShouldBeFalse(
-            "a click should still be ignored when OS foreground belongs to neither Glue nor the embedded game (issue #2154 must stay fixed)");
-        clickResponse.Data.SelectedObjectNames.ShouldBeEmpty();
-    }
-
-    /// <summary>
-    /// Reproduces the #2203 investigation's real-machine finding: on the affected machine,
-    /// GetForegroundWindow() returned IntPtr.Zero - not Glue's window, not the game's own window, no
-    /// window at all - on every single click while embedded, even though the click was clearly landing on
-    /// the embedded panel. The fix is a direct spatial hit-test (WindowFromPoint at the cursor) instead of
-    /// trusting OS foreground/activation state, so a click physically over our own window is recognized
-    /// even when GetForegroundWindow() can't identify anything. This test simulates the outcome of that
-    /// hit-test via TestOverride rather than moving a real cursor.
-    /// </summary>
-    [StaFact]
-    public async Task ClickWhileEmbeddedAndCursorOverOwnWindow_IsProcessed()
-    {
-        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
-
-        using var game = await LiveGameProcess.StartAsync(
-            "Samples/EditorTest1",
-            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
-            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
-            afterLoadBeforeEmbed: AddTestObjectToGameScreen);
-
-        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
-
-        var loadScreenResponse = await game.Send(new SelectObjectDto
-        {
-            ElementNameGlue = "Screens\\GameScreen",
-            ScreenSave = screen,
-        });
-        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
-
-        var editModeResponse = await game.Send(new SetEditMode
-        {
-            IsInEditMode = true,
-            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
-        });
-        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
-        await Task.Delay(1000);
-
-        var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
-        borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
-
-        var overrideResponse = await game.Send(new SetEmbeddedFocusTestOverrideDto
-        {
-            GlueProcessExists = true,
-            ForegroundMatchesGlueMainWindow = false,
-            ForegroundOwnedByThisGame = false,
-            CursorOverOwnWindow = true,
-        });
-        overrideResponse.Succeeded.ShouldBeTrue(overrideResponse.Message);
-
-        var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
-            new SimulateClickSelectRespectingActivityGateDto
-            {
-                ObjectName = "TestObjectA",
-                AdditiveModifierDown = false,
-            });
-
-        clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
-        clickResponse.Data.WasProcessed.ShouldBeTrue(
-            "a click should be processed when the cursor is physically over our own window, even though " +
-            "GetForegroundWindow() couldn't identify any window at all (issue #2203)");
-        clickResponse.Data.SelectedObjectNames.ShouldBe(new[] { "TestObjectA" });
-    }
-
-    /// <summary>
-    /// Regression guard for the #2203 fix: it must not reopen #2154. The earlier "treat unidentified
-    /// foreground as focused" approach was rejected specifically because this scenario - glueProcessExists
-    /// true, foreground belongs to neither Glue nor the game, AND the cursor is not over our own window
-    /// either (e.g. it's a lock screen, a UAC prompt, or the user genuinely alt-tabbed away) - must still
-    /// block the click. This is the same override values as
-    /// ClickWhileEmbeddedAndForegroundOwnedByUnrelatedWindow_IsIgnored above (CursorOverOwnWindow's default
-    /// is false), kept as its own explicit test so a future change to the default doesn't silently drop
-    /// this guarantee.
-    /// </summary>
-    [StaFact]
-    public async Task ClickWhileEmbeddedAndCursorNotOverOwnWindowEither_IsIgnored()
-    {
-        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
-
-        using var game = await LiveGameProcess.StartAsync(
-            "Samples/EditorTest1",
-            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
-            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe",
-            afterLoadBeforeEmbed: AddTestObjectToGameScreen);
-
-        var screen = ObjectFinder.Self.GetScreenSave("GameScreen");
-
-        var loadScreenResponse = await game.Send(new SelectObjectDto
-        {
-            ElementNameGlue = "Screens\\GameScreen",
-            ScreenSave = screen,
-        });
-        loadScreenResponse.Succeeded.ShouldBeTrue(loadScreenResponse.Message);
-
-        var editModeResponse = await game.Send(new SetEditMode
-        {
-            IsInEditMode = true,
-            AbsoluteGlueProjectFilePath = System.IO.Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
-        });
-        editModeResponse.Succeeded.ShouldBeTrue(editModeResponse.Message);
-        await Task.Delay(1000);
-
-        var borderlessResponse = await game.Send(new SetBorderlessDto { IsBorderless = true });
-        borderlessResponse.Succeeded.ShouldBeTrue(borderlessResponse.Message);
-
-        var overrideResponse = await game.Send(new SetEmbeddedFocusTestOverrideDto
-        {
-            GlueProcessExists = true,
-            ForegroundMatchesGlueMainWindow = false,
-            ForegroundOwnedByThisGame = false,
-            CursorOverOwnWindow = false,
-        });
-        overrideResponse.Succeeded.ShouldBeTrue(overrideResponse.Message);
-
-        var clickResponse = await game.Send<SimulateClickSelectRespectingActivityGateResponse>(
-            new SimulateClickSelectRespectingActivityGateDto
-            {
-                ObjectName = "TestObjectA",
-                AdditiveModifierDown = false,
-            });
-
-        clickResponse.Succeeded.ShouldBeTrue(clickResponse.Message);
-        clickResponse.Data.WasProcessed.ShouldBeFalse(
-            "a click must stay ignored when neither the foreground window nor the cursor position identify " +
-            "our own window - the #2203 fix must not reopen #2154");
+            "a click must be ignored when the topmost window under the cursor isn't the embedded game - " +
+            "it belongs to whatever is drawn on top (issues #2154, #2214)");
         clickResponse.Data.SelectedObjectNames.ShouldBeEmpty();
     }
 
@@ -414,12 +285,7 @@ public class EditModeActivityGateTests
         // Simulate: the mouse button goes down on the object while the gate is still closed (Glue's UI
         // still has real OS focus) - a real click on an unfocused embedded window is correctly ignored,
         // same as issue #2154.
-        var overrideGateClosed = await game.Send(new SetEmbeddedFocusTestOverrideDto
-        {
-            GlueProcessExists = true,
-            ForegroundMatchesGlueMainWindow = false,
-            ForegroundOwnedByThisGame = false,
-        });
+        var overrideGateClosed = await game.Send(new SetEmbeddedInputAllowedDto { IsAllowed = false });
         overrideGateClosed.Succeeded.ShouldBeTrue(overrideGateClosed.Message);
 
         var pushWhileGateClosed = await game.Send<SimulateGrabAcrossFocusGateResponse>(
@@ -439,12 +305,7 @@ public class EditModeActivityGateTests
         // brought it back) - the gate opens. The button is still down from the same continuous gesture,
         // so this is ButtonDown without a fresh ButtonPushed - exactly like a real held mouse-drag that
         // straddles the focus transition.
-        var overrideGateOpen = await game.Send(new SetEmbeddedFocusTestOverrideDto
-        {
-            GlueProcessExists = true,
-            ForegroundMatchesGlueMainWindow = false,
-            ForegroundOwnedByThisGame = true,
-        });
+        var overrideGateOpen = await game.Send(new SetEmbeddedInputAllowedDto { IsAllowed = true });
         overrideGateOpen.Succeeded.ShouldBeTrue(overrideGateOpen.Message);
 
         var heldDownAsGateOpens = await game.Send<SimulateGrabAcrossFocusGateResponse>(
@@ -508,12 +369,7 @@ public class EditModeActivityGateTests
 
         try
         {
-            var overrideGateClosed = await game.Send(new SetEmbeddedFocusTestOverrideDto
-            {
-                GlueProcessExists = true,
-                ForegroundMatchesGlueMainWindow = false,
-                ForegroundOwnedByThisGame = false,
-            });
+            var overrideGateClosed = await game.Send(new SetEmbeddedInputAllowedDto { IsAllowed = false });
             overrideGateClosed.Succeeded.ShouldBeTrue(overrideGateClosed.Message);
 
             var blockedClick = await game.Send<SimulateGrabAcrossFocusGateResponse>(
@@ -528,12 +384,7 @@ public class EditModeActivityGateTests
             blockedClick.Succeeded.ShouldBeTrue(blockedClick.Message);
             blockedClick.Data.WasProcessed.ShouldBeFalse();
 
-            var overrideGateOpen = await game.Send(new SetEmbeddedFocusTestOverrideDto
-            {
-                GlueProcessExists = true,
-                ForegroundMatchesGlueMainWindow = false,
-                ForegroundOwnedByThisGame = true,
-            });
+            var overrideGateOpen = await game.Send(new SetEmbeddedInputAllowedDto { IsAllowed = true });
             overrideGateOpen.Succeeded.ShouldBeTrue(overrideGateOpen.Message);
 
             var processedClick = await game.Send<SimulateGrabAcrossFocusGateResponse>(
@@ -568,75 +419,6 @@ public class EditModeActivityGateTests
                 System.IO.File.Delete(logFilePath);
             }
         }
-    }
-
-    /// <summary>
-    /// Pins EmbeddedWindowLogic.ComputeCursorOverOwnWindow's decision table directly, via synthetic Win32-
-    /// call outcomes (TestComputeCursorOverOwnWindowDto) rather than a real ClientToScreen/WindowFromPoint
-    /// round trip against a real overlapping window - moving the real OS cursor precisely enough for that
-    /// proved unreliable on a multi-monitor dev machine (issue #2205 discussion), so this is the regression
-    /// coverage that actually shipped for the occlusion fix instead. One process, four cases: covers both
-    /// fail-closed paths (no ClientToScreen result, no window found at the cursor) and both PID-match
-    /// outcomes (occluded by another window vs. genuinely on top).
-    /// </summary>
-    [StaFact]
-    public async Task ComputeCursorOverOwnWindow_DecisionTable()
-    {
-        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
-
-        using var game = await LiveGameProcess.StartAsync(
-            "Samples/EditorTest1",
-            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
-            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe");
-
-        var clientToScreenFailed = await game.Send<TestComputeCursorOverOwnWindowResponse>(
-            new TestComputeCursorOverOwnWindowDto
-            {
-                ClientToScreenSucceeded = false,
-                TopmostWindowFound = true,
-                TopmostWindowOwnerPid = 123,
-                ThisProcessId = 123,
-            });
-        clientToScreenFailed.Succeeded.ShouldBeTrue(clientToScreenFailed.Message);
-        clientToScreenFailed.Data.Result.ShouldBeFalse(
-            "a failed ClientToScreen call must fail closed even if the (unusable) window/PID inputs would otherwise match");
-
-        var noWindowFound = await game.Send<TestComputeCursorOverOwnWindowResponse>(
-            new TestComputeCursorOverOwnWindowDto
-            {
-                ClientToScreenSucceeded = true,
-                TopmostWindowFound = false,
-                TopmostWindowOwnerPid = 123,
-                ThisProcessId = 123,
-            });
-        noWindowFound.Succeeded.ShouldBeTrue(noWindowFound.Message);
-        noWindowFound.Data.Result.ShouldBeFalse(
-            "no window found at the cursor position (e.g. the desktop background) must fail closed");
-
-        var occludedByAnotherProcess = await game.Send<TestComputeCursorOverOwnWindowResponse>(
-            new TestComputeCursorOverOwnWindowDto
-            {
-                ClientToScreenSucceeded = true,
-                TopmostWindowFound = true,
-                TopmostWindowOwnerPid = 456,
-                ThisProcessId = 123,
-            });
-        occludedByAnotherProcess.Succeeded.ShouldBeTrue(occludedByAnotherProcess.Message);
-        occludedByAnotherProcess.Data.Result.ShouldBeFalse(
-            "a real window belonging to a different process is topmost at the cursor - this is the exact " +
-            "occlusion scenario from the #2205 follow-up report and must not be detected as our own window");
-
-        var genuinelyOnTop = await game.Send<TestComputeCursorOverOwnWindowResponse>(
-            new TestComputeCursorOverOwnWindowDto
-            {
-                ClientToScreenSucceeded = true,
-                TopmostWindowFound = true,
-                TopmostWindowOwnerPid = 123,
-                ThisProcessId = 123,
-            });
-        genuinelyOnTop.Succeeded.ShouldBeTrue(genuinelyOnTop.Message);
-        genuinelyOnTop.Data.Result.ShouldBeTrue(
-            "the topmost window at the cursor belongs to our own process - nothing is occluding us");
     }
 
     static async Task AddTestObjectToGameScreen()


### PR DESCRIPTION
## Root cause

The Win32 calls behind the embedded input gate have never run in a real project.

`GlueControl/Embedded/**` is `<Compile Remove>`d from `GameCommunicationPlugin.csproj` and compiles inside the **user's game project**, whose `DefineConstants` are `MONOGAME;DESKTOP_GL;MONOGAME_381`. `WINDOWS` is defined by exactly one project in this repo (`Tests/TestProjectDesktopNet6`) and by nothing a user ever gets — so `EditingManager.cs`'s `#if WINDOWS` block always compiled to its `#else` stubs:

```csharp
static IntPtr GetForegroundWindow() => IntPtr.Zero;
static bool ClientToScreen(IntPtr hWnd, ref Win32Point point) => false;
static bool GetCursorPos(out Win32Point point) { point = default; return false; }
```

That re-reads the last four bug reports:

| Issue | Diagnosis at the time | What was actually happening |
| --- | --- | --- |
| #2183 | "foreground is the game's own window, not Glue's" | `GetForegroundWindow()` returned `IntPtr.Zero` — the stub |
| #2205 | "`GetCursorPos` fails with error 87 on that machine" | the stub returns `false`; error 87 was a stale `GetLastWin32Error` |
| #2214 | occlusion check added, gated on `ClientToScreen` | the stub returns `false` → fails closed → **every click blocked** |

#2214 is the current "clicks do nothing". #2205's fix worked only because it used `Mouse.IsInGameWindow()`, the one check that touches no Win32.

## Fix

The decision moves to Glue, which is a genuinely Windows-only WPF/WinForms assembly where these APIs work. The OR-chain collapses to one question:

> Is the window the OS reports as topmost under the cursor our embedded game window?

Z-order aware (a window over the panel blocks the game — #2154, #2214) and activation independent (the click that returns focus still lands — #2183, #2187). Those are the two properties the heuristics kept trading against each other.

`EmbeddedInputAllowedService` polls it and pushes `SetEmbeddedInputAllowedDto` on change, mirroring `ModalReportingService`. It records a value as sent only once the game acknowledges it, so a send dropped during `Game1.Initialize` (connected, but `GlueControlManager.Self` still null) can't leave the gate shut for the session.

The game keeps the fast-changing half — `Mouse.IsInGameWindow()`, per-frame, no OS call — so the poll interval can't misplace a click. `EmbeddedWindowLogic` now holds no Win32 at all.

## Why this doesn't just become the fifth regression

The old suite tested the decision logic exhaustively with synthetic booleans and none of the Win32 calls. That is precisely the shape that let four regressions ship green: the code under test was never the code that broke.

- **`EmbeddedInputAllowedServiceTests`** drives the real `GetCursorPos`/`WindowFromPoint` against a real window with the real cursor. Reintroducing the stub (`&& false` on the `GetCursorPos` result) fails that test — while all six decision-table tests stay green. That contrast is the point.
- **`EmbeddedCodePlatformDefineTests`** fails the build if `#if WINDOWS` reappears anywhere under `GlueControl/Embedded`. Written first, watched fail against `EditingManager.cs:1818`.
- The `LiveGame` gate tests now send the production DTO instead of `SetEmbeddedFocusTestOverrideDto`, so they exercise the path a real session uses. Four permutation tests collapse into two, since there is one input now instead of an OR-chain.

## Verification

- Solution builds; 764 non-LiveGame tests pass. The 36 failures are pre-existing `Frb2*` failures, confirmed identical on unmodified `NetStandard`.
- `NestedInstanceVariableAssignmentTests` compiles the embedded `Dtos.Generated.cs` (including the new DTO) inside a real game project — green.
- **The `Category=LiveGame` suite could not be run locally** — all 17 fail before reaching any assertion, as does `GoldProjectCompileTests`, on a pre-existing MSBuild SDK resolver problem unrelated to this change (#2218). CI runs `GoldProjectCompileTests` under `Category=BuildSmoke`, which is what compiles the game-side closure here.

Manual test needed — steps in the PR discussion.

Part of #2214.
