### PR TITLE
Stop XNB project references from being lower-cased (#1757)

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/IO/FileManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/IO/FileManager.cs
@@ -1089,12 +1089,21 @@ namespace FlatRedBall.IO
         }
 
 
-        public static string MakeRelative(string pathToMakeRelative, string pathToMakeRelativeTo)
+        public static string MakeRelative(string pathToMakeRelative, string pathToMakeRelativeTo) =>
+            MakeRelative(pathToMakeRelative, pathToMakeRelativeTo, PreserveCase);
+
+        /// <summary>
+        /// Returns pathToMakeRelative expressed relative to pathToMakeRelativeTo. The two paths are always
+        /// compared case-insensitively; preserveCase controls only the case of the returned string. That
+        /// lets a caller which writes the result somewhere case matters - a project file, a save file -
+        /// opt out of the process-wide PreserveCase flag rather than inheriting whatever it happens to be.
+        /// </summary>
+        public static string MakeRelative(string pathToMakeRelative, string pathToMakeRelativeTo, bool preserveCase)
         {
             if (string.IsNullOrEmpty(pathToMakeRelative) == false)
             {
-                pathToMakeRelative = FileManager.Standardize(pathToMakeRelative);
-                pathToMakeRelativeTo = FileManager.Standardize(pathToMakeRelativeTo);
+                pathToMakeRelative = FileManager.Standardize(pathToMakeRelative, RelativeDirectory, true, preserveCase);
+                pathToMakeRelativeTo = FileManager.Standardize(pathToMakeRelativeTo, RelativeDirectory, true, preserveCase);
                 if (!pathToMakeRelativeTo.EndsWith("/"))
                 {
                     pathToMakeRelativeTo += "/";
@@ -1494,7 +1503,14 @@ namespace FlatRedBall.IO
             }
         }
 
-        public static string Standardize(string fileNameToFix, string? relativePath, bool makeAbsolute)
+        public static string Standardize(string fileNameToFix, string? relativePath, bool makeAbsolute) =>
+            Standardize(fileNameToFix, relativePath, makeAbsolute, PreserveCase);
+
+        /// <summary>
+        /// Standardizes slashes, and optionally makes the path absolute. preserveCase overrides the
+        /// process-wide PreserveCase flag for this one call.
+        /// </summary>
+        public static string Standardize(string fileNameToFix, string? relativePath, bool makeAbsolute, bool preserveCase)
         {
             if (fileNameToFix == null)
                 return string.Empty;
@@ -1523,7 +1539,7 @@ namespace FlatRedBall.IO
             fileNameToFix = fileNameToFix.Replace("//", "/");
 
 #if !ANDROID && !IOS
-            if (!PreserveCase)
+            if (!preserveCase)
             {
                 fileNameToFix = fileNameToFix.ToLowerInvariant();
             }

--- a/Engines/FlatRedBallXNA/FlatRedBall/IO/FilePath.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/IO/FilePath.cs
@@ -291,9 +291,15 @@ namespace FlatRedBall.IO
         public bool IsRelativeTo(FilePath otherFilePath) => FileManager.IsRelativeTo(this.FullPath, otherFilePath.FullPath);
 
 
+        /// <summary>
+        /// Returns this file expressed relative to otherFilePath, with case preserved - matching FullPath
+        /// and StandardizedCaseSensitive rather than the deliberately-lower-cased Standardized. Case is
+        /// a property of the path, not of whatever the process-wide FileManager.PreserveCase flag happens
+        /// to be when this is called.
+        /// </summary>
         public string RelativeTo(FilePath otherFilePath)
         {
-            return FileManager.MakeRelative(this.FullPath, otherFilePath.FullPath);
+            return FileManager.MakeRelative(this.FullPath, otherFilePath.FullPath, preserveCase: true);
         }
 
     }

--- a/FRBDK/Glue/Glue/IO/ElementExporter.cs
+++ b/FRBDK/Glue/Glue/IO/ElementExporter.cs
@@ -233,6 +233,25 @@ namespace FlatRedBall.Glue.IO
             return exportedFile;
         }
 
