### PR TITLE
Retry per-Entity live-edit reload on transient failure, with precise diagnostics

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -1527,7 +1527,19 @@ namespace GlueControl
 
                     if (reloadMethod != null && fileObjectReference != null)
                     {
-                        reloadMethod.Invoke(null, new object[] { fileObjectReference });
+                        // Glue only tells the game to reload after it believes the changed file has
+                        // finished copying to the build folder (see RefreshManager.HandleFileChanged's
+                        // CopyToBuildFolderTaskIdFor wait), but that belief can be wrong on a slow disk /
+                        // antivirus-scanned drive - the copy can complete while the source is still being
+                        // written by the editing tool (e.g. ProMotion NG), producing a truncated file that
+                        // fails to decode ("This image format is not supported" from the image loader).
+                        // RetryOnTransientReloadFailure below retries exactly that case; a failure here
+                        // must not silently abort the whole loop (which would also skip every later
+                        // element AND the GlobalContent.Reload call further down) - log which element/file
+                        // failed and move on to the next one.
+                        RetryOnTransientReloadFailure(
+                            () => reloadMethod.Invoke(null, new object[] { fileObjectReference }),
+                            $"{element}.{dto.StrippedFileName}");
                     }
                 }
 
@@ -1537,24 +1549,7 @@ namespace GlueControl
 
             if (file != null)
             {
-                int numberOfTimesToTry = 10;
-                int numberOfFailures = 0;
-                while (numberOfFailures < numberOfTimesToTry)
-                {
-                    try
-                    {
-                        GlobalContent.Reload(file);
-                        break;
-                    }
-                    catch (InvalidOperationException)
-                    {
-                        numberOfFailures++;
-
-                        // Deliberately a blocking sleep, not `await Task.Delay` - see the note at the top of
-                        // this method about staying on the primary thread through every retry.
-                        System.Threading.Thread.Sleep(250);
-                    }
-                }
+                RetryOnTransientReloadFailure(() => GlobalContent.Reload(file), $"GlobalContent.{dto.StrippedFileName}");
             }
 
 
@@ -1562,8 +1557,57 @@ namespace GlueControl
             if (dto.IsLocalizationDatabase)
             {
                 FlatRedBall.Localization.LocalizationManager.ClearDatabase();
-                // assume this uses commas, not tabs. 
+                // assume this uses commas, not tabs.
                 FlatRedBall.Localization.LocalizationManager.AddDatabase(dto.FileRelativeToProject, ',');
+            }
+        }
+
+        // Retries a reload action against the "file hasn't actually finished copying yet" race: Glue only
+        // sends a reload command after it believes the changed file finished copying to the build folder,
+        // but that copy can complete while the source is still being written by the editing tool, on a slow
+        // disk or under antivirus scanning - the copy then contains a truncated file. Loading it throws
+        // InvalidOperationException (directly from GlobalContent.Reload, or wrapped in
+        // TargetInvocationException when called through reflection.Invoke, as the per-Entity reload above
+        // is). Every attempt and the final outcome is logged with `label` (e.g. "EntityName.FileName") so a
+        // future occurrence pinpoints exactly what was being reloaded, instead of only a bare exception
+        // several call frames removed from the actual file.
+        private static void RetryOnTransientReloadFailure(Action action, string label)
+        {
+            const int maxAttempts = 10;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    action();
+                    if (attempt > 1)
+                    {
+                        System.Console.WriteLine($"[ReloadRetry] {label} succeeded on attempt {attempt}/{maxAttempts}.");
+                    }
+                    return;
+                }
+                catch (Exception ex) when (
+                    ex is InvalidOperationException ||
+                    (ex is System.Reflection.TargetInvocationException tie && tie.InnerException is InvalidOperationException))
+                {
+                    var actual = (ex as System.Reflection.TargetInvocationException)?.InnerException ?? ex;
+
+                    if (attempt == maxAttempts)
+                    {
+                        System.Console.WriteLine(
+                            $"[ReloadRetry] File \"{label}\" changed on disk, reloading, but got exception on " +
+                            $"attempt {attempt}/{maxAttempts} - giving up: {actual.GetType().Name}: {actual.Message}");
+                        return;
+                    }
+
+                    System.Console.WriteLine(
+                        $"[ReloadRetry] File \"{label}\" changed on disk, reloading, but got exception on " +
+                        $"attempt {attempt}/{maxAttempts}: {actual.GetType().Name}: {actual.Message}. Retrying in 250ms.");
+
+                    // Deliberately a blocking sleep, not `await Task.Delay` - see the note at the top of
+                    // HandleDto(Dtos.ForceReloadFileDto) about staying on the primary thread through every
+                    // retry (a resumed-on-a-thread-pool-thread continuation would race the renderer).
+                    System.Threading.Thread.Sleep(250);
+                }
             }
         }
 

