### PR TITLE
Send an enum's declared default when a live-edited variable is Made Default (#2272)

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
@@ -654,11 +654,25 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                     && type != "Nullable<String>"
                     )
                 {
+                    // "Make Default" clears the instruction, so what goes over the wire here is the
+                    // variable's default. For an enum that is the AssetTypeInfo's declared DefaultValue,
+                    // not the CLR zero: a Text's VerticalAlignment defaults to Center (2) and its
+                    // ColorOperation to ColorTextureAlpha (6), so clearing either used to revert the
+                    // running game to the wrong member - or, for an enum with no primitive default at all
+                    // (MaxWidthBehavior, HorizontalAlignment, BlendOperation), to send null and have the
+                    // game fail assigning it (issue #2272).
+                    var declaredDefault = ati?.VariableDefinitions
+                        .FirstOrDefault(item => item.Name == originalMemberName)?.DefaultValue;
+
+                    if (TypeManager.TryGetEnumValueAsNumber(type, declaredDefault, out string enumDefault))
+                    {
+                        value = enumDefault;
+                    }
                     // Only primitives have a known default. Anything else (BitmapFont, Layer, an entity type)
                     // is a reference type whose cleared value is null, which is what leaving value null sends.
                     // Throwing here would surface as an unhandled exception in RefreshManager's async void
                     // handlers and take Glue down (issue #2266).
-                    if (TypeManager.TryGetDefaultForType(type, out string defaultValue))
+                    else if (TypeManager.TryGetDefaultForType(type, out string defaultValue))
                     {
                         value = defaultValue;
                     }

--- a/FRBDK/Glue/Glue/Parsing/TypeManager.cs
+++ b/FRBDK/Glue/Glue/Parsing/TypeManager.cs
@@ -867,6 +867,49 @@ namespace FlatRedBall.Glue.Parsing
             }
         }
 
