### PR TITLE
Block embedded game input for any mouse gesture started in Glue (#2226)

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
+++ b/FRBDK/Glue/GameCommunicationPlugin/GameCommunicationPlugin.csproj
@@ -131,6 +131,7 @@
     <Compile Include="GlueControl\Dtos\Dtos.cs" />
     <Compile Include="GlueControl\Dtos\GeneratePreviewDto.cs" />
     <Compile Include="GlueControl\Managers\EmbeddedInputAllowedService.cs" />
+    <Compile Include="GlueControl\Managers\GlueMouseGestureWatcher.cs" />
     <Compile Include="GlueControl\Managers\ModalReportingService.cs" />
     <EmbeddedResource Include="GlueControl\Embedded\CommandReplayLogic.cs" />
     <Compile Include="GlueControl\MainCompilerPlugin.cs" />

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/MainCompilerPlugin.cs
@@ -128,8 +128,6 @@ namespace GameCommunicationPlugin.GlueControl
                 (System.ComponentModel.ISynchronizeInvoke)MainGlueWindow.Self, CommandSender.Self,
                 () => gameHostView?.EmbeddedGameWindowHandle ?? IntPtr.Zero);
             _embeddedInputAllowedService.Initialize();
-            GlueFormsCore.Controls.MainPanelControl.SplitterDragChanged +=
-                _embeddedInputAllowedService.SetBlockedByUiInteraction;
 
             CreateBuildControl();
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/EmbeddedInputAllowedService.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/EmbeddedInputAllowedService.cs
@@ -23,6 +23,10 @@ namespace GameCommunicationPlugin.GlueControl.Managers;
 /// That single check is Z-order-aware (so a window dragged over the panel blocks the game - #2154,
 /// #2214) and activation-independent (so the first click that returns focus to Glue still lands -
 /// #2183, #2187), which is exactly the pair the old heuristics kept trading against each other.
+///
+/// Z-order alone can't answer one thing, though: who a gesture already in progress belongs to. A drag
+/// that starts anywhere in Glue and passes over the game reads as "the game is topmost" at every
+/// instant it is. <see cref="GlueMouseGestureWatcher"/> supplies that missing half (#2226).
 /// </summary>
 class EmbeddedInputAllowedService
 {
@@ -39,8 +43,18 @@ class EmbeddedInputAllowedService
         _getEmbeddedGameWindowHandle = getEmbeddedGameWindowHandle;
     }
 
