### PR TITLE
Pick the newest usable .NET SDK for MSBUILD_EXE_PATH instead of a pre-.NET-7 one

### DIFF
--- a/FRBDK/Glue/Glue/MainGlueWindow.cs
+++ b/FRBDK/Glue/Glue/MainGlueWindow.cs
@@ -28,7 +28,6 @@ using Microsoft.Xna.Framework.Audio;
 using System.Windows.Forms.Integration;
 using GlueFormsCore.Controls;
 using System.Diagnostics;
-using System.Text.RegularExpressions;
 using System.Linq;
 using Newtonsoft.Json;
 using System.Threading;
@@ -36,6 +35,7 @@ using System.IO;
 using System.ServiceModel.Channels;
 using System.Windows.Media;
 using FlatRedBall.Glue.Themes;
+using FlatRedBall.Glue.VSHelpers;
 using System.Reflection;
 using Wpf = System.Windows;
 
@@ -66,7 +66,7 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
     #endregion
     
     // internal (not private) so a headless test host can run the same real SDK-discovery Glue.exe runs -
-    // without MSBUILD_EXE_PATH pointed at a pre-7 SDK, Microsoft.Build.Evaluation.Project can't resolve
+    // without MSBUILD_EXE_PATH pointed at a usable SDK, Microsoft.Build.Evaluation.Project can't resolve
     // the SDK imports in any SDK-style .csproj, so no real game project can be loaded.
     internal static void SetMsBuildEnvironmentVariable()
     {
@@ -147,55 +147,29 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
             return;
         }
 
-        var sdkPaths = Regex.Matches(output, "([0-9]+)[.]([0-9]+)[.]([0-9]+) \\[(.*)\\]")
-            .OfType<Match>()
-            // https://stackoverflow.com/questions/75702346/why-does-the-presence-of-net-7-0-2-sdk-cause-the-sdk-resolver-microsoft-dotnet?noredirect=1#comment133550210_75702346
-            // "7.0." instead of "7.0.201"
-            //.Where(item => item.Value.StartsWith("7.0.") == false)
-            .Where(m => int.Parse(m.Groups[1].Value) < 7)
-            .OrderByDescending(m => int.Parse(m.Groups[1].Value))
-            .ThenByDescending(m => int.Parse(m.Groups[2].Value))
-            .ThenByDescending(m => int.Parse(m.Groups[3].Value))
-            .Select(m => System.IO.Path.Combine(m.Groups[4].Value, m.Groups[1].Value + "." + m.Groups[2].Value + "." + m.Groups[3].Value, "MSBuild.dll"))
-            .ToArray();
+        // Newest first, capped at the runtime this process is running on - see MsBuildSdkSelector for why.
+        // This used to prefer the newest pre-.NET-7 SDK, which is now a bug rather than a workaround: a
+        // machine with no .NET 6 SDK installed falls back to a .NET 3.x SDK whose resolver cannot resolve
+        // a modern SDK-style project at all ("The SDK 'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator'
+        // specified could not be found"), and a machine with no pre-7 SDK at all gets nothing. GitHub
+        // issue #2218.
+        var sdkPaths = MsBuildSdkSelector.GetMsBuildPathsNewestFirst(output, Environment.Version.Major);
 
-        //Useful for debugging query above
-        //var allSdks = sdkPaths.Aggregate((a, b) => a + "," + b);
-        //MessageBox.Show(allSdks);
+        var sdkPath = sdkPaths.FirstOrDefault(File.Exists);
 