+        /// <summary>
+        /// Resolves <paramref name="type"/> as an enum and <paramref name="memberName"/> as one of its
+        /// members, handing back that member's underlying value as a string - "2" for
+        /// FlatRedBall.Graphics.VerticalAlignment.Center, for example. Returns false for anything that is
+        /// not an enum, or a name that enum does not define.
+        /// </summary>
+        /// <remarks>
+        /// The number rather than the name, because that is what the game can always read back: the
+        /// embedded VariableAssignmentLogic.ConvertStringToType parses an integer for every enum it
+        /// handles, while parsing a member *name* is either gated behind the MONOGAME_381/FNA define (the
+        /// enums it special-cases, such as HorizontalAlignment) or relies on an assembly scan finding the
+        /// type.
+        /// </remarks>
+        public static bool TryGetEnumValueAsNumber(string type, string memberName, out string valueAsNumber)
+        {
+            valueAsNumber = null;
+
+            if (string.IsNullOrWhiteSpace(type) || string.IsNullOrWhiteSpace(memberName))
+            {
+                return false;
+            }
+
+            var resolvedType = GetTypeFromString(type.Trim());
+
+            if (resolvedType?.IsEnum != true)
+            {
+                return false;
+            }
+
+            // AssetTypeInfo values come from ContentTypes.csv, which is written with loose spacing
+            // ("Name=MaxWidthBehavior, Category = Text, DefaultValue=Chop").
+            var trimmedMemberName = memberName.Trim();
+
+            if (!Enum.IsDefined(resolvedType, trimmedMemberName))
+            {
+                return false;
+            }
+
+            var asEnum = Enum.Parse(resolvedType, trimmedMemberName);
+            valueAsNumber = Convert.ToInt64(asEnum).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            return true;
+        }
+
         public static object Parse(string typeName, string value)
         {
             var toReturn = value;

--- a/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableSendingManagerMakeDefaultEnumTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/GlueControl/VariableSendingManagerMakeDefaultEnumTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using FlatRedBall.Glue.Elements;
+using FlatRedBall.Glue.SaveClasses;
+using GameCommunicationPlugin.GlueControl.Dtos;
+using GameCommunicationPlugin.GlueControl.Managers;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.GlueControlTests;
+
+// GitHub issue #2272: during live edit, changing a Text's MaxWidthBehavior (or HorizontalAlignment,
+// VerticalAlignment, BlendOperation) and then "Make Default" crashed Glue. The throw itself was the same
+// one as issue #2266 - TypeManager.GetDefaultForType has no default for any of those type names - and it
+// reached Glue's process-level handler through RefreshManager's async void handlers.
+//
+// Not throwing is only half of it though: "Make Default" has to tell the running game what the default
+// actually is. These pin the value each of the reported variables sends once its instruction is gone,
+// which is the shape Make Default leaves behind (PropertyGridRightClickHelper.SetVariableToDefault
+// removes the instruction, then notifies plugins with the old value).
+public class VariableSendingManagerMakeDefaultEnumTests : IDisposable
+{
+    private readonly GlueProjectSave _originalGlueProject;
+    private readonly VariableSendingManager _sendingManager;
+    private readonly NamedObjectSave _text;
+
+    public VariableSendingManagerMakeDefaultEnumTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+        _originalGlueProject = ObjectFinder.Self.GlueProject;
+
+        var glueProject = new GlueProjectSave { FileVersion = GlueProjectSave.LatestVersion };
+        var screen = new ScreenSave { Name = "Screens\\GameScreen" };
+        glueProject.Screens.Add(screen);
+        _text = new NamedObjectSave
+        {
+            InstanceName = "TextInstance",
+            SourceType = SourceType.FlatRedBallType,
+            SourceClassType = "FlatRedBall.Graphics.Text",
+        };
+        screen.NamedObjects.Add(_text);
+        ObjectFinder.Self.GlueProject = glueProject;
+
+        var refreshManager = new RefreshManager((_, _) => System.Threading.Tasks.Task.FromResult(""), (_, _) => { });
+        _sendingManager = new VariableSendingManager(refreshManager);
+    }
+
+    public void Dispose()
+    {
+        ObjectFinder.Self.GlueProject = _originalGlueProject;
+    }
+
+    [Theory]
+    // The report's own repro: set MaxWidthBehavior to Wrap, then Make Default. Chop is 0.
+    [InlineData("MaxWidthBehavior", "Wrap", "MaxWidthBehavior", "0")]
+    [InlineData("HorizontalAlignment", "Right", "HorizontalAlignment", "0")]
+    // Center is 2 (the members are Top, Bottom, Center), so this is the case that proves the value comes
+    // from the AssetTypeInfo's declared default rather than from the type's CLR default.
+    [InlineData("VerticalAlignment", "Top", "VerticalAlignment", "2")]
+    [InlineData("BlendOperation", "Add", "BlendOperation", "0")]
+    // ColorOperation didn't crash, because TypeManager does have an entry for it - but that entry says
+    // "0" (Texture), while a Text's ColorOperation default is ColorTextureAlpha (6).
+    [InlineData("ColorOperation", "Add", "ColorOperation", "6")]
+    public void GetNamedObjectValueChangedDtos_ShouldSendTheDeclaredDefault_WhenAnEnumIsMadeDefault(
+        string memberName, string oldValue, string expectedType, string expectedValue)
+    {
+        // Make Default removes the instruction outright, then notifies plugins with the old value:
+        _text.SetVariable(memberName, oldValue);
+        _text.InstructionSaves.RemoveAll(item => item.Member == memberName);
+
+        List<GlueVariableSetData> dtos = null;
+        Should.NotThrow(() => dtos = _sendingManager.GetNamedObjectValueChangedDtos(
+            memberName, oldValue, _text, AssignOrRecordOnly.Assign, gameScreenName: "Screens.GameScreen"));
+
+        var dto = dtos.ShouldHaveSingleItem();
+        dto.Type.ShouldBe(expectedType);
+        // The underlying number, not the member name: the game's ConvertStringToType parses an integer for
+        // every enum it handles, but only parses a member name under the MONOGAME_381/FNA define.
+        dto.VariableValue.ShouldBe(expectedValue);
+    }
+
+    [Fact]
+    public void GetNamedObjectValueChangedDtos_ShouldStillSendTheSetValue_WhenAnEnumIsNotDefault()
+    {
+        // The declared default must only stand in for a cleared variable, never overwrite a real one.
+        _text.SetVariable("MaxWidthBehavior", "Wrap");
+
+        var dto = _sendingManager.GetNamedObjectValueChangedDtos(
+            "MaxWidthBehavior", "Chop", _text, AssignOrRecordOnly.Assign, gameScreenName: "Screens.GameScreen")
+            .ShouldHaveSingleItem();
+
+        dto.VariableValue.ShouldBe("Wrap");
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/Parsing/TypeManagerEnumValueTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Parsing/TypeManagerEnumValueTests.cs
@@ -1,0 +1,61 @@
+using FlatRedBall.Glue.Parsing;
+using GlueUnitTests.TestSupport;
+using Shouldly;
+using Xunit;
+
+namespace GlueUnitTests.Parsing;
+
+// GitHub issue #2272: "Make Default" on an enum-typed variable has to send the game the variable's real
+// default, and TypeManager is what turns the AssetTypeInfo's declared default (a member name out of
+// ContentTypes.csv) into something the game can read back.
+public class TypeManagerEnumValueTests
+{
+    public TypeManagerEnumValueTests()
+    {
+        GlueTestBootstrap.EnsureInitialized();
+    }
+
+    [Theory]
+    // The four the report names, by the unqualified type name the AssetTypeInfo actually carries:
+    [InlineData("MaxWidthBehavior", "Chop", "0")]
+    [InlineData("HorizontalAlignment", "Left", "0")]
+    [InlineData("BlendOperation", "Regular", "0")]
+    // Center is 2, not 0 - VerticalAlignment is Top, Bottom, Center - which is why the declared default
+    // has to win over the CLR default for the type.
+    [InlineData("VerticalAlignment", "Center", "2")]
+    // Same story for a Text's ColorOperation, where TypeManager's own primitive table says "0" (Texture).
+    [InlineData("ColorOperation", "ColorTextureAlpha", "6")]
+    public void TryGetEnumValueAsNumber_ShouldResolveMemberName_ToItsUnderlyingValue(
+        string type, string memberName, string expected)
+    {
+        TypeManager.TryGetEnumValueAsNumber(type, memberName, out string value).ShouldBeTrue();
+        value.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void TryGetEnumValueAsNumber_ShouldTolerateSurroundingWhitespace()
+    {
+        // ContentTypes.csv is written with loose spacing ("Name=MaxWidthBehavior, Category = Text, ...").
+        TypeManager.TryGetEnumValueAsNumber(" MaxWidthBehavior ", " Wrap ", out string value).ShouldBeTrue();
+        value.ShouldBe("1");
+    }
+
+    [Theory]
+    // Not an enum at all - a reference type whose AssetTypeInfo default ("Default" for a Text's Font) is a
+    // UI label, not a value, so it must not be sent to the game.
+    [InlineData("BitmapFont", "Default")]
+    [InlineData("Texture2D", "None")]
+    [InlineData("float", "0")]
+    // An enum, but not a member of it:
+    [InlineData("MaxWidthBehavior", "NotAMember")]
+    // Nothing to go on:
+    [InlineData("MaxWidthBehavior", null)]
+    [InlineData(null, "Chop")]
+    [InlineData("SomeTypeThatDoesNotExist", "Chop")]
+    public void TryGetEnumValueAsNumber_ShouldReturnFalse_WhenTheTypeIsNotAnEnumWithThatMember(
+        string type, string memberName)
+    {
+        TypeManager.TryGetEnumValueAsNumber(type, memberName, out string value).ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+}

--- a/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/NamedObjectSaveVariableDataGridItemMakeDefaultTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/PropertyGrid/NamedObjectSaveVariableDataGridItemMakeDefaultTests.cs
@@ -86,12 +86,12 @@ public class NamedObjectSaveVariableDataGridItemMakeDefaultTests : IDisposable
         return (screen, text);
     }
 
-    private static NamedObjectSaveVariableDataGridItem GetFontMember(DataUiGrid grid)
+    private static NamedObjectSaveVariableDataGridItem GetMember(DataUiGrid grid, string variableName)
     {
         var member = grid.Categories.SelectMany(category => category.Members)
             .OfType<NamedObjectSaveVariableDataGridItem>()
-            .FirstOrDefault(item => item.NameOnInstance == "Font");
-        member.ShouldNotBeNull("the Text ATI should expose a Font variable in the grid");
+            .FirstOrDefault(item => item.NameOnInstance == variableName);
+        member.ShouldNotBeNull($"the Text ATI should expose a {variableName} variable in the grid");
         return member;
     }
 
@@ -102,7 +102,7 @@ public class NamedObjectSaveVariableDataGridItemMakeDefaultTests : IDisposable
 
         var grid = new DataUiGrid();
         NamedObjectVariableShowingLogic.UpdateShownVariables(grid, text, screen, text.GetAssetTypeInfo());
-        var fontMember = GetFontMember(grid);
+        var fontMember = GetMember(grid, "Font");
 
         // Step 1 of the report: pick <NONE> in the Font dropdown.
         fontMember.SetValue("<NONE>", SetPropertyCommitType.Full);
@@ -113,6 +113,33 @@ public class NamedObjectSaveVariableDataGridItemMakeDefaultTests : IDisposable
         TaskManager.Self.WaitForAllTasksFinished().Wait();
 
         text.GetCustomVariable("Font").ShouldBeNull("Make Default removes the instruction");
+    }
+
+    // GitHub issue #2272: the same context menu, on the enum-typed variables the report names. Each one's
+    // type is a name TypeManager has no primitive default for, so the throw that took Glue down was reached
+    // without any <NONE> sentinel involved - just set the variable, then Make Default.
+    [StaTheory]
+    [InlineData("MaxWidthBehavior", FlatRedBall.Graphics.MaxWidthBehavior.Wrap)]
+    [InlineData("HorizontalAlignment", FlatRedBall.Graphics.HorizontalAlignment.Right)]
+    [InlineData("VerticalAlignment", FlatRedBall.Graphics.VerticalAlignment.Top)]
+    [InlineData("BlendOperation", FlatRedBall.Graphics.BlendOperation.Add)]
+    public void MakeDefault_ShouldNotThrow_WhenAnEnumVariableWasChanged(string variableName, object newValue)
+    {
+        var (screen, text) = MakeScreenWithText();
+
+        var grid = new DataUiGrid();
+        NamedObjectVariableShowingLogic.UpdateShownVariables(grid, text, screen, text.GetAssetTypeInfo());
+        var member = GetMember(grid, variableName);
+
+        // Step 1 of the report: change the variable.
+        member.SetValue(newValue, SetPropertyCommitType.Full);
+        TaskManager.Self.WaitForAllTasksFinished().Wait();
+
+        // Step 2: "Make Default" - the grid's context menu sets IsDefault, nothing else.
+        Should.NotThrow(() => member.IsDefault = true);
+        TaskManager.Self.WaitForAllTasksFinished().Wait();
+
+        text.GetCustomVariable(variableName).ShouldBeNull("Make Default removes the instruction");
     }
 
     private class InlineUiThreadMarshaller : IUiThreadMarshaller


### PR DESCRIPTION
Closes #2272.

### The crash was already fixed; what was left was the wrong value

The reported crash (change a `TextInstance`'s `MaxWidthBehavior` / `HorizontalAlignment` / `VerticalAlignment` / `BlendOperation` during live edit, then **Make Default**) has the same root cause as #2266: `VariableSendingManager.ConvertValue` asked `TypeManager.GetDefaultForType` for a type name it has no primitive default for, and the `ArgumentException` escaped `RefreshManager`'s `async void` handler and took the process down. #2270 landed ~8 hours before this issue was filed, so the reporter's daily build predated it — the throw itself is gone at HEAD.

What #2270 left behind for these variables is a **null** `VariableValue`, which the game cannot assign to an enum property (`VariableAssignmentLogic` catches it and reports a failed assignment). So Make Default stopped crashing but still didn't revert the running game.

### The fix

On a cleared variable, prefer the `AssetTypeInfo`'s declared `DefaultValue` over the CLR zero for the type, when the type resolves to an enum:

- `MaxWidthBehavior` / `HorizontalAlignment` / `BlendOperation` — sent `null`, now send the real default.
- `VerticalAlignment` — the members are `Top, Bottom, Center`, so its default `Center` is **2**, not 0.
- `ColorOperation` — never crashed (`TypeManager` has an entry for it) but that entry says `"0"` (`Texture`), while a Text's default is `ColorTextureAlpha` (6). A Sprite's ATI correctly declares `Texture`, so this stays per-ATI.
- Also fixes `Layer.SortType` (`Z` = 1), `AxisAlignedRectangle.RepositionDirections`, `Camera.CameraCullMode`, `Sprite.TextureAddressMode`, all of which were sending `null` for the same reason.

`TypeManager.TryGetEnumValueAsNumber` resolves the declared member name to its **underlying number**, not its name, because that is what the game can always read back: the embedded `ConvertStringToType` parses an integer for every enum it handles, while parsing a member *name* is gated behind the `MONOGAME_381`/`FNA` define for the enums it special-cases. Reference types keep their existing behavior — a Text's `Font` has `DefaultValue=Default`, which is a UI label, not a value, so it still goes over as `null` (which the game maps to `TextManager.DefaultFont`).

No embedded/generated game code changed, so no syntax-version bump.

### Tests

- `TypeManagerEnumValueTests` — the new resolver, including the non-zero `VerticalAlignment.Center`, whitespace tolerance (ContentTypes.csv is loosely spaced), and the reference-type/non-member cases that must return false.
- `VariableSendingManagerMakeDefaultEnumTests` — the DTO each reported variable produces once its instruction is gone, plus one pinning that a variable that *is* set still sends its set value.
- `NamedObjectSaveVariableDataGridItemMakeDefaultTests` — the reported entry point (set the variable in the grid, then `IsDefault = true`) for all four enums, alongside the existing #2266 Font case.

**Note on verification:** this session ran in a Linux container with no .NET SDK, and `GlueUnitTests` targets `net8.0-windows` with WPF, so I could not build or watch these tests go red/green locally — the reasoning above is from reading the code, and the PR CI (`pr-tests.yml`, windows-latest) is the first real run.

**Manual verification:** launch a game into edit mode, set a Text's `VerticalAlignment` to `Top`, then Make Default — the text should jump back to vertically centered in the running game, not stay at `Top` and not error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsfoBZs2WRs2kduAnxHfTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsfoBZs2WRs2kduAnxHfTW)_