### PR TITLE
Retroactively version-gate ScreenLoadExceptionOccurred; fix stale test stubs

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GlueControlManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GlueControlManager.cs
@@ -69,7 +69,9 @@ namespace GlueControl
             FlatRedBallServices.AddManager(EditingManager);
             EditingManager.PropertyChanged += HandlePropertyChanged;
             EditingManager.ObjectSelected += HandleObjectsSelected;
+#if ScreenManagerHasScreenLoadExceptionOccurred || REFERENCES_FRB_SOURCE
             FlatRedBall.Screens.ScreenManager.ScreenLoadExceptionOccurred += HandleScreenLoadException;
+#endif
             //listener = new TcpListener(IPAddress.Any, port);
         }
 

--- a/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
+++ b/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
@@ -219,6 +219,10 @@ namespace FlatRedBall.Glue.SaveClasses
             // whether platformer physics is applied. Gated because ApplyPhysics is a new engine-side
             // property on the Delegate*Relationship classes.
             PlatformerCollisionSupportsApplyPhysicsDelegate = 70,
+            // September 9, 2026 - shipped alongside version 70 but missed being gated. Added retroactively
+            // at the same version: ScreenManager.ScreenLoadExceptionOccurred is a new engine-side event that
+            // GlueControlManager.cs (embedded) subscribes to.
+            ScreenManagerHasScreenLoadExceptionOccurred = 70,
 
             // Stop! If adding an entry here, modify SyntaxVersionAttribute on FlatRedBallServices
             // and LatestVersion down below

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/NestedInstanceVariableAssignmentTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/NestedInstanceVariableAssignmentTests.cs
@@ -268,7 +268,11 @@ public class NestedInstanceVariableAssignmentTests : IDisposable
                 public class GlueState
                 {
                     public static GlueState Self { get; } = new GlueState();
-                    public object CurrentElement { get; set; }
+                    // Real production type (GlueControl.Managers.GlueState, see Editing_Managers_GlueState's
+                    // GenerationOptions in GlueControlCodeGenerator) - VariableAssignmentLogic.TryQualifyFromRfs
+                    // calls the GlueElement-typed extension method GetReferencedFileSaveRecursively on this,
+                    // which a plain `object` stub can't satisfy.
+                    public GlueControl.Models.GlueElement CurrentElement { get; set; }
                 }
             }
             """ + Environment.NewLine);

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/PathInstanceVariableAssignmentTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/PathInstanceVariableAssignmentTests.cs
@@ -295,7 +295,11 @@ public class PathInstanceVariableAssignmentTests : IDisposable
                 public class GlueState
                 {
                     public static GlueState Self { get; } = new GlueState();
-                    public object CurrentElement { get; set; }
+                    // Real production type (GlueControl.Managers.GlueState, see Editing_Managers_GlueState's
+                    // GenerationOptions in GlueControlCodeGenerator) - VariableAssignmentLogic.TryQualifyFromRfs
+                    // calls the GlueElement-typed extension method GetReferencedFileSaveRecursively on this,
+                    // which a plain `object` stub can't satisfy.
+                    public GlueControl.Models.GlueElement CurrentElement { get; set; }
                 }
             }
             """ + Environment.NewLine);

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableAssignmentLogicEnumConversionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableAssignmentLogicEnumConversionTests.cs
@@ -357,7 +357,11 @@ public class VariableAssignmentLogicEnumConversionTests : IDisposable
                 public class GlueState
                 {
                     public static GlueState Self { get; } = new GlueState();
-                    public object CurrentElement { get; set; }
+                    // Real production type (GlueControl.Managers.GlueState, see Editing_Managers_GlueState's
+                    // GenerationOptions in GlueControlCodeGenerator) - VariableAssignmentLogic.TryQualifyFromRfs
+                    // calls the GlueElement-typed extension method GetReferencedFileSaveRecursively on this,
+                    // which a plain `object` stub can't satisfy.
+                    public GlueControl.Models.GlueElement CurrentElement { get; set; }
                 }
             }
             """ + Environment.NewLine);


### PR DESCRIPTION
## Summary

PR #2254 added `ScreenManager.ScreenLoadExceptionOccurred` and subscribed to it unconditionally from the embedded `GlueControlManager.cs`. Any game project referencing FlatRedBall via a released NuGet package (rather than engine source) fails to compile - `EditorTest1` (used by `LiveGameProcessTests`) hit this in CI on #2254 itself (failed, merged anyway) and again on #2253.

Fixed with the standard retroactive gate (`gluj-versions` skill): added `GluxVersions.ScreenManagerHasScreenLoadExceptionOccurred = 70` (same value as the version already shipped after the change) and wrapped the subscription in `#if ScreenManagerHasScreenLoadExceptionOccurred || REFERENCES_FRB_SOURCE`.

Running the `BuildSmoke` category locally (never exercised on #2254's CI - it failed on the `LiveGame` step first and every later step was skipped) surfaced a second, unrelated problem: `VariableAssignmentLogicEnumConversionTests`/`NestedInstanceVariableAssignmentTests`/`PathInstanceVariableAssignmentTests` each hand-roll a compile-only `GlueState` stub with `CurrentElement` typed as plain `object`. #2254 changed `TryQualifyFromRfs` to call the `GlueElement`-typed extension method `GetReferencedFileSaveRecursively` on it - the real generated `GlueState.Generated.cs` (`CurrentElement: GlueElement`) satisfies that fine, but the stale test stubs don't. Not a production bug: retyped the three stubs to `GlueControl.Models.GlueElement` (already available via each scratch project's existing `Models/**/*.cs` compile item).

## Testing

Watched both errors reproduce locally with each fix reverted in turn (`CS0117` for the version gate, `CS1929` for the test stubs), then confirmed green restored. Full local runs: `LiveGame` 17/17, `BuildSmoke` 69/69, fast suite 892/893 - the one failure (`EmbeddedInputAllowedServiceTests.ReadIsAllowed_RealWindow_TracksWhetherTheCursorIsOverIt`, a real `GetCursorPos` Win32 call) is unrelated to this diff and reproduces on this machine regardless.

Closes #2255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHHmGzQ8UTQiQAThjj8Faf
