### PR TITLE
Block embedded game input while dragging a Glue panel splitter

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -128,6 +128,8 @@ namespace GameCommunicationPlugin.GlueControl
                 (System.ComponentModel.ISynchronizeInvoke)MainGlueWindow.Self, CommandSender.Self,
                 () => gameHostView?.EmbeddedGameWindowHandle ?? IntPtr.Zero);
             _embeddedInputAllowedService.Initialize();
+            GlueFormsCore.Controls.MainPanelControl.SplitterDragChanged +=
+                _embeddedInputAllowedService.SetBlockedByUiInteraction;
 
             CreateBuildControl();
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/EmbeddedInputAllowedService.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/EmbeddedInputAllowedService.cs
@@ -54,8 +54,26 @@ class EmbeddedInputAllowedService
 
     bool? lastAcknowledged = null;
     bool isSending = false;
+    bool isBlockedByUiInteraction = false;
 
-    private async void UpdateTimer(object sender, ElapsedEventArgs e)
+    /// <summary>
+    /// Forces input blocked for the duration of a Glue-side drag gesture (e.g. resizing a panel with a
+    /// <see cref="System.Windows.Controls.GridSplitter"/>) that isn't itself a window the Z-order check
+    /// in <see cref="ReadIsAllowed"/> can see. While such a gesture is live, the embedded game's real OS
+    /// window can be mid-resize and transiently still cover the cursor, which would otherwise read as
+    /// "the game is topmost" and let the drag reach the game as a click (#2226). Checks immediately
+    /// rather than waiting for the next poll tick, since a fast drag can otherwise slip through the
+    /// 100ms gap between polls.
+    /// </summary>
+    public void SetBlockedByUiInteraction(bool isBlocked)
+    {
+        isBlockedByUiInteraction = isBlocked;
+        _ = CheckAndSendIfChanged();
+    }
+
+    private async void UpdateTimer(object sender, ElapsedEventArgs e) => await CheckAndSendIfChanged();
+
+    private async System.Threading.Tasks.Task CheckAndSendIfChanged()
     {
         if (!_commandSender.IsConnected)
         {
@@ -73,7 +91,7 @@ class EmbeddedInputAllowedService
             return;
         }
 
-        var isAllowed = ReadIsAllowed(_getEmbeddedGameWindowHandle());
+        var isAllowed = ReadIsAllowed(_getEmbeddedGameWindowHandle(), isBlockedByUiInteraction);
 
         if (lastAcknowledged == isAllowed)
         {
@@ -114,8 +132,19 @@ class EmbeddedInputAllowedService
     /// version of this feature had thorough tests of its decision logic and none of its Win32 calls,
     /// which is precisely why nobody noticed the calls weren't happening.
     /// </summary>
-    internal static bool ReadIsAllowed(IntPtr embeddedGameWindowHandle)
+    /// <param name="isBlockedByUiInteraction">
+    /// True while a Glue-side drag gesture (e.g. a splitter resize, see <see cref="SetBlockedByUiInteraction"/>)
+    /// is in progress. Short-circuits to false without consulting the Win32 Z-order check, since that
+    /// check can't distinguish "the game is genuinely topmost" from "the game's window is mid-resize and
+    /// transiently still covers the cursor" (#2226).
+    /// </param>
+    internal static bool ReadIsAllowed(IntPtr embeddedGameWindowHandle, bool isBlockedByUiInteraction)
     {
+        if (isBlockedByUiInteraction)
+        {
+            return false;
+        }
+
         var cursorPositionKnown = GetCursorPos(out var cursorPosition);
         var topmostWindowAtCursor = cursorPositionKnown ? WindowFromPoint(cursorPosition) : IntPtr.Zero;
 

--- a/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml
+++ b/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml
@@ -57,13 +57,15 @@
                     SelectedItem="{Binding SelectedTab}" 
                     Visibility="{Binding Visibility}"/>
 
-            <GridSplitter 
-            Height="6" 
-            Grid.Row="1" 
-            HorizontalAlignment="Stretch" 
-            VerticalAlignment="Center" 
+            <GridSplitter
+            Height="6"
+            Grid.Row="1"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Center"
             Background="Transparent"
-            Visibility="{Binding TopSplitterVisibility}" />
+            Visibility="{Binding TopSplitterVisibility}"
+            DragStarted="GridSplitter_DragStarted"
+            DragCompleted="GridSplitter_DragCompleted" />
 
             <Grid Grid.Row="2" x:Name="CenterGrid">
                 <Grid.ColumnDefinitions>
@@ -86,11 +88,13 @@
                         ItemsSource="{Binding Tabs}" 
                         SelectedItem="{Binding SelectedTab}" 
                         Visibility="{Binding Visibility}"/>
-                <GridSplitter Width="6" 
+                <GridSplitter Width="6"
                           HorizontalAlignment="Center"
-                          VerticalAlignment="Stretch" 
+                          VerticalAlignment="Stretch"
                           Grid.Column="1"
-                          Background="Transparent"/>
+                          Background="Transparent"
+                          DragStarted="GridSplitter_DragStarted"
+                          DragCompleted="GridSplitter_DragCompleted"/>
                 <TabControl x:Name="CenterTabControl" 
                         Grid.Column="2" 
                         Style="{StaticResource MainTabControl.Style}"
@@ -98,12 +102,14 @@
                         ItemsSource="{Binding Tabs}" 
                         SelectedItem="{Binding SelectedTab}" 
                         Visibility="{Binding Visibility}"/>
-                <GridSplitter Width="6" 
-                          Grid.Column="3" 
-                          HorizontalAlignment="Center" 
+                <GridSplitter Width="6"
+                          Grid.Column="3"
+                          HorizontalAlignment="Center"
                           VerticalAlignment="Stretch"
                           Background="Transparent"
-                          Visibility="{Binding RightSplitterVisibility}" />
+                          Visibility="{Binding RightSplitterVisibility}"
+                          DragStarted="GridSplitter_DragStarted"
+                          DragCompleted="GridSplitter_DragCompleted" />
                 <TabControl x:Name="RightTabControl" 
                         Grid.Column="4" 
                         Style="{StaticResource MainTabControl.Style}"
@@ -113,12 +119,14 @@
                         Visibility="{Binding Visibility}" />
             </Grid>
 
-            <GridSplitter Height="6" 
-                      HorizontalAlignment="Stretch" 
-                      VerticalAlignment="Center" 
-                      Grid.Row="3" 
+            <GridSplitter Height="6"
+                      HorizontalAlignment="Stretch"
+                      VerticalAlignment="Center"
+                      Grid.Row="3"
                       Background="Transparent"
-                      Visibility="{Binding BottomSplitterVisibility}"/>
+                      Visibility="{Binding BottomSplitterVisibility}"
+                      DragStarted="GridSplitter_DragStarted"
+                      DragCompleted="GridSplitter_DragCompleted"/>
 
             <TabControl Grid.Row="4" 
                     x:Name="BottomTabControl" 

--- a/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
+++ b/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
@@ -37,6 +37,15 @@ namespace GlueFormsCore.Controls
 
         public static MainPanelControl Self { get; private set; }
 
+        /// <summary>
+        /// Raised when any of the panel-resize GridSplitters starts/stops dragging - true for start,
+        /// false for stop. Lets a plugin (see GameCommunicationPlugin's EmbeddedInputAllowedService)
+        /// block embedded-game input for the duration, since the splitter drag resizes the embedded
+        /// game's real OS window live, and its bounds can transiently still cover the cursor mid-resize
+        /// in a way that would otherwise look like the game is legitimately topmost (#2226).
+        /// </summary>
+        public static event Action<bool> SplitterDragChanged;
+
         #endregion
 
         public MainPanelControl()
@@ -339,5 +348,11 @@ namespace GlueFormsCore.Controls
                 tab.OnMouseEvent(e);
             }
         }
+
+        private void GridSplitter_DragStarted(object sender, DragStartedEventArgs e) =>
+            SplitterDragChanged?.Invoke(true);
+
+        private void GridSplitter_DragCompleted(object sender, DragCompletedEventArgs e) =>
+            SplitterDragChanged?.Invoke(false);
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbeddedInputAllowedServiceTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbeddedInputAllowedServiceTests.cs
@@ -65,7 +65,7 @@ public class EmbeddedInputAllowedServiceTests
 
     [Fact]
     public void ReadIsAllowed_NoEmbeddedGame_IsFalse() =>
-        EmbeddedInputAllowedService.ReadIsAllowed(IntPtr.Zero).ShouldBeFalse();
+        EmbeddedInputAllowedService.ReadIsAllowed(IntPtr.Zero, isBlockedByUiInteraction: false).ShouldBeFalse();
 
     /// <summary>
     /// The real thing: a real window, the real cursor, real GetCursorPos/WindowFromPoint. Proves the OS
@@ -106,15 +106,22 @@ public class EmbeddedInputAllowedServiceTests
             SetCursorPos(centerX, centerY).ShouldBeTrue();
             PumpDispatcher();
 
-            EmbeddedInputAllowedService.ReadIsAllowed(handle).ShouldBeTrue(
+            EmbeddedInputAllowedService.ReadIsAllowed(handle, isBlockedByUiInteraction: false).ShouldBeTrue(
                 "the cursor is over the window and nothing covers it, so input belongs to it");
+
+            // A splitter drag (or other blocking UI interaction) in progress must win even though the
+            // window genuinely is topmost under the cursor - this is what a resizing embedded game
+            // window looks like mid-drag (#2226), and no amount of Win32 Z-order truth should let a
+            // drag gesture reach the game.
+            EmbeddedInputAllowedService.ReadIsAllowed(handle, isBlockedByUiInteraction: true).ShouldBeFalse(
+                "a blocking UI interaction (e.g. a splitter drag) is in progress, so input must not reach the game");
 
             // Move the cursor off the window (its top-left corner is at least 100px in from the screen
             // edge, so this lands outside it) and the same call must flip.
             SetCursorPos(rect.Left - 50, rect.Top - 50).ShouldBeTrue();
             PumpDispatcher();
 
-            EmbeddedInputAllowedService.ReadIsAllowed(handle).ShouldBeFalse(
+            EmbeddedInputAllowedService.ReadIsAllowed(handle, isBlockedByUiInteraction: false).ShouldBeFalse(
                 "the cursor is no longer over the window, so a click there isn't the window's");
         }
         finally


### PR DESCRIPTION
Closes #2226

Dragging a Glue panel GridSplitter (Variables tab, or any Top/Left/Right/Bottom panel) resizes the embedded game window live via `Runner_MoveWindow`. `EmbeddedInputAllowedService.ReadIsAllowed`'s Win32 Z-order check can transiently see the game's real OS window as still covering the cursor mid-resize, which it reads as legitimate topmost focus - letting the drag register as a rectangle-select in the game and change/clear the selection.

`MainPanelControl` now raises `SplitterDragChanged` on each GridSplitter's `DragStarted`/`DragCompleted`; `EmbeddedInputAllowedService` forces `IsAllowed=false` for the duration, and checks immediately (not just on its 100ms poll) so a fast drag can't slip through.

Found but did not fix: `EditModeActivityGateTests.EmbeddedDiagnostics_LogsBlockedClickGateSnapshotAndSelectionChange` fails on `NetStandard` independent of this change - it asserts on a log string (`foregroundOwnedByThisGame=`) that no production code emits (the real field is `isParentGlueFocused`/`isEmbedded`/etc., `EditingManager.cs:1623`). Filing separately.

## Manual test
Glue/editor UI change - see chat reply for repro steps.

## Test plan
- [x] New unit tests on `EmbeddedInputAllowedServiceTests` pin the fix (blocked-by-UI-interaction overrides a genuinely-topmost game window)
- [x] Full `GlueUnitTests` suite: 832/833 pass (1 pre-existing unrelated failure, see above)
