### PR TITLE
Pin Glue's SDK selection to the installed-SDK set with a CI matrix

### DIFF
--- a/.github/workflows/glue.yml
+++ b/.github/workflows/glue.yml
@@ -75,7 +75,7 @@ jobs:
 
     # Run via the .sln so $(SolutionDir) is defined (OfficialPlugins has a post-build step that needs it).
     - name: Run unit tests
-      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c ${{ matrix.configuration }} --filter "Category!=BuildSmoke&Category!=LiveGame"
+      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c ${{ matrix.configuration }} --filter "Category!=BuildSmoke&Category!=LiveGame&Category!=SdkMatrix"
 
     # Slower: creates a project from each template and runs `dotnet build` on it. Needs the net9 SDK
     # (installed above) and network access for the first NuGet restore.

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -49,7 +49,7 @@ jobs:
     # should fail the job rather than sit there until the runner's own limit kills it with no
     # attribution. It also names the test that hung. See issue #1969.
     - name: Run unit tests
-      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category!=BuildSmoke&Category!=LiveGame" --blame-hang-timeout 10m
+      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category!=BuildSmoke&Category!=LiveGame&Category!=SdkMatrix" --blame-hang-timeout 10m
 
     # The runners have no GPU, so opengl32.dll resolves to Windows' generic OpenGL 1.1, which has no
     # framebuffer objects - MonoGame's GraphicsDevice refuses to initialize on it and the game dies at
@@ -123,3 +123,59 @@ jobs:
     # Samples\ is unbuilt by CI.
     - name: Build the MonoGame.Extended particle sample
       run: dotnet build 'FlatRedBall\Samples\MonoGameExtendedParticles\MonoGameExtendedParticles.sln' -c Debug
+
+  # Glue evaluates .csproj files with an MSBuild engine it ships (Microsoft.Build in Glue.csproj) reading
+  # the targets of whichever installed SDK MsBuildSdkSelector picks, so whether a project loads depends on
+  # the user's installed-SDK set. The job above always has .NET 6 installed and proves nothing about a
+  # machine without it. Each cell here is a different installed-SDK set, isolated from the runner image's
+  # preinstalled SDKs by DOTNET_INSTALL_DIR (setup-dotnet puts that directory first on PATH, and `dotnet
+  # --list-sdks` only lists the SDKs under the dotnet root it runs from). Every cell needs an 8.0 SDK to
+  # build Glue itself; the rest is the scenario.
+  sdk-matrix:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: net6-net8
+            sdks: |
+              6.0.x
+              8.0.x
+          - name: net8-only
+            sdks: 8.0.x
+          # A machine that skipped .NET 6: 3.1 is the newest SDK whose MSBuild Glue's engine can read.
+          - name: net3.1-net8-net10
+            sdks: |
+              3.1.x
+              8.0.x
+              10.0.x
+    name: sdk-matrix (${{ matrix.name }})
+    env:
+      DOTNET_INSTALL_DIR: ${{ github.workspace }}\dotnet-${{ matrix.name }}
+    steps:
+    - name: Checkout FRB
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        path: 'FlatRedBall'
+
+    - name: Checkout Gum
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository_owner }}/Gum
+        fetch-depth: 1
+        path: 'Gum'
+
+    - name: Install .NET (${{ matrix.name }})
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ matrix.sdks }}
+
+    - name: Installed SDKs
+      run: dotnet --list-sdks
+
+    - name: Build
+      run: dotnet build -c Debug 'FlatRedBall\FRBDK\Glue\Glue with All.sln'
+
+    - name: Load checked-in projects with the SDK Glue selects
+      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --no-build --filter "Category=SdkMatrix" --blame-hang-timeout 10m

--- a/FRBDK/Glue/Glue/Glue.csproj
+++ b/FRBDK/Glue/Glue/Glue.csproj
@@ -175,13 +175,13 @@
     <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
     <PackageReference Include="MaterialDesignThemes" Version="5.1.0" />
 
-    <PackageReference Include="Microsoft.Build" Version="17.3.1">
+    <PackageReference Include="Microsoft.Build" Version="17.11.48">
       <!--<ExcludeAssets>runtime</ExcludeAssets>-->
     </PackageReference>
 
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.3.1" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.48" />
 
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.1">
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.48">
       <!--<ExcludeAssets>runtime</ExcludeAssets>-->
     </PackageReference>
 