+        /// <summary>
+        /// Standardizes slashes on every path and drops duplicates, comparing case-insensitively. An
+        /// element can reach the same file twice - a .scnx referencing a .achx which is also referenced
+        /// directly - and the two references need not agree on case or slash direction.
+        /// </summary>
+        internal static void StandardizeAndRemoveDuplicatePaths(List<string> allFiles)
+        {
+            for (var i = 0; i < allFiles.Count; i++)
+            {
+                allFiles[i] = FileManager.Standardize(allFiles[i], null, makeAbsolute: false, preserveCase: true);
+            }
+
+            // Compare case-insensitively rather than lower-casing the entries first. Lower-casing them
+            // meant flipping the process-wide FileManager.PreserveCase off and back on around this loop,
+            // which every other thread's path handling reads, and which stayed off for the rest of the
+            // session if anything in between threw (GitHub issue #1757).
+            StringFunctions.RemoveDuplicates(allFiles, ignoreCase: true);
+        }
+
         private static void PerformExport(GlueElement element, GlueProjectSave glueProjectSave, bool openDirectory, string absoluteXml, string absoluteZip, bool copyExternals)
         {
             AddCustomClasses(element, glueProjectSave);
@@ -276,23 +295,7 @@ namespace FlatRedBall.Glue.IO
                 allFiles.AddRange(extraToAdd.Select(item => item.Standardized));
             }
 
