### PR TITLE
Drop the vestigial -windows TFM suffix from GlueCommon and StateInterpolationNet6

### DIFF
--- a/FRBDK/Glue/GlueCommon/GlueCommon.csproj
+++ b/FRBDK/Glue/GlueCommon/GlueCommon.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU</Platforms>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>

--- a/FRBDK/Glue/StateInterpolationPlugin/StateInterpolationNet6/StateInterpolationNet6.csproj
+++ b/FRBDK/Glue/StateInterpolationPlugin/StateInterpolationNet6/StateInterpolationNet6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>1591</NoWarn>

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/RepoHygieneTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/RepoHygieneTests.cs
@@ -75,6 +75,64 @@ public class RepoHygieneTests
             string.Join(Environment.NewLine, offenders));
     }
 
+    // Issues #2274 and #2275, in service of #2276: these Glue projects carry no UI and no Windows-only
+    // dependency, so they target a platform-neutral TFM and build anywhere. That is what makes them
+    // usable as the seed for a UI-free Glue logic assembly - and it is cheap to undo by accident,
+    // since re-adding a "-windows" suffix or a UseWPF to one of them costs nothing on a Windows dev
+    // machine and nothing in a Windows-only CI job. This list is a ratchet: it should only ever grow.
+    private static readonly string[] PlatformNeutralGlueProjects =
+    {
+        @"FRBDK\Glue\GlueCommon\GlueCommon.csproj",
+        @"FRBDK\Glue\StateInterpolationPlugin\StateInterpolationNet6\StateInterpolationNet6.csproj",
+    };
+
+    [Fact]
+    public void PlatformNeutralGlueProjectsShouldStayPlatformNeutral()
+    {
+        var offenders = new List<string>();
+
+        foreach (var relativePath in PlatformNeutralGlueProjects)
+        {
+            var csproj = Path.Combine(FindFrbRoot(), ToLocalPath(relativePath));
+
+            if (!File.Exists(csproj))
+            {
+                offenders.Add($"{relativePath} is listed here but is not on disk");
+                continue;
+            }
+
+            var document = XDocument.Load(csproj);
+
+            var frameworks = (GetProperty(document, "TargetFrameworks") ?? GetProperty(document, "TargetFramework") ?? "")
+                .Split(';', StringSplitOptions.RemoveEmptyEntries)
+                .Select(framework => framework.Trim())
+                .Where(framework => framework.Length > 0)
+                .ToList();
+
+            if (frameworks.Count == 0)
+            {
+                offenders.Add($"{relativePath} declares no target framework");
+            }
+
+            // net8.0 is neutral; net8.0-windows, net9.0-android and the like are not.
+            foreach (var framework in frameworks.Where(framework => framework.Contains('-')))
+            {
+                offenders.Add($"{relativePath} targets {framework}");
+            }
+
+            foreach (var uiProperty in new[] { "UseWPF", "UseWindowsForms" })
+            {
+                if (string.Equals(GetProperty(document, uiProperty), "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    offenders.Add($"{relativePath} sets {uiProperty}");
+                }
+            }
+        }
+
+        offenders.ShouldBeEmpty("These Glue projects are meant to build on any platform, but something " +
+            "has tied them back to Windows:" + Environment.NewLine + string.Join(Environment.NewLine, offenders));
+    }
+
     [Fact]
     public void EverySolutionShouldOnlyReferenceProjectsThatExist()
     {


### PR DESCRIPTION
Closes #2274.
Closes #2275.

Two one-line TFM changes. Neither project has a Windows dependency, so neither needs a Windows TFM.

### `GlueCommon`: `net8.0-windows` → `net8.0`

No `UseWPF`, no `UseWindowsForms`, and three references, all already cross-platform: the engine (`net6.0;net8.0`), `MonoGame.Framework.DesktopGL`, `Newtonsoft.Json`.

Its one apparent Windows reference, `System.Drawing`, turns out not to be one. The only actual use is `System.Drawing.Rectangle` in a `PropertySave` `[XmlElement]` attribute — that type lives in **System.Drawing.Primitives**, part of the shared framework. The Windows-only package is `System.Drawing.Common`, and nothing in GlueCommon's reference graph carries it (`Glue.csproj`, `CompilerLibrary` and `NpcWpfLib` do, but none of them is a GlueCommon dependency — the arrow points the other way). The remaining `System.Drawing` mentions in the project are a stale `using`, a commented-out `//using System.Windows.Forms;`, and two XML doc comments.

A repo-wide sweep for Windows-only API surface across its 38 files — `System.Drawing.Common` types, `Microsoft.Win32`, `Registry`, `DllImport`, `System.Windows.*`, `ProtectedData`, `WindowsIdentity` — came back with nothing but MonoGame's own `Microsoft.Xna.Framework.Graphics` and one string literal.

### `StateInterpolationNet6`: `net6.0-windows` → `net6.0`

No `UseWPF`/`UseWindowsForms`, no sources of its own, one reference (the engine). Everything it compiles comes from `StateInterpolationShared.projitems`: 14 tweening files (`Back`, `Bounce`, `Circular`, `Cubic`, `Elastic`, `Exponential`, `Instant`, `Linear`, `Quadratic`, `Quartic`, `Quintic`, `Sinusoidal`, `Tweener`, `TweenerManager`) whose only non-BCL usings are FlatRedBall engine namespaces.

The two files sitting in that same folder that *do* touch Windows APIs — `StateInterpolationPlugin.cs` and `CodeBuildItemAdder.cs` — are not in the shared items; they are `<Compile Include>`d by `StateInterpolationPluginCore`, which stays `net8.0-windows` + `UseWPF`.

### Consumers

Unaffected. A `net8.0-windows` project may reference a platform-neutral one, so `Glue.csproj` and every plugin keep working unchanged. I also checked for hardcoded `bin/Debug/net8.0-windows/`-style output paths in build scripts, `.targets`, workflows and `PostBuild` steps — there are none for either project — and confirmed `RepoHygieneTests.IsNet6OrAbove` treats the platform suffix as optional, so the existing sweep still passes.

### Regression guard

`RepoHygieneTests.PlatformNeutralGlueProjectsShouldStayPlatformNeutral` pins both projects against a `-windows` suffix and against `UseWPF`/`UseWindowsForms`. Re-adding either costs nothing on a Windows dev machine and nothing in a Windows-only CI job, so without a test this quietly reverts. The list is written as a ratchet that should only grow — see #2276.

Unlike the tests in #2273, I can state this one's red/green with confidence: it reads the two csproj files this PR changes, and against the previous content it would report `GlueCommon.csproj targets net8.0-windows`.

### Verification

Still no .NET SDK on my side, so the build is CI's to do — but for a TFM change the build *is* the test: if something in either project still needs Windows, the compiler names it. Everything above is static analysis of the csproj files, their reference graphs, and their sources.

Deliberately not done here: removing the stale `using System.Drawing;` from `NamedObjectSave.cs`. It's harmless on `net8.0` (System.Drawing.Primitives is in the shared framework) and it's cosmetic, so it's better folded into a change someone can compile than bundled into a PR whose whole point is "does this still build".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsfoBZs2WRs2kduAnxHfTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsfoBZs2WRs2kduAnxHfTW)_