### PR TITLE
Refresh Link Game to FRB Source dropdown when a synced project is added

### DIFF
--- a/FRBDK/Glue/OfficialPlugins/FrbSourcePlugin/FrbSourcePlugin.cs
+++ b/FRBDK/Glue/OfficialPlugins/FrbSourcePlugin/FrbSourcePlugin.cs
@@ -67,6 +67,11 @@ namespace PluginTestbed.GlobalContentManagerPlugins
 
         public override string FriendlyName => "FRB Source";
 
+        // Test-only seam: the dropdown itself is a WinForms ToolStripMenuItem, so tests assert on the
+        // project names it currently lists rather than reaching into WinForms internals.
+        internal IEnumerable<string> LinkToSourceDropDownProjectNames =>
+            _linkToSourceMenuItem.DropDownItems.Cast<ToolStripItem>().Select(item => item.Text);
+
         #endregion
 
         public FrbSourcePlugin()
@@ -82,6 +87,7 @@ namespace PluginTestbed.GlobalContentManagerPlugins
 
             this.ReactToLoadedGlux -= HandleGluxLoaded;
             this.ReactToUnloadedGlux -= HandleGluxUnloaded;
+            this.ReactToLoadedSyncedProject -= HandleSyncedProjectLoaded;
 
             return true;
         }
@@ -89,19 +95,25 @@ namespace PluginTestbed.GlobalContentManagerPlugins
         public override void StartUp()
         {
             _linkToSourceMenuItem = this.AddMenuItemTo(
-                "Link Game to FRB Source", 
-                (Action)null, 
+                "Link Game to FRB Source",
+                (Action)null,
                 "Project");
 
             _linkToSourceMenuItem.Enabled = false;
 
             this.ReactToLoadedGlux += HandleGluxLoaded;
             this.ReactToUnloadedGlux += HandleGluxUnloaded;
+            this.ReactToLoadedSyncedProject += HandleSyncedProjectLoaded;
         }
 
         private void HandleGluxUnloaded()
         {
             _linkToSourceMenuItem.Enabled = false;
+            RefreshLinkToSourceItems();
+        }
+
+        private void HandleSyncedProjectLoaded(ProjectBase syncedProject)
+        {
             RefreshLinkToSourceItems();
         }
 

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/FrbSourcePluginSyncedProjectDropdownTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/FrbSourcePluginSyncedProjectDropdownTests.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using System.Linq;
+using GlueUnitTests.TestSupport;
+using OfficialPlugins.FrbSourcePlugin.Managers;
+using PluginTestbed.GlobalContentManagerPlugins;
+using Shouldly;
+
+namespace GlueUnitTests.Projects;
+
+// Regression test for GitHub issue #1735: adding a synced project (Glue > Add Synced Project, or a
+// project discovered via file-watch sync) only showed up in the "Link Game to FRB Source" dropdown
+// after restarting Glue. RefreshLinkToSourceItems only ran off ReactToLoadedGlux/ReactToUnloadedGlux,
+// so a synced project added mid-session never triggered a rebuild of the dropdown.
+public class FrbSourcePluginSyncedProjectDropdownTests
+{
+    [StaFact]
+    public void LinkToSourceDropdown_ShouldIncludeSyncedProject_AddedAfterGluxAlreadyLoaded()
+    {
+        GlueTestBootstrap.EnsureHeadlessProjectLoadReady();
+
+        var plugin = new FrbSourcePlugin();
+        FlatRedBall.Glue.Plugins.PluginManager.RegisterPluginForTesting(plugin);
+
+        var mainProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var mainDirectory, "MainProject");
+        var syncedProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out var syncedDirectory, "SyncedProject");
+
+        var glueState = FlatRedBall.Glue.Plugins.ExportedImplementations.GlueState.Self;
+        var originalMainProject = glueState.CurrentMainProject;
+        var originalSyncedProjects = glueState.SyncedProjects.ToList();
+
+        try
+        {
+            glueState.CurrentMainProject = mainProject;
+            glueState.SyncedProjects.Clear();
+
+            // Simulates the real ReactToLoadedGlux dispatch (PluginManager.ReactToLoadedGlux) that
+            // happens when a project is loaded/reloaded.
+            plugin.ReactToLoadedGlux();
+
+            plugin.LinkToSourceDropDownProjectNames.ShouldBe(new[] { mainProject.Name });
+
+            // Mirrors what ProjectCommands.AddSyncedProject (and ProjectLoader's file-watch sync path)
+            // do in production: mutate GlueState.SyncedProjects, then notify plugins via
+            // PluginManager.ReactToSyncedProjectLoad - without reloading the whole glux.
+            glueState.SyncedProjects.Add(syncedProject);
+            FlatRedBall.Glue.Plugins.PluginManager.ReactToSyncedProjectLoad(syncedProject);
+
+            plugin.LinkToSourceDropDownProjectNames.ShouldBe(new[] { mainProject.Name, syncedProject.Name });
+        }
+        finally
+        {
+            glueState.CurrentMainProject = originalMainProject;
+            glueState.SyncedProjects.Clear();
+            glueState.SyncedProjects.AddRange(originalSyncedProjects);
+
+            Directory.Delete(mainDirectory, recursive: true);
+            Directory.Delete(syncedDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1735.

## Root cause
`FrbSourcePlugin.RefreshLinkToSourceItems` (which rebuilds the "Link Game to FRB Source" dropdown from `GlueState.CurrentMainProject` + `GlueState.SyncedProjects`) only ran off `ReactToLoadedGlux`/`ReactToUnloadedGlux`. Adding a synced project mid-session (Glue > Add Synced Project, or file-watch discovery) never fired either of those, so the new project was invisible in the dropdown until a restart.

## Fix
Subscribe `FrbSourcePlugin` to the existing `ReactToLoadedSyncedProject` plugin event too (the same event `ProjectCommands.AddSyncedProject` and `ProjectLoader`'s file-watch sync path already fire) and refresh the dropdown from there.

## Test
`FrbSourcePluginSyncedProjectDropdownTests` (new): registers a real `FrbSourcePlugin`, loads a main project, then adds a synced project via the production `PluginManager.ReactToSyncedProjectLoad` dispatch — asserts the dropdown lists both projects without any glux reload. Confirmed Red without the fix (dropdown stayed at just the main project) and Green with it. Full fast suite (891 tests) green from a clean rebuild.

Manual test: not needed — covered by the unit test plus compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
