### PR TITLE
Default new .achx files to pixel coordinates

### DIFF
--- a/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/NewFiles/NewFilePlugin.cs
+++ b/FRBDK/Glue/Glue/Plugins/EmbeddedPlugins/NewFiles/NewFilePlugin.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using FlatRedBall.Content.AnimationChain;
 using FlatRedBall.Glue.Elements;
+using FlatRedBall.Graphics;
 using FlatRedBall.IO;
 using System.ComponentModel.Composition;
 using FlatRedBall.Glue.Controls;
@@ -242,7 +244,7 @@ T_Paused,Paused,En Pausa,Pausiert
             }
             else if (assetTypeInfo.SaveType != null)
             {
-                object saveInstance = Activator.CreateInstance(assetTypeInfo.SaveType);
+                object saveInstance = CreateSaveInstance(assetTypeInfo.SaveType);
                 FileManager.XmlSerialize(assetTypeInfo.SaveType, saveInstance, createdFile);
             }
             else if(assetTypeInfo.QualifiedSaveTypeName != null)
@@ -260,6 +262,27 @@ T_Paused,Paused,En Pausa,Pausiert
             {
                 FileManager.SaveText(null, createdFile);
             }
+        }
+
+        /// <summary>
+        /// Creates the default (blank) save-class instance written for a brand-new file. Most types
+        /// just need their plain default constructor, but <see cref="AnimationChainListSave"/> has no
+        /// frames yet to interpret as UV or pixel, so it's created explicitly in the pixel format -
+        /// the format the AnimationEditor expects and won't warn about. This does NOT change
+        /// <see cref="AnimationChainListSave.CoordinateType"/>'s own class default, which other
+        /// callers (e.g. the Aseprite importer) rely on staying UV when they fill in real UV data
+        /// without setting the property themselves.
+        /// </summary>
+        internal static object CreateSaveInstance(Type saveType)
+        {
+            object saveInstance = Activator.CreateInstance(saveType);
+
+            if (saveInstance is AnimationChainListSave animationChainListSave)
+            {
+                animationChainListSave.CoordinateType = TextureCoordinateType.Pixel;
+            }
+
+            return saveInstance;
         }
 
         private bool TryGetTemplateFileForAti(AssetTypeInfo assetTypeInfo, out string availableFile)

--- a/FRBDK/Glue/Tests/GlueUnitTests/Plugins/NewFilePluginTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Plugins/NewFilePluginTests.cs
@@ -1,0 +1,35 @@
+using FlatRedBall.Content.AnimationChain;
+using FlatRedBall.Glue.Plugins.EmbeddedPlugins.NewFiles;
+using FlatRedBall.Graphics;
+using Xunit;
+
+namespace GlueUnitTests.Plugins;
+
+/// <summary>
+/// GitHub issue #2249: a brand-new (empty) .achx created via Glue's "Add New File" window
+/// used to inherit <c>AnimationChainListSave</c>'s legacy UV default, which pops a "Convert to
+/// Pixel Coordinates" warning the first time the file is opened in the Avalonia AnimationEditor -
+/// even though the file has no UV data to convert. <see cref="AnimationChainListSave.CoordinateType"/>'s
+/// class-level default itself must stay UV: <c>AsepriteAnimationChainLoader</c> constructs a save
+/// instance and fills it with genuinely-normalized UV coordinates without ever setting the property,
+/// so flipping the shared default would silently reinterpret those as pixel values instead.
+/// </summary>
+public class NewFilePluginTests
+{
+    [Fact]
+    public void CreateSaveInstance_ForAnimationChainListSave_DefaultsToPixelCoordinates()
+    {
+        var instance = NewFilePlugin.CreateSaveInstance(typeof(AnimationChainListSave));
+
+        var achx = Assert.IsType<AnimationChainListSave>(instance);
+        Assert.Equal(TextureCoordinateType.Pixel, achx.CoordinateType);
+    }
+
+    [Fact]
+    public void CreateSaveInstance_ForOtherSaveTypes_UsesThePlainDefaultConstructor()
+    {
+        var instance = NewFilePlugin.CreateSaveInstance(typeof(AnimationChainSave));
+
+        Assert.IsType<AnimationChainSave>(instance);
+    }
+}


### PR DESCRIPTION
Fixes #2249

Brand-new `.achx` files created via Glue's Add New File window had no frames yet, but still got `AnimationChainListSave`'s legacy UV coordinate default, so the Avalonia AnimationEditor popped a "Convert to Pixel Coordinates" warning the first time one was opened.

Didn't just flip the class-level default to Pixel like the issue suggests, because `AsepriteAnimationChainLoader` constructs a save instance and fills it with genuinely-normalized UV coordinates without ever setting `CoordinateType` itself, relying on that default staying UV. Flipping it would silently mis-scale every Aseprite-imported animation. Instead, `NewFilePlugin` now sets `CoordinateType = Pixel` explicitly only for the truly-blank instance it creates for a brand-new file.

Covered by a new unit test (`NewFilePluginTests`) pinning the extracted `NewFilePlugin.CreateSaveInstance` helper; full fast suite (892 tests) green.

Manual test: not needed - covered by the unit test, and no other code path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbrvVhHSoA5frVGuJv1T8b
