### PR TITLE
Stop Make Default on a live-edited Text Font from crashing Glue

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
@@ -654,7 +654,14 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                     && type != "Nullable<String>"
                     )
                 {
-                    value = TypeManager.GetDefaultForType(type);
+                    // Only primitives have a known default. Anything else (BitmapFont, Layer, an entity type)
+                    // is a reference type whose cleared value is null, which is what leaving value null sends.
+                    // Throwing here would surface as an unhandled exception in RefreshManager's async void
+                    // handlers and take Glue down (issue #2266).
+                    if (TypeManager.TryGetDefaultForType(type, out string defaultValue))
+                    {
+                        value = defaultValue;
+                    }
                 }
             }
         }

--- a/FRBDK/Glue/Glue/Diagnostics/CrashLog.cs
+++ b/FRBDK/Glue/Glue/Diagnostics/CrashLog.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+
+namespace FlatRedBall.Glue.Diagnostics;
+
+/// <summary>
+/// Writes an unhandled exception to a file before Glue goes down. The output tab and the plugin-error
+/// dialog die with the process, so without this a crash report reads "Glue crashes" with nothing to go on.
+/// Files land next to the other diagnostics logs under %LOCALAPPDATA%\FlatRedBall\Glue\Diagnostics.
+/// </summary>
+public static class CrashLog
+{
+    public static string Directory { get; set; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "FlatRedBall", "Glue", "Diagnostics");
+
+    /// <summary>
+    /// Returns the written file's path, or null if writing failed - this runs inside the crash handler, so
+    /// it must never throw.
+    /// </summary>
+    public static string Write(object exceptionObject)
+    {
+        try
+        {
+            System.IO.Directory.CreateDirectory(Directory);
+            var filePath = Path.Combine(Directory, $"crash-{DateTime.Now:yyyyMMdd-HHmmss-fff}.log");
+            File.WriteAllText(filePath,
+                $"{DateTime.Now:O}{Environment.NewLine}{exceptionObject}{Environment.NewLine}");
+            return filePath;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/FRBDK/Glue/Glue/Parsing/TypeManager.cs
+++ b/FRBDK/Glue/Glue/Parsing/TypeManager.cs
@@ -788,6 +788,20 @@ namespace FlatRedBall.Glue.Parsing
 
         public static string GetDefaultForType(string type)
         {
+            if (TryGetDefaultForType(type, out string defaultValue))
+            {
+                return defaultValue;
+            }
+            throw new ArgumentException("Could not find the value for type " + type);
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="type"/> is one of the primitives this class knows the code-string
+        /// default for. Callers that must not fail on an arbitrary type (a BitmapFont, a Layer, any engine
+        /// reference type) use this and decide their own fallback.
+        /// </summary>
+        public static bool TryGetDefaultForType(string type, out string defaultValue)
+        {
             switch (type)
             {
                 case "string":
@@ -797,12 +811,14 @@ namespace FlatRedBall.Glue.Parsing
                 case "String?":
                 case "Nullable<string>":
                 case "Nullable<String>":
-                    return "null";
+                    defaultValue = "null";
+                    return true;
 
                 case "Boolean":
                 case "bool":
                 case "System.Boolean":
-                    return "false";
+                    defaultValue = "false";
+                    return true;
 
                 case "Single":
                 case "float":
@@ -816,7 +832,8 @@ namespace FlatRedBall.Glue.Parsing
                 case "Decimal":
                 case "System.Decimal":
 
-                    return "0";
+                    defaultValue = "0";
+                    return true;
                 case "Int16":
 
                 case "Int32":
@@ -829,10 +846,11 @@ namespace FlatRedBall.Glue.Parsing
 
                 case "byte":
                 case "Byte":
-                    
+
                 case "ColorOperation":
 
-                    return "0";
+                    defaultValue = "0";
+                    return true;
                 case "float?":
                 case "int?":
                 case "long?":
@@ -841,9 +859,11 @@ namespace FlatRedBall.Glue.Parsing
                 case "bool?":
                 case "Nullable<Boolean>":
                 case "Nullable<Int32>":
-                    return "null";
+                    defaultValue = "null";
+                    return true;
                 default:
-                    throw new ArgumentException("Could not find the value for type " + type);
+                    defaultValue = null;
+                    return false;
             }
         }
 

--- a/FRBDK/Glue/Glue/Plugins/PluginManager.cs
+++ b/FRBDK/Glue/Glue/Plugins/PluginManager.cs
@@ -2311,7 +2311,7 @@ public class PluginManager : PluginManagerBase
 
     #endregion
 
-    internal static bool TryHandleException(Exception exception)
+    internal static bool TryHandleException(Exception exception, string crashLogPath = null)
     {
         bool wasHandled = false;
 
@@ -2330,8 +2330,9 @@ public class PluginManager : PluginManagerBase
                     // We're going to blame this plugin for the error
                     DialogService.ShowMessage($"A plugin has had an error.\n" +
                         $"Shutting down the plugin {plugin.Name} version {plugin.Plugin.Version} at file location\n{plugin.AssemblyLocation}\n\n" +
-                        $"Additional information:\n\n" + 
-                        exception.ToString());
+                        $"Additional information:\n\n" +
+                        exception.ToString() +
+                        (crashLogPath != null ? $"\n\nWritten to {crashLogPath}" : ""));
 
                     wasHandled = true;
 

--- a/FRBDK/Glue/Glue/Program.cs
+++ b/FRBDK/Glue/Glue/Program.cs
@@ -71,10 +71,15 @@ static class Program
 
     private static void HandleExceptionsUnified(object objectToPrint)
     {
-        bool wasPluginError = PluginManager.TryHandleException(objectToPrint as Exception);
+        // An exception escaping an async void handler ends the process no matter what runs here, so the
+        // file is the only record that survives. Write it first.
+        var crashLogPath = FlatRedBall.Glue.Diagnostics.CrashLog.Write(objectToPrint);
+
+        bool wasPluginError = PluginManager.TryHandleException(objectToPrint as Exception, crashLogPath);
         if (!wasPluginError)
         {
-            GlueCommands.Self.PrintError(objectToPrint?.ToString());
+            GlueCommands.Self.PrintError(objectToPrint?.ToString() +
+                (crashLogPath != null ? $"{Environment.NewLine}Written to {crashLogPath}" : ""));
         }
     }
 

--- a/FRBDK/Glue/Glue/SetVariable/NamedObjectSaves/NamedObjectSetVariableLogic.cs
+++ b/FRBDK/Glue/Glue/SetVariable/NamedObjectSaves/NamedObjectSetVariableLogic.cs
@@ -381,7 +381,7 @@ namespace FlatRedBall.Glue.SetVariable
             if (changedMember == "Font" && namedObjectSave.SourceType == SourceType.FlatRedBallType &&
                 namedObjectSave.GetAssetTypeInfo() == AvailableAssetTypes.CommonAtis.Text && namedObjectSave.IsPixelPerfect)
             {
-                ReactToFontSet(namedObjectSave, oldValue);
+                ReactToFontSet(namedObjectSave, element);
             }
 
             PropertyGridHelper.UpdateNamedObjectDisplay();
@@ -681,14 +681,12 @@ namespace FlatRedBall.Glue.SetVariable
 
         }
 
-        private void ReactToFontSet(NamedObjectSave namedObjectSave, object oldValue)
+        private void ReactToFontSet(NamedObjectSave namedObjectSave, GlueElement element)
         {
-            string value = namedObjectSave.GetCustomVariable("Font").Value as string;
+            string value = namedObjectSave.GetCustomVariable("Font")?.Value as string;
 
-            if (!string.IsNullOrEmpty(value))
+            if (!string.IsNullOrEmpty(value) && element != null)
             {
-                IElement element = GlueState.Self.CurrentElement;
-
                 ReferencedFileSave referencedFileSave = element.GetReferencedFileSaveByInstanceNameRecursively(value);
 
 

--- a/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
+++ b/FRBDK/Glue/GlueCommon/SaveClasses/GlueProjectSave.cs
@@ -219,10 +219,6 @@ namespace FlatRedBall.Glue.SaveClasses
             // whether platformer physics is applied. Gated because ApplyPhysics is a new engine-side
             // property on the Delegate*Relationship classes.
             PlatformerCollisionSupportsApplyPhysicsDelegate = 70,
-            // September 9, 2026 - shipped alongside version 70 but missed being gated. Added retroactively
-            // at the same version: ScreenManager.ScreenLoadExceptionOccurred is a new engine-side event that
-            // GlueControlManager.cs (embedded) subscribes to.
-            ScreenManagerHasScreenLoadExceptionOccurred = 70,
 
             // September 11, 2026 - the existing "Set Collision From Animation" checkbox now also works on
             // non-ICollidable entities. At this version, Glue calls the new Sprite.SyncShapesFromAnimation
@@ -232,6 +228,10 @@ namespace FlatRedBall.Glue.SaveClasses
             // only when the entity is ICollidable, same as the old method's behavior. Gated because it's a
             // new engine-side Sprite method.
             SpriteHasSyncShapesFromAnimation = 72,
+            // ScreenManager.ScreenLoadExceptionOccurred (subscribed to by the embedded GlueControlManager.cs)
+            // landed after the engine's version-70 bump without a bump of its own, so an engine reporting 70
+            // may or may not have it. 72 is the first syntax version guaranteed to.
+            ScreenManagerHasScreenLoadExceptionOccurred = 72,
 
             // Stop! If adding an entry here, modify SyntaxVersionAttribute on FlatRedBallServices
             // and LatestVersion down below

--- a/FRBDK/Glue/Tests/GlueUnitTests/Diagnostics/CrashLogTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Diagnostics/CrashLogTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.Diagnostics;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Diagnostics;
+
+public class CrashLogTests : IDisposable
+{
+    private readonly string _originalDirectory = CrashLog.Directory;
+    private readonly TempDir _tempDir = new();
+
+    public CrashLogTests()
+    {
+        CrashLog.Directory = Path.Combine(_tempDir.Root, "Diagnostics");
+    }
+
+    public void Dispose()
+    {
+        CrashLog.Directory = _originalDirectory;
+        _tempDir.Dispose();
+    }
+
+    [Fact]
+    public void Write_ShouldPersistTheExceptionText_AndReturnThePath()
+    {
+        var exception = new InvalidOperationException("Could not find the value for type BitmapFont");
+
+        var path = CrashLog.Write(exception);
+
+        path.ShouldNotBeNull();
+        File.ReadAllText(path).ShouldContain("Could not find the value for type BitmapFont");
+    }
+
+    [Fact]
+    public void Write_ShouldReturnNull_InsteadOfThrowing_WhenTheDirectoryCannotBeCreated()
+    {
+        // A file where the directory should be makes CreateDirectory fail.
+        File.WriteAllText(CrashLog.Directory, "");
+
+        Should.NotThrow(() => CrashLog.Write(new Exception("x"))).ShouldBeNull();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableSendingManagerFontTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableSendingManagerFontTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GameCommunicationPlugin.GlueControl.Managers;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GlueControlTests;
+
+// GitHub issue #2266: during live edit, setting a Text's Font to <NONE> and then "Make Default" crashes
+// Glue. Both steps reach the game through RefreshManager's async void handlers, so any exception in the
+// DTO conversion below takes the process down instead of landing in the output tab. These pin the Glue-side
+// conversion for both shapes the report produces: the instruction holding the "<NONE>" sentinel, and the
+// instruction gone entirely (what Make Default leaves behind).
+public class VariableSendingManagerFontTests : IDisposable
+{
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly VariableSendingManager _sendingManager;
+    private readonly NamedObjectSave _text;
+
+    public VariableSendingManagerFontTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+
+        var glueProject = new GlueProjectSave { FileVersion = GlueProjectSave.LatestVersion };
+        var screen = new ScreenSave { Name = "Screens\\GameScreen" };
+        glueProject.Screens.Add(screen);
+        _text = new NamedObjectSave
+        {
+            InstanceName = "TextInstance",
+            SourceType = SourceType.FlatRedBallType,
+            SourceClassType = "FlatRedBall.Graphics.Text",
+        };
+        screen.NamedObjects.Add(_text);
+        ObjectFinder.Self.GlueProject = glueProject;
+
+        var refreshManager = new RefreshManager((_, _) => System.Threading.Tasks.Task.FromResult(""), (_, _) => { });
+        _sendingManager = new VariableSendingManager(refreshManager);
+    }
+
+    public void Dispose()
+    {
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+    }
+
+    [Fact]
+    public void GetNamedObjectValueChangedDtos_ShouldNotThrow_WhenFontInstructionIsNoneSentinel()
+    {
+        _text.SetVariable("Font", "<NONE>");
+
+        List<GlueVariableSetData> dtos = null;
+        Should.NotThrow(() => dtos = _sendingManager.GetNamedObjectValueChangedDtos(
+            "Font", oldValue: "SomeFont", _text, AssignOrRecordOnly.Assign, gameScreenName: "Screens.GameScreen"));
+
+        dtos.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void GetNamedObjectValueChangedDtos_ShouldNotThrow_WhenFontInstructionWasRemovedByMakeDefault()
+    {
+        // Make Default removes the instruction outright (PropertyGridRightClickHelper.SetVariableToDefault),
+        // then notifies plugins with the old "<NONE>" value:
+        _text.InstructionSaves.RemoveAll(item => item.Member == "Font");
+
+        List<GlueVariableSetData> dtos = null;
+        Should.NotThrow(() => dtos = _sendingManager.GetNamedObjectValueChangedDtos(
+            "Font", oldValue: "<NONE>", _text, AssignOrRecordOnly.Assign, gameScreenName: "Screens.GameScreen"));
+
+        // BitmapFont is a reference type with no primitive default, so the cleared value goes over as null -
+        // the game's VariableAssignmentLogic already treats a null BitmapFont as "no font".
+        var dto = dtos.ShouldHaveSingleItem();
+        dto.Type.ShouldBe("BitmapFont");
+        dto.VariableValue.ShouldBeNull();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/NamedObjectSaveVariableDataGridItemMakeDefaultTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/NamedObjectSaveVariableDataGridItemMakeDefaultTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using System.Linq;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Managers;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using GlueUnitTests.Tasks;
+using GlueUnitTests.TestSupport;
+using OfficialPlugins.PropertyGrid;
+using OfficialPlugins.VariableDisplay;
+using Shouldly;
+using WpfDataUi;
+using WpfDataUi.DataTypes;
+
+namespace GlueUnitTests.PropertyGrid;
+
+// GitHub issue #2266: with a Text's Font set to <NONE> in the Variables tab, "Make Default" crashes Glue.
+// "Make Default" in the grid sets DataGridItem.IsDefault = true, whose IsDefaultSet handler in
+// NamedObjectSaveVariableDataGridItem runs SetVariableToDefault, element codegen, project save, and the
+// plugin change notifications. This drives that exact entry point against the real Text ATI and a real
+// on-disk project so every one of those steps runs for real.
+[Collection(nameof(TaskManagerSequentialCollection))]
+public class NamedObjectSaveVariableDataGridItemMakeDefaultTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _originalRelativeDirectory;
+    private readonly bool _originalSynchronousMode;
+    private readonly IUiThreadMarshaller _originalMarshaller;
+    private readonly string _tempProjectDirectory;
+
+    public NamedObjectSaveVariableDataGridItemMakeDefaultTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+        _originalRelativeDirectory = FlatRedBall.IO.FileManager.RelativeDirectory;
+        _originalSynchronousMode = TaskManager.SynchronousMode;
+        _originalMarshaller = TaskManager.UiThreadMarshaller;
+
+        var vsProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+
+        GlueState.Self.CurrentMainProject = vsProject;
+        ObjectFinder.Self.GlueProject = new GlueProjectSave { FileVersion = GlueProjectSave.LatestVersion };
+        FlatRedBall.IO.FileManager.RelativeDirectory = _tempProjectDirectory + "\\";
+
+        TaskManager.SynchronousMode = true;
+        TaskManager.UiThreadMarshaller = new InlineUiThreadMarshaller();
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentElement = null;
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        FlatRedBall.IO.FileManager.RelativeDirectory = _originalRelativeDirectory;
+        TaskManager.SynchronousMode = _originalSynchronousMode;
+        TaskManager.UiThreadMarshaller = _originalMarshaller;
+
+        try
+        {
+            Directory.Delete(_tempProjectDirectory, recursive: true);
+        }
+        catch
+        {
+            // best-effort cleanup; a stray temp dir isn't worth failing the test over
+        }
+    }
+
+    private static (ScreenSave screen, NamedObjectSave text) MakeScreenWithText()
+    {
+        var screen = new ScreenSave { Name = "Screens\\GameScreen" };
+        ObjectFinder.Self.GlueProject.Screens.Add(screen);
+        GlueState.Self.CurrentElement = screen;
+
+        var text = new NamedObjectSave
+        {
+            InstanceName = "TextInstance",
+            SourceType = SourceType.FlatRedBallType,
+            SourceClassType = "FlatRedBall.Graphics.Text",
+        };
+        screen.NamedObjects.Add(text);
+
+        return (screen, text);
+    }
+
+    private static NamedObjectSaveVariableDataGridItem GetFontMember(DataUiGrid grid)
+    {
+        var member = grid.Categories.SelectMany(category => category.Members)
+            .OfType<NamedObjectSaveVariableDataGridItem>()
+            .FirstOrDefault(item => item.NameOnInstance == "Font");
+        member.ShouldNotBeNull("the Text ATI should expose a Font variable in the grid");
+        return member;
+    }
+
+    [StaFact]
+    public void MakeDefault_ShouldNotThrow_WhenFontWasSetToNone()
+    {
+        var (screen, text) = MakeScreenWithText();
+
+        var grid = new DataUiGrid();
+        NamedObjectVariableShowingLogic.UpdateShownVariables(grid, text, screen, text.GetAssetTypeInfo());
+        var fontMember = GetFontMember(grid);
+
+        // Step 1 of the report: pick <NONE> in the Font dropdown.
+        fontMember.SetValue("<NONE>", SetPropertyCommitType.Full);
+        TaskManager.Self.WaitForAllTasksFinished().Wait();
+
+        // Step 2: "Make Default" - the grid's context menu sets IsDefault, nothing else.
+        Should.NotThrow(() => fontMember.IsDefault = true);
+        TaskManager.Self.WaitForAllTasksFinished().Wait();
+
+        text.GetCustomVariable("Font").ShouldBeNull("Make Default removes the instruction");
+    }
+
+    private class InlineUiThreadMarshaller : IUiThreadMarshaller
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public System.Threading.Tasks.Task Invoke(Func<System.Threading.Tasks.Task> func) => func();
+        public System.Threading.Tasks.Task<T> Invoke<T>(Func<System.Threading.Tasks.Task<T>> func) => func();
+        public void BeginInvoke(Action action) => action();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/CodeBuildItemAdderVersionDefinesTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/VSHelpers/CodeBuildItemAdderVersionDefinesTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.Plugins.ExportedImplementations;
+using FlatRedBall.Glue.SaveClasses;
+using FlatRedBall.Glue.VSHelpers;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.VSHelpers;
+
+// The #defines written at the top of every embedded file come from the gluj FileVersion, and the engine
+// dll a project references reports its own SyntaxVersion. A gate whose version is lower than the one the
+// engine actually gained the member at compiles a call into a project whose engine lacks it: CS0117 on
+// GlueControlManager.Generated.cs. ScreenManager.ScreenLoadExceptionOccurred landed after the version-70
+// bump without one of its own, so 72 is the first version guaranteed to have it.
+public class CodeBuildItemAdderVersionDefinesTests : IDisposable
+{
+    private readonly FlatRedBall.Glue.VSHelpers.Projects.VisualStudioProject _originalMainProject;
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly string _tempProjectDirectory;
+
+    public CodeBuildItemAdderVersionDefinesTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        _originalMainProject = GlueState.Self.CurrentMainProject;
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+
+        GlueState.Self.CurrentMainProject = TestVisualStudioProjectFactory.CreateInNewTempDirectory(out _tempProjectDirectory);
+    }
+
+    public void Dispose()
+    {
+        GlueState.Self.CurrentMainProject = _originalMainProject;
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+        try { Directory.Delete(_tempProjectDirectory, recursive: true); } catch { }
+    }
+
+    [Theory]
+    [InlineData(70, false)]
+    [InlineData(71, false)]
+    [InlineData(72, true)]
+    public void GetGlueVersionsString_DefinesScreenLoadExceptionGate_OnlyFromVersion72(int fileVersion, bool expectDefined)
+    {
+        ObjectFinder.Self.GlueProject = new GlueProjectSave { FileVersion = fileVersion };
+
+        var defines = CodeBuildItemAdder.GetGlueVersionsString();
+
+        defines.Contains("#define ScreenManagerHasScreenLoadExceptionOccurred\n").ShouldBe(expectDefined);
+    }
+}


### PR DESCRIPTION
Closes #2266

With the game running, "Make Default" on a Text's Font removed the instruction and then `VariableSendingManager.ConvertValue` asked `TypeManager.GetDefaultForType("BitmapFont")` for the cleared value. That throws for any non-primitive type, and it was inside `RefreshManager`'s `async void` handler, so the process died instead of an error landing in the output tab. Same shape for any other reference-typed variable (Layer, an entity type) cleared during live edit.

- `TypeManager.TryGetDefaultForType` added; `ConvertValue` uses it and sends null for anything non-primitive (the game already treats a null BitmapFont as "no font", #2161).
- `ReactToFontSet` uses the NOS's containing element instead of `GlueState.CurrentElement`.
- Unhandled exceptions are now also written to `%LOCALAPPDATA%\FlatRedBall\Glue\Diagnostics\crash-*.log` and the path is shown in the plugin-error dialog, so the next "Glue crashes" report comes with a stack.

Also: `ScreenManagerHasScreenLoadExceptionOccurred` moves from 70 to 72. The event landed after the version-70 engine bump without a bump of its own, so an engine reporting 70 can lack it and the embedded `GlueControlManager` fails with CS0117.

Tests: the `VariableSendingManager` one went red with the ArgumentException above before the fix. The property-grid test drives the real `IsDefault = true` entry point; it is green with or without the fix because the live-edit plugin doesn't run in the test host, and stays as coverage for the non-live-edit half of the path. `CodeBuildItemAdderVersionDefinesTests` went red at the old gate.

Manual test: needed. Run a game from Glue, set a Text's Font to `<NONE>`, right-click it and choose Make Default. Glue stays up and the game's text loses its font.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPiGcrBDipF3Lm1hnQhsuK
