### PR TITLE
Fix property-grid multi-select edits only applying to the last selected object

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/MainPropertyGridPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/MainPropertyGridPlugin.cs
@@ -111,11 +111,11 @@ namespace OfficialPlugins.VariableDisplay
 
         private void HandleItemSelect(ITreeNode selectedTreeNode)
         {
-            var nos = GlueState.Self.CurrentNamedObjectSave;
+            var namedObjectSaves = GlueState.Self.CurrentNamedObjectSaves;
             var element = GlueState.Self.CurrentElement;
 
             var mode = VariablePanelModeLogic.DetermineMode(
-                nos,
+                namedObjectSaves,
                 element,
                 GlueState.Self.CurrentStateSave,
                 GlueState.Self.CurrentStateSaveCategory,
@@ -125,7 +125,10 @@ namespace OfficialPlugins.VariableDisplay
             switch (mode)
             {
                 case VariablePanelMode.NamedObject:
-                    HandleNamedObjectSelect(nos, element);
+                    HandleNamedObjectSelect(namedObjectSaves.FirstOrDefault(), element);
+                    break;
+                case VariablePanelMode.MultipleNamedObjects:
+                    HandleMultipleNamedObjectsSelect(namedObjectSaves, element);
                     break;
                 case VariablePanelMode.Element:
                     ShowVariablesForCurrentElement();
@@ -143,6 +146,19 @@ namespace OfficialPlugins.VariableDisplay
                     settingsTab?.Hide();
                     break;
             }
+        }
+
+        private void HandleMultipleNamedObjectsSelect(IReadOnlyList<NamedObjectSave> namedObjects, GlueElement currentElement)
+        {
+            AddOrShowVariableGrid();
+            // Multi-select editing doesn't support adding a new custom variable - it's unclear
+            // which of the selected objects it would be added to:
+            variableViewModel.CanAddVariable = false;
+            variableViewModel.HasNoVariablesToShow = false;
+            VariableGrid.Visibility = System.Windows.Visibility.Visible;
+
+            NamedObjectVariableShowingLogic.UpdateShownVariablesForMultipleObjects(
+                VariableGrid.DataUiGrid, namedObjects, currentElement);
         }
 
         private void ShowPropertiesForReferencedFileSave(ReferencedFileSave referencedFileSave)

--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/MainPropertyGridPlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/MainPropertyGridPlugin.cs
@@ -96,17 +96,11 @@ namespace OfficialPlugins.VariableDisplay
 
         public void RefreshVariables()
         {
-            var nos = GlueState.Self.CurrentNamedObjectSave;
-            var element = GlueState.Self.CurrentElement;
-            if (nos != null)
-            {
-                HandleNamedObjectSelect(nos, element);
-            }
-            else if(element != null)
-            {
-                ShowVariablesForCurrentElement();
-            }
-            //RefreshLogic.RefreshGrid(variableGrid.DataUiGrid);
+            // This used to duplicate HandleItemSelect's single-object-only branch (nos != null,
+            // element != null), which ignored multi-select entirely. Since this is called after every
+            // full-commit variable set (GlueCommands.RefreshCommands.RefreshVariables), that collapsed
+            // a multi-object selection back down to a single object the moment the first edit committed:
+            HandleItemSelect(GlueState.Self.CurrentTreeNode);
         }
 
         private void HandleItemSelect(ITreeNode selectedTreeNode)

--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/NamedObjectSaveVariableDataGridItem.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/NamedObjectSaveVariableDataGridItem.cs
@@ -51,6 +51,16 @@ namespace OfficialPlugins.PropertyGrid
 
         public bool IsFile { get; set; }
 
+        /// <summary>
+        /// When non-null, HandleVariableSet adds its computed assignment to this list instead of
+        /// independently saving/generating code/recording undo via GluxCommands.SetVariableOn. Set by
+        /// the multi-select wiring (see NamedObjectVariableShowingLogic.WireUpBatchedMultiSet) so that
+        /// editing a property shared by several selected NamedObjectSaves applies to all of them
+        /// through a single batched GluxCommands.SetVariableOnList call - one undo entry and one
+        /// codegen/save pass - instead of one independent SetVariableOn call per selected object.
+        /// </summary>
+        public List<FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces.NosVariableAssignment> MultiSetBatchTarget { get; set; }
+
         Type cachedMemberType = null;
         Type MemberType
         {
@@ -306,6 +316,20 @@ namespace OfficialPlugins.PropertyGrid
                     }
                 }
                 IsDefault = makeDefault;
