### PR TITLE
Report screen-load exceptions to Glue; fix entity-preview NRE

### DIFF
--- a/Engines/FlatRedBallXNA/FlatRedBall/Screens/ScreenManager.cs
+++ b/Engines/FlatRedBallXNA/FlatRedBall/Screens/ScreenManager.cs
@@ -130,7 +130,10 @@ namespace FlatRedBall.Screens
         #endregion
 
         static Exception GlueViewLoadException;
-		
+
+        // Raised once per LoadScreen attempt (not every frame) so callers can report the exception elsewhere.
+        public static Action<Exception> ScreenLoadExceptionOccurred;
+
 		public static Action<string> RehydrateAction
 		{
 			get;
@@ -501,6 +504,7 @@ namespace FlatRedBall.Screens
                     {
                         // I guess do nothing?
                         GlueViewLoadException = e;
+                        ScreenLoadExceptionOccurred?.Invoke(e);
                     }
 
                 }

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandReceiving/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/CommandReceiving/CommandReceiver.cs
@@ -790,6 +790,15 @@ namespace OfficialPlugins.Compiler.CommandReceiving
 
         #endregion
 
+        #region ScreenLoadExceptionDto
+
+        private void HandleDto(ScreenLoadExceptionDto dto)
+        {
+            GlueCommands.Self.PrintError("Exception thrown loading screen in game:\n" + dto.Exception);
+        }
+
+        #endregion
+
         #region Glue/XXXX/CommandDto
 
         private async Task<string> HandleDto(GlueCommandDto dto) => await HandleFacadeCommand(GlueCommands.Self, dto);

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -204,6 +204,15 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
 
     #endregion
 
+    #region ScreenLoadExceptionDto
+
+    public class ScreenLoadExceptionDto
+    {
+        public string Exception { get; set; }
+    }
+
+    #endregion
+
     #region GetCameraPosition
     public class GetCameraPosition
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -205,6 +205,15 @@ namespace GlueControl.Dtos
 
     #endregion
 
+    #region ScreenLoadExceptionDto
+
+    public class ScreenLoadExceptionDto
+    {
+        public string Exception { get; set; }
+    }
+
+    #endregion
+
     #region GetCameraPosition
     public class GetCameraPosition
     {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/VariableAssignmentLogic.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/VariableAssignmentLogic.cs
@@ -1636,9 +1636,9 @@ namespace GlueControl.Editing
 
         private static string TryQualifyFromRfs(string variableValue)
         {
-            var currentScreen = GlueControl.Managers.GlueState.Self.CurrentElement as GlueControl.Models.ScreenSave;
+            var currentElement = GlueControl.Managers.GlueState.Self.CurrentElement;
 
-            var rfs = currentScreen.GetReferencedFileSaveRecursively(variableValue);
+            var rfs = currentElement?.GetReferencedFileSaveRecursively(variableValue);
 
             if (rfs != null)
             {

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GlueControlManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GlueControlManager.cs
@@ -69,7 +69,13 @@ namespace GlueControl
             FlatRedBallServices.AddManager(EditingManager);
             EditingManager.PropertyChanged += HandlePropertyChanged;
             EditingManager.ObjectSelected += HandleObjectsSelected;
+            FlatRedBall.Screens.ScreenManager.ScreenLoadExceptionOccurred += HandleScreenLoadException;
             //listener = new TcpListener(IPAddress.Any, port);
+        }
+
+        private void HandleScreenLoadException(Exception e)
+        {
+            _ = SendToGlue(new Dtos.ScreenLoadExceptionDto { Exception = e.ToString() });
         }
 
         //public void Start()


### PR DESCRIPTION
## Summary
- Screen-load exceptions during live edit only ever rendered as in-game text (`ScreenManager.LoadScreen`'s catch -> `Debugger.Write`), with no way to copy them out.
- Added `ScreenManager.ScreenLoadExceptionOccurred` (fired once per load attempt, not per frame) and wired `GlueControlManager` to send it to Glue as a new `ScreenLoadExceptionDto`, surfaced via `GlueCommands.Self.PrintError` - same sink `VariableAssignmentLogic`'s errors already use.
- That surfaced a real bug: `VariableAssignmentLogic.TryQualifyFromRfs` assumed `GlueState.Self.CurrentElement` is always a `ScreenSave`. Previewing an entity (`EntityViewingScreen`) makes it an `EntitySave` instead, so the `as ScreenSave` cast silently returned null, and `GetReferencedFileSave` NRE'd dereferencing it. Any unqualified `Texture2D`/`AnimationChainList` variable value hit this while previewing any entity, not just the one in the original repro. Fixed by using `CurrentElement` directly (`GlueElement`, the base of both) instead of narrowing to `ScreenSave`.

## Test plan
- [x] Engine (`FlatRedBallDesktopGLNet6.sln`) and `GameCommunicationPlugin.csproj` build clean (0 C# errors).
- [x] Manually reproduced and confirmed fixed against a real linked game project (entity-preview crash no longer occurs; Glue's Output window now shows the reported exception).
- [ ] No automated regression test added - reproducing this specific NRE via `LiveGameProcess` would require extending the `EditorTest1` gold-project fixture with a `Texture2D`/`AnimationChainList`-typed object, which felt like scope creep on a shared test fixture for this PR. Flagging in case a follow-up test is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LT6X7kqdV2boMHXn2V4Hcm