### PR TITLE
Correct the stale timing claim in pr-tests.yml's hang-timeout comment

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -43,9 +43,11 @@ jobs:
 
     # Run via the .sln so $(SolutionDir) is defined (OfficialPlugins has a post-build step that needs it).
     #
-    # --blame-hang-timeout is a backstop, not an expectation: these suites run in well under a minute each
-    # (see issue #1969), so a test sitting for 10 minutes is wedged and should fail the job rather than sit
-    # there until the runner's own limit kills it with no attribution. It also names the test that hung.
+    # --blame-hang-timeout is a backstop, not an expectation. No single test here runs for minutes (the
+    # whole 827-test run below takes about 100s, and the slower steps are slow because of how many tests
+    # they have, not how long any one of them takes), so a test sitting for the timeout is wedged and
+    # should fail the job rather than sit there until the runner's own limit kills it with no
+    # attribution. It also names the test that hung. See issue #1969.
     - name: Run unit tests
       run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category!=BuildSmoke&Category!=LiveGame" --blame-hang-timeout 10m
 


### PR DESCRIPTION
Comment-only. `pr-tests.yml` said "these suites run in well under a minute each", which stopped being true as the suite grew. Measured on the last run: unit tests ~100s (827 tests), live game ~210s (17), build smoke ~570s (69).

That matters because the comment is what someone reads while deciding whether a slow job is wedged. As written it says yes when the answer is no.

Reworded around what the timeout actually detects: no single test runs for minutes, and the slow steps are slow because of how many tests they have. That stays true as the suite grows instead of going stale again at the next threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V51cyK2TChimexiXiR9xuK