+    readonly GlueMouseGestureWatcher _gestureWatcher = new();
+
     public void Initialize()
     {
+        // Watches Glue's own message loop, so any mouse gesture that starts on any Glue surface blocks
+        // the game for its duration - no per-control wiring, and nothing the user does inside the game
+        // (a separate process) reaches it. Re-check immediately when a gesture starts or ends rather
+        // than waiting for the next tick: a splitter drag resizes the embedded game window live, so its
+        // edge can slide under the cursor well inside one poll interval.
+        System.Windows.Forms.Application.AddMessageFilter(_gestureWatcher);
+        _gestureWatcher.GestureChanged += () => _ = CheckAndSendIfChanged();
+
         // Occlusion and app switching change on human timescales (dragging a window off the panel,
         // alt-tabbing), not per-frame, so this doesn't need to keep up with the mouse. The game
         // combines this with its own per-frame FlatRedBall.Input.Mouse.IsInGameWindow() for the
@@ -54,24 +68,13 @@ class EmbeddedInputAllowedService
 
     bool? lastAcknowledged = null;
     bool isSending = false;
-    bool isBlockedByUiInteraction = false;
 
-    /// <summary>
-    /// Forces input blocked for the duration of a Glue-side drag gesture (e.g. resizing a panel with a
-    /// <see cref="System.Windows.Controls.GridSplitter"/>) that isn't itself a window the Z-order check
-    /// in <see cref="ReadIsAllowed"/> can see. While such a gesture is live, the embedded game's real OS
-    /// window can be mid-resize and transiently still cover the cursor, which would otherwise read as
-    /// "the game is topmost" and let the drag reach the game as a click (#2226). Checks immediately
-    /// rather than waiting for the next poll tick, since a fast drag can otherwise slip through the
-    /// 100ms gap between polls.
-    /// </summary>
-    public void SetBlockedByUiInteraction(bool isBlocked)
+    private async void UpdateTimer(object sender, ElapsedEventArgs e)
     {
-        isBlockedByUiInteraction = isBlocked;
-        _ = CheckAndSendIfChanged();
+        // Ends a gesture whose button-up Glue never saw because it happened over the game's window.
+        _gestureWatcher.Refresh();
+        await CheckAndSendIfChanged();
     }
-
-    private async void UpdateTimer(object sender, ElapsedEventArgs e) => await CheckAndSendIfChanged();
 
     private async System.Threading.Tasks.Task CheckAndSendIfChanged()
     {
@@ -91,7 +94,7 @@ class EmbeddedInputAllowedService
             return;
         }
 
-        var isAllowed = ReadIsAllowed(_getEmbeddedGameWindowHandle(), isBlockedByUiInteraction);
+        var isAllowed = ReadIsAllowed(_getEmbeddedGameWindowHandle(), _gestureWatcher.IsGestureInProgress);
 
         if (lastAcknowledged == isAllowed)
         {
@@ -132,19 +135,12 @@ class EmbeddedInputAllowedService
     /// version of this feature had thorough tests of its decision logic and none of its Win32 calls,
     /// which is precisely why nobody noticed the calls weren't happening.
     /// </summary>
-    /// <param name="isBlockedByUiInteraction">
-    /// True while a Glue-side drag gesture (e.g. a splitter resize, see <see cref="SetBlockedByUiInteraction"/>)
-    /// is in progress. Short-circuits to false without consulting the Win32 Z-order check, since that
-    /// check can't distinguish "the game is genuinely topmost" from "the game's window is mid-resize and
-    /// transiently still covers the cursor" (#2226).
+    /// <param name="isGlueGestureInProgress">
+    /// True while a mouse gesture that started on a Glue surface is still held down - see
+    /// <see cref="GlueMouseGestureWatcher"/>.
     /// </param>
-    internal static bool ReadIsAllowed(IntPtr embeddedGameWindowHandle, bool isBlockedByUiInteraction)
+    internal static bool ReadIsAllowed(IntPtr embeddedGameWindowHandle, bool isGlueGestureInProgress)
     {
-        if (isBlockedByUiInteraction)
-        {
-            return false;
-        }
-
         var cursorPositionKnown = GetCursorPos(out var cursorPosition);
         var topmostWindowAtCursor = cursorPositionKnown ? WindowFromPoint(cursorPosition) : IntPtr.Zero;
 
@@ -155,7 +151,7 @@ class EmbeddedInputAllowedService
                 IsChild(embeddedGameWindowHandle, topmostWindowAtCursor));
 
         return ComputeIsAllowed(embeddedGameWindowHandle, cursorPositionKnown, topmostWindowAtCursor,
-            topmostBelongsToEmbeddedGame);
+            topmostBelongsToEmbeddedGame, isGlueGestureInProgress);
     }
 
     /// <summary>
@@ -169,10 +165,22 @@ class EmbeddedInputAllowedService
     /// Whether that topmost window is the embedded game window or a child of it. SDL/MonoGame uses a
     /// single HWND today, but a child is still the game as far as this question goes.
     /// </param>
