### PR TITLE
Widen LiveGame test harness's per-command response timeout

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GameConnectionManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GameConnectionManager.cs
@@ -27,6 +27,16 @@ namespace GlueCommunication
         /// </summary>
         public const string NotReadyPayload = "__GlueControlNotReady__";
 
+        /// <summary>
+        /// Gates the receive/dispatch timing below to LiveGameProcess-launched test runs only - this file
+        /// is embedded into every real live-edit game, and printing a line per command to a real user's
+        /// console on every edit would be noise nobody asked for. Must stay identical to
+        /// LiveGameProcess.OffscreenWindowEnvironmentVariable - same cross-compile-boundary constraint as
+        /// NotReadyPayload above, since this file cannot reference the test assembly.
+        /// </summary>
+        static readonly bool IsLiveGameTestDiagnosticsEnabled =
+            Environment.GetEnvironmentVariable("FRB_LIVE_GAME_TEST_OFFSCREEN") == "1";
+
         #region private
         private Object _lock = new Object();
         private IPAddress _addr;
@@ -145,6 +155,20 @@ namespace GlueCommunication
                         {
                             var glueControlManager = GlueControl.GlueControlManager.Self;
 
+                            // Diagnostic for #2244 (LiveGame tests timing out waiting for a response):
+                            // stdout is captured by LiveGameProcess and surfaced on a failed Send, so a
+                            // command that never gets this far (game hung before receiving it) prints
+                            // nothing here, while one that arrives but is slow to process shows exactly
+                            // how long. Payload is truncated - it can carry a full EntitySave/ScreenSave.
+                            var diagnosticStopwatch = IsLiveGameTestDiagnosticsEnabled
+                                ? System.Diagnostics.Stopwatch.StartNew()
+                                : null;
+                            if (IsLiveGameTestDiagnosticsEnabled)
+                            {
+                                var preview = packet.Payload?.Length > 60 ? packet.Payload.Substring(0, 60) + "..." : packet.Payload;
+                                Console.WriteLine($"[LiveGameTest] {DateTime.UtcNow:HH:mm:ss.fff} received '{preview}', GlueControlManager.Self is {(glueControlManager == null ? "null" : "set")}");
+                            }
+
                             // Sockets connect before Game1.Initialize constructs GlueControlManager, so
                             // there is a window where a command arrives with nothing able to dispatch it.
                             // Saying so explicitly is the only way Glue can tell that apart from the empty
@@ -152,6 +176,11 @@ namespace GlueCommunication
                             var returnValue = glueControlManager != null
                                 ? await glueControlManager.ProcessMessage(packet.Payload)
                                 : NotReadyPayload;
+
+                            if (IsLiveGameTestDiagnosticsEnabled)
+                            {
+                                Console.WriteLine($"[LiveGameTest] {DateTime.UtcNow:HH:mm:ss.fff} responded after {diagnosticStopwatch.Elapsed.TotalSeconds:0.00}s");
+                            }
 
                             var sendBytes = returnValue != null
                                 ? Encoding.ASCII.GetBytes(returnValue)

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
@@ -55,6 +55,7 @@ internal sealed class LiveGameProcess : IDisposable
     readonly GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager;
     readonly ConcurrentQueue<string> capturedStandardOutput;
     readonly ConcurrentQueue<string> capturedStandardError;
+    readonly ConcurrentQueue<string> connectionDiagnosticLog;
 
     /// <summary>
     /// Response timeout for every command a LiveGame test sends after the process has connected -
@@ -73,13 +74,15 @@ internal sealed class LiveGameProcess : IDisposable
     LiveGameProcess(TempDir project, System.Diagnostics.Process process,
         GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager,
         ConcurrentQueue<string> capturedStandardOutput,
-        ConcurrentQueue<string> capturedStandardError)
+        ConcurrentQueue<string> capturedStandardError,
+        ConcurrentQueue<string> connectionDiagnosticLog)
     {
         this.project = project;
         this.process = process;
         this.connectionManager = connectionManager;
         this.capturedStandardOutput = capturedStandardOutput;
         this.capturedStandardError = capturedStandardError;
+        this.connectionDiagnosticLog = connectionDiagnosticLog;
     }
 
     /// <summary>
@@ -157,10 +160,17 @@ internal sealed class LiveGameProcess : IDisposable
             // Glue-side of the protocol: listens, and completes the two-socket handshake the game's
             // GlueCommunication.GameConnectionManager initiates on startup (see GameConnectionManager.cs -
             // Glue-side accepts twice, byte 1 for glue->game, byte 2 for game->glue).
