### PR TITLE
Reconcile FRB2 generated code files on rename (#2060)

### DIFF
--- a/FRBDK/Glue/Glue/CodeGeneration/CodeWriter.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/CodeWriter.cs
@@ -2411,6 +2411,14 @@ namespace FlatRedBallAddOns.Entities
     /// <returns>Stack of file paths.</returns>
     public static List<FilePath> GetAllCodeFilesFor(IElement element)
     {
+        // Both halves of this - the directory to enumerate and the names the enumerated files are
+        // matched against - have to hang off the same root, and that root is the Glue project's own
+        // directory, since element.Name ("Screens\GameScreen") is relative to it. For FRB1 the .gluj
+        // sits beside the .csproj so FileManager.RelativeDirectory would agree; for FRB2 the .gluj is
+        // three levels down under Content/FrbEditor/, and matching against the .csproj's folder gave
+        // every file a "Content\FrbEditor\" prefix that no element name starts with - so this returned
+        // nothing at all and a rename left the old .cs pair orphaned. See GitHub issue #2060.
+        string glueProjectDirectory = GlueState.Self.CurrentGlueProjectDirectory;
         string directory = FileManager.GetDirectory(GlueCommands.Self.GetAbsoluteFileName(element.Name + "/", false));
 
 
@@ -2420,7 +2428,7 @@ namespace FlatRedBallAddOns.Entities
         for (int i = foundCsFiles.Count - 1; i > -1; i--)
         {
             FilePath file = foundCsFiles[i];
-            string relativeFile = FileManager.MakeRelative(file.Original).Replace('/', '\\');
+            string relativeFile = FileManager.MakeRelative(file.Original, glueProjectDirectory).Replace('/', '\\');
             bool isValid = relativeFile.StartsWith(element.Name) && relativeFile[element.Name.Length] == '.';
 
             if (!isValid)

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ElementCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/ElementCommands.cs
@@ -422,6 +422,11 @@ public class ElementCommands : IScreenCommands, IEntityCommands,IElementCommands
                 // etc).
                 if (File.Exists(absoluteOldFile))
                 {
+                    // A rename that also moves the element into a subfolder - which is what dragging it
+                    // onto a folder in the tree does, see DragDropManager.MoveElementToDirectory - can
+                    // name a directory that does not exist yet. File.Move does not create one, so the
+                    // rename threw part-way through, after the .glsj/.glej had already been moved.
+                    Directory.CreateDirectory(FileManager.GetDirectory(absoluteNewFile));
                     File.Move(absoluteOldFile, absoluteNewFile);
                 }
 

--- a/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/MainTreeViewViewModel.Refresh.cs
+++ b/FRBDK/Glue/OfficialPlugins/TreeViewPlugin/ViewModels/MainTreeViewViewModel.Refresh.cs
@@ -88,6 +88,16 @@ namespace OfficialPlugins.TreeViewPlugin.ViewModels
 
                             var newParentTreeNode = GetTreeNodeByRelativePath(desiredFolderForElement);
 
+                            if (newParentTreeNode == null)
+                            {
+                                // Folder nodes are built from Directory.GetDirectories, which otherwise
+                                // only runs on project load - so a rename that names a folder which does
+                                // not exist yet (typing "NewFolder/Ball" into the inline rename creates
+                                // it) has nowhere to move the element to. Re-scan before giving up.
+                                RefreshDirectoryNodes();
+                                newParentTreeNode = GetTreeNodeByRelativePath(desiredFolderForElement);
+                            }
+
                             // on a rename, the parent node hasn't yet been renamed yet, so let's tolerate nulls:
                             if(newParentTreeNode != null)
                             {

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2RenameDeleteTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/Frb2RenameDeleteTests.cs
@@ -1,0 +1,180 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueFormsCore.ViewModels;
+using GlueUnitTests.TestSupport;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// Renaming or deleting a Screen/Entity in an FRB2 project that opted into code generation
+/// (<see cref="GlueProjectSave.GenerateCode"/>) has to take the generated/custom .cs pair with it, the
+/// same way FRB1's rename and delete do.
+/// </summary>
+/// <remarks>
+/// FRB1's paths reconcile .csproj items; an FRB2 project has none, and its code lives under
+/// Content/FrbEditor/ beside the JSON rather than beside the .csproj. See GitHub issue #2060.
+/// </remarks>
+[Collection("Frb2ProjectLoad")]
+public class Frb2RenameDeleteTests : DeleteDialogTestBase
+{
+    /// <summary>
+    /// The same opt-in a user performs: add the elements, turn the setting on in the .gluj, reopen. The
+    /// reload is what generates the pair, so it is the setup rather than an artifact.
+    /// </summary>
+    static async Task<string> LoadOptedIn(string root)
+    {
+        var csprojPath = Frb2ProjectFixture.Write(root);
+        await GoldProject.LoadInGlueAsync(csprojPath);
+
+        await GlueCommands.Self.GluxCommands.ScreenCommands.AddScreen("GameScreen");
+        await GlueCommands.Self.GluxCommands.EntityCommands.AddEntityAsync(
+            new AddEntityViewModel { Name = "PlayerEntity" });
+
+        GlueState.Self.CurrentGlueProject.GenerateCode = true;
+        GlueCommands.Self.GluxCommands.SaveProjectAndElements();
+
+        await GoldProject.LoadInGlueAsync(csprojPath);
+        return csprojPath;
+    }
+
+    static IReadOnlyList<string> CodeFilesUnder(string root) =>
+        Directory.GetFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Select(f => Path.GetRelativePath(root, f).Replace('\\', '/'))
+            .Where(f => f != Frb2ProjectFixture.HandWrittenCodeFile)
+            .OrderBy(f => f, System.StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    [StaFact]
+    public async Task RenamingAScreen_MovesItsGeneratedAndCustomFiles_RatherThanOrphaningThem()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2RenameCode_");
+        using var dialogs = new RecordedChoiceDialogs();
+
+        await LoadOptedIn(temp.Root);
+        var screen = GlueState.Self.CurrentGlueProject.Screens.Single(item => item.Name == @"Screens\GameScreen");
+
+        await GlueCommands.Self.GluxCommands.ElementCommands.RenameElement(
+            screen, @"Screens\RenamedScreen", showRenameWindow: false);
+
+        Assert.Equal(
+            new[]
+            {
+                "Content/FrbEditor/Entities/PlayerEntity.Generated.cs",
+                "Content/FrbEditor/Entities/PlayerEntity.cs",
+                "Content/FrbEditor/Screens/RenamedScreen.Generated.cs",
+                "Content/FrbEditor/Screens/RenamedScreen.cs",
+            }.OrderBy(f => f, System.StringComparer.OrdinalIgnoreCase),
+            CodeFilesUnder(temp.Root));
+    }
+
+    [StaFact]
+    public async Task RenamingAScreen_CarriesTheUsersCustomCodeOver_UnderTheNewClassName()
+    {
+        // The custom half is the user's, so a rename moves and edits it rather than regenerating it. The
+        // stub the generator writes for the new name also says "partial class RenamedScreen", so the
+        // assertion has to be the hand-written body - otherwise a rename that silently dropped the user's
+        // code and made a fresh stub reads as a pass.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2RenameClass_");
+        using var dialogs = new RecordedChoiceDialogs();
+
+        await LoadOptedIn(temp.Root);
+        var screen = GlueState.Self.CurrentGlueProject.Screens.Single(item => item.Name == @"Screens\GameScreen");
+
+        var customFile = Path.Combine(temp.Root, "Content", "FrbEditor", "Screens", "GameScreen.cs");
+        File.WriteAllText(customFile, File.ReadAllText(customFile)
+            .Replace("partial class GameScreen", "partial class GameScreen // HandWrittenMarker"));
+
+        await GlueCommands.Self.GluxCommands.ElementCommands.RenameElement(
+            screen, @"Screens\RenamedScreen", showRenameWindow: false);
+
+        var customCode = File.ReadAllText(Path.Combine(
+            temp.Root, "Content", "FrbEditor", "Screens", "RenamedScreen.cs"));
+
+        Assert.Contains("HandWrittenMarker", customCode);
+        Assert.Contains("partial class RenamedScreen", customCode);
+        Assert.DoesNotContain("GameScreen", customCode);
+    }
+
+    [StaFact]
+    public async Task MovingAnEntityIntoASubfolder_TakesItsGeneratedAndCustomFilesWithIt()
+    {
+        // Dragging an element onto a folder in the tree is a rename - DragDropManager.MoveElementToDirectory
+        // calls RenameElement with the new qualified name - so it reconciles files through the same path.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2MoveToFolder_");
+        using var dialogs = new RecordedChoiceDialogs();
+
+        await LoadOptedIn(temp.Root);
+        var entity = GlueState.Self.CurrentGlueProject.Entities.Single(item => item.Name == @"Entities\PlayerEntity");
+
+        await GlueCommands.Self.GluxCommands.ElementCommands.RenameElement(
+            entity, @"Entities\Characters\PlayerEntity", showRenameWindow: false);
+
+        Assert.Equal(
+            new[]
+            {
+                "Content/FrbEditor/Entities/Characters/PlayerEntity.Generated.cs",
+                "Content/FrbEditor/Entities/Characters/PlayerEntity.cs",
+                "Content/FrbEditor/Screens/GameScreen.Generated.cs",
+                "Content/FrbEditor/Screens/GameScreen.cs",
+            }.OrderBy(f => f, System.StringComparer.OrdinalIgnoreCase),
+            CodeFilesUnder(temp.Root));
+    }
+
+    [StaFact]
+    public async Task DeletingAnEntity_DeletesItsGeneratedAndCustomFiles()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2DeleteCode_");
+        using var dialogs = new RecordedChoiceDialogs();
+
+        await LoadOptedIn(temp.Root);
+        var entity = GlueState.Self.CurrentGlueProject.Entities.Single(item => item.Name == @"Entities\PlayerEntity");
+
+        AnswerDeleteDialog();
+
+        await GlueCommands.Self.DialogCommands.AskToRemoveEntityAsync(entity);
+
+        Assert.Equal(
+            new[]
+            {
+                "Content/FrbEditor/Screens/GameScreen.Generated.cs",
+                "Content/FrbEditor/Screens/GameScreen.cs",
+            }.OrderBy(f => f, System.StringComparer.OrdinalIgnoreCase),
+            CodeFilesUnder(temp.Root));
+    }
+
+    [StaFact]
+    public async Task TheDeleteDialog_ListsTheGeneratedAndCustomFiles_WhereTheyActuallyAre()
+    {
+        // The dialog shows the user the files a delete is about to remove. Composed the FRB1 way they
+        // would be listed beside the .csproj, three directories from where they really are.
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var temp = new TempDir("Frb2DeletePlan_");
+        using var dialogs = new RecordedChoiceDialogs();
+
+        await LoadOptedIn(temp.Root);
+        var entity = GlueState.Self.CurrentGlueProject.Entities.Single(item => item.Name == @"Entities\PlayerEntity");
+
+        AnswerDeleteDialog(confirm: false);
+
+        await GlueCommands.Self.DialogCommands.AskToRemoveEntityAsync(entity);
+
+        var listed = TheOnlyDeleteDialog.FilesToRemove.Select(item => item.Replace('\\', '/')).ToList();
+
+        Assert.Contains(listed, item => item.EndsWith("Content/FrbEditor/Entities/PlayerEntity.Generated.cs"));
+        Assert.Contains(listed, item => item.EndsWith("Content/FrbEditor/Entities/PlayerEntity.cs"));
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/ElementFolderRelocationTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TreeViewPlugin/ElementFolderRelocationTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using System.Linq;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces;
+using FlatRedBall.Glue.Plugins.ExportedInterfaces.CommandInterfaces;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.TestSupport;
+using Moq;
+using OfficialPlugins.TreeViewPlugin.Models;
+using OfficialPlugins.TreeViewPlugin.ViewModels;
+using Shouldly;
+
+namespace GlueUnitTests.TreeViewPlugin;
+
+/// <summary>
+/// Renaming an element into a folder that does not exist yet - typing "NewFolder/Ball" into the tree's
+/// inline rename - creates that folder on disk as part of the rename. The tree has to show the element
+/// in it.
+/// </summary>
+/// <remarks>
+/// Folder nodes come from <c>Directory.GetDirectories</c>, which only ran on project load, so the node
+/// the element needs to move into did not exist and the relocation in
+/// <c>MainTreeViewViewModel.RefreshTreeNodeFor</c> was skipped. The element stayed under its old parent
+/// while its files, .glsj/.glej and namespace had all moved - the tree was the only thing saying
+/// otherwise, until the project was reopened.
+/// </remarks>
+public class ElementFolderRelocationTests : IDisposable
+{
+    readonly string _root;
+    readonly string _originalRelativeDirectory;
+    readonly GlueProjectSave _originalGlueProject;
+    readonly GlueProjectSave _project = new();
+    readonly MainTreeViewViewModel _viewModel;
+
+    public ElementFolderRelocationTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _root = Path.Combine(Path.GetTempPath(), "TreeViewRelocate_" + Guid.NewGuid()) +
+            Path.DirectorySeparatorChar;
+        Directory.CreateDirectory(Path.Combine(_root, "Entities"));
+
+        // Node refreshes read the static singleton rather than the injected mock, so without one this
+        // passes mid-suite off whatever an earlier test left behind and NREs on its own.
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        ObjectFinder.Self.GlueProject = _project;
+
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _root;
+
+        var glueState = new Mock<IGlueState>();
+        glueState.Setup(item => item.CurrentGlueProject).Returns(_project);
+        glueState.Setup(item => item.CurrentGlueProjectDirectory).Returns(_root);
+        glueState.Setup(item => item.ContentDirectory).Returns(_root);
+
+        var glueCommands = new Mock<IGlueCommands>();
+        glueCommands
+            .Setup(item => item.GetAbsoluteFileName(It.IsAny<string>(), It.IsAny<bool>()))
+            .Returns((string relative, bool _) => Path.Combine(_root, relative ?? string.Empty));
+
+        _viewModel = new MainTreeViewViewModel(glueState.Object, glueCommands.Object);
+    }
+
+    public void Dispose()
+    {
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [StaFact]
+    public void RefreshTreeNodeFor_MovesTheElementIntoAFolderCreatedSinceTheProjectLoaded()
+    {
+        var entity = AddEntityAtRoot("Entities\\Ball");
+
+        // What the rename does before the tree is refreshed: the folder appears on disk and the
+        // element's name gains it.
+        Directory.CreateDirectory(Path.Combine(_root, "Entities", "NewFolder"));
+        entity.Name = "Entities\\NewFolder\\Ball";
+
+        _viewModel.RefreshTreeNodeFor(entity, TreeNodeRefreshType.All);
+
+        var folderNode = _viewModel.EntityRootNode.Children.FirstOrDefault(node => node.Text == "NewFolder");
+
+        folderNode.ShouldNotBeNull("the folder the rename created should have a node");
+        folderNode.Children.ShouldContain(node => node.Tag == entity,
+            "the element should have moved into the folder its name now names");
+        _viewModel.EntityRootNode.Children.ShouldNotContain(node => node.Tag == entity,
+            "the element should no longer sit beside the folder it moved into");
+    }
+
+    [StaFact]
+    public void RefreshTreeNodeFor_StillMovesTheElement_WhenTheFolderNodeAlreadyExists()
+    {
+        // The guard against fixing this by always re-scanning and losing the relocation itself: a folder
+        // that was already on the tree still has to receive the element.
+        var entity = AddEntityAtRoot("Entities\\Ball");
+
+        Directory.CreateDirectory(Path.Combine(_root, "Entities", "Existing"));
+        _viewModel.AddDirectoryNodes(_root + "Entities/", _viewModel.EntityRootNode, ScreenOrEntity.Entity);
+
+        entity.Name = "Entities\\Existing\\Ball";
+
+        _viewModel.RefreshTreeNodeFor(entity, TreeNodeRefreshType.All);
+
+        _viewModel.EntityRootNode.Children
+            .First(node => node.Text == "Existing")
+            .Children.ShouldContain(node => node.Tag == entity);
+    }
+
+    EntitySave AddEntityAtRoot(string name)
+    {
+        var entity = new EntitySave { Name = name };
+        _project.Entities.Add(entity);
+
+        var node = new GlueElementNodeViewModel(_viewModel.EntityRootNode, entity, createChildrenNodes: false);
+        _viewModel.EntityRootNode.Children.Add(node);
+
+        return entity;
+    }
+}


### PR DESCRIPTION
Renaming a Screen/Entity in an opted-in FRB2 project left the old `<Name>.Generated.cs`/`<Name>.cs` pair behind under `Content/FrbEditor/`.

`CodeWriter.GetAllCodeFilesFor` enumerated the element's directory relative to the `.gluj` but matched the results against `FileManager.RelativeDirectory` (the `.csproj` folder). Those are the same directory for FRB1, so it went unnoticed; for FRB2 the `.gluj` is three levels down under `Content/FrbEditor/`, so every found file carried a `Content\FrbEditor\` prefix no element name starts with and the method returned an empty list. The rename then had nothing to move.

Two more fixes fall out of renaming an element into a folder that does not exist yet — typing `NewFolder/Ball` into the tree's inline rename. Both were broken for FRB1 too:

- `ElementCommands` now creates the target directory before `File.Move`, which used to throw `DirectoryNotFoundException` after the `.glsj`/`.glej` had already moved.
- `MainTreeViewViewModel.RefreshTreeNodeFor` re-scans directory nodes when the element's new folder has no node yet. Folder nodes are built from `Directory.GetDirectories` only on project load, so the relocation was silently skipped and the tree kept showing the element under its old parent while its files, JSON and namespace had all moved.

The delete half of the issue turned out to already work: `DeletionPlanner` and `DialogCommands.RemoveFilesAsync` both resolve paths through `GetAbsoluteFileName(..., isContent: false)`, which is already rooted at the `.gluj`. Two tests here pin that rather than change it.

Closes #2060

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Nk1apsMUF3cNDz9W7t2o5