+    /// <param name="isGlueGestureInProgress">
+    /// Whether a mouse gesture that started on a Glue surface is still held down. It wins over the
+    /// Z-order answer, which can't tell "the game is genuinely topmost under the cursor" from "the user
+    /// is dragging out of Glue and happens to be over the game right now" - and, while a splitter drag
+    /// resizes the game window live, can't tell it from "the game's window is mid-resize and transiently
+    /// still covers the cursor" either (#2226).
+    /// </param>
     internal static bool ComputeIsAllowed(IntPtr embeddedGameWindowHandle, bool cursorPositionKnown,
-        IntPtr topmostWindowAtCursor, bool topmostBelongsToEmbeddedGame)
+        IntPtr topmostWindowAtCursor, bool topmostBelongsToEmbeddedGame, bool isGlueGestureInProgress)
     {
         if (embeddedGameWindowHandle == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        if (isGlueGestureInProgress)
         {
             return false;
         }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/GlueMouseGestureWatcher.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/GlueMouseGestureWatcher.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace GameCommunicationPlugin.GlueControl.Managers;
+
+/// <summary>
+/// Answers "is a mouse gesture that began on a Glue surface still in progress?" by watching Glue's own
+/// message loop. Registered with <see cref="Application.AddMessageFilter"/>, so it sees every message
+/// that loop pumps - WinForms controls and the WPF content in Glue's ElementHost alike.
+///
+/// The embedded game is a separate process whose window is reparented into Glue, so its mouse messages
+/// go to that process's queue and never reach this filter. A button press seen here therefore started
+/// somewhere in Glue: a panel splitter, the tree view, the output window, a tab header. Such a gesture
+/// belongs to Glue until the button comes back up, no matter where the cursor travels in between,
+/// which is what keeps a drag out of Glue and over the Game tab from also registering inside the game
+/// as a click or a rectangle-select (#2226).
+///
+/// Asking where the gesture started replaces the earlier approach of hooking each control that was
+/// reported broken - originally only the panel GridSplitters. Every drag source in Glue hits the same
+/// defect, so the gate can't be a list of controls somebody remembered to wire up.
+/// </summary>
+class GlueMouseGestureWatcher : IMessageFilter
+{
+    const int WM_NCLBUTTONDOWN = 0x00A1;
+    const int WM_NCLBUTTONUP = 0x00A2;
+    const int WM_NCRBUTTONDOWN = 0x00A4;
+    const int WM_NCRBUTTONUP = 0x00A5;
+    const int WM_NCMBUTTONDOWN = 0x00A7;
+    const int WM_NCMBUTTONUP = 0x00A8;
+    const int WM_NCXBUTTONDOWN = 0x00AB;
+    const int WM_NCXBUTTONUP = 0x00AC;
+    const int WM_LBUTTONDOWN = 0x0201;
+    const int WM_LBUTTONUP = 0x0202;
+    const int WM_RBUTTONDOWN = 0x0204;
+    const int WM_RBUTTONUP = 0x0205;
+    const int WM_MBUTTONDOWN = 0x0207;
+    const int WM_MBUTTONUP = 0x0208;
+    const int WM_XBUTTONDOWN = 0x020B;
+    const int WM_XBUTTONUP = 0x020C;
+
+    const int VK_LBUTTON = 0x01;
+    const int VK_RBUTTON = 0x02;
+    const int VK_MBUTTON = 0x04;
+    const int VK_XBUTTON1 = 0x05;
+    const int VK_XBUTTON2 = 0x06;
+
+    readonly Func<bool> _getIsAnyMouseButtonDown;
+
+    public GlueMouseGestureWatcher() : this(IsAnyMouseButtonPhysicallyDown) { }
+
+    internal GlueMouseGestureWatcher(Func<bool> getIsAnyMouseButtonDown) =>
+        _getIsAnyMouseButtonDown = getIsAnyMouseButtonDown;
+
+    public bool IsGestureInProgress { get; private set; }
+
+    /// <summary>
+    /// Raised when <see cref="IsGestureInProgress"/> flips, so the embedded input gate can be
+    /// re-evaluated the moment a drag starts rather than on its next poll tick. A splitter drag resizes
+    /// the embedded game window live, so the game's edge can slide under the cursor well inside one
+    /// poll interval.
+    /// </summary>
+    public event Action GestureChanged;
+
+    public bool PreFilterMessage(ref Message m)
+    {
+        switch (m.Msg)
+        {
+            case WM_LBUTTONDOWN:
+            case WM_RBUTTONDOWN:
+            case WM_MBUTTONDOWN:
+            case WM_XBUTTONDOWN:
+            case WM_NCLBUTTONDOWN:
+            case WM_NCRBUTTONDOWN:
+            case WM_NCMBUTTONDOWN:
+            case WM_NCXBUTTONDOWN:
+                SetIsGestureInProgress(true);
+                break;
+            case WM_LBUTTONUP:
+            case WM_RBUTTONUP:
+            case WM_MBUTTONUP:
+            case WM_XBUTTONUP:
+            case WM_NCLBUTTONUP:
+            case WM_NCRBUTTONUP:
+            case WM_NCMBUTTONUP:
+            case WM_NCXBUTTONUP:
+                Refresh();
+                break;
+        }
+
+        // Only ever observes; Glue's own controls still get every message.
+        return false;
+    }
+
+    /// <summary>
+    /// Ends a gesture once no mouse button is physically down. Glue does not always see the button-up
+    /// itself: a drag released over the embedded game delivers it to the game's process instead, so
+    /// without this the gate would stay shut for good and every later click in the game would be
+    /// swallowed. Called both on the button-up messages Glue does see and on every poll tick.
+    /// </summary>
+    public void Refresh()
+    {
+        if (IsGestureInProgress && !_getIsAnyMouseButtonDown())
+        {
+            SetIsGestureInProgress(false);
+        }
+    }
+
+    void SetIsGestureInProgress(bool value)
+    {
+        if (IsGestureInProgress == value)
+        {
+            return;
+        }
+
+        IsGestureInProgress = value;
+        GestureChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// GetAsyncKeyState rather than Control.MouseButtons: this is called from inside PreFilterMessage,
+    /// before the button-up message has been dispatched, and the message-queue-synchronous key state
+    /// GetKeyState reports still says "down" at that point.
+    /// </summary>
+    static bool IsAnyMouseButtonPhysicallyDown() =>
+        IsPhysicallyDown(VK_LBUTTON) || IsPhysicallyDown(VK_RBUTTON) || IsPhysicallyDown(VK_MBUTTON) ||
+        IsPhysicallyDown(VK_XBUTTON1) || IsPhysicallyDown(VK_XBUTTON2);
+
+    static bool IsPhysicallyDown(int virtualKey) => (GetAsyncKeyState(virtualKey) & 0x8000) != 0;
+
+    [DllImport("user32.dll")]
+    static extern short GetAsyncKeyState(int virtualKey);
+}

--- a/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml
+++ b/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml
@@ -63,9 +63,7 @@
             HorizontalAlignment="Stretch"
             VerticalAlignment="Center"
             Background="Transparent"
-            Visibility="{Binding TopSplitterVisibility}"
-            DragStarted="GridSplitter_DragStarted"
-            DragCompleted="GridSplitter_DragCompleted" />
+            Visibility="{Binding TopSplitterVisibility}" />
 
             <Grid Grid.Row="2" x:Name="CenterGrid">
                 <Grid.ColumnDefinitions>
@@ -92,9 +90,7 @@
                           HorizontalAlignment="Center"
                           VerticalAlignment="Stretch"
                           Grid.Column="1"
-                          Background="Transparent"
-                          DragStarted="GridSplitter_DragStarted"
-                          DragCompleted="GridSplitter_DragCompleted"/>
+                          Background="Transparent"/>
                 <TabControl x:Name="CenterTabControl" 
                         Grid.Column="2" 
                         Style="{StaticResource MainTabControl.Style}"
@@ -107,9 +103,7 @@
                           HorizontalAlignment="Center"
                           VerticalAlignment="Stretch"
                           Background="Transparent"
-                          Visibility="{Binding RightSplitterVisibility}"
-                          DragStarted="GridSplitter_DragStarted"
-                          DragCompleted="GridSplitter_DragCompleted" />
+                          Visibility="{Binding RightSplitterVisibility}" />
                 <TabControl x:Name="RightTabControl" 
                         Grid.Column="4" 
                         Style="{StaticResource MainTabControl.Style}"
@@ -124,9 +118,7 @@
                       VerticalAlignment="Center"
                       Grid.Row="3"
                       Background="Transparent"
-                      Visibility="{Binding BottomSplitterVisibility}"
-                      DragStarted="GridSplitter_DragStarted"
-                      DragCompleted="GridSplitter_DragCompleted"/>
+                      Visibility="{Binding BottomSplitterVisibility}"/>
 
             <TabControl Grid.Row="4" 
                     x:Name="BottomTabControl" 

--- a/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
+++ b/FRBDK/Glue/Glue/Controls/MainPanelControl.xaml.cs
@@ -37,15 +37,6 @@ namespace GlueFormsCore.Controls
 
         public static MainPanelControl Self { get; private set; }
 
-        /// <summary>
-        /// Raised when any of the panel-resize GridSplitters starts/stops dragging - true for start,
-        /// false for stop. Lets a plugin (see GameCommunicationPlugin's EmbeddedInputAllowedService)
-        /// block embedded-game input for the duration, since the splitter drag resizes the embedded
-        /// game's real OS window live, and its bounds can transiently still cover the cursor mid-resize
-        /// in a way that would otherwise look like the game is legitimately topmost (#2226).
-        /// </summary>
-        public static event Action<bool> SplitterDragChanged;
-
         #endregion
 
         public MainPanelControl()
@@ -348,11 +339,5 @@ namespace GlueFormsCore.Controls
                 tab.OnMouseEvent(e);
             }
         }
-
-        private void GridSplitter_DragStarted(object sender, DragStartedEventArgs e) =>
-            SplitterDragChanged?.Invoke(true);
-
-        private void GridSplitter_DragCompleted(object sender, DragCompletedEventArgs e) =>
-            SplitterDragChanged?.Invoke(false);
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbeddedInputAllowedServiceTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/EmbeddedInputAllowedServiceTests.cs
@@ -26,7 +26,7 @@ public class EmbeddedInputAllowedServiceTests
     public void ComputeIsAllowed_NoEmbeddedGame_IsFalse()
     {
         EmbeddedInputAllowedService.ComputeIsAllowed(IntPtr.Zero, cursorPositionKnown: true,
-            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true)
+            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true, isGlueGestureInProgress: false)
             .ShouldBeFalse("no game is embedded, so there is nothing for a click to reach");
     }
 