+            var connectionDiagnosticLog = new ConcurrentQueue<string>();
             var connectionManager = new GameJsonCommunicationPlugin.Common.GameConnectionManager((_, __) => { })
             {
                 Port = port,
-                TimeoutInSeconds = CommandResponseTimeoutInSeconds
+                TimeoutInSeconds = CommandResponseTimeoutInSeconds,
+                // Records every connect/reset transition with a wall-clock timestamp - if a Send times out
+                // because the socket was silently torn down and re-listened mid-request (rather than the
+                // game genuinely being slow to reply), this is the only place that would show it; the
+                // default LogAction only reaches Debug.WriteLine and a WPF-only plugin host, neither of
+                // which this headless test process has.
+                LogAction = message => connectionDiagnosticLog.Enqueue($"{DateTime.UtcNow:HH:mm:ss.fff} {message}")
             };
             GameJsonCommunicationPlugin.Common.GameConnectionManager.Self = connectionManager;
 
@@ -238,7 +248,7 @@ internal sealed class LiveGameProcess : IDisposable
             // IsPrintEditorToGameCheckboxChecked defaults false, so this only needs to exist.
             CommandSender.Self.CompilerViewModel = CompilerViewModel.Self;
 
-            return new LiveGameProcess(project, process, connectionManager, capturedStandardOutput, capturedStandardError);
+            return new LiveGameProcess(project, process, connectionManager, capturedStandardOutput, capturedStandardError, connectionDiagnosticLog);
         }
         catch
         {
@@ -323,8 +333,9 @@ internal sealed class LiveGameProcess : IDisposable
     /// </summary>
     public async Task<GeneralResponse<string>> Send(object dto)
     {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         var response = await CommandSender.Self.Send(dto);
-        AppendCapturedOutputOnFailure(response);
+        AppendDiagnosticsOnFailure(response, stopwatch.Elapsed);
         return response;
     }
 
@@ -335,8 +346,9 @@ internal sealed class LiveGameProcess : IDisposable
     /// </summary>
     public async Task<GeneralResponse<T>> Send<T>(object dto)
     {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         var response = await CommandSender.Self.Send<T>(dto);
-        AppendCapturedOutputOnFailure(response);
+        AppendDiagnosticsOnFailure(response, stopwatch.Elapsed);
         return response;
     }
 
@@ -344,13 +356,21 @@ internal sealed class LiveGameProcess : IDisposable
     /// A failed Send (e.g. the timeout described by <see cref="CommandResponseTimeoutInSeconds"/>
     /// elapsing) otherwise gives no way to tell "the game hung" from "the game crashed" from outside
     /// the process - appending what it printed is the only account of which, same rationale as
-    /// <see cref="DescribeCapturedOutput"/>'s use in <see cref="StartAsync"/>.
+    /// <see cref="DescribeCapturedOutput"/>'s use in <see cref="StartAsync"/>. The elapsed time and
+    /// IsConnected snapshot separate "the request legitimately took the whole timeout" from "the
+    /// socket was torn down mid-request and this failed fast" - see #2244, where the failure message
+    /// alone ("No response received") could not tell those apart.
     /// </summary>
-    void AppendCapturedOutputOnFailure<T>(GeneralResponse<T> response)
+    void AppendDiagnosticsOnFailure<T>(GeneralResponse<T> response, TimeSpan elapsed)
     {
         if (response?.Succeeded == false)
         {
-            response.Message += DescribeCapturedOutput(capturedStandardOutput, capturedStandardError);
+            response.Message +=
+                $"{Environment.NewLine}{Environment.NewLine}Send took {elapsed.TotalSeconds:0.00}s " +
+                $"(configured timeout {CommandResponseTimeoutInSeconds:0}s), IsConnected={connectionManager.IsConnected}." +
+                $"{Environment.NewLine}{Environment.NewLine}connection log:{Environment.NewLine}" +
+                (connectionDiagnosticLog.IsEmpty ? "<empty>" : string.Join(Environment.NewLine, connectionDiagnosticLog)) +
+                DescribeCapturedOutput(capturedStandardOutput, capturedStandardError);
         }
     }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
@@ -54,17 +54,32 @@ internal sealed class LiveGameProcess : IDisposable
     readonly System.Diagnostics.Process process;
     readonly GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager;
     readonly ConcurrentQueue<string> capturedStandardOutput;
+    readonly ConcurrentQueue<string> capturedStandardError;
+
+    /// <summary>
+    /// Response timeout for every command a LiveGame test sends after the process has connected -
+    /// see <see cref="Send"/>/<see cref="Send{T}"/>. Deliberately well above
+    /// GameConnectionManager's interactive-editor default of 10 seconds (unchanged there - a real
+    /// user wants a dead game reported quickly): a test's first command routinely drives real work
+    /// (e.g. loading a Screen's content) on a freshly-launched, cold-JIT'd game, on CI rendering
+    /// through Mesa's llvmpipe software GL rather than a GPU - see issue #2244, where that combination
+    /// took long enough to blow through the 10-second default and fail with "No response received"
+    /// though the same test passed on a re-run of the same commit.
+    /// </summary>
+    const double CommandResponseTimeoutInSeconds = 30;
 
     public string ProjectRoot => project.Root;
 
     LiveGameProcess(TempDir project, System.Diagnostics.Process process,
         GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager,
-        ConcurrentQueue<string> capturedStandardOutput)
+        ConcurrentQueue<string> capturedStandardOutput,
+        ConcurrentQueue<string> capturedStandardError)
     {
         this.project = project;
         this.process = process;
         this.connectionManager = connectionManager;
         this.capturedStandardOutput = capturedStandardOutput;
+        this.capturedStandardError = capturedStandardError;
     }
 
     /// <summary>