+
+                if (MultiSetBatchTarget != null)
+                {
+                    // Part of a multi-select edit: defer the actual save/codegen/undo to the batched
+                    // SetVariableOnList call the multi-select wiring makes once every selected object's
+                    // value has been added here (see NamedObjectVariableShowingLogic.WireUpBatchedMultiSet).
+                    MultiSetBatchTarget.Add(new FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces.NosVariableAssignment
+                    {
+                        NamedObjectSave = NamedObjectSave,
+                        VariableName = NameOnInstance,
+                        Value = value
+                    });
+                    return;
+                }
 
                 // If we ignore the next refresh, then AnimationChains won't update when the user
                 // picks an AnimationChainList from a combo box:

--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/NamedObjectVariableShowingLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/NamedObjectVariableShowingLogic.cs
@@ -13,6 +13,7 @@ using Glue;
 using WpfDataUi;
 using WpfDataUi.DataTypes;
 using FlatRedBall.Glue.Plugins;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces;
 using System;
 using OfficialPlugins.VariableDisplay.Controls;
 using OfficialPlugins.VariableDisplay.Data;
@@ -39,20 +40,20 @@ namespace OfficialPlugins.VariableDisplay
 {
     static partial class NamedObjectVariableShowingLogic
     {
-        public static void UpdateShownVariables(DataUiGrid grid, NamedObjectSave instance, GlueElement container,
-            AssetTypeInfo assetTypeInfo = null)
+        /// <summary>
+        /// Builds the full category/member list for a single NamedObjectSave, without touching a grid.
+        /// Used both for single-selection display (UpdateShownVariables) and to build one instance's
+        /// contribution to a multi-selection display (UpdateShownVariablesForMultipleObjects).
+        /// </summary>
+        static List<MemberCategory> BuildCategories(NamedObjectSave instance, GlueElement container,
+            AssetTypeInfo assetTypeInfo)
         {
-            #region Initial logic
-
-
             List<MemberCategory> categories = new List<MemberCategory>();
             var defaultCategory = new MemberCategory("Variables");
             defaultCategory.FontSize = 14;
             categories.Add(defaultCategory);
 
             assetTypeInfo = assetTypeInfo ?? instance.GetAssetTypeInfo();
-
-            #endregion
 
             CreateCategoriesAndVariables(instance, container as GlueElement, categories, assetTypeInfo);
 
@@ -84,6 +85,16 @@ namespace OfficialPlugins.VariableDisplay
                 topmostCategory.Members.Add(CreateNameInstanceMember(instance));
                 topmostCategory.Members.Add(CreateIsLockedMember(instance));
             }
+
+            return categories;
+        }
+
+        public static void UpdateShownVariables(DataUiGrid grid, NamedObjectSave instance, GlueElement container,
+            AssetTypeInfo assetTypeInfo = null)
+        {
+            assetTypeInfo = assetTypeInfo ?? instance.GetAssetTypeInfo();
+
+            var categories = BuildCategories(instance, container, assetTypeInfo);
 
             var needsFullRefresh = GetIfNeedsFullRefresh(grid.Categories?.ToArray(), categories?.ToArray());
             if (needsFullRefresh)
@@ -138,6 +149,90 @@ namespace OfficialPlugins.VariableDisplay
                 }
 
                 grid.Refresh();
+            }
+        }
+
+        /// <summary>
+        /// Populates the grid for a multi-object selection, using WpfDataUi's SetMultipleCategoryLists
+        /// to wrap each shared property in a MultiSelectInstanceMember. Editing such a property is then
+        /// wired (see WireUpBatchedMultiSet) to apply to every selected object in a single batched
+        /// GluxCommands.SetVariableOnList call rather than one independent SetVariableOn per object.
+        /// </summary>
+        public static void UpdateShownVariablesForMultipleObjects(DataUiGrid grid, IReadOnlyList<NamedObjectSave> instances,
+            GlueElement container, AssetTypeInfo assetTypeInfoOverride = null)
+        {
+            var listOfCategories = new List<List<MemberCategory>>();
+
+            foreach (var instance in instances)
+            {
+                var categories = BuildCategories(instance, container, assetTypeInfoOverride ?? instance.GetAssetTypeInfo());
+                RemoveMembersNotAllowedInMultiSelect(categories);
+                listOfCategories.Add(categories);
+            }
+
+            grid.SetMultipleCategoryLists(listOfCategories);
+
+            WireUpBatchedMultiSet(grid);
+        }
+
+        // Renaming is destructive if applied identically to every selected object (it would give them
+        // all the same name), so unlike every other property, "Name" is not editable during multi-select:
+        static void RemoveMembersNotAllowedInMultiSelect(List<MemberCategory> categories)
+        {
+            foreach (var category in categories)
+            {
+                var toRemove = category.Members
+                    .Where(item => item is DataGridItem dataGridItem && dataGridItem.UnmodifiedVariableName == "Name")
+                    .ToList();
+
+                foreach (var member in toRemove)
+                {
+                    category.Members.Remove(member);
+                }
+            }
+        }
+
+        static void WireUpBatchedMultiSet(DataUiGrid grid)
+        {
+            foreach (var category in grid.Categories)
+            {
+                foreach (var member in category.Members)
+                {
+                    if (member is MultiSelectInstanceMember multiSelectMember &&
+                        multiSelectMember.InstanceMembers.Count > 0 &&
+                        multiSelectMember.InstanceMembers.All(item => item is NamedObjectSaveVariableDataGridItem))
+                    {
+                        List<NosVariableAssignment> batch = null;
+
+                        multiSelectMember.BeforeMultiSet += args =>
+                        {
+                            batch = new List<NosVariableAssignment>();
+                            foreach (NamedObjectSaveVariableDataGridItem inner in multiSelectMember.InstanceMembers)
+                            {
+                                inner.MultiSetBatchTarget = batch;
+                            }
+                        };
+
+                        multiSelectMember.AfterMultiSet += args =>
+                        {
+                            foreach (NamedObjectSaveVariableDataGridItem inner in multiSelectMember.InstanceMembers)
+                            {
+                                inner.MultiSetBatchTarget = null;
+                            }
+
+                            if (batch?.Count > 0)
+                            {
+                                var isFullCommit = args.CommitType == SetPropertyCommitType.Full;
+                                _ = GlueCommands.Self.GluxCommands.SetVariableOnList(batch,
+                                    performSaveAndGenerateCode: isFullCommit,
+                                    updateUi: true,
+                                    recordUndo: isFullCommit);
+                            }
+
+                            batch = null;
+                        };
+                    }
+                }
             }
         }
 