@@ -34,7 +34,7 @@ public class EmbeddedInputAllowedServiceTests
     public void ComputeIsAllowed_CursorPositionUnknown_FailsClosed()
     {
         EmbeddedInputAllowedService.ComputeIsAllowed(new IntPtr(1), cursorPositionKnown: false,
-            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true)
+            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true, isGlueGestureInProgress: false)
             .ShouldBeFalse("GetCursorPos failed, so the answer can't be confirmed and must fail closed (#2154)");
     }
 
@@ -42,7 +42,7 @@ public class EmbeddedInputAllowedServiceTests
     public void ComputeIsAllowed_NoWindowAtCursor_FailsClosed()
     {
         EmbeddedInputAllowedService.ComputeIsAllowed(new IntPtr(1), cursorPositionKnown: true,
-            topmostWindowAtCursor: IntPtr.Zero, topmostBelongsToEmbeddedGame: false)
+            topmostWindowAtCursor: IntPtr.Zero, topmostBelongsToEmbeddedGame: false, isGlueGestureInProgress: false)
             .ShouldBeFalse("nothing is drawn at the cursor (e.g. off-screen), so fail closed");
     }
 
@@ -50,7 +50,7 @@ public class EmbeddedInputAllowedServiceTests
     public void ComputeIsAllowed_AnotherWindowIsTopmost_IsFalse()
     {
         EmbeddedInputAllowedService.ComputeIsAllowed(new IntPtr(1), cursorPositionKnown: true,
-            topmostWindowAtCursor: new IntPtr(2), topmostBelongsToEmbeddedGame: false)
+            topmostWindowAtCursor: new IntPtr(2), topmostBelongsToEmbeddedGame: false, isGlueGestureInProgress: false)
             .ShouldBeFalse("something else is drawn over the embedded game at the cursor - the click is " +
                 "that window's, not the game's (#2154, #2214)");
     }
