### PR TITLE
Send a new object's position with its creation instead of after it

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandSending/CommandSender.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandSending/CommandSender.cs
@@ -49,7 +49,11 @@ namespace GameCommunicationPlugin.GlueControl.CommandSending
             }
         }
 
-        public static CommandSender Self { get; private set; }
+        /// <summary>
+        /// The process-wide sender. The setter is for tests only, which swap in a subclass that answers
+        /// without a game running; production code never reassigns it.
+        /// </summary>
+        public static CommandSender Self { get; internal set; }
 
         GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager;
         /// <summary>
@@ -84,7 +88,7 @@ namespace GameCommunicationPlugin.GlueControl.CommandSending
             return await SendCommand($"{dtoTypeName}:{serialized}", importance, waitForResponse:waitForResponse);
         }
 
-        public async Task<ToolsUtilities.GeneralResponse<T>> Send<T>(object dto, SendImportance importance = SendImportance.Normal)
+        public virtual async Task<ToolsUtilities.GeneralResponse<T>> Send<T>(object dto, SendImportance importance = SendImportance.Normal)
         {
 
             var sendResponse = await Send(dto, importance);
@@ -316,14 +320,19 @@ namespace GameCommunicationPlugin.GlueControl.CommandSending
             }
         }
 
-        internal async Task<Vector3> GetCameraPosition()
+        /// <summary>
+        /// The game's camera position, or null if the game did not answer. Callers use the position to
+        /// decide where to put a new object, so "the game is gone" has to be distinguishable from "the
+        /// camera is at the origin" - otherwise a dead game silently positions new objects at 0,0.
+        /// </summary>
+        internal virtual async Task<Vector3?> GetCameraPosition()
         {
             var sendResponse = await Send(new Dtos.GetCameraPosition());
             var cameraPositionAsString = sendResponse.Succeeded ? sendResponse.Data : String.Empty;
 
             if(string.IsNullOrEmpty(cameraPositionAsString))
             {
-                return Vector3.Zero;
+                return null;
             }
             else
             {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/RefreshManager.cs
@@ -535,13 +535,25 @@ namespace GameCommunicationPlugin.GlueControl.Managers
 
         internal async Task HandleNewObjectList(List<NamedObjectSave> newObjectList)
         {
-            var shouldSkipPositioning = NextPositionValues?.SkipPositioningForNextGroup == true;
-            if(NextPositionValues != null)
-            {
-                NextPositionValues = null;
-            }
+            // Read once and clear: this is a hand-off from whoever caused the add (a drop on the game
+            // window, a paste), and it only applies to this group.
+            var positionValues = NextPositionValues;
+            NextPositionValues = null;
+
             if (ViewModel.IsRunning && ViewModel.IsEditChecked)
             {
+                // Position before sending, so the object is created where it belongs instead of being
+                // created at the origin and moved by a second command that may never be sent.
+                if (positionValues?.SkipPositioningForNextGroup != true)
+                {
+                    var firstPositionedObject = newObjectList.FirstOrDefault(ShouldPositionNewObjectAtCamera);
+
+                    if (firstPositionedObject != null)
+                    {
+                        await ApplyNewObjectPosition(firstPositionedObject, positionValues?.ForcedNextObjectPosition);
+                    }
+                }
+
                 var list = new Dtos.AddObjectDtoList();
 
                 foreach (var newObject in newObjectList)
@@ -558,18 +570,6 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                 if (restartReason != null)
                 {
                     CreateStopAndRestartTask(restartReason);
-                }
-                else
-                {
-                    if(!shouldSkipPositioning)
-                    {
-                        var firstPositionedObject = newObjectList.FirstOrDefault(ShouldPositionNewObjectAtCamera);
-
-                        if (firstPositionedObject != null)
-                        {
-                            await AdjustNewObjectToCameraPosition(firstPositionedObject, NextPositionValues?.ForcedNextObjectPosition);
-                        }
-                    }
                 }
             }
         }
@@ -655,61 +655,61 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                 assetTypeInfo != AvailableAssetTypes.CommonAtis?.Camera;
         }
 
-        private async Task AdjustNewObjectToCameraPosition(NamedObjectSave newNamedObject, Vector2? forcedNextObjectPosition)
+        /// <summary>
+        /// Writes the position a newly added object should have onto the object itself, so that the
+        /// position is part of the object's creation rather than a separate command sent afterwards.
+        /// </summary>
+        /// <remarks>
+        /// Assigning the variables here instead of through GluxCommands.SetVariableOnAsync is deliberate:
+        /// that would notify plugins, which sends the game a second command setting a variable on an
+        /// object it is being told to create in the same breath. The AddObjectDto carries the whole
+        /// NamedObjectSave and the game applies its InstructionSaves on creation, so one message is enough.
+        /// </remarks>
+        private async Task ApplyNewObjectPosition(NamedObjectSave newNamedObject, Vector2? forcedPosition)
         {
-            Vector2 newPosition = Vector2.Zero;
+            var element = ObjectFinder.Self.GetElementContaining(newNamedObject);
+            var newPosition = forcedPosition;
 
-            if (forcedNextObjectPosition != null)
+            if (newPosition == null && element is ScreenSave)
             {
-                newPosition = forcedNextObjectPosition.Value;
-                forcedNextObjectPosition = null;
-            }
-            else
-            {
-                if (GlueState.Self.CurrentScreenSave != null)
+                // Only objects in a Screen go to the camera. One added to an Entity is positioned relative
+                // to that Entity, where the origin is the right place for it.
+                var cameraPosition = await CommandSender.Self.GetCameraPosition();
+
+                if (cameraPosition != null)
                 {
-                    newPosition = await GetNewNosPositionFromCamera(newNamedObject);
+                    newPosition = GetNonOverlappingPosition(
+                        new Vector2(cameraPosition.Value.X, cameraPosition.Value.Y), newNamedObject);
                 }
             }
 
-
-            bool didSetValue = false;
-            var gluxCommands = GlueCommands.Self.GluxCommands;
-
-            if (newPosition.X != 0)
+            if (newPosition == null)
             {
-                await gluxCommands.SetVariableOnAsync(newNamedObject, "X", newPosition.X, false, updateUi: false);
-                didSetValue = true;
-            }
-            if (newPosition.Y != 0)
-            {
-                await gluxCommands.SetVariableOnAsync(newNamedObject, "Y", newPosition.Y, false, updateUi: false);
-
-                didSetValue = true;
+                // Either the game never answered, or this object is not one that gets positioned. Writing
+                // 0,0 anyway would put a variable assignment on the object that the user never asked for,
+                // and codegen would then emit it.
+                return;
             }
 
+            newNamedObject.SetVariable("X", newPosition.Value.X);
+            newNamedObject.SetVariable("Y", newPosition.Value.Y);
 
-
-            if (didSetValue)
+            // Saving is the caller's job - whatever added this object persists it, and the position is now
+            // part of the object rather than a change made to it afterwards. Code generation is not, because
+            // GluxCommands.AddNewNamedObjectToAsync generates before it raises the event that reaches here.
+            if (element != null)
             {
-                GlueCommands.Self.GenerateCodeCommands.GenerateCurrentElementCode();
-                GlueCommands.Self.RefreshCommands.RefreshPropertyGrid();
-                GlueCommands.Self.GluxCommands.SaveProjectAndElements();
+                GlueCommands.Self.GenerateCodeCommands.GenerateElementCode(element);
             }
         }
 
-        private async Task<Vector2> GetNewNosPositionFromCamera(NamedObjectSave newNamedObject)
+        /// <summary>
+        /// Moves the desired position to the right until it is clear of the objects already sitting next to
+        /// the new one, so that adding several objects in a row does not stack them all in one spot.
+        /// </summary>
+        private static Vector2 GetNonOverlappingPosition(Vector2 desiredPosition, NamedObjectSave newNamedObject)
         {
-            // If it's in a screen, then we position the object on the camera:
-
-            var cameraPosition = Microsoft.Xna.Framework.Vector3.Zero;
-
-            cameraPosition = await CommandSender.Self.GetCameraPosition();
-
-            var gluxCommands = GlueCommands.Self.GluxCommands;
-
-
-            Vector2 newPosition = new Vector2(cameraPosition.X, cameraPosition.Y);
+            Vector2 newPosition = desiredPosition;
 
             var element = ObjectFinder.Self.GetElementContaining(newNamedObject);
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/NewObjectPositionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GameCommunicationPlugin/NewObjectPositionTests.cs
@@ -1,0 +1,322 @@
+using CompilerLibrary.ViewModels;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.VSHelpers.Projects;
+
+using GameCommunicationPlugin.GlueControl.CommandSending;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GameCommunicationPlugin.GlueControl.Managers;
+using GlueUnitTests.TestSupport;
+using Microsoft.Xna.Framework;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using ToolsUtilities;
+using Xunit;
+
+namespace GlueUnitTests.GameCommunicationPlugin
+{
+    /// <summary>
+    /// Where a newly added object ends up. Creating the object and positioning it used to be separate
+    /// messages to the game, so the position could be computed and then dropped - leaving the object at
+    /// the origin both on screen and in the saved project. These pin that the position travels with the
+    /// object's creation instead.
+    /// </summary>
+    public class NewObjectPositionTests : IDisposable
+    {
+        #region Test doubles
+
+        /// <summary>
+        /// Answers as a running game would, without one. <see cref="SentDtos"/> records what the
+        /// RefreshManager decided to send, which is what the game would have acted on.
+        /// </summary>
+        class FakeCommandSender : CommandSender
+        {
+            public List<object> SentDtos { get; } = new List<object>();
+            public Vector3? CameraPosition { get; set; } = Vector3.Zero;
+            public bool AddObjectSucceeds { get; set; } = true;
+
+            internal override Task<Vector3?> GetCameraPosition() => Task.FromResult(CameraPosition);
+
+            public override Task<GeneralResponse<T>> Send<T>(object dto, SendImportance importance = SendImportance.Normal)
+            {
+                SentDtos.Add(dto);
+
+                if (typeof(T) == typeof(AddObjectDtoListResponse))
+                {
+                    var list = dto as AddObjectDtoList;
+
+                    if (!AddObjectSucceeds)
+                    {
+                        return Task.FromResult(GeneralResponse<T>.UnsuccessfulWith(
+                            "The game is not ready to handle commands yet"));
+                    }
+
+                    var responseData = new AddObjectDtoListResponse
+                    {
+                        Data = list.Data.Select(_ => new AddObjectDtoResponse
+                        {
+                            CreationResponse = OptionallyAttemptedGeneralResponse.SuccessfulAttempt
+                        }).ToList()
+                    };
+
+                    return Task.FromResult(new GeneralResponse<T>
+                    {
+                        Succeeded = true,
+                        Data = (T)(object)responseData
+                    });
+                }
+
+                return Task.FromResult(new GeneralResponse<T> { Succeeded = true });
+            }
+        }
+
+        #endregion
+
+        readonly CommandSender originalCommandSender;
+        readonly bool originalIsRunning;
+        readonly bool originalIsEditChecked;
+        readonly VisualStudioProject originalMainProject;
+        readonly GlueProjectSave originalGlueProject;
+        readonly string originalRelativeDirectory;
+        readonly bool originalSynchronousMode;
+        readonly string tempProjectDirectory;
+        readonly FakeCommandSender fakeCommandSender = new FakeCommandSender();
+        readonly ScreenSave screen;
+
+        public NewObjectPositionTests()
+        {
+            GlueTestBootstrap.EnsureInitialized();
+
+            originalCommandSender = CommandSender.Self;
+            CommandSender.Self = fakeCommandSender;
+
+            originalIsRunning = CompilerViewModel.Self.IsRunning;
+            originalIsEditChecked = CompilerViewModel.Self.IsEditChecked;
+            originalMainProject = GlueState.Self.CurrentMainProject;
+            originalGlueProject = ObjectFinder.Self.GlueProject;
+            originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+            originalSynchronousMode = TaskManager.SynchronousMode;
+
+            // Positioning regenerates the element it changed, which needs a real code project to write to.
+            var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out tempProjectDirectory);
+            GlueState.Self.CurrentMainProject = vsProject;
+            FlatRedBall.IO.FileManager.RelativeDirectory = tempProjectDirectory + "\\";
+            TaskManager.SynchronousMode = true;
+
+            screen = new ScreenSave { Name = "Screens\\GameScreen" };
+
+            ObjectFinder.Self.GlueProject = new GlueProjectSave();
+            ObjectFinder.Self.GlueProject.Screens.Add(screen);
+        }
+
+        public void Dispose()
+        {
+            CommandSender.Self = originalCommandSender;
+            CompilerViewModel.Self.IsRunning = originalIsRunning;
+            CompilerViewModel.Self.IsEditChecked = originalIsEditChecked;
+            GlueState.Self.CurrentMainProject = originalMainProject;
+            ObjectFinder.Self.GlueProject = originalGlueProject;
+            FlatRedBall.IO.FileManager.RelativeDirectory = originalRelativeDirectory;
+            TaskManager.SynchronousMode = originalSynchronousMode;
+
+            try
+            {
+                Directory.Delete(tempProjectDirectory, recursive: true);
+            }
+            catch
+            {
+                // best-effort cleanup; a stray temp dir isn't worth failing the test over
+            }
+        }
+
+        #region Helpers
+
+        RefreshManager CreateRefreshManagerInEditMode()
+        {
+            // CompilerViewModel's constructor is private and it is a singleton, so the test drives the
+            // real one and restores it in Dispose rather than building its own.
+            CompilerViewModel.Self.IsRunning = true;
+            CompilerViewModel.Self.IsEditChecked = true;
+
+            var refreshManager = new RefreshManager((_, __) => Task.FromResult((string)null), (_, __) => { })
+            {
+                ViewModel = CompilerViewModel.Self
+            };
+
+            // Its constructor assigns itself to RefreshManager.VariableSendingManager, which
+            // CreateAddObjectDtoFor uses to qualify each variable's type.
+            new VariableSendingManager(refreshManager);
+
+            return refreshManager;
+        }
+
+        NamedObjectSave AddEntityInstanceToScreen(string instanceName)
+        {
+            var namedObject = new NamedObjectSave
+            {
+                InstanceName = instanceName,
+                SourceType = SourceType.Entity,
+                SourceClassType = "Entities\\Player"
+            };
+
+            screen.NamedObjects.Add(namedObject);
+
+            return namedObject;
+        }
+
+        static float? GetVariable(NamedObjectSave namedObject, string name) =>
+            namedObject.GetCustomVariable(name)?.Value as float?;
+
+        /// <summary>
+        /// The same variable read off an object that has been through the DTO's JSON round trip, which
+        /// widens a float to a double. What matters here is the value the game receives, not its boxed type.
+        /// </summary>
+        static float? GetRoundTrippedVariable(NamedObjectSave namedObject, string name)
+        {
+            var value = namedObject.GetCustomVariable(name)?.Value;
+
+            return value == null ? (float?)null : Convert.ToSingle(value);
+        }
+
+        static NamedObjectSave GetSentNamedObject(FakeCommandSender sender, string instanceName) =>
+            sender.SentDtos.OfType<AddObjectDtoList>()
+                .SelectMany(item => item.Data)
+                .Select(item => item.NamedObjectSave)
+                .FirstOrDefault(item => item.InstanceName == instanceName);
+
+        #endregion
+
+        /// <summary>
+        /// Dropping an entity onto the game window computes a world position in Glue and hands it to the
+        /// RefreshManager. That position is the whole point of dropping at a spot rather than adding from
+        /// the tree, so it has to reach the object.
+        /// </summary>
+        [Fact]
+        public async Task NewObject_WhenAPositionWasForced_GetsThatPosition()
+        {
+            var refreshManager = CreateRefreshManagerInEditMode();
+            var namedObject = AddEntityInstanceToScreen("PlayerInstance");
+
+            refreshManager.NextPositionValues = new RefreshManager.NewObjectListPositionValues
+            {
+                ForcedNextObjectPosition = new System.Numerics.Vector2(300, 200)
+            };
+
+            await refreshManager.HandleNewObjectList(new List<NamedObjectSave> { namedObject });
+
+            GetVariable(namedObject, "X").ShouldBe(300f);
+            GetVariable(namedObject, "Y").ShouldBe(200f);
+        }
+
+        /// <summary>
+        /// The position has to be on the object before it is sent, or the game creates it at the origin and
+        /// only moves it if a second message arrives.
+        /// </summary>
+        [Fact]
+        public async Task NewObject_WhenAPositionWasForced_SendsItWithTheObjectsCreation()
+        {
+            var refreshManager = CreateRefreshManagerInEditMode();
+            var namedObject = AddEntityInstanceToScreen("PlayerInstance");
+
+            refreshManager.NextPositionValues = new RefreshManager.NewObjectListPositionValues
+            {
+                ForcedNextObjectPosition = new System.Numerics.Vector2(300, 200)
+            };
+
+            await refreshManager.HandleNewObjectList(new List<NamedObjectSave> { namedObject });
+
+            var sent = GetSentNamedObject(fakeCommandSender, "PlayerInstance");
+
+            sent.ShouldNotBeNull();
+            GetRoundTrippedVariable(sent, "X").ShouldBe(300f);
+            GetRoundTrippedVariable(sent, "Y").ShouldBe(200f);
+        }
+
+        /// <summary>
+        /// A failed add falls back to a full stop/rebuild/relaunch. The restart rebuilds from the saved
+        /// project, so a position that was only going to be applied afterwards is lost for good - the
+        /// object is at the origin in the game and in the .glsj.
+        /// </summary>
+        [Fact]
+        public async Task NewObject_WhenTheAddFailedAndTriggeredARestart_KeepsTheForcedPosition()
+        {
+            var refreshManager = CreateRefreshManagerInEditMode();
+            var namedObject = AddEntityInstanceToScreen("PlayerInstance");
+
+            fakeCommandSender.AddObjectSucceeds = false;
+
+            refreshManager.NextPositionValues = new RefreshManager.NewObjectListPositionValues
+            {
+                ForcedNextObjectPosition = new System.Numerics.Vector2(300, 200)
+            };
+
+            await refreshManager.HandleNewObjectList(new List<NamedObjectSave> { namedObject });
+
+            GetVariable(namedObject, "X").ShouldBe(300f);
+            GetVariable(namedObject, "Y").ShouldBe(200f);
+        }
+
+        /// <summary>
+        /// Dropping at the origin is a deliberate choice, so it has to be written like any other position.
+        /// Skipping the write because the value happens to be zero leaves whatever was there before.
+        /// </summary>
+        [Fact]
+        public async Task NewObject_WhenTheForcedPositionIsTheOrigin_StillWritesIt()
+        {
+            var refreshManager = CreateRefreshManagerInEditMode();
+            var namedObject = AddEntityInstanceToScreen("PlayerInstance");
+
+            refreshManager.NextPositionValues = new RefreshManager.NewObjectListPositionValues
+            {
+                ForcedNextObjectPosition = new System.Numerics.Vector2(0, 0)
+            };
+
+            await refreshManager.HandleNewObjectList(new List<NamedObjectSave> { namedObject });
+
+            GetVariable(namedObject, "X").ShouldBe(0f);
+            GetVariable(namedObject, "Y").ShouldBe(0f);
+        }
+
+        /// <summary>
+        /// Adding from the tree has no drop point, so the object goes to the camera so the user can see it.
+        /// </summary>
+        [Fact]
+        public async Task NewObject_WithNoForcedPosition_GoesToTheCamera()
+        {
+            var refreshManager = CreateRefreshManagerInEditMode();
+            var namedObject = AddEntityInstanceToScreen("PlayerInstance");
+
+            fakeCommandSender.CameraPosition = new Vector3(50, 75, 0);
+
+            await refreshManager.HandleNewObjectList(new List<NamedObjectSave> { namedObject });
+
+            GetVariable(namedObject, "X").ShouldBe(50f);
+            GetVariable(namedObject, "Y").ShouldBe(75f);
+        }
+
+        /// <summary>
+        /// A game that died mid-operation answers nothing, which is not the same as a camera at the origin.
+        /// Writing 0,0 in that case puts a real variable assignment on the object that the user never asked
+        /// for, so the position is left alone instead.
+        /// </summary>
+        [Fact]
+        public async Task NewObject_WhenTheGameDidNotAnswer_LeavesThePositionAlone()
+        {
+            var refreshManager = CreateRefreshManagerInEditMode();
+            var namedObject = AddEntityInstanceToScreen("PlayerInstance");
+
+            fakeCommandSender.CameraPosition = null;
+
+            await refreshManager.HandleNewObjectList(new List<NamedObjectSave> { namedObject });
+
+            namedObject.GetCustomVariable("X").ShouldBeNull();
+            namedObject.GetCustomVariable("Y").ShouldBeNull();
+        }
+    }
+}


### PR DESCRIPTION
Dragging an entity onto the running game sometimes left it at 0,0 instead of where it was dropped. Two separate causes, both in `RefreshManager`:

**The drop coordinate was always discarded.** `HandleNewObjectList` set `NextPositionValues` to null and then read `NextPositionValues?.ForcedNextObjectPosition` off it, so the forced position was never seen and positioning always fell through to the camera. Regression from 05f70c177, which moved the field into a wrapper object and captured only `SkipPositioningForNextGroup` into a local.

**A restart threw the position away entirely.** Positioning lived in the `else` of the restart branch, so when an add failed and fell back to stop/rebuild/relaunch, X/Y were never written. The object had already been saved at 0,0, so that is what the `.glsj` kept — the wrong position survived the restart.

## What changed

Positioning now runs before the `AddObjectDto` is built and writes X/Y onto the `NamedObjectSave` itself. The DTO already carries the whole `NamedObjectSave` and the game applies its `InstructionSaves` in `InstanceLogic.AssignVariablesOnNewlyCreatedObject`, so the object is created in the right place from a single message instead of being created at the origin and moved by two follow-up variable commands. A restart now preserves the position because it is in the project before anything is sent.

Three smaller things fall out of that:

- `CommandSender.GetCameraPosition` returns `Vector3?` instead of `Vector3.Zero` on failure, so a game that died mid-operation is distinguishable from a camera at the origin. Previously the `if (newPosition.X != 0)` guards hid this by accident; without them, a dead game would have written a real `X = 0` assignment nobody asked for.
- Those `!= 0` guards are gone, so dropping deliberately at the origin is now written like any other position.
- The camera path keys off `ObjectFinder.GetElementContaining(...) is ScreenSave` rather than `GlueState.CurrentScreenSave`, so it depends on where the object actually is rather than on what happens to be selected.

Positioning still only runs while the game is running in edit mode, unchanged.

## Tests

`NewObjectPositionTests` drives `HandleNewObjectList` through a `CommandSender` subclass that answers as a running game would. Five of the six fail against the previous code with real assertion failures. The sixth (`WhenTheGameDidNotAnswer_LeavesThePositionAlone`) passed before by accident via the `!= 0` guards and now pins the nullable behavior deliberately.

Making that possible needed a scoped test seam first: `CommandSender.Send<T>` and `GetCameraPosition` are virtual and `CommandSender.Self` has an internal setter.

Full non-BuildSmoke suite: 849/850. The one failure, `EditModeActivityGateTests.EmbeddedDiagnostics_LogsBlockedClickGateSnapshotAndSelectionChange`, fails the same way on clean `origin/NetStandard` (verified by stashing).

## Manual test

Needed — the drop path itself is UI.

1. Open a project with an entity, run it into edit mode.
2. Drag the entity from the tree onto the game window, away from the center.
3. It should appear under the cursor, not at the origin or the middle of the view.
4. Add an object from the tree with no drop point — it should land at the camera, nudged clear of anything already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162iC7cgmZ7TcK4DfWPSzx8
