### PR TITLE
Cover #1770's codegen output, not just its decision predicate

### DIFF
--- a/FRBDK/Glue/.claude/skills/glue-project-codegen/SKILL.md
+++ b/FRBDK/Glue/.claude/skills/glue-project-codegen/SKILL.md
@@ -60,6 +60,12 @@ Landmines: constructing an entity needs `FlatRedBall.FlatRedBallServices.Initial
 (null headless) — use the `(contentManagerName, addToManagers: false)` overload; a CSV-generated custom
 class emits public fields, not properties.
 
+A tile map's *data* needs no GraphicsDevice: `TiledMapSave.FromFile` plus
+`ReducedTileMapInfo.FromTiledMapSave` yield layer names, map dimensions, per-layer tileset image paths and
+every tile position headlessly. Only `LayeredTileMap`'s per-layer texture load
+(`TextureContentLoader.LoadTexture2D`, which throws when `Renderer.Graphics` is null) needs one — assert on
+the reduced info when a test cares which map loaded rather than how it rasterizes.
+
 ## Related skills
 
 - `gluj-versions` — the `GluxVersions` enum, `FileVersion` gating, and the version-bump checklist. This skill assumes that context; don't restate it here.

--- a/FRBDK/Glue/Tests/GlueUnitTests/CodeGeneration/NamedObjectSaveCodeGeneratorTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CodeGeneration/NamedObjectSaveCodeGeneratorTests.cs
@@ -1,5 +1,8 @@
+using System.Collections.Generic;
 using FlatRedBall.Glue.CodeGeneration;
+using FlatRedBall.Glue.CodeGeneration.CodeBuilder;
 using FlatRedBall.Glue.Elements;
+using GlueFormsCore.Managers;
 using FlatRedBall.Glue.SaveClasses;
 using GlueUnitTests.Tasks;
 using GlueUnitTests.TestSupport;
@@ -111,5 +114,113 @@ public class NamedObjectSaveCodeGeneratorTests
 
         NamedObjectSaveCodeGenerator.ShouldReinstantiateDespiteInstantiatedByBase(nos, entity)
             .ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Builds a base/derived pair where both entities own a real ReferencedFileSave, since
+    /// GenerateInstantiationOrAssignment resolves the file through
+    /// EntitySave.GetReferencedFileSave(SourceFile) and emits nothing at all when that lookup misses -
+    /// an assertion against generated text is silently vacuous without it.
+    /// </summary>
+    private static (EntitySave baseEntity, EntitySave derivedEntity, NamedObjectSave derivedNos)
+        CreateExposedInDerivedTileMapPair(string baseSourceFile, string derivedSourceFile)
+    {
+        var (baseEntity, derivedEntity) = CreateBaseAndDerivedEntities();
+
+        var baseNos = CreateFileSourcedNamedObject(baseSourceFile, instantiatedByBase: false);
+        baseNos.SourceName = "Entire File (LayeredTileMap)";
+        baseNos.ExposedInDerived = true;
+        baseEntity.NamedObjects.Add(baseNos);
+        baseEntity.ReferencedFiles.Add(new ReferencedFileSave { Name = baseSourceFile });
+
+        var derivedNos = CreateFileSourcedNamedObject(derivedSourceFile, instantiatedByBase: true);
+        derivedNos.SourceName = "Entire File (LayeredTileMap)";
+        derivedEntity.NamedObjects.Add(derivedNos);
+        derivedEntity.ReferencedFiles.Add(new ReferencedFileSave { Name = derivedSourceFile });
+
+        return (baseEntity, derivedEntity, derivedNos);
+    }
+
+    private static string GenerateInitializeCodeFor(NamedObjectSave namedObject, EntitySave container)
+    {
+        NamedObjectSaveCodeGenerator.ReusableEntireFileRfses ??= new Dictionary<string, string>();
+
+        var codeBlock = new CodeBlockBase();
+        NamedObjectSaveCodeGenerator.WriteCodeForNamedObjectInitialize(
+            namedObject, container, codeBlock, overridingContainerName: null);
+        return codeBlock.ToString();
+    }
+
+    /// <summary>
+    /// The predicate tests above pin the decision; this pins the generated text that decision is
+    /// supposed to produce, so mis-wiring the predicate into WriteCodeForNamedObjectInitialize still
+    /// fails a test.
+    /// </summary>
+    [Fact]
+    public void WriteCodeForNamedObjectInitialize_ShouldAssignFromDerivedsOwnFile_WhenDerivedSourceFileDiffersFromBase()
+    {
+        var (_, derivedEntity, derivedNos) =
+            CreateExposedInDerivedTileMapPair("Content/BaseMap.tmx", "Content/DerivedMap.tmx");
+
+        var generatedCode = GenerateInitializeCodeFor(derivedNos, derivedEntity);
+
+        generatedCode.ShouldContain("Map = DerivedMap;");
+        generatedCode.ShouldNotContain("BaseMap");
+    }
+
+    /// <summary>
+    /// The unchanged InstantiatedByBase path: a derived object still pointing at the base's file must
+    /// keep deferring to the base's single instantiation rather than emitting a duplicate one.
+    /// </summary>
+    [Fact]
+    public void WriteCodeForNamedObjectInitialize_ShouldGenerateNoInstantiation_WhenDerivedSourceFileMatchesBase()
+    {
+        var (_, derivedEntity, derivedNos) =
+            CreateExposedInDerivedTileMapPair("Content/BaseMap.tmx", "Content/BaseMap.tmx");
+
+        var generatedCode = GenerateInitializeCodeFor(derivedNos, derivedEntity);
+
+        generatedCode.ShouldNotContain("Map = ");
+    }
+
+    /// <summary>
+    /// The whole reported path, with no hand-set InstantiatedByBase: InheritanceManager.UpdateFromBaseType
+    /// clones the base's ExposedInDerived object into the variant (the real production cloning, which is
+    /// what sets InstantiatedByBase), the variant is then pointed at its own .tmx the way dropping a file
+    /// on the object does, and the generated code has to load that file rather than the base's.
+    ///
+    /// showPopupAboutObjectErrors: false - the true default reaches DialogService and would block the run
+    /// on a real modal dialog.
+    /// </summary>
+    [Fact]
+    public void UpdateFromBaseType_ThenChangingDerivedSourceFile_ShouldGenerateCodeLoadingTheDerivedsOwnFile()
+    {
+        var (baseEntity, derivedEntity) = CreateBaseAndDerivedEntities();
+
+        var baseNos = CreateFileSourcedNamedObject("Content/BaseMap.tmx", instantiatedByBase: false);
+        baseNos.SourceName = "Entire File (LayeredTileMap)";
+        baseNos.ExposedInDerived = true;
+        baseEntity.NamedObjects.Add(baseNos);
+        baseEntity.ReferencedFiles.Add(new ReferencedFileSave { Name = "Content/BaseMap.tmx" });
+
+        InheritanceManager.Self.UpdateFromBaseType(derivedEntity, showPopupAboutObjectErrors: false);
+
+        var derivedNos = derivedEntity.NamedObjects.ShouldHaveSingleItem();
+        // Pins the premise the rest of this class's tests assume rather than restating it by hand: the
+        // clone really does arrive instantiated by the base, which is why a SourceFile override on it was
+        // dead data before the fix.
+        derivedNos.InstantiatedByBase.ShouldBeTrue();
+        // "BaseMap.tmx", not the "Content/..." that was assigned: NamedObjectSave's SourceFile setter
+        // strips a leading "content/" segment, so both entities' stored values are already relative to
+        // the content root by the time ShouldReinstantiateDespiteInstantiatedByBase compares them.
+        derivedNos.SourceFile.ShouldBe("BaseMap.tmx");
+
+        derivedNos.SourceFile = "Content/DerivedMap.tmx";
+        derivedEntity.ReferencedFiles.Add(new ReferencedFileSave { Name = "Content/DerivedMap.tmx" });
+
+        var generatedCode = GenerateInitializeCodeFor(derivedNos, derivedEntity);
+
+        generatedCode.ShouldContain("Map = DerivedMap;");
+        generatedCode.ShouldNotContain("BaseMap");
     }
 }

--- a/FRBDK/Glue/Tests/GlueUnitTests/EntityInputMovementPlugin/LadderTopOfLadderYTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/EntityInputMovementPlugin/LadderTopOfLadderYTests.cs
@@ -25,9 +25,15 @@ namespace GlueUnitTests.EntityInputMovementPlugin;
 ///
 /// Builds a synthetic 3-tile ladder column via the real TileShapeCollection.AddCollisionAtWorld API
 /// (the same method TileShapeCollectionLayeredTileMapExtensions.AddCollisionFrom uses per tile) rather
-/// than loading the real Level1Map.tmx through LayeredTileMap - that path needs a GraphicsDevice to
-/// load tileset textures, which a headless test process doesn't have. The synthetic column is real
-/// engine geometry, just not sourced from the shipped map file.
+/// than loading the real Level1Map.tmx through LayeredTileMap. The synthetic column is real engine
+/// geometry, just not sourced from the shipped map file.
+///
+/// Only the texture half of a tile map needs a GraphicsDevice, not the map itself: LayeredTileMap's
+/// per-layer MapDrawableBatch calls FlatRedBallServices.Load&lt;Texture2D&gt;, which throws when
+/// Renderer.Graphics is null (see TextureContentLoader.LoadTexture2D). Everything upstream of that -
+/// TiledMapSave.FromFile and ReducedTileMapInfo.FromTiledMapSave, which carry layer names, map
+/// dimensions, per-layer tileset image paths and every tile's position - loads fine headlessly, and is
+/// the right level to assert on when a test cares about map *content* rather than tile rendering.
 /// </summary>
 [Trait("Category", "BuildSmoke")]
 public class LadderTopOfLadderYTests
@@ -59,8 +65,8 @@ public class LadderTopOfLadderYTests
 
         // A real TileShapeCollection, built the same way production code adds tiles one at a time
         // (TileShapeCollectionLayeredTileMapExtensions.AddCollisionFrom calls AddCollisionAtWorld per
-        // tile) - just without going through a LayeredTileMap loaded from the .tmx, which needs a
-        // GraphicsDevice this headless test process doesn't have.
+        // tile) - just without going through a LayeredTileMap, whose tileset texture load needs a
+        // GraphicsDevice this headless test process doesn't have (see this class's doc comment).
         var ladderCollision = Activator.CreateInstance(tileShapeCollectionType!);
         const float gridSize = 16f; // matches Level1Map.tmx's tilewidth/tileheight
         tileShapeCollectionType!.GetProperty("GridSize")!.SetValue(ladderCollision, gridSize);


### PR DESCRIPTION
## Problem

`NamedObjectSaveCodeGeneratorTests` (added with #1937) only called `ShouldReinstantiateDespiteInstantiatedByBase` directly. Nothing asserted that the predicate is actually consulted by `WriteCodeForNamedObjectInitialize`, so unwiring the fix left all four tests green — verified by disabling it.

## Change

Three tests that assert on generated text:

- derived object pointing at its own file emits `Map = DerivedMap;`
- derived object still pointing at the base's file emits no instantiation (the unchanged `InstantiatedByBase` path)
- the reported end-to-end path, driving the real `InheritanceManager.UpdateFromBaseType` cloning instead of hand-setting `InstantiatedByBase`

All three fail with the fix disabled, pass with it.

The third test also pins two behaviors worth not re-deriving: the clone really does arrive `InstantiatedByBase = true`, and `NamedObjectSave.SourceFile`'s setter strips a leading `content/`, so both sides are already content-root-relative when the predicate compares them.

## Comment correction

Two comments in `LadderTopOfLadderYTests` said loading a .tmx "needs a GraphicsDevice this headless test process doesn't have." That is true of `LayeredTileMap` but reads as "a .tmx is off-limits headlessly," which is wrong and discourages tests that are entirely feasible.

Only the texture load needs a device (`TextureContentLoader.LoadTexture2D` throws when `Renderer.Graphics` is null). `TiledMapSave.FromFile` plus `ReducedTileMapInfo.FromTiledMapSave` run fine headlessly — verified against `Level1Map.tmx`, which returns 5 layers, 30x30 cells, 16px tiles, per-layer tileset image paths and every tile position in ~120ms. Recorded in the `glue-project-codegen` skill.

## Testing

854/854 non-BuildSmoke tests pass from a clean rebuild (`obj`/`bin` deleted). No production code changed.

Part of #1770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqaGWkFmSJv8usqv97N948