-        if (sdkPaths.Any())
+        if (sdkPath == null)
         {
-            string sdkPath = null;
-
-            foreach (var path in sdkPaths)
-            {
-                if (File.Exists(path))
-                {
-                    sdkPath = path;
-                    break;
-                }
-            }
-
-            //sdkPaths.FirstOrDefault(item => item.Contains("sdk\\6."));
-            if (String.IsNullOrEmpty(sdkPath))
-            {
-                //    sdkPath = sdkPaths.Last();
-
-                var message = String.Format(Localization.Texts.ErrorCouldNotFindNetSix, output);
-                GlueCommands.Self.PrintOutput(message);
-                DialogService.ShowMessage(message);
-            }
-            else
-            {
-                Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", sdkPath);
-                GlueCommands.Self.PrintOutput($"Using MSBUILD from {sdkPath}");
-            }
+            var message = $"Could not find an installed .NET SDK that Glue can load projects with. " +
+                $"Glue runs on .NET {Environment.Version.Major}, so it needs an SDK no newer than that " +
+                $"- installing the .NET {Environment.Version.Major} SDK will fix this. " +
+                $"dotnet --list-sdks output: {output}";
+            GlueCommands.Self.PrintOutput(message);
+            DialogService.ShowMessage(message);
         }
         else
         {
-            var message = String.Format(Localization.Texts.ErrorCouldNotFindNetSix, output);
-            GlueCommands.Self.PrintOutput(message);
-            DialogService.ShowMessage(message);
+            Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", sdkPath);
+            GlueCommands.Self.PrintOutput($"Using MSBUILD from {sdkPath}");
         }
     }
 

--- a/FRBDK/Glue/Glue/VSHelpers/MsBuildSdkSelector.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/MsBuildSdkSelector.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace FlatRedBall.Glue.VSHelpers;
+
+/// <summary>
+/// Decides which installed .NET SDK's MSBuild the editor evaluates .csproj files with - the value that
+/// goes into MSBUILD_EXE_PATH. Split out of MainGlueWindow so the choice can be unit tested against real
+/// "dotnet --list-sdks" output instead of only against whatever SDKs the developer happens to have.
+/// </summary>
+public static class MsBuildSdkSelector
+{
+    // "8.0.303 [C:\Program Files\dotnet\sdk]"
+    static readonly Regex SdkLine = new("([0-9]+)[.]([0-9]+)[.]([0-9]+) \\[(.*)\\]");
+
+    /// <summary>
+    /// Candidate MSBuild.dll paths parsed out of "dotnet --list-sdks" output, newest first, skipping any
+    /// SDK whose major version is above <paramref name="maximumMajorVersion"/>.
+    ///
+    /// The cap exists because the SDK resolvers MSBuild loads out of the chosen SDK's folder are compiled
+    /// against that SDK's runtime: pointing a .NET 8 process at the .NET 10 SDK fails with "Could not load
+    /// file or assembly 'System.Runtime, Version=10.0.0.0'" before resolving anything. So the caller passes
+    /// the running runtime's major version. Any older SDK still resolves modern SDK-style projects, which
+    /// is why everything below the cap stays in the list as a fallback.
+    /// </summary>
+    public static IReadOnlyList<string> GetMsBuildPathsNewestFirst(string dotnetListSdksOutput, int maximumMajorVersion)
+    {
+        return SdkLine.Matches(dotnetListSdksOutput)
+            .OfType<Match>()
+            .Where(m => int.Parse(m.Groups[1].Value) <= maximumMajorVersion)
+            .OrderByDescending(m => int.Parse(m.Groups[1].Value))
+            .ThenByDescending(m => int.Parse(m.Groups[2].Value))
+            .ThenByDescending(m => int.Parse(m.Groups[3].Value))
+            .Select(m => System.IO.Path.Combine(m.Groups[4].Value,
+                m.Groups[1].Value + "." + m.Groups[2].Value + "." + m.Groups[3].Value, "MSBuild.dll"))
+            .ToArray();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/MsBuildSdkSelectorTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/MsBuildSdkSelectorTests.cs
@@ -1,0 +1,59 @@
+using FlatRedBall.Glue.VSHelpers;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+public class MsBuildSdkSelectorTests
+{
+    // Real "dotnet --list-sdks" output from a machine with the .NET 10 SDK installed - the case that
+    // broke every project-loading test (GitHub issue #2218).
+    const string ListSdksOutput = @"3.0.103 [C:\Program Files\dotnet\sdk]
+3.1.417 [C:\Program Files\dotnet\sdk]
+7.0.101 [C:\Program Files\dotnet\sdk]
+8.0.303 [C:\Program Files\dotnet\sdk]
+10.0.400 [C:\Program Files\dotnet\sdk]
+";
+
+    [Fact]
+    public void NewestUsableSdkIsPreferred()
+    {
+        var paths = MsBuildSdkSelector.GetMsBuildPathsNewestFirst(ListSdksOutput, maximumMajorVersion: 8);
+
+        paths[0].ShouldBe(@"C:\Program Files\dotnet\sdk\8.0.303\MSBuild.dll");
+    }
+
+    [Fact]
+    public void SdksNewerThanTheRunningRuntimeAreExcluded()
+    {
+        // Their MSBuild and SDK resolvers are compiled against a newer runtime than the editor process,
+        // so loading them throws "Could not load file or assembly 'System.Runtime, Version=10.0.0.0'"
+        // rather than resolving anything.
+        var paths = MsBuildSdkSelector.GetMsBuildPathsNewestFirst(ListSdksOutput, maximumMajorVersion: 8);
+
+        paths.ShouldNotContain(@"C:\Program Files\dotnet\sdk\10.0.400\MSBuild.dll");
+    }
+
+    [Fact]
+    public void OlderSdksRemainAsFallbacksInDescendingOrder()
+    {
+        var paths = MsBuildSdkSelector.GetMsBuildPathsNewestFirst(ListSdksOutput, maximumMajorVersion: 8);
+
+        paths.ShouldBe(new[]
+        {
+            @"C:\Program Files\dotnet\sdk\8.0.303\MSBuild.dll",
+            @"C:\Program Files\dotnet\sdk\7.0.101\MSBuild.dll",
+            @"C:\Program Files\dotnet\sdk\3.1.417\MSBuild.dll",
+            @"C:\Program Files\dotnet\sdk\3.0.103\MSBuild.dll",
+        });
+    }
+
+    [Fact]
+    public void NoUsableSdkYieldsNoCandidates()
+    {
+        var paths = MsBuildSdkSelector.GetMsBuildPathsNewestFirst(
+            @"10.0.400 [C:\Program Files\dotnet\sdk]", maximumMajorVersion: 8);
+
+        paths.ShouldBeEmpty();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/SdkStyleProjectLoadTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/SdkStyleProjectLoadTests.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// Pins the one thing every end-to-end test depends on: that the test host can evaluate a real
+/// SDK-style .csproj through the same <see cref="ProjectCreator"/> call Glue.exe's File > Load Project
+/// makes. When it can't, the whole LiveGame/gold-project suite fails with a "Missing SDK" exception
+/// that says nothing about the real cause (which .NET SDK MSBUILD_EXE_PATH points at). See GitHub
+/// issue #2218.
+/// </summary>
+public class SdkStyleProjectLoadTests
+{
+    public SdkStyleProjectLoadTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    [Fact]
+    public void CreateProject_EvaluatesACheckedInSdkStyleProject()
+    {
+        GlueTestBootstrap.EnsureMsBuildEnvironmentVariable();
+
+        var csproj = Path.Combine(GoldProject.FindRepoRoot(),
+            "Samples", "EditorTest1", "EditorTest1", "EditorTest1.csproj");
+
+        var result = ProjectCreator.CreateProject(csproj);
+
+        Assert.NotNull(result.Project);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -217,7 +217,7 @@ internal static class GlueTestBootstrap
     ///    seam is *not* covered by ShowGui - several production paths call DialogService directly - so
     ///    without it a load that hits an error path pops a real modal and wedges the run.
     ///  - <see cref="MainGlueWindow"/>.<c>SetMsBuildEnvironmentVariable</c>, Glue's real SDK discovery. It
-    ///    points MSBUILD_EXE_PATH at a pre-7 SDK; without it <c>Microsoft.Build.Evaluation.Project</c> cannot
+    ///    points MSBUILD_EXE_PATH at an installed SDK; without it <c>Microsoft.Build.Evaluation.Project</c> cannot
     ///    resolve the SDK imports of any SDK-style .csproj ("The SDK
     ///    'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' specified could not be found"), which is what
     ///    previously forced <see cref="TestVisualStudioProjectFactory"/> to use a bare non-SDK-style project.
@@ -352,7 +352,7 @@ internal static class GlueTestBootstrap
     };
 
     /// <summary>
-    /// Points MSBUILD_EXE_PATH at a pre-7 SDK by running Glue.exe's own discovery, unless it is already set.
+    /// Points MSBUILD_EXE_PATH at an installed SDK by running Glue.exe's own discovery, unless it is already set.
     ///
     /// Called before every gold-project load rather than once per process on purpose: production clears this
     /// variable around its own nested dotnet invocations (CompilerPlugin's Compiler.cs, SyncedProjects'

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GoldProject.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GoldProject.cs
@@ -247,7 +247,7 @@ internal static class GoldProject
         }
     }
 
-    static string FindRepoRoot()
+    internal static string FindRepoRoot()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
         while (directory != null)

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCli.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCli.cs
@@ -74,7 +74,7 @@ internal static class NestedDotnetCli
         }
 
         // GlueTestBootstrap.EnsureHeadlessProjectLoadReady runs Glue's real SetMsBuildEnvironmentVariable,
-        // which points MSBUILD_EXE_PATH at a pre-7 SDK so Microsoft.Build.Evaluation can resolve SDK-style
+        // which points MSBUILD_EXE_PATH at an installed SDK so Microsoft.Build.Evaluation can resolve SDK-style
         // .csproj files in-process. A child dotnet CLI must not inherit that - it pins the child to that old
         // MSBuild and breaks the build. Production clears it around its own nested invocations for exactly
         // this reason (see CompilerPlugin's Compiler.cs and SyncedProjects' ProjectListEntry.xaml.cs).

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
@@ -54,7 +54,7 @@ EndProject
         // Microsoft.Build resolves and caches its toolset on the first project evaluation in the process.
         // This bare non-SDK-style project evaluates fine without MSBUILD_EXE_PATH, but if it is the first
         // evaluation, it fixes the toolset for the whole run - and a later gold-project load (which needs a
-        // pre-7 SDK to resolve SDK-style imports) then fails with "The SDK
+        // pre-selected SDK to resolve SDK-style imports) then fails with "The SDK
         // 'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' specified could not be found" while passing
         // when run on its own. Setting the variable here means whichever test evaluates first, it is set.
         GlueTestBootstrap.EnsureMsBuildEnvironmentVariable();


### PR DESCRIPTION
Fixes #2218.

Glue picks the MSBuild it evaluates `.csproj` files with by scanning `dotnet --list-sdks` and setting `MSBUILD_EXE_PATH`. It preferred the newest SDK **below major version 7** — a 2023 workaround for a .NET 7 resolver bug. On a machine with no .NET 6 SDK that now falls through to a .NET 3.x SDK, whose resolver can't resolve a modern SDK-style project at all:

```
The SDK 'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' specified could not be found.
```

That's the whole local `Category=LiveGame` suite, `GoldProjectCompileTests`, and every other real-project load. CI passes only because its runners install the 6.0.x SDK.

**Change:** pick the newest installed SDK whose major version isn't above the runtime the process is on (a newer SDK's resolvers throw `Could not load file or assembly 'System.Runtime, Version=10.0.0.0'`), older SDKs staying as fallbacks. Measured: SDK 7, 8 resolve fine under Microsoft.Build 17.3.1; 3.1 does not; 10 can't load into a net8 process.

Extracted the choice into `MsBuildSdkSelector` so it's unit testable against real `dotnet --list-sdks` output, and inlined the now-inaccurate "could not find .NET 6" localized string per `FRBDK/Glue/CLAUDE.md`.

**Tests:** `MsBuildSdkSelectorTests` (selection rule) and `SdkStyleProjectLoadTests` (the reported symptom — `ProjectCreator.CreateProject` on a checked-in SDK-style csproj), both red before the change. Full suite from a clean build: 809/809 non-BuildSmoke, plus `LiveGameProcessTests` 4/4 and `GoldProjectCompileTests` 6/6 locally — all of which failed before.

Note for CI: runners have 6.0.x/8.0.x/9.0.x, so this switches them from the 6.0.x SDK to 8.0.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaUaW877upuDnE7A638HPd