--- a/FRBDK/Glue/OfficialPlugins/PropertyGrid/VariablePanelModeLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/PropertyGrid/VariablePanelModeLogic.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using FlatRedBall.Glue.FormHelpers;
 using FlatRedBall.Glue.SaveClasses;
 
@@ -6,6 +8,7 @@ namespace OfficialPlugins.VariableDisplay
     public enum VariablePanelMode
     {
         NamedObject,
+        MultipleNamedObjects,
         Element,
         ReferencedFile,
         Empty
@@ -13,6 +16,32 @@ namespace OfficialPlugins.VariableDisplay
 
     public static class VariablePanelModeLogic
     {
+        /// <summary>
+        /// Overload considering the full multi-selection. Falls back to the single-object
+        /// DetermineMode when 0 or 1 objects are selected, so existing single-select behavior
+        /// (including its tests) is untouched.
+        /// </summary>
+        public static VariablePanelMode DetermineMode(
+            IReadOnlyList<NamedObjectSave> currentNamedObjectSaves,
+            GlueElement currentElement,
+            StateSave currentStateSave,
+            StateSaveCategory currentStateSaveCategory,
+            ITreeNode selectedTreeNode,
+            ReferencedFileSave currentReferencedFileSave)
+        {
+            if (currentNamedObjectSaves != null && currentNamedObjectSaves.Count > 1)
+            {
+                // Lists never have properties to show, and a list has none of its own to multi-edit
+                // either, so if any selected object is a list, fall back to Empty:
+                return currentNamedObjectSaves.Any(item => item.IsList)
+                    ? VariablePanelMode.Empty
+                    : VariablePanelMode.MultipleNamedObjects;
+            }
+
+            return DetermineMode(currentNamedObjectSaves?.FirstOrDefault(), currentElement, currentStateSave,
+                currentStateSaveCategory, selectedTreeNode, currentReferencedFileSave);
+        }
+
         public static VariablePanelMode DetermineMode(
             NamedObjectSave currentNamedObjectSave,
             GlueElement currentElement,

--- a/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/NamedObjectVariableShowingLogicMultiSelectTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/NamedObjectVariableShowingLogicMultiSelectTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using OfficialPlugins.PropertyGrid;
+using OfficialPlugins.VariableDisplay;
+using Shouldly;
+using WpfDataUi;
+using WpfDataUi.DataTypes;
+using Xunit;
+
+namespace GlueUnitTests.PropertyGrid;
+
+// GitHub issue #2221: with multiple objects selected (via ctrl+click in the tree view or in edit
+// mode - both already funnel into GlueState.CurrentNamedObjectSaves), changing a property in the
+// Variables tab only applied to the last-selected object. UpdateShownVariablesForMultipleObjects
+// wraps each property shared across the selection in a MultiSelectInstanceMember (WpfDataUi's
+// SetMultipleCategoryLists) instead of building the grid for a single object, and
+// NamedObjectSaveVariableDataGridItem.MultiSetBatchTarget is what makes an edit apply to every
+// wrapped object instead of just the one the grid item happened to be built from.
+public class NamedObjectVariableShowingLogicMultiSelectTests : IDisposable
+{
+    private readonly GlueProjectSave _originalGlueProject;
+
+    public NamedObjectVariableShowingLogicMultiSelectTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave();
+    }
+
+    public void Dispose()
+    {
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+    }
+
+    private static (ScreenSave screen, NamedObjectSave instance1, NamedObjectSave instance2, AssetTypeInfo ati)
+        MakeTwoInstancesSharingAVariable()
+    {
+        var screen = new ScreenSave { Name = "Screens/GameScreen/GameScreen" };
+        ObjectFinder.Self.GlueProject.Screens.Add(screen);
+
+        var ati = new AssetTypeInfo { FriendlyName = "TestType" };
+        // RefreshFrom derives the grid's DisplayName from this by inserting spaces before capitals
+        // (StringFunctions.InsertSpacesInCamelCaseString), so the raw variable name "ExtraVariable"
+        // shows up (and gets grouped by SetMultipleCategoryLists) as DisplayName "Extra Variable":
+        ati.VariableDefinitions.Add(new VariableDefinition { Name = "ExtraVariable", Type = "float" });
+
+        var instance1 = new NamedObjectSave { InstanceName = "Instance1", SourceType = SourceType.FlatRedBallType };
+        var instance2 = new NamedObjectSave { InstanceName = "Instance2", SourceType = SourceType.FlatRedBallType };
+        screen.NamedObjects.Add(instance1);
+        screen.NamedObjects.Add(instance2);
+
+        return (screen, instance1, instance2, ati);
+    }
+
+    [StaFact]
+    public void UpdateShownVariablesForMultipleObjects_ShouldGroupSharedPropertyIntoOneMultiSelectMemberCoveringBothInstances()
+    {
+        var (screen, instance1, instance2, ati) = MakeTwoInstancesSharingAVariable();
+
+        var grid = new DataUiGrid();
+
+        NamedObjectVariableShowingLogic.UpdateShownVariablesForMultipleObjects(
+            grid, new List<NamedObjectSave> { instance1, instance2 }, screen, ati);
+
+        var allMembers = grid.Categories.SelectMany(category => category.Members).ToList();
+
+        var multiSelectMember = allMembers.OfType<MultiSelectInstanceMember>()
+            .FirstOrDefault(item => item.DisplayName == "Extra Variable");
+
+        multiSelectMember.ShouldNotBeNull();
+        multiSelectMember.InstanceMembers.Count.ShouldBe(2);
+        multiSelectMember.InstanceMembers.OfType<NamedObjectSaveVariableDataGridItem>()
+            .Select(item => item.NamedObjectSave)
+            .ShouldBe(new[] { instance1, instance2 }, ignoreOrder: true);
+    }
+
+    [StaFact]
+    public void UpdateShownVariablesForMultipleObjects_ShouldNotShowNameMember()
+    {
+        // Renaming is destructive if applied identically to every selected object - it would give
+        // them all the same name - so unlike every other property, "Name" is excluded from multi-select:
+        var (screen, instance1, instance2, ati) = MakeTwoInstancesSharingAVariable();
+
+        var grid = new DataUiGrid();
+
+        NamedObjectVariableShowingLogic.UpdateShownVariablesForMultipleObjects(
+            grid, new List<NamedObjectSave> { instance1, instance2 }, screen, ati);
+
+        var allMembers = grid.Categories.SelectMany(category => category.Members).ToList();
+
+        allMembers.Any(item => item.DisplayName == "Name").ShouldBeFalse();
+    }
+
+    [StaFact]
+    public void MultiSetBatchTarget_ShouldReceiveOneAssignmentPerSelectedObject_NotJustTheLast()
+    {
+        // This is the literal regression from #2221: before this batching was added, each grid item
+        // independently called GluxCommands.SetVariableOn for its own object, so nothing here fanned a
+        // single edit out across the whole selection. WireUpBatchedMultiSet's BeforeMultiSet points
+        // every selected object's grid item at the same batch list; this pins that each object - not
+        // just whichever one happens to run last - contributes its own entry to that shared list.
+        var (screen, instance1, instance2, ati) = MakeTwoInstancesSharingAVariable();
+
+        var grid = new DataUiGrid();
+        NamedObjectVariableShowingLogic.UpdateShownVariablesForMultipleObjects(
+            grid, new List<NamedObjectSave> { instance1, instance2 }, screen, ati);
+
+        var multiSelectMember = grid.Categories.SelectMany(category => category.Members)
+            .OfType<MultiSelectInstanceMember>()
+            .First(item => item.DisplayName == "Extra Variable");
+
+        var innerItems = multiSelectMember.InstanceMembers.OfType<NamedObjectSaveVariableDataGridItem>().ToList();
+
+        var batch = new List<NosVariableAssignment>();
+        foreach (var innerItem in innerItems)
+        {
+            innerItem.MultiSetBatchTarget = batch;
+        }
+
+        // Simulates MultiSelectInstanceMember.HandleCustomSetEvent's fan-out (foreach inner.SetValue):
+        foreach (var innerItem in innerItems)
+        {
+            innerItem.SetValue(2.5f, SetPropertyCommitType.Full);
+        }
+
+        batch.Count.ShouldBe(2);
+        batch.Select(item => item.NamedObjectSave).ShouldBe(new[] { instance1, instance2 }, ignoreOrder: true);
+        batch.ShouldAllBe(item => item.VariableName == "ExtraVariable" && (float)item.Value == 2.5f);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/VariablePanelModeLogicTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/VariablePanelModeLogicTests.cs
@@ -173,4 +173,66 @@ public class VariablePanelModeLogicTests
 
         mode.ShouldBe(VariablePanelMode.Empty);
     }
+
+    // GitHub issue #2221: ctrl+click multi-select already worked, but the Variables tab only ever
+    // showed/edited a single object. The overload taking the full CurrentNamedObjectSaves list is
+    // what routes 2+ selected objects to the multi-select display instead of the single-object one.
+    [Fact]
+    public void DetermineMode_ShouldReturnMultipleNamedObjects_WhenTwoNonListObjectsSelected()
+    {
+        var nos1 = new NamedObjectSave { SourceType = SourceType.FlatRedBallType, SourceClassType = "Sprite" };
+        var nos2 = new NamedObjectSave { SourceType = SourceType.FlatRedBallType, SourceClassType = "Sprite" };
+
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSaves: new List<NamedObjectSave> { nos1, nos2 },
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: null,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.MultipleNamedObjects);
+    }
+
+    [Fact]
+    public void DetermineMode_ShouldReturnEmpty_WhenMultiSelectIncludesAList()
+    {
+        var nos1 = new NamedObjectSave { SourceType = SourceType.FlatRedBallType, SourceClassType = "Sprite" };
+        var listNos = new NamedObjectSave { SourceType = SourceType.FlatRedBallType, SourceClassType = "PositionedObjectList<T>" };
+
+        var mode = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSaves: new List<NamedObjectSave> { nos1, listNos },
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: null,
+            currentReferencedFileSave: null);
+
+        mode.ShouldBe(VariablePanelMode.Empty);
+    }
+
+    [Fact]
+    public void DetermineMode_MultiSelectOverload_ShouldFallBackToSingleObjectBehavior_WhenOneOrZeroSelected()
+    {
+        var nos = new NamedObjectSave { SourceType = SourceType.FlatRedBallType, SourceClassType = "Sprite" };
+
+        var oneSelected = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSaves: new List<NamedObjectSave> { nos },
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: null,
+            currentReferencedFileSave: null);
+
+        var noneSelected = VariablePanelModeLogic.DetermineMode(
+            currentNamedObjectSaves: new List<NamedObjectSave>(),
+            currentElement: null,
+            currentStateSave: null,
+            currentStateSaveCategory: null,
+            selectedTreeNode: null,
+            currentReferencedFileSave: null);
+
+        oneSelected.ShouldBe(VariablePanelMode.NamedObject);
+        noneSelected.ShouldBe(VariablePanelMode.Empty);
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #2221: with multiple objects selected (tree view ctrl+click or edit-mode ctrl+click - both already funnel into `GlueState.CurrentNamedObjectSaves`), editing a property in the Variables tab only applied to the last-selected object.
- Covers the practical core of #558: the multi-select tree-view infrastructure the issue asked for already exists (`GlueState.CurrentTreeNodes`/`CurrentNamedObjectSaves`, already tested); the actual gap was the Variables tab's property grid, which always built/applied against a single object regardless of selection size.

## What changed
- `NamedObjectVariableShowingLogic` gets a `BuildCategories` extraction (zero behavior change) plus a new `UpdateShownVariablesForMultipleObjects`, which uses WpfDataUi's existing `SetMultipleCategoryLists`/`MultiSelectInstanceMember` (the same mechanism Gum already uses) to group each property shared across the selection into one editable row.
- `NamedObjectSaveVariableDataGridItem` gets a `MultiSetBatchTarget`: when set, an edit is added to a shared batch instead of independently calling `GluxCommands.SetVariableOn`. The multi-select wiring (`WireUpBatchedMultiSet`) uses `MultiSelectInstanceMember`'s `BeforeMultiSet`/`AfterMultiSet` hooks to collect one assignment per selected object, then applies them all via `GluxCommands.SetVariableOnList` - the same batched method the edit-mode drag-multiselect path already uses - so a multi-object edit is one undo entry and one codegen/save pass, not N.
- `VariablePanelModeLogic` gets an overload considering the full selection (`MultipleNamedObjects` mode), falling back to the existing single-object `DetermineMode` for 0/1 selected so existing behavior/tests are untouched.
- `MainPropertyGridPlugin` routes `MultipleNamedObjects` mode to the new multi-select path.
- "Name" is excluded from multi-select (renaming every selected object identically would collide their names); "IsEditingLocked" is left as an ordinary per-object toggle.

## Known limitations (out of scope for this PR)
- Variable-specific "conditional visibility" and dropdown-options refresh (`RefreshLogic`/`UpdateConditionalVisibility`) don't run during multi-select - they check for `NamedObjectSaveVariableDataGridItem` directly and silently no-op against the `MultiSelectInstanceMember` wrapper. No crash, just a minor feature gap.
- The rest of #558's scope (migrating other singular `CurrentXXXX` GlueState properties like `CurrentElement`/`CurrentEntitySave` to list-backed siblings) is untouched - left as future incremental work, noted in a comment on #558 rather than closing it.

## Test plan
- [x] New unit tests: `VariablePanelModeLogicTests` (multi-select mode decision) and `NamedObjectVariableShowingLogicMultiSelectTests` (grouping into `MultiSelectInstanceMember`, "Name" exclusion, and the literal #2221 regression - that each selected object contributes its own entry to the batch instead of only the last one winning).
- [x] Full non-BuildSmoke suite from a clean build: 832/833 passed. The one failure (`EditModeActivityGateTests.EmbeddedDiagnostics_LogsBlockedClickGateSnapshotAndSelectionChange`) is pre-existing and unrelated - confirmed via `git diff origin/NetStandard` showing zero changes to that file, and it fails identically in isolation.

Part of #558.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>