### PR TITLE
Group the New Project platform dropdown by engine version

### DIFF
--- a/FRBDK/Glue/NpcWpfLib/Data/EmptyTemplates.cs
+++ b/FRBDK/Glue/NpcWpfLib/Data/EmptyTemplates.cs
@@ -11,13 +11,19 @@ namespace Npc.Data
     // uploaded, so a platform belongs here only while its engine is registered in the release
     // tooling's AllData -- otherwise the wizard hands out whatever zip was last uploaded, however
     // old, with nothing to say so. NewProjectTemplateListTests pins that.
+    //
+    // An entry's name is split across Category (the group header), FriendlyName (the row) and Details
+    // (the muted second line) rather than crammed onto one line. Web and FNA are FlatRedBall 1
+    // engines, so they sit in the FlatRedBall 1 group; a flat list made them look like separate
+    // products. NewProjectPlatformNamingTests pins that.
     public static class EmptyTemplates
     {
         public static List<PlatformProjectInfo> Projects { get; private set; } = new List<PlatformProjectInfo>();
 
         static EmptyTemplates()
         {
-            Add("Desktop GL .NET 9 (Windows, Mac, Linux) - MonoGame", "FlatRedBallDesktopGlMonoGameTemplate",
+            Add(PlatformProjectInfo.Frb1Category, "Desktop - MonoGame", "Windows, Mac, Linux · .NET 9",
+                "FlatRedBallDesktopGlMonoGameTemplate",
                 "http://files.flatredball.com/content/FrbXnaTemplates/DailyBuild/ZippedTemplates/FlatRedBallDesktopGlMonoGameTemplate.zip");
 
             // Android and iOS are deliberately absent: their engines stopped building when the
@@ -25,11 +31,13 @@ namespace Npc.Data
             // server predates that. Restore these entries together with the commented-out blocks in
             // AllData and Engine.yml once the mobile projects are retargeted off net8.
 
-            Add("Web (Browsers) - Kni", "FlatRedBallWebTemplate",
-                "https://files.flatredball.com/content/FrbXnaTemplates/DailyBuild/ZippedTemplates/FlatRedBallWebTemplate.zip");
-
-            Add("FNA .NET 7 (Windows, Mac, Linux)", "FlatRedBallDesktopFnaTemplate",
+            Add(PlatformProjectInfo.Frb1Category, "Desktop - FNA", "Windows, Mac, Linux · .NET 7",
+                "FlatRedBallDesktopFnaTemplate",
                 "http://files.flatredball.com/content/FrbXnaTemplates/DailyBuild/ZippedTemplates/FlatRedBallDesktopFnaTemplate.zip");
+
+            Add(PlatformProjectInfo.Frb1Category, "Web - Kni", "Browsers",
+                "FlatRedBallWebTemplate",
+                "https://files.flatredball.com/content/FrbXnaTemplates/DailyBuild/ZippedTemplates/FlatRedBallWebTemplate.zip");
 
             // FlatRedBall 2 ships its templates as a nuget package rather than a zip this repo builds,
             // so this entry is created by the dotnet CLI and is exempt from the zip-pipeline checks in
@@ -37,7 +45,9 @@ namespace Npc.Data
             // the content and the engine reference, while .Desktop is only a launcher.
             Projects.Add(new DotnetNewProjectInfo
             {
-                FriendlyName = "FlatRedBall 2 Desktop (Windows, Mac, Linux) - MonoGame",
+                Category = PlatformProjectInfo.Frb2Category,
+                FriendlyName = "Desktop - MonoGame",
+                Details = "Windows, Mac, Linux",
                 Namespace = "FlatRedBall2DesktopTemplate",
                 TemplatePackageId = "FlatRedBall2.Templates",
                 TemplateShortName = "frb2-desktop",
@@ -48,13 +58,16 @@ namespace Npc.Data
             Projects.Add(new AddNewLocalProjectOption());
         }
 
-        static void Add(string friendlyName, string namespaceName, string url, bool supportedInGlue = true)
+        static void Add(string category, string friendlyName, string details, string namespaceName, string url,
+            bool supportedInGlue = true)
         {
             var newItem = new PlatformProjectInfo();
 
             var zipName = FileManager.RemovePath(url);
 
+            newItem.Category = category;
             newItem.FriendlyName = friendlyName;
+            newItem.Details = details;
             newItem.Namespace = namespaceName;
             newItem.ZipName = zipName;
             newItem.Url = url;

--- a/FRBDK/Glue/NpcWpfLib/MainWindow.xaml
+++ b/FRBDK/Glue/NpcWpfLib/MainWindow.xaml
@@ -9,7 +9,41 @@
     <Window.Resources>
         <Style x:Key="myStyle" TargetType="Button">
             <Setter Property="Background" Value="#71AA34" />
-            
+
+        </Style>
+
+        <!-- A platform row: a short name over a muted detail line. The engine version is not on the
+             row because the group header above it already carries that. The closed ComboBox draws no
+             group header though, so the trigger below swaps in the fully qualified name and drops the
+             detail line whenever this template renders outside a ComboBoxItem - which is exactly the
+             selection box. -->
+        <DataTemplate x:Key="PlatformItemTemplate">
+            <StackPanel Margin="0,1">
+                <TextBlock x:Name="NameText" Text="{Binding FriendlyName}" />
+                <TextBlock x:Name="DetailsText" Text="{Binding Details}" FontSize="10" Opacity="0.6" />
+            </StackPanel>
+            <DataTemplate.Triggers>
+                <DataTrigger Binding="{Binding Details}" Value="{x:Null}">
+                    <Setter TargetName="DetailsText" Property="Visibility" Value="Collapsed" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBoxItem}}}" Value="{x:Null}">
+                    <Setter TargetName="NameText" Property="Text" Value="{Binding QualifiedFriendlyName}" />
+                    <Setter TargetName="DetailsText" Property="Visibility" Value="Collapsed" />
+                </DataTrigger>
+            </DataTemplate.Triggers>
+        </DataTemplate>
+
+        <Style x:Key="PlatformGroupStyle" TargetType="GroupItem">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="GroupItem">
+                        <StackPanel>
+                            <TextBlock Text="{Binding Name}" FontWeight="Bold" Margin="4,6,0,2" />
+                            <ItemsPresenter Margin="10,0,0,0" />
+                        </StackPanel>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
     </Window.Resources>
     <Grid Margin="12,24,12,12">
@@ -40,7 +74,16 @@
                      KeyDown="TextBox_KeyDown"></TextBox>
 
             <TextBlock FontWeight="Bold" Grid.Column="0" Grid.Row="1" Margin="0,0,16,10" Text="Platform:" />
-            <ComboBox VerticalAlignment="Top"  ItemsSource="{Binding AvailableProjects, Mode=OneWay}" SelectedItem="{Binding SelectedProject}" Grid.Column="1" Grid.Row="1"></ComboBox>
+            <ComboBox VerticalAlignment="Top"
+                      x:Name="PlatformComboBox" x:FieldModifier="public"
+                      ItemsSource="{Binding GroupedProjects, Mode=OneWay}"
+                      SelectedItem="{Binding SelectedProject}"
+                      ItemTemplate="{StaticResource PlatformItemTemplate}"
+                      Grid.Column="1" Grid.Row="1">
+                <ComboBox.GroupStyle>
+                    <GroupStyle ContainerStyle="{StaticResource PlatformGroupStyle}" />
+                </ComboBox.GroupStyle>
+            </ComboBox>
 
             <TextBlock FontWeight="Bold" Grid.Column="0" Grid.Row="2" Margin="0,0,16,10" Text="Use local copy if available:" />
             <CheckBox IsChecked="{Binding UseLocalCopy}" Grid.Column="1" Grid.Row="2">

--- a/FRBDK/Glue/NpcWpfLib/MainWindow.xaml.cs
+++ b/FRBDK/Glue/NpcWpfLib/MainWindow.xaml.cs
@@ -71,7 +71,13 @@ namespace Npc
                             var folder = dialog.SelectedPath;
 
                             var project = new PlatformProjectInfo();
-                            project.FriendlyName = "Local Project";
+                            // The folder name reads as the row and the full path as the muted line
+                            // under it - picking two local templates whose folders sit in different
+                            // places used to give two rows of near-identical long paths.
+                            project.Category = PlatformProjectInfo.OtherCategory;
+                            var folderName = FileManager.RemovePath(folder.TrimEnd('\\', '/'));
+                            project.FriendlyName = string.IsNullOrEmpty(folderName) ? folder : folderName;
+                            project.Details = folder;
                             project.LocalSourceFile = folder;
                             // assume true:
                             project.SupportedInGlue = true;

--- a/FRBDK/Glue/NpcWpfLib/Models/PlatformProjectInfo.cs
+++ b/FRBDK/Glue/NpcWpfLib/Models/PlatformProjectInfo.cs
@@ -8,29 +8,50 @@ namespace Npc
 {
     public class PlatformProjectInfo
     {
-        public string FriendlyName;
+        /// <summary>The engine version an entry belongs to. The platform dropdown groups on these.</summary>
+        public const string Frb1Category = "FlatRedBall 1";
+        public const string Frb2Category = "FlatRedBall 2";
+        public const string OtherCategory = "Other";
+
+        /// <summary>
+        /// The dropdown row's main line, such as "Desktop - MonoGame". Deliberately short and free of the
+        /// engine version, which <see cref="Category"/> supplies as a group header instead.
+        /// </summary>
+        public string FriendlyName { get; set; }
+
+        /// <summary>The group header this entry sits under - one of the category constants above.</summary>
+        public string Category { get; set; }
+
+        /// <summary>
+        /// The dropdown row's muted second line, such as "Windows, Mac, Linux · .NET 9". This is where
+        /// everything that used to make the single-line names unreadably long lives. Null hides the line.
+        /// </summary>
+        public string Details { get; set; }
+
+        /// <summary>
+        /// <see cref="Category"/> and <see cref="FriendlyName"/> joined. A closed ComboBox draws no group
+        /// header, so "Desktop - MonoGame" on its own would not say which engine version is selected -
+        /// exactly the confusion the short names are meant to remove. The closed box shows this instead.
+        /// </summary>
+        public string QualifiedFriendlyName =>
+            string.IsNullOrEmpty(Category) ? FriendlyName : $"{Category} - {FriendlyName}";
+
         public string Namespace;
         public string ZipName;
         public string Url;
         public FilePath LocalSourceFile;
         public bool SupportedInGlue;
 
-        public override string ToString()
-        {
-            if(LocalSourceFile != null)
-            {
-                return LocalSourceFile.FullPath;
-            }
-            else
-            {
-                return FriendlyName;
-            }
-        }
+        public override string ToString() => QualifiedFriendlyName;
     }
 
     public class AddNewLocalProjectOption : PlatformProjectInfo
     {
-        public override string ToString() => "Select Local Project...";
+        public AddNewLocalProjectOption()
+        {
+            FriendlyName = "Select Local Project...";
+            Category = OtherCategory;
+        }
     }
 
     /// <summary>

--- a/FRBDK/Glue/NpcWpfLib/Services/IDownloadService.cs
+++ b/FRBDK/Glue/NpcWpfLib/Services/IDownloadService.cs
@@ -20,7 +20,7 @@ public class WpfDownloadService : IDownloadService
     {
         var urs = new UpdaterRuntimeSettings();
         urs.FileToDownload = fileToDownload;
-        urs.FormTitle = "Downloading " + viewModel.SelectedProject.FriendlyName;
+        urs.FormTitle = "Downloading " + viewModel.SelectedProject.QualifiedFriendlyName;
 
         urs.LocationToSaveFile = destinationZip;
 

--- a/FRBDK/Glue/NpcWpfLib/ViewModels/NewProjectViewModel.cs
+++ b/FRBDK/Glue/NpcWpfLib/ViewModels/NewProjectViewModel.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Text;
 using System.Windows;
+using System.Windows.Data;
 using System.Windows.Media;
 using ToolsUtilities;
 
@@ -153,6 +155,28 @@ namespace Npc.ViewModels
             get;
             private set;
         } = new ObservableCollection<PlatformProjectInfo>();
+
+        ICollectionView groupedProjects;
+
+        /// <summary>
+        /// <see cref="AvailableProjects"/> grouped by <see cref="PlatformProjectInfo.Category"/>, so the
+        /// platform dropdown gets a header per engine version. Built on first use rather than in the
+        /// constructor because a CollectionView binds to the thread that creates it, and the headless
+        /// tests that construct this view model have no UI thread to bind to.
+        /// </summary>
+        public ICollectionView GroupedProjects
+        {
+            get
+            {
+                if (groupedProjects == null)
+                {
+                    groupedProjects = CollectionViewSource.GetDefaultView(AvailableProjects);
+                    groupedProjects.GroupDescriptions.Add(
+                        new PropertyGroupDescription(nameof(PlatformProjectInfo.Category)));
+                }
+                return groupedProjects;
+            }
+        }
 
         public PlatformProjectInfo SelectedProject
         {

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/NewProjectPlatformDropdownTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/NewProjectPlatformDropdownTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using Npc;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+// The platform dropdown renders a row's engine version as a group header and its OS/framework detail as
+// a muted second line, so the row itself can stay short. Neither of those survives into the closed
+// ComboBox, which draws the selected item with no group header and only one line of room - the
+// ItemTemplate has a trigger that swaps in the qualified name for that case. It is invisible in the
+// XAML's happy path and silently degrades to a short, version-less name if it stops matching, so it
+// gets driven through real WPF layout rather than trusted. See GitHub issue #2127.
+public class NewProjectPlatformDropdownTests
+{
+    [StaFact]
+    public void ClosedPlatformDropdown_ShouldShowTheEngineVersionWithTheProjectType()
+    {
+        var selectionBoxText = RenderSelectionBoxText();
+
+        selectionBoxText.ShouldContain(
+            $"{PlatformProjectInfo.Frb1Category} - Desktop - MonoGame",
+            $"The closed dropdown shows '{string.Join("' / '", selectionBoxText)}', which does not say " +
+            "which engine version the selected template builds.");
+    }
+
+    // The muted detail line is what lets the row be short; drawing it in the closed box too would make
+    // the single-line ComboBox two lines tall.
+    [StaFact]
+    public void ClosedPlatformDropdown_ShouldNotShowTheDetailLine()
+    {
+        RenderSelectionBoxText().ShouldNotContain(text => text.Contains(".NET 9"));
+    }
+
+    [StaFact]
+    public void PlatformDropdown_ShouldGroupByEngineVersion()
+    {
+        var window = new MainWindow();
+
+        var groupNames = window.ViewModel.GroupedProjects.Groups
+            .OfType<CollectionViewGroup>()
+            .Select(group => (string)group.Name)
+            .ToList();
+
+        groupNames.ShouldBe(new[]
+        {
+            PlatformProjectInfo.Frb1Category,
+            PlatformProjectInfo.Frb2Category,
+            PlatformProjectInfo.OtherCategory,
+        });
+    }
+
+    /// <summary>
+    /// Every line of text the closed platform ComboBox actually draws. The window has to be shown for
+    /// WPF to build a visual tree at all - Measure/Arrange alone leave it empty, which reads as a
+    /// passing "the detail line is absent" while proving nothing - so it is shown far off-screen and
+    /// closed again rather than flashed onto whoever is running the suite.
+    /// </summary>
+    static List<string> RenderSelectionBoxText()
+    {
+        var window = new MainWindow
+        {
+            WindowStartupLocation = WindowStartupLocation.Manual,
+            Left = -32000,
+            Top = -32000,
+            ShowInTaskbar = false,
+        };
+
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+
+            // IsVisible, not just Text: a collapsed TextBlock keeps whatever it was bound to, so reading
+            // every TextBlock's text would report the detail line as drawn when it is hidden.
+            var text = TextBlocksIn(window.PlatformComboBox)
+                .Where(item => item.IsVisible)
+                .Select(item => item.Text)
+                .Where(item => !string.IsNullOrEmpty(item))
+                .ToList();
+
+            text.ShouldNotBeEmpty("The closed dropdown drew no text at all, so nothing below this is " +
+                "actually asserting anything about what it shows.");
+
+            return text;
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    static IEnumerable<TextBlock> TextBlocksIn(DependencyObject root)
+    {
+        for (var i = 0; i < VisualTreeHelper.GetChildrenCount(root); i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+
+            if (child is TextBlock textBlock)
+            {
+                yield return textBlock;
+            }
+
+            foreach (var descendant in TextBlocksIn(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/NewProjectPlatformNamingTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/NewProjectPlatformNamingTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using Npc;
+using Npc.Data;
+using Shouldly;
+
+namespace GlueUnitTests.Projects;
+
+// The New Project wizard's platform dropdown groups its rows by engine version, so an entry's name is
+// split in three: a short FriendlyName, the Category that becomes the group header, and the muted
+// Details line. Splitting it that way is what stops the rows being unreadably long, but it also means a
+// row on its own no longer says which engine it belongs to -- these pin the parts of that split which
+// are not visible until someone opens the dropdown. See GitHub issue #2127.
+public class NewProjectPlatformNamingTests
+{
+    [Fact]
+    public void EveryWizardEntry_ShouldDeclareACategory()
+    {
+        foreach (var project in EmptyTemplates.Projects)
+        {
+            project.Category.ShouldNotBeNullOrEmpty(
+                $"'{project.FriendlyName}' has no Category, so it falls under a blank group header and " +
+                "its name never says which engine version it creates.");
+        }
+    }
+
+    // Both engines offer a MonoGame desktop template, so the short names collide by design. The
+    // qualified name is the only thing separating them in the closed ComboBox.
+    [Fact]
+    public void NoTwoWizardEntries_ShouldShareAQualifiedName()
+    {
+        var duplicates = EmptyTemplates.Projects
+            .GroupBy(project => project.QualifiedFriendlyName)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        duplicates.ShouldBeEmpty(
+            $"These names appear more than once in the platform dropdown: {string.Join(", ", duplicates)}. " +
+            "Rows that read identically once the dropdown is closed cannot be told apart.");
+    }
+
+    // The category is prepended to build the qualified name, so an entry carrying it in FriendlyName too
+    // renders as "FlatRedBall 1 - FlatRedBall 1 Desktop".
+    [Fact]
+    public void NoWizardEntryFriendlyName_ShouldRepeatItsEngineVersion()
+    {
+        foreach (var project in EmptyTemplates.Projects)
+        {
+            project.FriendlyName.ShouldNotContain("FlatRedBall 1", Case.Insensitive);
+            project.FriendlyName.ShouldNotContain("FlatRedBall 2", Case.Insensitive);
+        }
+    }
+
+    // Web and FNA are FlatRedBall 1 engines. Listing them outside the FlatRedBall 1 group reads as though
+    // they were a third and fourth product.
+    [Theory]
+    [InlineData("FlatRedBallDesktopGlMonoGameTemplate")]
+    [InlineData("FlatRedBallWebTemplate")]
+    [InlineData("FlatRedBallDesktopFnaTemplate")]
+    public void ZipTemplates_ShouldBeCategorizedUnderFlatRedBall1(string templateNamespace)
+    {
+        var project = EmptyTemplates.Projects
+            .FirstOrDefault(item => item.Namespace == templateNamespace);
+
+        project.ShouldNotBeNull($"The wizard no longer offers '{templateNamespace}'.");
+        project.Category.ShouldBe(PlatformProjectInfo.Frb1Category);
+    }
+
+    [Fact]
+    public void TheFlatRedBall2Template_ShouldBeCategorizedUnderFlatRedBall2()
+    {
+        var project = EmptyTemplates.Projects.OfType<DotnetNewProjectInfo>().Single();
+
+        project.Category.ShouldBe(PlatformProjectInfo.Frb2Category);
+    }
+}


### PR DESCRIPTION
The New Project platform list read as four unrelated products, with nothing on a row saying that Web and FNA are FlatRedBall 1 engines:

```
Desktop GL .NET 9 (Windows, Mac, Linux) - MonoGame
Web (Browsers) - Kni
FNA .NET 7 (Windows, Mac, Linux)
FlatRedBall 2 Desktop (Windows, Mac, Linux) - MonoGame
Select Local Project...
```

Prefixing each row with its engine version would have made the already-long rows longer, so the name is split three ways instead — `Category` becomes a ComboBox group header, `FriendlyName` is the short row, and `Details` is a muted second line:

```
FlatRedBall 1
  Desktop - MonoGame
    Windows, Mac, Linux · .NET 9
  Desktop - FNA
    Windows, Mac, Linux · .NET 7
  Web - Kni
    Browsers
FlatRedBall 2
  Desktop - MonoGame
    Windows, Mac, Linux
Other
  Select Local Project...
```

A closed ComboBox draws no group header, so "Desktop - MonoGame" alone would not say which engine is selected — and both engines offer one. An `ItemTemplate` trigger keyed on the absence of a `ComboBoxItem` ancestor swaps in `Category - FriendlyName` and hides the detail line for that case.

A picked local template now shows its folder name as the row with the full path underneath, rather than one long path.

## Tests

`NewProjectPlatformNamingTests` covers the data: every entry has a category, no two entries share a qualified name, and no `FriendlyName` repeats the engine version the header already carries.

`NewProjectPlatformDropdownTests` drives the window through real WPF layout, because the closed-box trigger is invisible in the XAML's happy path and degrades silently. Two things it took to make that test mean something: `Measure`/`Arrange` alone leave the visual tree empty (the window has to be shown — off-screen — for WPF to build one), and a collapsed `TextBlock` keeps its `Text`, so it filters on `IsVisible`. Both were passing vacuously first. Confirmed red with the trigger's setter removed.

## Manual test

Not needed to see the layout — the tests assert what the closed and grouped dropdown actually render. Worth one look at Glue > File > New Project if you want to judge the spacing and the muted line's contrast, which the tests don't cover.

Closes #2127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FykAr2FDyKjy7hDTemcWZ5