@@ -59,13 +59,23 @@ public class EmbeddedInputAllowedServiceTests
     public void ComputeIsAllowed_EmbeddedGameIsTopmost_IsTrue()
     {
         EmbeddedInputAllowedService.ComputeIsAllowed(new IntPtr(1), cursorPositionKnown: true,
-            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true)
+            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true, isGlueGestureInProgress: false)
             .ShouldBeTrue("the game window is what the OS reports as topmost under the cursor");
     }
 
     [Fact]
+    public void ComputeIsAllowed_GlueGestureInProgress_IsFalse()
+    {
+        EmbeddedInputAllowedService.ComputeIsAllowed(new IntPtr(1), cursorPositionKnown: true,
+            topmostWindowAtCursor: new IntPtr(1), topmostBelongsToEmbeddedGame: true,
+            isGlueGestureInProgress: true)
+            .ShouldBeFalse("the drag over the game started somewhere in Glue, so it is Glue's - dragging " +
+                "a tree node onto the Game tab, or a splitter that is resizing the game window (#2226)");
+    }
+
+    [Fact]
     public void ReadIsAllowed_NoEmbeddedGame_IsFalse() =>
-        EmbeddedInputAllowedService.ReadIsAllowed(IntPtr.Zero, isBlockedByUiInteraction: false).ShouldBeFalse();
+        EmbeddedInputAllowedService.ReadIsAllowed(IntPtr.Zero, isGlueGestureInProgress: false).ShouldBeFalse();
 
     /// <summary>
     /// The real thing: a real window, the real cursor, real GetCursorPos/WindowFromPoint. Proves the OS