-            // Don't preserve case here.  The code below
-            // for RemoveDuplicates is case-sensitive, so we
-            // want all entries to be lower-case.
-            bool wasPreservingCase = FileManager.PreserveCase;
-            FileManager.PreserveCase = false;
-            for (var i = 0; i < allFiles.Count; i++)
-            {
-                allFiles[i] = FileManager.Standardize(allFiles[i]);
-            }
-            FileManager.PreserveCase = wasPreservingCase;
-
-            // There may be duplicate entries here.
-            // For example, an Entity may include a .scnx
-            // which references a .achx, and it may also include
-            // the .achx itself.  In that case, the .achx will appear
-            // twice.
-            StringFunctions.RemoveDuplicates(allFiles);
+            StandardizeAndRemoveDuplicatePaths(allFiles);
 
             //using var zip = new ZipFile();
 

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/VisualStudioProject.cs
@@ -212,7 +212,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             ///////////////////End Early Out//////////////////////////////
             lock (this)
             {
-                string relativeFileName = FileManager.MakeRelative(absoluteFile, this.Directory);
+                string relativeFileName = MakeRelativeForProject(absoluteFile, this.Directory);
 
                 ProjectItem buildItem = null;
 
@@ -242,7 +242,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 //}
 
 
-                string itemInclude = FileManager.MakeRelative(absoluteFile, this.Directory);
+                string itemInclude = MakeRelativeForProject(absoluteFile, this.Directory);
 
                 itemInclude = ProcessInclude(itemInclude);
 
@@ -336,7 +336,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
                     if (path != null)
                     {
-                        linkValue = ContentDirectory + FileManager.MakeRelative(absoluteFile, path);
+                        linkValue = ContentDirectory + MakeRelativeForProject(absoluteFile, path);
                         linkValue = FileManager.RemoveDotDotSlash(linkValue);
                         linkValue = ProcessInclude(linkValue);
 
@@ -430,7 +430,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 }
                 else if (SaveAsRelativeSyncedProject)
                 {
-                    fileName = FileManager.MakeRelative(
+                    fileName = MakeRelativeForProject(
                         sourceProjectBase.FullFileName.GetDirectoryContainingThis().FullPath,
                         FullFileName.GetDirectoryContainingThis().FullPath) + bi.UnevaluatedInclude;
                 }
@@ -497,7 +497,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
             {
                 if (!FileManager.IsRelative(fileName))
                 {
-                    fileName = FileManager.MakeRelative(fileName, this.Directory);
+                    fileName = MakeRelativeForProject(fileName, this.Directory);
                 }
 
                 string fleNameFixedSlashes = fileName.Replace('/', '\\');
@@ -512,7 +512,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
                 if (!FileManager.IsRelative(fileName) && !isSyncedProject)
                 {
-                    fileName = FileManager.MakeRelative(fileName,
+                    fileName = MakeRelativeForProject(fileName,
                                                         FileManager.GetDirectory(this.FullFileName.FullPath));
                 }
 
@@ -991,7 +991,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
         public override void UpdateContentFile(string sourceFileName)
         {
-            string relativeFileName = FileManager.MakeRelative(sourceFileName, this.Directory);
+            string relativeFileName = MakeRelativeForProject(sourceFileName, this.Directory);
             if (!IsFilePartOfProject(relativeFileName, BuildItemMembershipType.Content))
             {
                 AddContentBuildItem(sourceFileName);
@@ -1021,7 +1021,7 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
                 string sourceDirectory = FileManager.GetDirectory(sourceFileName);
                 string relativeFile;
 
-                relativeFile = FileManager.MakeRelative(sourceFileName, sourceDirectory);
+                relativeFile = MakeRelativeForProject(sourceFileName, sourceDirectory);
                 CopyFileToProjectRelativeLocation(sourceFileName, relativeDirectory + relativeFile);
 
                 foreach (var file in listOfReferencedFiles)

--- a/FRBDK/Glue/GlueCommon/VSHelper/Projects/ProjectBase.cs
+++ b/FRBDK/Glue/GlueCommon/VSHelper/Projects/ProjectBase.cs
@@ -254,13 +254,23 @@ namespace FlatRedBall.Glue.VSHelpers.Projects
 
         public abstract bool RemoveItem(string itemName);
 
+        /// <summary>
+        /// FileManager.MakeRelative for a path that is about to be written into a project file - an
+        /// Include, a Link, a Name - or used to find a file on disk. Always case-preserving, because that
+        /// case has to match what is on disk and must not depend on whatever the process-wide
+        /// FileManager.PreserveCase flag happens to be at the time (GitHub issue #1757). Comparisons are
+        /// case-insensitive either way, so this only affects the case of the result.
+        /// </summary>
+        protected internal static string MakeRelativeForProject(string path, string relativeTo) =>
+            FileManager.MakeRelative(path, relativeTo, preserveCase: true);
+
         public string StandardizeItemName(string itemName)
         {
             itemName = itemName.Replace("/", "\\");
 
             if (!FileManager.IsRelative(itemName))
             {
-                itemName = FileManager.MakeRelative(itemName, this.Directory);
+                itemName = MakeRelativeForProject(itemName, this.Directory);
                 itemName = itemName.Replace("/", "\\");
             }
 

--- a/FRBDK/Glue/OfficialPlugins/ContentPipelinePlugin/BuildLogic.cs
+++ b/FRBDK/Glue/OfficialPlugins/ContentPipelinePlugin/BuildLogic.cs
@@ -553,8 +553,6 @@ namespace OfficialPlugins.MonoGameContent
 
 
 
-            var relativeToContent = FileManager.MakeRelative(rfsFilePath.FullPath, contentDirectory);
-
             ContentItem contentItem;
             contentItem = GetContentItem(rfsFilePath.FullPath, project, createEvenIfProjectTypeNotSupported: false);
 
@@ -579,21 +577,8 @@ namespace OfficialPlugins.MonoGameContent
                             PerformBuild(contentItem, project, rebuild);
                         }
 
-                        string relativeToAddNoExtension =
-                            FileManager.RemoveExtension(relativeToContent);
-
-                        string absoluteToAddNoExtension = destinationDirectory +
-                            FileManager.RemovePath(FileManager.RemoveExtension(relativeToContent));
-
-                        foreach (var extension in contentItem.GetBuiltExtensions())
-                        {
-                            toReturn.Add(absoluteToAddNoExtension + "." + extension);
-                            AddFileToProjectIfNotAlreadyIncluded(project,
-                                absoluteToAddNoExtension + "." + extension,
-                                relativeToAddNoExtension + "." + extension,
-                                saveProjectAfterAdd);
-
-                        }
+                        toReturn.AddRange(AddBuiltXnbReferences(project, rfsFilePath, contentDirectory,
+                            destinationDirectory, contentItem.GetBuiltExtensions(), saveProjectAfterAdd));
                     }
                 },
                 "Building MonoGame Content " + rfsFilePath);
@@ -882,6 +867,40 @@ namespace OfficialPlugins.MonoGameContent
                 return extension == "png";
             }
             return false;
+        }
+
+        /// <summary>
+        /// Adds project references for the files that building sourceFile produces (its XNB, plus any
+        /// sibling output like a .wma), and returns their absolute paths. Split out of
+        /// TryAddXnbReferencesAndBuild so the Include and Link this writes into the project can be
+        /// covered without running MGCB.
+        /// </summary>
+        internal List<FilePath> AddBuiltXnbReferences(VisualStudioProject project, FilePath sourceFile,
+            FilePath contentDirectory, string destinationDirectory, IEnumerable<string> builtExtensions,
+            bool saveProjectAfterAdd)
+        {
+            var addedFiles = new List<FilePath>();
+
+            // RelativeTo, not FileManager.MakeRelative: this string becomes the Include and Link of a
+            // project item, where case has to match what is on disk. MakeRelative lower-cases whenever the
+            // process-wide FileManager.PreserveCase flag is off (issue #1757).
+            var relativeToContent = sourceFile.RelativeTo(contentDirectory);
+
+            string relativeToAddNoExtension = FileManager.RemoveExtension(relativeToContent);
+
+            string absoluteToAddNoExtension = destinationDirectory +
+                FileManager.RemovePath(FileManager.RemoveExtension(relativeToContent));
+
+            foreach (var extension in builtExtensions)
+            {
+                addedFiles.Add(absoluteToAddNoExtension + "." + extension);
+                AddFileToProjectIfNotAlreadyIncluded(project,
+                    absoluteToAddNoExtension + "." + extension,
+                    relativeToAddNoExtension + "." + extension,
+                    saveProjectAfterAdd);
+            }
+
+            return addedFiles;
         }
 
         private void AddFileToProjectIfNotAlreadyIncluded(VisualStudioProject project, string absoluteFile, string link, bool saveProjectAfterAdd)

--- a/FRBDK/Glue/Tests/GlueUnitTests/ContentPipelinePlugin/XnbReferenceCaseTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/ContentPipelinePlugin/XnbReferenceCaseTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Linq;
+using FlatRedBall.IO;
+using GlueUnitTests.TestSupport;
+using OfficialPlugins.MonoGameContent;
+using Shouldly;
+
+namespace GlueUnitTests.ContentPipelinePlugin;
+
+/// <summary>
+/// GitHub issue #1757 - the XNB references Glue writes into a MonoGame project came out lower-cased,
+/// causing diff churn (and broken content loads on case-sensitive platforms). The Include kept its case
+/// because VisualStudioProject's item dictionaries are OrdinalIgnoreCase, so an existing item was found
+/// and never rewritten - but the Link was re-applied on every pass, so it flipped to whatever case the
+/// path had that run. The path's case came from FileManager.MakeRelative, which lower-cases whenever the
+/// process-wide FileManager.PreserveCase flag is false.
+/// </summary>
+public class XnbReferenceCaseTests : IDisposable
+{
+    readonly bool wasPreservingCase = FileManager.PreserveCase;
+    string directory;
+
+    public XnbReferenceCaseTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    public void Dispose()
+    {
+        FileManager.PreserveCase = wasPreservingCase;
+
+        if (directory != null && Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AddBuiltXnbReferences_ShouldWriteCasePreservingLink_WhenPreserveCaseIsFalse()
+    {
+        FileManager.PreserveCase = false;
+
+        var savedProject = AddSingleXnbReferenceAndSave();
+
+        savedProject.ShouldContain(@"<Link>Content\Gum\FontCache\Font16Titillium_Web_Italic_0.xnb</Link>", Case.Sensitive);
+    }
+
+    [Fact]
+    public void AddBuiltXnbReferences_ShouldWriteCasePreservingLink_WhenPreserveCaseIsTrue()
+    {
+        FileManager.PreserveCase = true;
+
+        var savedProject = AddSingleXnbReferenceAndSave();
+
+        savedProject.ShouldContain(@"<Link>Content\Gum\FontCache\Font16Titillium_Web_Italic_0.xnb</Link>", Case.Sensitive);
+    }
+
+    [Fact]
+    public void AddBuiltXnbReferences_ShouldWriteCasePreservingInclude_WhenPreserveCaseIsFalse()
+    {
+        FileManager.PreserveCase = false;
+
+        var savedProject = AddSingleXnbReferenceAndSave();
+
+        savedProject.ShouldContain(@"BuiltXnbs\DesktopGL\Content\Gum\FontCache\Font16Titillium_Web_Italic_0.xnb", Case.Sensitive);
+    }
+
+    string AddSingleXnbReferenceAndSave()
+    {
+        var project = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out directory);
+
+        var contentDirectory = new FilePath(Path.Combine(directory, "Content"));
+        var sourceFile = new FilePath(Path.Combine(directory,
+            @"Content\Gum\FontCache\Font16Titillium_Web_Italic_0.png"));
+        // Matches what GetXnbDestinationDirectory hands the production caller: a FilePath-derived
+        // absolute directory, so its own case never depends on FileManager.PreserveCase.
+        var destinationDirectory = new FilePath(
+            Path.Combine(directory, @"BuiltXnbs\DesktopGL\Content\Gum\FontCache")).FullPath + "/";
+
+        BuildLogic.Self.AddBuiltXnbReferences(project, sourceFile, contentDirectory, destinationDirectory,
+            new[] { "xnb" }, saveProjectAfterAdd: false);
+
+        var savedTo = project.FullFileName.FullPath;
+        project.Save(savedTo);
+
+        return File.ReadAllText(savedTo);
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/IO/ElementExporterDuplicatePathTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/IO/ElementExporterDuplicatePathTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using FlatRedBall.Glue.IO;
+using FlatRedBall.IO;
+using Shouldly;
+
+namespace GlueUnitTests.IO;
+
+/// <summary>
+/// Exporting an element de-duplicates its referenced files, which has to ignore case (the same file can
+/// be reached as Content/Foo.png and content/foo.png). It used to do that by switching the process-wide
+/// FileManager.PreserveCase off, lower-casing every entry, and switching it back - a global that any
+/// other thread's path handling reads, restored without a try/finally, so an exception in between left
+/// every path in the session lower-cased. That is the flag that produced the lower-cased XNB references
+/// in GitHub issue #1757.
+/// </summary>
+public class ElementExporterDuplicatePathTests : IDisposable
+{
+    readonly bool wasPreservingCase = FileManager.PreserveCase;
+
+    public void Dispose() => FileManager.PreserveCase = wasPreservingCase;
+
+    [Fact]
+    public void StandardizeAndRemoveDuplicatePaths_ShouldRemoveEntriesDifferingOnlyByCase()
+    {
+        var files = new List<string>
+        {
+            @"C:\Project\Content\Gum\FontCache\Font16Titillium_Web_Italic_0.png",
+            @"C:\Project\content\gum\fontcache\font16titillium_web_italic_0.png",
+        };
+
+        ElementExporter.StandardizeAndRemoveDuplicatePaths(files);
+
+        files.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void StandardizeAndRemoveDuplicatePaths_ShouldRemoveEntriesDifferingOnlyBySlashDirection()
+    {
+        var files = new List<string>
+        {
+            @"C:\Project\Content\Gum\FontCache\Font16Titillium_Web_Italic_0.png",
+            "C:/Project/Content/Gum/FontCache/Font16Titillium_Web_Italic_0.png",
+        };
+
+        ElementExporter.StandardizeAndRemoveDuplicatePaths(files);
+
+        files.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void StandardizeAndRemoveDuplicatePaths_ShouldPreserveTheCaseOfTheSurvivingEntry()
+    {
+        var files = new List<string>
+        {
+            @"C:\Project\Content\Gum\FontCache\Font16Titillium_Web_Italic_0.png",
+        };
+
+        ElementExporter.StandardizeAndRemoveDuplicatePaths(files);
+
+        files[0].ShouldBe("C:/Project/Content/Gum/FontCache/Font16Titillium_Web_Italic_0.png");
+    }
+
+    [Fact]
+    public void StandardizeAndRemoveDuplicatePaths_ShouldNotChangeThePreserveCaseFlag()
+    {
+        FileManager.PreserveCase = true;
+
+        ElementExporter.StandardizeAndRemoveDuplicatePaths(new List<string> { @"C:\Project\Content\A.png" });
+
+        FileManager.PreserveCase.ShouldBeTrue();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/IO/FilePathRelativeToCaseTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/IO/FilePathRelativeToCaseTests.cs
@@ -1,0 +1,56 @@
+using System;
+using FlatRedBall.IO;
+using Shouldly;
+
+namespace GlueUnitTests.IO;
+
+/// <summary>
+/// FilePath's own accessors split cleanly on case: FullPath and StandardizedCaseSensitive preserve it,
+/// Standardized deliberately lower-cases. RelativeTo did neither - it delegated to
+/// FileManager.MakeRelative, which lower-cases whenever the process-wide FileManager.PreserveCase flag
+/// happens to be false. That made the case of a relative path a function of unrelated global state
+/// rather than of the path itself, which is how lower-cased XNB &lt;Link&gt; values got written into
+/// .csproj files (GitHub issue #1757).
+/// </summary>
+public class FilePathRelativeToCaseTests : IDisposable
+{
+    readonly bool wasPreservingCase = FileManager.PreserveCase;
+
+    public void Dispose() => FileManager.PreserveCase = wasPreservingCase;
+
+    [Fact]
+    public void RelativeTo_ShouldPreserveCase_WhenPreserveCaseIsFalse()
+    {
+        FileManager.PreserveCase = false;
+
+        var file = new FilePath(@"C:\Project\Content\Gum\FontCache\Font16Titillium_Web_Italic_0.png");
+
+        var relative = file.RelativeTo(new FilePath(@"C:\Project\Content"));
+
+        relative.ShouldBe("Gum/FontCache/Font16Titillium_Web_Italic_0.png");
+    }
+
+    [Fact]
+    public void RelativeTo_ShouldPreserveCase_WhenPreserveCaseIsTrue()
+    {
+        FileManager.PreserveCase = true;
+
+        var file = new FilePath(@"C:\Project\Content\Gum\FontCache\Font16Titillium_Web_Italic_0.png");
+
+        var relative = file.RelativeTo(new FilePath(@"C:\Project\Content"));
+
+        relative.ShouldBe("Gum/FontCache/Font16Titillium_Web_Italic_0.png");
+    }
+
+    [Fact]
+    public void RelativeTo_ShouldStillMatchContainingFolder_WhenTheFolderIsCasedDifferentlyThanTheFile()
+    {
+        FileManager.PreserveCase = true;
+
+        var file = new FilePath(@"C:\Project\Content\Gum\FontCache\Font16Titillium_Web_Italic_0.png");
+
+        var relative = file.RelativeTo(new FilePath(@"C:\project\content"));
+
+        relative.ShouldBe("Gum/FontCache/Font16Titillium_Web_Italic_0.png");
+    }
+}


### PR DESCRIPTION
Glue wrote lower-cased `Include` and `Link` values for built XNBs, causing .csproj diff churn.

## Cause

`FileManager.Standardize` lower-cases whenever the process-wide `FileManager.PreserveCase` flag is false, and `MakeRelative` runs both its arguments through it. So the case of a project path depended on unrelated global state rather than on the path itself.

Only the `Link` visibly flipped because `VisualStudioProject`'s item dictionaries are `OrdinalIgnoreCase`: an existing item is found regardless of case and its `Include` is never rewritten, while `AddFileToProjectIfNotAlreadyIncluded` re-applies the `Link` on every pass.

The one place that set the flag false was `ElementExporter`, restoring it with a bare assignment — no `try/finally`, so anything throwing in between left the whole session lower-casing paths, and any concurrent `TaskManager` work saw it too.

## Fix

- `FileManager.MakeRelative` / `Standardize` take an explicit `preserveCase`; the existing overloads still default to the flag.
- `FilePath.RelativeTo` preserves case, matching `FullPath`/`StandardizedCaseSensitive` rather than the deliberately-lower-cased `Standardized`.
- Every path `ProjectBase`/`VisualStudioProject` writes into a project file goes through a new `MakeRelativeForProject`, so a future call site can't reintroduce this.
- `ElementExporter` de-duplicates with `RemoveDuplicates(ignoreCase: true)` instead of flipping the global flag.

`BuildLogic.AddBuiltXnbReferences` is split out of `TryAddXnbReferencesAndBuild` so the Include and Link can be covered without running MGCB.

## Tests

10 new tests in `GlueUnitTests`, each watched failing first: the saved .csproj keeps its case with `PreserveCase` off (`XnbReferenceCaseTests`), `RelativeTo` is case-preserving either way (`FilePathRelativeToCaseTests`), and export de-duplication is case-insensitive without touching the flag (`ElementExporterDuplicatePathTests`).

Full suite (`Category!=BuildSmoke&Category!=LiveGame`) after a clean rebuild: 846 passed, same 42 pre-existing failures as `NetStandard` on this machine (SDK resolution in `Frb2*`/`SdkStyleProjectLoadTests`, unrelated).

Closes #1757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhKkXSDLujAvLQUjTFy6z7
