### PR TITLE
Keep post-delete selection in the same tree folder (#2265)

### DIFF
--- a/FRBDK/Glue/Glue/Elements/RemovalSelection.cs
+++ b/FRBDK/Glue/Glue/Elements/RemovalSelection.cs
@@ -1,0 +1,38 @@
+using FlatRedBall.Glue.SaveClasses;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FlatRedBall.Glue.Elements
+{
+    /// <summary>
+    /// Decides which object gets selected after one is deleted, so the tree view's selection lands next to
+    /// where the user was.
+    /// </summary>
+    public static class RemovalSelection
+    {
+        /// <summary>
+        /// Picks the neighbour to select after <paramref name="removed"/> has been taken out of
+        /// <paramref name="remainingSiblings"/>. <paramref name="indexOfRemoved"/> is where it used to be.
+        /// Returns null when nothing suitable is left, so the caller can fall back to the container.
+        ///
+        /// Only siblings shown in the same tree folder count. The list is flat, but the tree shows layers
+        /// and collision relationships under their own folder nodes, so a neighbour picked purely by index
+        /// can sit in a different (collapsed) folder and selecting it pops that folder open. See GitHub
+        /// issue #2265.
+        /// </summary>
+        public static NamedObjectSave PickSuccessor(IList<NamedObjectSave> remainingSiblings, NamedObjectSave removed, int indexOfRemoved)
+        {
+            bool IsInSameFolder(NamedObjectSave candidate) =>
+                candidate.IsLayer == removed.IsLayer &&
+                candidate.IsCollisionRelationship() == removed.IsCollisionRelationship();
+
+            var after = remainingSiblings.Skip(indexOfRemoved).FirstOrDefault(IsInSameFolder);
+            if (after != null)
+            {
+                return after;
+            }
+
+            return remainingSiblings.Take(indexOfRemoved).LastOrDefault(IsInSameFolder);
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
@@ -1747,6 +1747,29 @@ public class GluxCommands : IGluxCommands
         "Performing object removal logic");
     }
 
+    /// <summary>
+    /// Moves the selection off a just-removed object onto its nearest remaining neighbour in the same tree
+    /// folder, falling back to the list it was in, then to the element. See GitHub issue #2265.
+    /// </summary>
+    private static void SelectSuccessorOf(NamedObjectSave removed, List<NamedObjectSave> remainingSiblings, int indexOfRemoved,
+        NamedObjectSave containerOfRemoved, GlueElement element)
+    {
+        var successor = RemovalSelection.PickSuccessor(remainingSiblings, removed, indexOfRemoved);
+
+        if (successor != null)
+        {
+            GlueState.Self.CurrentNamedObjectSave = successor;
+        }
+        else if (containerOfRemoved != null)
+        {
+            GlueState.Self.CurrentNamedObjectSave = containerOfRemoved;
+        }
+        else
+        {
+            GlueState.Self.CurrentElement = element;
+        }
+    }
+
     private static void GetSelectionInfo(NamedObjectSave namedObjectToRemove, out bool wasSelected, out int indexInChild, out NamedObjectSave containerOfRemoved, out GlueElement element)
     {
         wasSelected = GlueState.Self.CurrentNamedObjectSave == namedObjectToRemove;
@@ -1776,8 +1799,24 @@ public class GluxCommands : IGluxCommands
     public async Task RemoveNamedObjectListAsync(List<NamedObjectSave> namedObjectListToRemove, bool performSaveAndGenerateCode = true,
         bool updateUi = true, List<string> additionalFilesToRemove = null, bool notifyPluginsOfRemoval = true)
     {
-        bool wasSelected =
-            namedObjectListToRemove.Contains(GlueState.Self.CurrentNamedObjectSave);
+        // Captured before anything is removed so the successor can be picked from the trimmed list afterwards
+        var selectedNos = GlueState.Self.CurrentNamedObjectSave;
+        List<NamedObjectSave> selectedSiblings = null;
+        int selectedIndex = -1;
+        NamedObjectSave selectedContainer = null;
+        GlueElement selectedElement = null;
+        if (selectedNos != null && namedObjectListToRemove.Contains(selectedNos))
+        {
+            GetSelectionInfo(selectedNos, out _, out selectedIndex, out selectedContainer, out selectedElement);
+            if (selectedElement != null)
+            {
+                selectedSiblings = selectedContainer?.ContainedObjects ?? selectedElement.NamedObjects;
+                // Siblings ahead of it that are also being removed shift its position in the trimmed list
+                selectedIndex -= namedObjectListToRemove
+                    .Select(item => selectedSiblings.IndexOf(item))
+                    .Count(index => index >= 0 && index < selectedIndex);
+            }
+        }
 
         List<NamedObjectSave> objectsRemovingInludingDerived = new List<NamedObjectSave>();
 
@@ -1838,21 +1877,9 @@ public class GluxCommands : IGluxCommands
         }
 
 
-        if (wasSelected)
+        if (selectedSiblings != null)
         {
-            var owner = ownerHashSet.FirstOrDefault();
-            if (owner != null)
-            {
-                var nos = owner.NamedObjects.FirstOrDefault();
-                if (nos != null)
-                {
-                    GlueState.Self.CurrentNamedObjectSave = nos;
-                }
-                else
-                {
-                    GlueState.Self.CurrentElement = owner;
-                }
-            }
+            SelectSuccessorOf(selectedNos, selectedSiblings, selectedIndex, selectedContainer, selectedElement);
         }
 
         if(notifyPluginsOfRemoval)
@@ -2305,30 +2332,7 @@ public class GluxCommands : IGluxCommands
                     {
                         List<NamedObjectSave> containerList = containerOfRemoved?.ContainedObjects ?? element.NamedObjects;
 
-                        if (containerList.Count == 0)
-                        {
-                            if (containerOfRemoved != null)
-                            {
-                                GlueState.Self.CurrentNamedObjectSave = containerOfRemoved;
-                            }
-                            else
-                            {
-                                // do nothing...
-                            }
-                        }
-                        else
-                        {
-                            if (indexInChild < containerList.Count)
-                            {
-                                GlueState.Self.CurrentNamedObjectSave = containerList[indexInChild];
-                            }
-                            else
-                            {
-                                GlueState.Self.CurrentNamedObjectSave = containerList.LastOrDefault();
-
-                            }
-
-                        }
+                        SelectSuccessorOf(namedObjectToRemove, containerList, indexInChild, containerOfRemoved, element);
                     }
 
                     GlueCommands.Self.DialogCommands.FocusOnTreeView();

--- a/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/RemovalSelectionTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/CommandInterfaces/RemovalSelectionTests.cs
@@ -1,0 +1,95 @@
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GlueUnitTests.CommandInterfaces;
+
+/// <summary>
+/// After a delete, Glue selects a neighbour of the removed object. <c>GlueElement.NamedObjects</c> is a
+/// flat list, but the tree shows plain objects at the top level and layers / collision relationships
+/// under their own folder nodes, so a neighbour picked by list index can land in a different folder and
+/// pop it open. See GitHub issue #2265.
+/// </summary>
+public class RemovalSelectionTests
+{
+    static NamedObjectSave Sprite(string name) => new NamedObjectSave
+    {
+        InstanceName = name,
+        SourceType = SourceType.FlatRedBallType,
+        SourceClassType = "FlatRedBall.Sprite"
+    };
+
+    static NamedObjectSave CollisionRelationship(string name) => new NamedObjectSave
+    {
+        InstanceName = name,
+        SourceType = SourceType.FlatRedBallType,
+        SourceClassType = "FlatRedBall.Math.Collision.CollisionRelationship"
+    };
+
+    static NamedObjectSave Layer(string name) => new NamedObjectSave
+    {
+        InstanceName = name,
+        SourceType = SourceType.FlatRedBallType,
+        SourceClassType = "Layer"
+    };
+
+    // Simulates what the callers hand over: the list *after* removal plus the removed object's old index.
+    static NamedObjectSave PickAfterRemoving(List<NamedObjectSave> list, NamedObjectSave removed)
+    {
+        var index = list.IndexOf(removed);
+        list.Remove(removed);
+        return RemovalSelection.PickSuccessor(list, removed, index);
+    }
+
+    [Fact]
+    public void RemovingAPlainObject_ShouldSelectThePlainObjectThatFollowedIt()
+    {
+        var first = Sprite("First");
+        var second = Sprite("Second");
+        var third = Sprite("Third");
+
+        PickAfterRemoving(new List<NamedObjectSave> { first, second, third }, second).ShouldBe(third);
+    }
+
+    [Fact]
+    public void RemovingTheLastPlainObject_ShouldSelectThePlainObjectBeforeIt_NotTheCollisionRelationshipAfterIt()
+    {
+        var first = Sprite("First");
+        var second = Sprite("Second");
+        var relationship = CollisionRelationship("FirstVsSecond");
+
+        PickAfterRemoving(new List<NamedObjectSave> { first, second, relationship }, second).ShouldBe(first);
+    }
+
+    [Fact]
+    public void RemovingTheOnlyPlainObject_ShouldSelectNothing_WhenOnlyCollisionRelationshipsRemain()
+    {
+        var only = Sprite("Only");
+        var relationship = CollisionRelationship("OnlyVsOnly");
+
+        PickAfterRemoving(new List<NamedObjectSave> { only, relationship }, only).ShouldBeNull();
+    }
+
+    [Fact]
+    public void RemovingACollisionRelationship_ShouldSelectAnotherCollisionRelationship_NotAPlainObject()
+    {
+        var firstRelationship = CollisionRelationship("FirstRelationship");
+        var secondRelationship = CollisionRelationship("SecondRelationship");
+        // Objects added after the relationships land after them in the flat list
+        var sprite = Sprite("Sprite");
+
+        PickAfterRemoving(new List<NamedObjectSave> { firstRelationship, secondRelationship, sprite }, secondRelationship)
+            .ShouldBe(firstRelationship);
+    }
+
+    [Fact]
+    public void RemovingALayer_ShouldNotSelectACollisionRelationship()
+    {
+        var layer = Layer("Layer");
+        var relationship = CollisionRelationship("Relationship");
+
+        PickAfterRemoving(new List<NamedObjectSave> { layer, relationship }, layer).ShouldBeNull();
+    }
+}


### PR DESCRIPTION
Fixes #2265

After a delete, the next selection was picked by index into the flat `NamedObjects` list. The tree groups layers and collision relationships under their own folder nodes, so when the deleted object was the last plain one, the index landed on a collision relationship and selecting it expanded that folder. Same shape for the multi-delete path, which just took `NamedObjects.FirstOrDefault()`.

`RemovalSelection.PickSuccessor` now only considers siblings in the same tree folder (plain / layer / collision relationship): the one after, else the one before, else null. Both delete paths use it; when nothing suitable remains they fall back to the containing list, then the element (the single-delete path previously left the selection on the deleted object in that case).

Tests: `RemovalSelectionTests`, 4 of 5 red against the old index logic. The `GlueState.CurrentNamedObjectSave` setter isn't reachable in the test host (`FakeFindManager` deliberately doesn't resolve `NamedObjectSave`), so the picker is tested directly.

Manual test: delete the last plain object in a screen that also has a collision relationship, with the Collision Relationships folder collapsed. Selection should move to the previous object and the folder should stay collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeqtenJCH71W3QsnRpCrCg