@@ -106,22 +116,23 @@ public class EmbeddedInputAllowedServiceTests
             SetCursorPos(centerX, centerY).ShouldBeTrue();
             PumpDispatcher();
 
-            EmbeddedInputAllowedService.ReadIsAllowed(handle, isBlockedByUiInteraction: false).ShouldBeTrue(
+            EmbeddedInputAllowedService.ReadIsAllowed(handle, isGlueGestureInProgress: false).ShouldBeTrue(
                 "the cursor is over the window and nothing covers it, so input belongs to it");
 
-            // A splitter drag (or other blocking UI interaction) in progress must win even though the
-            // window genuinely is topmost under the cursor - this is what a resizing embedded game
-            // window looks like mid-drag (#2226), and no amount of Win32 Z-order truth should let a
-            // drag gesture reach the game.
-            EmbeddedInputAllowedService.ReadIsAllowed(handle, isBlockedByUiInteraction: true).ShouldBeFalse(
-                "a blocking UI interaction (e.g. a splitter drag) is in progress, so input must not reach the game");
+            // A gesture that started in Glue must win even though the window genuinely is topmost under
+            // the cursor - that is exactly what dragging a tree node over the Game tab, or resizing a
+            // panel whose splitter is shrinking the game window, looks like to the Z-order check
+            // (#2226). No amount of Win32 truth about who is on top should let such a drag reach the
+            // game.
+            EmbeddedInputAllowedService.ReadIsAllowed(handle, isGlueGestureInProgress: true).ShouldBeFalse(
+                "a gesture that started on a Glue surface is still held down, so input must not reach the game");
 
             // Move the cursor off the window (its top-left corner is at least 100px in from the screen
             // edge, so this lands outside it) and the same call must flip.
             SetCursorPos(rect.Left - 50, rect.Top - 50).ShouldBeTrue();
             PumpDispatcher();
 
-            EmbeddedInputAllowedService.ReadIsAllowed(handle, isBlockedByUiInteraction: false).ShouldBeFalse(
+            EmbeddedInputAllowedService.ReadIsAllowed(handle, isGlueGestureInProgress: false).ShouldBeFalse(
                 "the cursor is no longer over the window, so a click there isn't the window's");
         }
         finally

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GlueMouseGestureWatcherTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/GlueMouseGestureWatcherTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Windows.Forms;
+using GameCommunicationPlugin.GlueControl.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin;
+
+/// <summary>
+/// The embedded game runs in its own process, so the mouse messages for its window are posted to that
+/// process's queue and never reach Glue's message loop. Every button press this filter sees therefore
+/// started on a Glue surface, and the game must not act on the same gesture for as long as it lasts -
+/// however far the cursor travels in the meantime.
+/// </summary>
+public class GlueMouseGestureWatcherTests
+{
+    const int WM_MOUSEMOVE = 0x0200;
+    const int WM_LBUTTONDOWN = 0x0201;
+    const int WM_LBUTTONUP = 0x0202;
+    const int WM_RBUTTONDOWN = 0x0204;
+    const int WM_RBUTTONUP = 0x0205;
+    const int WM_NCLBUTTONDOWN = 0x00A1;
+
+    bool isAnyMouseButtonPhysicallyDown;
+    readonly GlueMouseGestureWatcher watcher;
+
+    public GlueMouseGestureWatcherTests() =>
+        watcher = new GlueMouseGestureWatcher(() => isAnyMouseButtonPhysicallyDown);
+
+    bool Send(int message)
+    {
+        var windowsMessage = Message.Create(IntPtr.Zero, message, IntPtr.Zero, IntPtr.Zero);
+        return watcher.PreFilterMessage(ref windowsMessage);
+    }
+
+    [Fact]
+    public void NothingHappened_NoGestureInProgress() =>
+        watcher.IsGestureInProgress.ShouldBeFalse("no button has been pressed anywhere in Glue");
+
+    [Fact]
+    public void ButtonDownInGlue_StartsGesture()
+    {
+        isAnyMouseButtonPhysicallyDown = true;
+        Send(WM_LBUTTONDOWN);
+
+        watcher.IsGestureInProgress.ShouldBeTrue(
+            "Glue's message loop saw the press, so the gesture started on a Glue surface");
+    }
+
+    [Fact]
+    public void NonClientButtonDown_StartsGesture()
+    {
+        isAnyMouseButtonPhysicallyDown = true;
+        Send(WM_NCLBUTTONDOWN);
+
+        watcher.IsGestureInProgress.ShouldBeTrue(
+            "a press on a non-client area (title bar, window border) is still a Glue gesture");
+    }
+
+    [Fact]
+    public void MouseMoveWithButtonHeld_DoesNotStartGesture()
+    {
+        isAnyMouseButtonPhysicallyDown = true;
+        Send(WM_MOUSEMOVE);
+
+        watcher.IsGestureInProgress.ShouldBeFalse(
+            "the cursor merely passing over Glue while a button is held elsewhere is not a Glue gesture");
+    }
+
+    [Fact]
+    public void ButtonUp_EndsGesture()
+    {
+        isAnyMouseButtonPhysicallyDown = true;
+        Send(WM_LBUTTONDOWN);
+
+        isAnyMouseButtonPhysicallyDown = false;
+        Send(WM_LBUTTONUP);
+
+        watcher.IsGestureInProgress.ShouldBeFalse("the button came back up, so the gesture is over");
+    }
+
+    [Fact]
+    public void ButtonUp_WhileAnotherButtonIsStillHeld_KeepsGesture()
+    {
+        isAnyMouseButtonPhysicallyDown = true;
+        Send(WM_RBUTTONDOWN);
+        Send(WM_LBUTTONDOWN);
+
+        Send(WM_RBUTTONUP);
+
+        watcher.IsGestureInProgress.ShouldBeTrue(
+            "a button is still held, so the gesture that started in Glue is still in progress");
+    }
+
+    /// <summary>
+    /// The case that makes the physical-state check necessary rather than nice to have: a drag that
+    /// starts in Glue and is released over the embedded game delivers its button-up to the game's
+    /// process, so Glue's message loop never sees the end of the gesture. Without this the gate would
+    /// stay shut for good and every later click in the game would be swallowed.
+    /// </summary>
+    [Fact]
+    public void ButtonReleasedOverTheGame_EndsGestureOnRefresh()
+    {
+        isAnyMouseButtonPhysicallyDown = true;
+        Send(WM_LBUTTONDOWN);
+
+        isAnyMouseButtonPhysicallyDown = false;
+        watcher.Refresh();
+
+        watcher.IsGestureInProgress.ShouldBeFalse(
+            "no button is physically down any more, so the gesture ended even though Glue never saw the up");
+    }
+
+    [Fact]
+    public void Refresh_WhileButtonStillHeld_KeepsGesture()
+    {
+        isAnyMouseButtonPhysicallyDown = true;
+        Send(WM_LBUTTONDOWN);
+
+        watcher.Refresh();
+
+        watcher.IsGestureInProgress.ShouldBeTrue("the button is still down, so the drag is still going");
+    }
+
+    [Fact]
+    public void GestureChanged_RaisedOnlyOnTransitions()
+    {
+        var raiseCount = 0;
+        watcher.GestureChanged += () => raiseCount++;
+
+        isAnyMouseButtonPhysicallyDown = true;
+        Send(WM_LBUTTONDOWN);
+        Send(WM_LBUTTONDOWN);
+        raiseCount.ShouldBe(1, "the gesture only started once");
+
+        isAnyMouseButtonPhysicallyDown = false;
+        Send(WM_LBUTTONUP);
+        watcher.Refresh();
+        raiseCount.ShouldBe(2, "the gesture only ended once");
+    }
+
+    [Fact]
+    public void FilterNeverConsumesMessages()
+    {
+        isAnyMouseButtonPhysicallyDown = true;
+
+        Send(WM_LBUTTONDOWN).ShouldBeFalse("Glue's own controls must still receive the press");
+        Send(WM_MOUSEMOVE).ShouldBeFalse();
+        Send(WM_LBUTTONUP).ShouldBeFalse("Glue's own controls must still receive the release");
+    }
+}


### PR DESCRIPTION
Dragging a tree node into the Game tab — the normal way to add an entity instance to a screen — also registered inside the game as a click/rectangle-select. So did dragging from the Output window, or from anywhere else in Glue. #2227 fixed only the panel splitters, by hooking those four `GridSplitter`s by name, which left every other drag source broken.

## Cause

`EmbeddedInputAllowedService.ReadIsAllowed` asks who the OS reports as topmost under the cursor. That's the right question for occlusion, but it can't answer who a gesture *already in progress* belongs to: a drag out of Glue that passes over the game reads as "the game is topmost" at every instant it's over the game.

## Fix

`GlueMouseGestureWatcher` supplies the missing half. It's an `IMessageFilter` on Glue's own message loop, so it sees every mouse-button message Glue pumps — WinForms controls and the WPF `ElementHost` content alike — while the embedded game, being a separate process, never reaches it. A button press it sees therefore started on a Glue surface, and input stays blocked until no button is physically down.

The physical-button check (`GetAsyncKeyState`, not just the button-up message) is what keeps the gate from sticking: a drag released over the game delivers its button-up to the game's process, so Glue never sees the end of the gesture.

The `GridSplitter` `DragStarted`/`DragCompleted` handlers and `MainPanelControl.SplitterDragChanged` are removed — splitter drags are covered by the general rule now.

Tree-node drops still work: `DragDropManagerGameWindow` does the whole thing Glue-side off `GlueState.Self.DraggedTreeNode`, and never needed the game to receive mouse input.

## Tests

`GlueMouseGestureWatcherTests` (10 new): gesture starts on a button-down Glue sees, survives a mouse-move, survives one button releasing while another is held, and ends both on a button-up Glue sees and on the physical-state refresh when it doesn't. `EmbeddedInputAllowedServiceTests` covers the gesture flag in the pure decision and against a real window.

Full non-BuildSmoke suite: 843 passed, 1 failed. The failure (`EditModeActivityGateTests.EmbeddedDiagnostics_LogsBlockedClickGateSnapshotAndSelectionChange`) reproduces identically on unmodified `NetStandard` — see #2231.

Follow-up to #2226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WqfuV7nPLK32KYMLeNef6