--- a/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/ReferencedFileSaveCodeGenerator.cs
@@ -1157,18 +1157,47 @@ namespace FlatRedBall.Glue.CodeGeneration
                         {
                             var innerBlock = codeBlock.Block();
 
+                            var instanceName = referencedFile.GetInstanceName();
+                            var previousVariable = $"previous{instanceName}";
+                            var wasTrackedVariable = $"wasTracked{instanceName}";
+
                             innerBlock.Line("var cm = FlatRedBall.FlatRedBallServices.GetContentManagerByName(\"Global\");");
+                            innerBlock.Line($"var {previousVariable} = {instanceName};");
                             // See the matching guard/comment in GetReload's AnimationChainList branch above -
                             // a shared-static file can be reloaded through more than one static field pointing
                             // at the same underlying disposable, and whichever reload runs first already
                             // unloads it, leaving every later one's UnloadAsset call throwing ArgumentException.
-                            innerBlock.If($"cm.IsAssetLoadedByReference({referencedFile.GetInstanceName()})")
-                                .Line($"cm.UnloadAsset({referencedFile.GetInstanceName()});");
+                            innerBlock.Line($"var {wasTrackedVariable} = cm.IsAssetLoadedByReference({previousVariable});");
 
-                            string code =
-                                $"{referencedFile.GetInstanceName()} = " +
-                                $"FlatRedBall.FlatRedBallServices.Load<{ati.QualifiedRuntimeTypeName.QualifiedType}>(\"{fileName}\");";
-                            innerBlock.Line(code);
+                            // Load can throw (e.g. the file on disk is mid-write or genuinely malformed -
+                            // see GitHub issue reproduced against CrankyChibiCthulhu's ChibiCthulhuTiles.png).
+                            // The previous instance must stay alive and tracked until the replacement has
+                            // actually loaded: disposing it first (the old unconditional UnloadAsset-then-Load
+                            // order) left every Sprite/holder still referencing it pointing at a disposed
+                            // object the moment Load failed, regardless of how many times the caller retries -
+                            // a single failed reload permanently corrupted the shared asset until restart.
+                            // For a disposable asset, evict it from the cache without disposing it (so Load
+                            // is forced to hit disk again instead of returning the still-cached previous
+                            // instance) and only Dispose() it after the replacement is confirmed loaded; on
+                            // failure, re-track it so the asset isn't orphaned. A non-disposable asset can
+                            // still be unloaded up front - UnloadAsset never disposes those, so there's
+                            // nothing to protect.
+                            var evictIf = innerBlock.If($"{wasTrackedVariable} && {previousVariable} is System.IDisposable");
+                            evictIf.Line($"cm.RemoveDisposable((System.IDisposable){previousVariable});");
+                            evictIf.End()
+                                .ElseIf($"{wasTrackedVariable}")
+                                .Line($"cm.UnloadAsset({previousVariable});");
+
+                            var tryBlock = innerBlock.Try();
+                            tryBlock.Line(
+                                $"{instanceName} = FlatRedBall.FlatRedBallServices.Load<{ati.QualifiedRuntimeTypeName.QualifiedType}>(\"{fileName}\");");
+                            tryBlock.If($"{previousVariable} is System.IDisposable")
+                                .Line($"((System.IDisposable){previousVariable}).Dispose();");
+
+                            var catchBlock = tryBlock.End().Catch("System.Exception");
+                            catchBlock.If($"{wasTrackedVariable} && {previousVariable} is System.IDisposable")
+                                .Line($"cm.AddDisposable(\"{fileName}\", (System.IDisposable){previousVariable});");
+                            catchBlock.Line("throw;");
                         }
                     }
                     else if(referencedFile.IsCsvOrTreatedAsCsv)

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/ForceReloadFileDtoTransientFailureRetryTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/ForceReloadFileDtoTransientFailureRetryTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin;
+
+/// <summary>
+/// A user's live-edit PNG save crashed with a TargetInvocationException wrapping
+/// "System.InvalidOperationException: This image format is not supported". Glue only tells the game to
+/// reload after it believes the changed file finished copying to the build folder (see
+/// RefreshManager.HandleFileChanged's CopyToBuildFolderTaskIdFor wait), but that belief can be wrong on a
+/// slow disk / antivirus-scanned drive - the copy can complete while the source is still being written by
+/// the editing tool (e.g. ProMotion NG), leaving a truncated file in the build folder that fails to decode.
+///
+/// `GlobalContent.Reload(file)` already had a 10-attempt retry loop specifically for this
+/// InvalidOperationException, but the per-Entity reflection-based reload right above it (called through
+/// `MethodInfo.Invoke`, so the same InvalidOperationException arrives wrapped in
+/// TargetInvocationException) had none - one entity hitting the race aborted the whole
+/// HandleDto(ForceReloadFileDto) call, silently skipping every later entity AND the GlobalContent.Reload
+/// call, with only a bare, context-free exception dump reaching the logs.
+///
+/// See the sibling ForceReloadFileDtoThreadSafetyTests/ForceReloadFileDtoFieldLookupTests for why this
+/// asserts against the checked-in source text rather than compiling/running it directly - CommandReceiver.cs
+/// only compiles inside a real running game process.
+/// </summary>
+[Trait("Category", "BuildSmoke")]
+public class ForceReloadFileDtoTransientFailureRetryTests
+{
+    [Fact]
+    public void HandleDto_ForceReloadFileDto_RetriesBothReloadPathsWithDiagnosticLogging()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "FRBDK", "Glue", "GameCommunicationPlugin", "GlueControl", "Embedded", "CommandReceiver.cs"));
+
+        var methodBody = ExtractMethodBody(source, "HandleDto(Dtos.ForceReloadFileDto dto)");
+
+        // Both reload paths - the per-Entity reflection call and GlobalContent.Reload - must go through the
+        // same retry helper. Before the fix, only GlobalContent.Reload had any retry protection.
+        Assert.Contains("RetryOnTransientReloadFailure(", methodBody);
+        Assert.Contains("reloadMethod.Invoke(", methodBody);
+        Assert.Contains("GlobalContent.Reload(file)", methodBody);
+
+        // The helper itself: must unwrap TargetInvocationException (reflection.Invoke's wrapper) down to
+        // the real InvalidOperationException, and must log with enough context (which file, which attempt,
+        // the actual exception) to diagnose the next occurrence without guessing.
+        var helperBody = ExtractMethodBody(source, "RetryOnTransientReloadFailure(Action action, string label)");
+        Assert.Contains("TargetInvocationException", helperBody);
+        Assert.Contains("InvalidOperationException", helperBody);
+        Assert.Contains("changed on disk, reloading, but got exception", helperBody);
+        Assert.Contains("Console.WriteLine", helperBody);
+    }
+
+    // Mirrors ForceReloadFileDtoThreadSafetyTests's helper.
+    static string ExtractMethodBody(string source, string signatureFragment)
+    {
+        var signatureIndex = source.IndexOf(signatureFragment, StringComparison.Ordinal);
+        Assert.True(signatureIndex >= 0, $"Could not find \"{signatureFragment}\" in CommandReceiver.cs");
+
+        var lineStart = source.LastIndexOf('\n', signatureIndex) + 1;
+
+        var openBraceIndex = source.IndexOf('{', signatureIndex);
+        Assert.True(openBraceIndex > 0);
+
+        var depth = 0;
+        for (var i = openBraceIndex; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(lineStart, i - lineStart + 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Could not find the end of the method body for \"{signatureFragment}\"");
+    }
+
+    static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (Directory.Exists(Path.Combine(directory.FullName, "Samples")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "Engines")))
+            {
+                return directory.FullName;
+            }
+            directory = directory.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate the repo root (a directory containing both Samples/ and Engines/) above " +
+            AppContext.BaseDirectory);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/SharedStaticTextureReloadCodegenTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/SharedStaticTextureReloadCodegenTests.cs
@@ -82,7 +82,53 @@ public class SharedStaticTextureReloadCodegenTests : IDisposable
 
         // Before the fix, this was an unconditional "cm.UnloadAsset(ChibiCthulhuTiles);" - fine the first
         // time any holder of the shared texture reloads it, but every later holder's call throws
