### PR TITLE
Select the MSBuild SDK by engine compatibility instead of a magic version cap

### DIFF
--- a/FRBDK/Glue/Glue/MainGlueWindow.cs
+++ b/FRBDK/Glue/Glue/MainGlueWindow.cs
@@ -28,7 +28,7 @@ using Microsoft.Xna.Framework.Audio;
 using System.Windows.Forms.Integration;
 using GlueFormsCore.Controls;
 using System.Diagnostics;
-using System.Text.RegularExpressions;
+using FlatRedBall.Glue.VSHelpers;
 using System.Linq;
 using Newtonsoft.Json;
 using System.Threading;
@@ -66,27 +66,14 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
     #endregion
     
     // internal (not private) so a headless test host can run the same real SDK-discovery Glue.exe runs -
-    // without MSBUILD_EXE_PATH pointed at a pre-7 SDK, Microsoft.Build.Evaluation.Project can't resolve
-    // the SDK imports in any SDK-style .csproj, so no real game project can be loaded.
+    // without MSBUILD_EXE_PATH pointed at an SDK whose MSBuild matches the one Glue loads,
+    // Microsoft.Build.Evaluation.Project can't resolve the SDK imports in any SDK-style .csproj, so no real
+    // game project can be loaded. MsBuildSdkSelector documents which SDKs qualify and why.
     internal static void SetMsBuildEnvironmentVariable()
     {
-        // August 21, 2023
-        // At some point in 
-        // the past, loading
-        // .NET 6.0 projects in
-        // Glue failed. It seemed
-        // to happen on machines which
-        // only had .NET 7 installed. At
-        // one point I had a Github issue which
-        // discussed this but I can't find it anymore.
-        // This problem does not occur for older (.NET 4.7)
-        // projects, so this is only needed when loading .NET
-        // 6 projects. However, this code is run 1 time when Glue
-        // first starts up. At this point we don't know what kind of 
-        // project will be loaded. In fact, one project could get loaded
-        // then a different one could get loaded. Also, .NET 4.7 is old, and
-        // fewer and fewer projects using .NET 4.7 exist, so over time this will
-        // be for all projects. Therefore, just do the check always.
+        // This only matters for SDK-style (.NET 6 and up) projects - older .NET 4.7 projects evaluate
+        // without it. But this runs once at startup, before we know which kind of project will be loaded
+        // (and one session can load several), so just always do the check.
         var startInfo = new ProcessStartInfo("dotnet", "--list-sdks")
         {
             RedirectStandardOutput = true
@@ -139,7 +126,10 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
 
         if (String.IsNullOrEmpty(output))
         {
-            var message = String.Format(Localization.Texts.ErrorCouldNotFindNetSix, output) + Localization.Texts.ErrorDotnetMultipleIssue;
+            var message = NoUsableSdkMessage(output) +
+                "You may have multiple installations of .NET on your machine. More info here: " +
+                "https://stackoverflow.com/questions/65692530/why-dotnet-list-sdks-does-not-show-installed-sdks-on-windows-10. " +
+                "Press CTRL+C on this popup to copy the text so you can paste it in an external editor and open that URL.";
 
             GlueCommands.Self.PrintOutput(message);
 
@@ -147,57 +137,27 @@ public partial class MainGlueWindow : Form, IMainGlueWindow
             return;
         }
 
-        var sdkPaths = Regex.Matches(output, "([0-9]+)[.]([0-9]+)[.]([0-9]+) \\[(.*)\\]")
-            .OfType<Match>()
-            // https://stackoverflow.com/questions/75702346/why-does-the-presence-of-net-7-0-2-sdk-cause-the-sdk-resolver-microsoft-dotnet?noredirect=1#comment133550210_75702346
-            // "7.0." instead of "7.0.201"
-            //.Where(item => item.Value.StartsWith("7.0.") == false)
-            .Where(m => int.Parse(m.Groups[1].Value) < 7)
-            .OrderByDescending(m => int.Parse(m.Groups[1].Value))
-            .ThenByDescending(m => int.Parse(m.Groups[2].Value))
-            .ThenByDescending(m => int.Parse(m.Groups[3].Value))
-            .Select(m => System.IO.Path.Combine(m.Groups[4].Value, m.Groups[1].Value + "." + m.Groups[2].Value + "." + m.Groups[3].Value, "MSBuild.dll"))
-            .ToArray();
+        var sdkPaths = MsBuildSdkSelector.GetUsableMsBuildPathsNewestFirst(output,
+            MsBuildSdkSelector.EngineVersion, MsBuildSdkSelector.GetMsBuildVersionOrNull);
 
-        //Useful for debugging query above
-        //var allSdks = sdkPaths.Aggregate((a, b) => a + "," + b);
-        //MessageBox.Show(allSdks);
-
-        if (sdkPaths.Any())
+        if (sdkPaths.Count > 0)
         {
-            string sdkPath = null;
-
-            foreach (var path in sdkPaths)
-            {
-                if (File.Exists(path))
-                {
-                    sdkPath = path;
-                    break;
-                }
-            }
-
-            //sdkPaths.FirstOrDefault(item => item.Contains("sdk\\6."));
-            if (String.IsNullOrEmpty(sdkPath))
-            {
-                //    sdkPath = sdkPaths.Last();
-
-                var message = String.Format(Localization.Texts.ErrorCouldNotFindNetSix, output);
-                GlueCommands.Self.PrintOutput(message);
-                DialogService.ShowMessage(message);
-            }
-            else
-            {
-                Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", sdkPath);
-                GlueCommands.Self.PrintOutput($"Using MSBUILD from {sdkPath}");
-            }
+            var sdkPath = sdkPaths[0];
+            Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", sdkPath);
+            GlueCommands.Self.PrintOutput($"Using MSBUILD from {sdkPath}");
         }
         else
         {
-            var message = String.Format(Localization.Texts.ErrorCouldNotFindNetSix, output);
+            var message = NoUsableSdkMessage(output);
             GlueCommands.Self.PrintOutput(message);
             DialogService.ShowMessage(message);
         }
     }
+
+    static string NoUsableSdkMessage(string dotnetListSdksOutput) =>
+        $"Could not find an installed .NET SDK whose MSBuild is compatible with the one Glue uses " +
+        $"({MsBuildSdkSelector.EngineVersion}). Glue may not be able to load projects. We recommend " +
+        $"installing the .NET 6 SDK. dotnet --list-sdks output: {dotnetListSdksOutput}";
 
     public MainGlueWindow()
     {

--- a/FRBDK/Glue/Glue/VSHelpers/MsBuildSdkSelector.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/MsBuildSdkSelector.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace FlatRedBall.Glue.VSHelpers;
+
+/// <summary>
+/// Decides which installed .NET SDK's MSBuild the editor evaluates .csproj files with - the value that
+/// goes into MSBUILD_EXE_PATH. Split out of MainGlueWindow so the choice can be unit tested against real
+/// "dotnet --list-sdks" output instead of only against whatever SDKs the developer happens to have.
+/// </summary>
+public static class MsBuildSdkSelector
+{
+    // "8.0.303 [C:\Program Files\dotnet\sdk]"
+    static readonly Regex SdkLine = new("([0-9]+)[.]([0-9]+)[.]([0-9]+) \\[(.*)\\]");
+
+    /// <summary>
+    /// The version of the Microsoft.Build engine Glue itself loads. MSBUILD_EXE_PATH does not change which
+    /// engine runs - it only changes which SDK's targets and resolvers that engine reads - so this is the
+    /// version an SDK's targets have to be written against.
+    /// </summary>
+    public static Version EngineVersion => GetMsBuildVersionOrNull(
+        typeof(Microsoft.Build.Evaluation.Project).Assembly.Location) ?? new Version(0, 0);
+
+    /// <summary>
+    /// The MSBuild version an SDK ships, read off its MSBuild.dll, or null if there is no such file.
+    /// </summary>
+    public static Version? GetMsBuildVersionOrNull(string msBuildDllPath)
+    {
+        if (string.IsNullOrEmpty(msBuildDllPath) || !File.Exists(msBuildDllPath))
+        {
+            return null;
+        }
+
+        var fileVersion = FileVersionInfo.GetVersionInfo(msBuildDllPath);
+        return new Version(fileVersion.FileMajorPart, fileVersion.FileMinorPart);
+    }
+
+    /// <summary>
+    /// Usable MSBuild.dll paths parsed out of "dotnet --list-sdks" output, newest first.
+    ///
+    /// An SDK is usable when the MSBuild it ships is no newer than <paramref name="engineVersion"/>. An SDK
+    /// newer than the engine is not: its Microsoft.Common.CurrentVersion.targets calls property functions
+    /// the engine does not have (the .NET 8.0.4xx SDK uses [MSBuild]::SubstringByAsciiChars, added well
+    /// after MSBuild 17.3), and every project evaluation dies on "Method not found". A newer *major* SDK
+    /// fails earlier still - its resolvers are compiled against a newer runtime than the editor process, so
+    /// they throw "Could not load file or assembly 'System.Runtime, Version=10.0.0.0'" before resolving
+    /// anything. Older SDKs stay in the list as fallbacks; their targets evaluate modern SDK-style projects
+    /// fine.
+    ///
+    /// Comparison is on major.minor because that is the band MSBuild adds features in - the .NET 6.0.4xx
+    /// SDK ships MSBuild 17.3.4, which the 17.3.1 engine reads without trouble.
+    /// </summary>
+    /// <param name="getSdkMsBuildVersion">
+    /// Reads an SDK's MSBuild version from a candidate path, returning null when the file is missing.
+    /// Injected so the rule can be tested without installing SDKs.
+    /// </param>
+    public static IReadOnlyList<string> GetUsableMsBuildPathsNewestFirst(string dotnetListSdksOutput,
+        Version engineVersion, Func<string, Version?> getSdkMsBuildVersion)
+    {
+        return SdkLine.Matches(dotnetListSdksOutput)
+            .OfType<Match>()
+            .OrderByDescending(m => int.Parse(m.Groups[1].Value))
+            .ThenByDescending(m => int.Parse(m.Groups[2].Value))
+            .ThenByDescending(m => int.Parse(m.Groups[3].Value))
+            .Select(m => Path.Combine(m.Groups[4].Value,
+                m.Groups[1].Value + "." + m.Groups[2].Value + "." + m.Groups[3].Value, "MSBuild.dll"))
+            .Where(path =>
+            {
+                var sdkMsBuildVersion = getSdkMsBuildVersion(path);
+                return sdkMsBuildVersion != null && sdkMsBuildVersion <= engineVersion;
+            })
+            .ToArray();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/MsBuildSdkSelectorTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/MsBuildSdkSelectorTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using FlatRedBall.Glue.VSHelpers;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+public class MsBuildSdkSelectorTests
+{
+    // Real "dotnet --list-sdks" output shape, covering the three ways an SDK can be unusable: too old to
+    // exist on disk, MSBuild newer than the engine (8.0.4xx), and a newer major entirely (10.x).
+    const string ListSdksOutput = @"3.1.417 [C:\Program Files\dotnet\sdk]
+6.0.428 [C:\Program Files\dotnet\sdk]
+8.0.303 [C:\Program Files\dotnet\sdk]
+8.0.424 [C:\Program Files\dotnet\sdk]
+10.0.400 [C:\Program Files\dotnet\sdk]
+";
+
+    // What each of those SDKs ships, as read off its MSBuild.dll.
+    static readonly Dictionary<string, Version> InstalledMsBuildVersions = new()
+    {
+        [@"C:\Program Files\dotnet\sdk\3.1.417\MSBuild.dll"] = new Version(16, 7),
+        [@"C:\Program Files\dotnet\sdk\6.0.428\MSBuild.dll"] = new Version(17, 3),
+        [@"C:\Program Files\dotnet\sdk\8.0.303\MSBuild.dll"] = new Version(17, 10),
+        [@"C:\Program Files\dotnet\sdk\8.0.424\MSBuild.dll"] = new Version(17, 14),
+        [@"C:\Program Files\dotnet\sdk\10.0.400\MSBuild.dll"] = new Version(18, 9),
+    };
+
+    static Version LookUp(string path) =>
+        InstalledMsBuildVersions.TryGetValue(path, out var version) ? version : null;
+
+    static readonly Version Engine = new(17, 3);
+
+    [Fact]
+    public void NewestSdkTheEngineCanReadIsPreferred()
+    {
+        var paths = MsBuildSdkSelector.GetUsableMsBuildPathsNewestFirst(ListSdksOutput, Engine, LookUp);
+
+        paths[0].ShouldBe(@"C:\Program Files\dotnet\sdk\6.0.428\MSBuild.dll");
+    }
+
+    [Fact]
+    public void SdksShippingAnMsBuildNewerThanTheEngineAreExcluded()
+    {
+        // Their Microsoft.Common.CurrentVersion.targets calls property functions the engine does not have,
+        // e.g. "[MSBuild]::SubstringByAsciiChars" in the 8.0.4xx SDK, and every evaluation dies on it.
+        var paths = MsBuildSdkSelector.GetUsableMsBuildPathsNewestFirst(ListSdksOutput, Engine, LookUp);
+
+        paths.ShouldNotContain(@"C:\Program Files\dotnet\sdk\8.0.424\MSBuild.dll");
+        paths.ShouldNotContain(@"C:\Program Files\dotnet\sdk\8.0.303\MSBuild.dll");
+        paths.ShouldNotContain(@"C:\Program Files\dotnet\sdk\10.0.400\MSBuild.dll");
+    }
+
+    [Fact]
+    public void OlderSdksRemainAsFallbacksInDescendingOrder()
+    {
+        var paths = MsBuildSdkSelector.GetUsableMsBuildPathsNewestFirst(ListSdksOutput, Engine, LookUp);
+
+        paths.ShouldBe(new[]
+        {
+            @"C:\Program Files\dotnet\sdk\6.0.428\MSBuild.dll",
+            @"C:\Program Files\dotnet\sdk\3.1.417\MSBuild.dll",
+        });
+    }
+
+    [Fact]
+    public void ANewerEngineUnlocksNewerSdks()
+    {
+        var paths = MsBuildSdkSelector.GetUsableMsBuildPathsNewestFirst(
+            ListSdksOutput, new Version(17, 14), LookUp);
+
+        paths[0].ShouldBe(@"C:\Program Files\dotnet\sdk\8.0.424\MSBuild.dll");
+    }
+
+    [Fact]
+    public void SdksWhoseMsBuildIsMissingAreSkipped()
+    {
+        var paths = MsBuildSdkSelector.GetUsableMsBuildPathsNewestFirst(
+            @"5.0.100 [C:\Program Files\dotnet\sdk]", Engine, LookUp);
+
+        paths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void NoUsableSdkYieldsNoCandidates()
+    {
+        var paths = MsBuildSdkSelector.GetUsableMsBuildPathsNewestFirst(
+            @"10.0.400 [C:\Program Files\dotnet\sdk]", Engine, LookUp);
+
+        paths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void EngineVersionIsTheMsBuildGlueActuallyLoads()
+    {
+        // Guards the assumption the whole rule rests on: that the version is readable at all. A default of
+        // 0.0 (unreadable Location, e.g. a single-file publish) would exclude every installed SDK.
+        MsBuildSdkSelector.EngineVersion.Major.ShouldBeGreaterThan(0);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/SdkStyleProjectLoadTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/SdkStyleProjectLoadTests.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// Pins the one thing every end-to-end test depends on: that the test host can evaluate a real
+/// SDK-style .csproj through the same <see cref="ProjectCreator"/> call Glue.exe's File > Load Project
+/// makes. When it can't, the whole LiveGame/gold-project suite fails with a "Missing SDK" exception
+/// that says nothing about the real cause (which .NET SDK MSBUILD_EXE_PATH points at). See GitHub
+/// issue #2218.
+/// </summary>
+public class SdkStyleProjectLoadTests
+{
+    public SdkStyleProjectLoadTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    [Fact]
+    public void CreateProject_EvaluatesACheckedInSdkStyleProject()
+    {
+        GlueTestBootstrap.EnsureMsBuildEnvironmentVariable();
+
+        var csproj = Path.Combine(GoldProject.FindRepoRoot(),
+            "Samples", "EditorTest1", "EditorTest1", "EditorTest1.csproj");
+
+        var result = ProjectCreator.CreateProject(csproj);
+
+        Assert.NotNull(result.Project);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GlueTestBootstrap.cs
@@ -217,7 +217,7 @@ internal static class GlueTestBootstrap
     ///    seam is *not* covered by ShowGui - several production paths call DialogService directly - so
     ///    without it a load that hits an error path pops a real modal and wedges the run.
     ///  - <see cref="MainGlueWindow"/>.<c>SetMsBuildEnvironmentVariable</c>, Glue's real SDK discovery. It
-    ///    points MSBUILD_EXE_PATH at a pre-7 SDK; without it <c>Microsoft.Build.Evaluation.Project</c> cannot
+    ///    points MSBUILD_EXE_PATH at a compatible SDK; without it <c>Microsoft.Build.Evaluation.Project</c> cannot
     ///    resolve the SDK imports of any SDK-style .csproj ("The SDK
     ///    'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' specified could not be found"), which is what
     ///    previously forced <see cref="TestVisualStudioProjectFactory"/> to use a bare non-SDK-style project.
@@ -352,7 +352,7 @@ internal static class GlueTestBootstrap
     };
 
     /// <summary>
-    /// Points MSBUILD_EXE_PATH at a pre-7 SDK by running Glue.exe's own discovery, unless it is already set.
+    /// Points MSBUILD_EXE_PATH at a compatible SDK by running Glue.exe's own discovery, unless it is already set.
     ///
     /// Called before every gold-project load rather than once per process on purpose: production clears this
     /// variable around its own nested dotnet invocations (CompilerPlugin's Compiler.cs, SyncedProjects'

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GoldProject.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/GoldProject.cs
@@ -247,7 +247,7 @@ internal static class GoldProject
         }
     }
 
-    static string FindRepoRoot()
+    internal static string FindRepoRoot()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
         while (directory != null)

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCli.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/NestedDotnetCli.cs
@@ -74,7 +74,7 @@ internal static class NestedDotnetCli
         }
 
         // GlueTestBootstrap.EnsureHeadlessProjectLoadReady runs Glue's real SetMsBuildEnvironmentVariable,
-        // which points MSBUILD_EXE_PATH at a pre-7 SDK so Microsoft.Build.Evaluation can resolve SDK-style
+        // which points MSBUILD_EXE_PATH at a compatible SDK so Microsoft.Build.Evaluation can resolve SDK-style
         // .csproj files in-process. A child dotnet CLI must not inherit that - it pins the child to that old
         // MSBuild and breaks the build. Production clears it around its own nested invocations for exactly
         // this reason (see CompilerPlugin's Compiler.cs and SyncedProjects' ProjectListEntry.xaml.cs).

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/TestVisualStudioProjectFactory.cs
@@ -54,7 +54,7 @@ EndProject
         // Microsoft.Build resolves and caches its toolset on the first project evaluation in the process.
         // This bare non-SDK-style project evaluates fine without MSBUILD_EXE_PATH, but if it is the first
         // evaluation, it fixes the toolset for the whole run - and a later gold-project load (which needs a
-        // pre-7 SDK to resolve SDK-style imports) then fails with "The SDK
+        // pre-selected SDK to resolve SDK-style imports) then fails with "The SDK
         // 'Microsoft.NET.SDK.WorkloadAutoImportPropsLocator' specified could not be found" while passing
         // when run on its own. Setting the variable here means whichever test evaluates first, it is set.
         GlueTestBootstrap.EnsureMsBuildEnvironmentVariable();


### PR DESCRIPTION
Replaces #2220, which used the wrong constraint and broke CI.

`MSBUILD_EXE_PATH` changes which SDK's targets and resolvers the engine reads, not which engine reads them. So the real requirement is that the chosen SDK's MSBuild is no newer than the `Microsoft.Build` Glue loads (17.3.1). The old `major < 7` filter satisfied that by luck: the .NET 6.0.4xx SDK ships MSBuild 17.3.4.

#2220 replaced the cap with "newest SDK at or below the running runtime's major", which on CI selects the 8.0.4xx SDK — whose `Microsoft.Common.CurrentVersion.targets` calls `[MSBuild]::SubstringByAsciiChars`, a function MSBuild 17.3 doesn't have. 37 tests failed.

**Change:** pick the newest SDK whose `MSBuild.dll` version is at or below the engine's, older SDKs staying as fallbacks. Extracted into `MsBuildSdkSelector` so the rule is unit testable against real `dotnet --list-sdks` output. The startup message names the engine version instead of reading "could not find .NET 6" (inlined from `Localization` per `FRBDK/Glue/CLAUDE.md`).

Also adds `SdkStyleProjectLoadTests`, which evaluates a checked-in SDK-style `.csproj` through `ProjectCreator`. That's the #2218 symptom, and without it a bad SDK choice shows up only as unrelated-looking "Missing SDK" failures spread across the end-to-end suite.

**Scope:** this does not close #2218. On a machine with only the .NET 10 SDK there is no valid choice at all — its resolvers are net10 assemblies and can't load into net8-targeted Glue (`Could not load file or assembly 'System.Runtime, Version=10.0.0.0'`), regardless of engine version. That needs Glue retargeted to net10 plus an MSBuild upgrade. A 6.0.4xx SDK stays a hard requirement until then; this PR at least makes the error say so.

**Behavior today is unchanged** — both the old rule and this one select the 6.0.4xx SDK on CI and on my machine. The win is that the rule stays correct when the engine is upgraded, and that it rejects the SDK #2220 picked.

**Tests:** 835/835 non-BuildSmoke, non-LiveGame locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsJtpngqBhi43jXQdxjCjB