@@ -144,7 +159,8 @@ internal sealed class LiveGameProcess : IDisposable
             // Glue-side accepts twice, byte 1 for glue->game, byte 2 for game->glue).
             var connectionManager = new GameJsonCommunicationPlugin.Common.GameConnectionManager((_, __) => { })
             {
-                Port = port
+                Port = port,
+                TimeoutInSeconds = CommandResponseTimeoutInSeconds
             };
             GameJsonCommunicationPlugin.Common.GameConnectionManager.Self = connectionManager;
 
@@ -222,7 +238,7 @@ internal sealed class LiveGameProcess : IDisposable
             // IsPrintEditorToGameCheckboxChecked defaults false, so this only needs to exist.
             CommandSender.Self.CompilerViewModel = CompilerViewModel.Self;
 
-            return new LiveGameProcess(project, process, connectionManager, capturedStandardOutput);
+            return new LiveGameProcess(project, process, connectionManager, capturedStandardOutput, capturedStandardError);
         }
         catch
         {
@@ -305,14 +321,38 @@ internal sealed class LiveGameProcess : IDisposable
     /// Sends any DTO over the real CommandSender, for tests that care about what the running game answers
     /// rather than about a particular editor gesture.
     /// </summary>
-    public Task<GeneralResponse<string>> Send(object dto) => CommandSender.Self.Send(dto);
+    public async Task<GeneralResponse<string>> Send(object dto)
+    {
+        var response = await CommandSender.Self.Send(dto);
+        AppendCapturedOutputOnFailure(response);
+        return response;
+    }
 
     /// <summary>
     /// Same as <see cref="Send"/>, but deserializes the game's raw JSON reply into <typeparamref name="T"/>
     /// - see <see cref="CommandSender.Send{T}"/> - for tests that need the handler's typed return value
     /// rather than just success/failure.
     /// </summary>
-    public Task<GeneralResponse<T>> Send<T>(object dto) => CommandSender.Self.Send<T>(dto);
+    public async Task<GeneralResponse<T>> Send<T>(object dto)
+    {
+        var response = await CommandSender.Self.Send<T>(dto);
+        AppendCapturedOutputOnFailure(response);
+        return response;
+    }
+
+    /// <summary>
+    /// A failed Send (e.g. the timeout described by <see cref="CommandResponseTimeoutInSeconds"/>
+    /// elapsing) otherwise gives no way to tell "the game hung" from "the game crashed" from outside
+    /// the process - appending what it printed is the only account of which, same rationale as
+    /// <see cref="DescribeCapturedOutput"/>'s use in <see cref="StartAsync"/>.
+    /// </summary>
+    void AppendCapturedOutputOnFailure<T>(GeneralResponse<T> response)
+    {
+        if (response?.Succeeded == false)
+        {
+            response.Message += DescribeCapturedOutput(capturedStandardOutput, capturedStandardError);
+        }
+    }
 
     /// <summary>
     /// Sends the same SelectObjectDto Glue sends when the user clicks an entity in the tree, over the real


### PR DESCRIPTION
Closes #2244.

`GameConnectionManager.TimeoutInSeconds` (10s default) is tuned for an interactive editor session - report a dead game quickly. Every LiveGame test's first `Send` drives real work (a Screen load) on a freshly-launched, cold-JIT'd game rendering through Mesa's llvmpipe software GL on CI. The failed run's log ([job 101544396984](https://github.com/vchelaru/FlatRedBall/actions/runs/34054715827/job/101544396984)) shows "No response received", not the fast `NotReadyPayload` a not-yet-ready `GlueControlManager` sends - so the game was just slow to finish the load, not unreachable. `GameReadinessRetryPolicy` (the mechanism production code uses for this exact startup race) doesn't help here either: its whole budget is 1 second, dwarfed by a single slow attempt.

I can't reproduce the CI-only slowness locally to prove the exact duration, so this is a targeted mitigation, not a proven root cause:

- `LiveGameProcess` now sets the test-only connection's timeout to 30s (production default untouched).
- `Send`/`Send<T>` append captured stdout/stderr to a failed response's message, so if this recurs, the next failure shows what the game was actually doing instead of just "no response."

All 17 `Category=LiveGame` tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MQYxPG4eQot2KyZ14L6w4