-        // ArgumentException once the first one has already unloaded/disposed it.
-        Assert.Contains("if (cm.IsAssetLoadedByReference(ChibiCthulhuTiles))", generatedCode);
+        // ArgumentException once the first one has already unloaded/disposed it. Guarded via a captured
+        // "was it tracked" flag now (see GetReload_ForSharedStaticTexture_DoesNotDisposePreviousInstanceUntilLoadSucceeds
+        // for why disposal itself moved past the Load call).
+        Assert.Contains("cm.IsAssetLoadedByReference(previousChibiCthulhuTiles)", generatedCode);
+    }
+
+    [Fact]
+    public void GetReload_ForSharedStaticTexture_DoesNotDisposePreviousInstanceUntilLoadSucceeds()
+    {
+        // Reproduces the field-confirmed crash: a live-edit PNG save races the editing tool still writing
+        // the file (worse on a slower machine), so Load<Texture2D> throws (observed:
+        // "InvalidOperationException: This image format is not supported"). Before this fix, the previous
+        // texture was disposed via UnloadAsset BEFORE the Load call - so a failed Load left every Sprite
+        // still referencing the previous (now-disposed) instance permanently broken, no matter how many
+        // times the caller retries. The previous instance must stay alive and tracked until the replacement
+        // has actually loaded.
+        var rfs = new ReferencedFileSave
+        {
+            Name = "GlobalContent/ChibiCthulhuTiles.png",
+            LoadedAtRuntime = true,
+            IsSharedStatic = true,
+        };
+
+        var codeBlock = new CodeBlockBase();
+        ReferencedFileSaveCodeGenerator.GetReload(rfs, container: null, codeBlock, LoadType.MaintainInstance);
+        var generatedCode = codeBlock.ToString();
+
+        // The previous instance is captured before anything else touches the field...
+        Assert.Contains("var previousChibiCthulhuTiles = ChibiCthulhuTiles;", generatedCode);
+        // ...evicted from the cache WITHOUT disposing it (forces Load to hit disk instead of returning the
+        // still-cached previous instance, but keeps the object itself alive)...
+        Assert.Contains("cm.RemoveDisposable((System.IDisposable)previousChibiCthulhuTiles);", generatedCode);
+        // ...the Load call and the actual Dispose() of the previous instance are both inside the try, with
+        // Dispose() only reachable after Load succeeds...
+        var loadIndex = generatedCode.IndexOf("FlatRedBall.FlatRedBallServices.Load<", StringComparison.Ordinal);
+        var disposeIndex = generatedCode.IndexOf("((System.IDisposable)previousChibiCthulhuTiles).Dispose();", StringComparison.Ordinal);
+        Assert.True(loadIndex >= 0 && disposeIndex > loadIndex,
+            "Dispose() of the previous instance must appear after the Load call, not before it.");
+        // ...and on failure, the previous (still-alive, undisposed) instance is re-registered under the same
+        // key the Load call used (not hardcoding Glue's path-casing/prefix rules here) rather than left
+        // orphaned, then the exception is rethrown rather than swallowed.
+        var loadCallStart = generatedCode.IndexOf("FlatRedBall.FlatRedBallServices.Load<", StringComparison.Ordinal);
+        var quoteStart = generatedCode.IndexOf('"', loadCallStart);
+        var quoteEnd = generatedCode.IndexOf('"', quoteStart + 1);
+        var loadedFileName = generatedCode.Substring(quoteStart, quoteEnd - quoteStart + 1);
+        Assert.Contains("catch(System.Exception)", generatedCode);
+        Assert.Contains($"cm.AddDisposable({loadedFileName}, (System.IDisposable)previousChibiCthulhuTiles);", generatedCode);
+        Assert.Contains("throw;", generatedCode);
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #2223 (merged, squashed all 3 pre-merge commits: terminal logger fix, protected-field GetField fix, redundant-dispatch fix). This PR carries the remaining commit, pushed after that merge:

- **Transient reload failure retry**: the real crash from the field report - `TargetInvocationException` wrapping `InvalidOperationException: This image format is not supported`, from a race where Glue's build-folder copy completes while the source PNG is still being written (slow disk/antivirus/editor). `GlobalContent.Reload` already retried this; the per-Entity reflection-based reload had no retry and aborted the whole call silently. Extracted a shared `RetryOnTransientReloadFailure` helper with precise per-attempt diagnostic logging.

## Test plan
- [x] `ForceReloadFileDtoTransientFailureRetryTests` - new, green.
- [x] Broader GlueControl/GameCommunicationPlugin regression run (165 tests) green.

https://claude.ai/code/session_01TZX3qwRrWdxnVPKwFvK9vT