--- a/FRBDK/Glue/Glue/VSHelpers/Projects/ProjectCreator.cs
+++ b/FRBDK/Glue/Glue/VSHelpers/Projects/ProjectCreator.cs
@@ -136,8 +136,13 @@ Additional Info:
                 }
                 else if (exceptionMessage.Contains("Microsoft.NET.Sdk"))
                 {
+                    var msBuildExePath = Environment.GetEnvironmentVariable("MSBUILD_EXE_PATH");
                     message = $"Could not load the project {fileName}\n" +
-                        $"Missing SDK:\n\n" + exceptionMessage;
+                        $"Missing SDK:\n\n" + exceptionMessage + "\n\n" +
+                        $"Glue is currently evaluating projects using MSBuild from:\n{msBuildExePath ?? "(not set)"}\n" +
+                        $"which is older than the SDK this project needs. Install a newer .NET SDK whose MSBuild " +
+                        $"Glue can use (see \"Using MSBUILD from ...\" in the Glue output window at startup for " +
+                        $"which SDKs it considered), or check for a Glue update that supports a newer MSBuild.";
                 }
                 else
                 {

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/ProjectCreatorMissingSdkTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/ProjectCreatorMissingSdkTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// Pins the "Missing SDK" error ProjectCreator.CreateProject raises when a .csproj asks for an SDK the
+/// selected MSBuild engine cannot find (e.g. Blazor's SDK missing under an old fallback engine, GitHub
+/// issue #2278). The old message only echoed MSBuild's raw exception, which never says which MSBuild
+/// Glue picked or that installing a newer SDK would fix it.
+/// </summary>
+public class ProjectCreatorMissingSdkTests
+{
+    public ProjectCreatorMissingSdkTests()
+    {
+        GlueTestBootstrap.EnsureMsBuildEnvironmentVariable();
+    }
+
+    [Fact]
+    public void CreateProject_NamesTheSelectedMsBuildAndSuggestsInstallingANewerSdk()
+    {
+        using var tempDir = new TempDir();
+        var csproj = Path.Combine(tempDir.Root, "MissingSdk.csproj");
+        File.WriteAllText(csproj, """
+            <Project Sdk="Microsoft.NET.Sdk.ThisSdkDoesNotExist">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var msBuildExePath = Environment.GetEnvironmentVariable("MSBUILD_EXE_PATH");
+
+        var exception = Should.Throw<Exception>(() => ProjectCreator.CreateProject(csproj));
+
+        exception.Message.ShouldContain("Missing SDK");
+        exception.Message.ShouldContain(msBuildExePath);
+        exception.Message.ShouldContain("Install a newer .NET SDK");
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/SdkSelectionProjectLoadTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/SdkSelectionProjectLoadTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Linq;
+using FlatRedBall.Glue.VSHelpers;
+using FlatRedBall.Glue.VSHelpers.Projects;
+using GlueUnitTests.TestSupport;
+using Xunit;
+
+namespace GlueUnitTests.Projects;
+
+/// <summary>
+/// Runs Glue.exe's real SDK discovery (dotnet --list-sdks -> MsBuildSdkSelector -> MSBUILD_EXE_PATH) against
+/// whatever SDKs this machine actually has, then evaluates checked-in projects through the same
+/// <see cref="ProjectCreator"/> call File > Load Project makes. Which SDK Glue picks depends only on what
+/// is installed, so CI runs this under several installed-SDK sets (the sdk-matrix job in pr-tests.yml);
+/// a machine where Glue picks an SDK too old for the project fails here, naming the SDK, instead of in
+/// the user's output window.
+///
+/// Its own category, run in its own process: the engine reads MSBUILD_EXE_PATH once, on first use, so a
+/// test host that has already evaluated a project (SdkStyleProjectLoadTests inherits the var from the
+/// `dotnet test` parent) cannot be re-pointed.
+/// </summary>
+[Trait("Category", "SdkMatrix")]
+public class SdkSelectionProjectLoadTests
+{
+    // The parent `dotnet test` leaks its own MSBuild location into the test host through these. Glue.exe
+    // launched from Explorer has none of them, and with them set the SDK resolver ignores MSBUILD_EXE_PATH
+    // and reads the CLI's SDK instead, so the selection under test would be the CLI's, not Glue's.
+    static readonly string[] LeakedFromDotnetCli = { "MSBUILD_EXE_PATH", "MSBuildSDKsPath", "MSBuildExtensionsPath" };
+
+    public SdkSelectionProjectLoadTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    [Theory]
+    [InlineData("Samples/EditorTest1/EditorTest1/EditorTest1.csproj")]  // Microsoft.NET.Sdk
+    [InlineData("Samples/BeefballWeb/BeefballWeb/BeefballWeb.csproj")]  // Microsoft.NET.Sdk.BlazorWebAssembly
+    public void CreateProject_EvaluatesWithTheSdkGlueSelects(string relativeCsproj)
+    {
+        var saved = LeakedFromDotnetCli.ToDictionary(name => name, Environment.GetEnvironmentVariable);
+        try
+        {
+            foreach (var name in LeakedFromDotnetCli)
+            {
+                Environment.SetEnvironmentVariable(name, null);
+            }
+
+            Glue.MainGlueWindow.SetMsBuildEnvironmentVariable();
+            var selected = Environment.GetEnvironmentVariable("MSBUILD_EXE_PATH");
+
+            var csproj = Path.Combine(GoldProject.FindRepoRoot(), relativeCsproj);
+
+            try
+            {
+                var result = ProjectCreator.CreateProject(csproj);
+                Assert.NotNull(result.Project);
+            }
+            catch (Exception e)
+            {
+                throw new Exception(
+                    $"Glue selected MSBUILD_EXE_PATH={selected ?? "(none)"} (engine {MsBuildSdkSelector.EngineVersion}) " +
+                    $"and could not load {relativeCsproj}\n" +
+                    $"MSBuild/dotnet environment:\n{MsBuildEnvironment()}", e);
+            }
+        }
+        finally
+        {
+            foreach (var pair in saved)
+            {
+                Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+            }
+        }
+    }
+
+    static string MsBuildEnvironment() => string.Join("\n",
+        Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
+            .Select(kv => (Key: kv.Key.ToString(), Value: kv.Value))
+            .Where(kv => kv.Key.Contains("MSBUILD", StringComparison.OrdinalIgnoreCase) ||
+                         kv.Key.Contains("DOTNET", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(kv => kv.Key)
+            .Select(kv => $"  {kv.Key}={kv.Value}"));
+}


### PR DESCRIPTION
Closes #2278.

Glue shipped Microsoft.Build 17.3 and reads targets from whichever installed SDK `MsBuildSdkSelector` picks (newest SDK whose MSBuild is not newer than the engine). On a machine with 3.1/7/8/10 and no 6 it fell back to 3.1, whose SDK has no `Microsoft.NET.Sdk.BlazorWebAssembly`, and a synced web project failed to load with a raw stack trace. With only 8.0+ installed it picked nothing at all. The main CI job always installs .NET 6, so nothing covered it.

**Tests (deliberately red first):**
- `SdkSelectionProjectLoadTests` (Category `SdkMatrix`): runs Glue's real discovery against the machine's SDKs, then loads `EditorTest1` and `BeefballWeb` through `ProjectCreator`. Clears the MSBuild location vars `dotnet test` leaks into the host first, otherwise the resolver uses the CLI's SDK and the test never exercises Glue's choice.
- New `sdk-matrix` job in `pr-tests.yml`: three isolated SDK sets via `DOTNET_INSTALL_DIR` (`net6-net8`, `net8-only`, `net3.1-net8-net10`).
- `SdkMatrix` excluded from the main unit-test filter in both workflows.

**Fix:**
- Bump `Microsoft.Build`/`Microsoft.Build.Framework`/`Microsoft.Build.Utilities.Core` to 17.11.48 (the last line that still runs on net8.0) so every 8.0.x SDK's MSBuild qualifies.
- `ProjectCreator`'s "Missing SDK" error now names which MSBuild `MSBUILD_EXE_PATH` points at and suggests installing a newer SDK, instead of just dumping the raw MSBuild exception.

Verified locally (6.0/8.0.425/10.0 installed): engine now picks `8.0.425`; both `SdkMatrix` cases and the full non-slow/BuildSmoke suites pass. CI's `net8-only` and `net3.1-net8-net10` cells are the real proof for the reported machine.

Longer term: `Microsoft.Build.Locator` (load the engine from the selected SDK instead of shipping one) removes the engine/SDK coupling entirely — left as a follow-up per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TS4twbmudM5cNt53zbuJW
