### PR TITLE
Test-pin #2261's root cause; flush diagnostics log to disk on failure

### DIFF
--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Dtos/Dtos.cs
@@ -14,6 +14,15 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
         public string GlueElementName { get; set; }
         public string ContainerName { get; set; }
         public NamedObjectSave NamedObjectSave { get; set; }
+
+        /// <summary>
+        /// Set only when NamedObjectSave.InstanceName was just renamed - the name the existing bookkeeping
+        /// entry to replace is still under, since NamedObjectSave.InstanceName is already the new name by
+        /// the time this is built. Null for every other kind of update, where InstanceName hasn't changed
+        /// and is itself the right thing to match the existing entry by (see
+        /// EditingManager.ReplaceNamedObjectSave).
+        /// </summary>
+        public string OldInstanceName { get; set; }
     }
 
     public class UpdateCurrentElementDto
@@ -642,6 +651,27 @@ namespace GameCommunicationPlugin.GlueControl.Dtos
     public class GetEmbeddedDiagnosticsLogResponse
     {
         public string LogText { get; set; }
+    }
+    #endregion
+
+    #region GetCurrentElementNamedObjectsDto
+
+    /// <summary>
+    /// Fetches the InstanceNames of the game's own current-element bookkeeping
+    /// (EditingManager.CurrentGlueElement.NamedObjects) - a duplicate entry here (as opposed to in
+    /// SpriteManager.ManagedPositionedObjects, the actual runtime objects) means a NamedObjectsToUpdate
+    /// push replaced the wrong entry or added a new one instead of replacing - see
+    /// EditingManager.ReplaceNamedObjectSave.
+    /// </summary>
+    public class GetCurrentElementNamedObjectsDto
+    {
+    }
+    #endregion
+
+    #region GetCurrentElementNamedObjectsResponse
+    public class GetCurrentElementNamedObjectsResponse
+    {
+        public List<string> InstanceNames { get; set; } = new List<string>();
     }
     #endregion
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/CommandReceiver.cs
@@ -1735,6 +1735,19 @@ namespace GlueControl
 
         #endregion
 
+        #region GetCurrentElementNamedObjectsDto
+
+        private static object HandleDto(GetCurrentElementNamedObjectsDto dto)
+        {
+            var instanceNames = Editing.EditingManager.Self.CurrentGlueElement?.NamedObjects
+                .Select(item => item.InstanceName)
+                .ToList() ?? new List<string>();
+
+            return new GetCurrentElementNamedObjectsResponse { InstanceNames = instanceNames };
+        }
+
+        #endregion
+
         #region SetEmbeddedInputAllowedDto
 
         private static void HandleDto(SetEmbeddedInputAllowedDto dto)
@@ -1786,7 +1799,7 @@ namespace GlueControl
         {
             foreach (var update in dto.NamedObjectsToUpdate)
             {
-                EditingManager.Self.ReplaceNamedObjectSave(update.NamedObjectSave, update.GlueElementName, update.ContainerName);
+                EditingManager.Self.ReplaceNamedObjectSave(update.NamedObjectSave, update.GlueElementName, update.ContainerName, update.OldInstanceName);
             }
         }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Dtos.cs
@@ -16,6 +16,15 @@ namespace GlueControl.Dtos
         public string GlueElementName { get; set; }
         public string ContainerName { get; set; }
         public NamedObjectSave NamedObjectSave { get; set; }
+
+        /// <summary>
+        /// Set only when NamedObjectSave.InstanceName was just renamed - the name the existing bookkeeping
+        /// entry to replace is still under, since NamedObjectSave.InstanceName is already the new name by
+        /// the time this is built. Null for every other kind of update, where InstanceName hasn't changed
+        /// and is itself the right thing to match the existing entry by (see
+        /// EditingManager.ReplaceNamedObjectSave).
+        /// </summary>
+        public string OldInstanceName { get; set; }
     }
 
     public class UpdateCurrentElementDto
@@ -627,6 +636,27 @@ namespace GlueControl.Dtos
     public class GetEmbeddedDiagnosticsLogResponse
     {
         public string LogText { get; set; }
+    }
+    #endregion
+
+    #region GetCurrentElementNamedObjectsDto
+
+    /// <summary>
+    /// Fetches the InstanceNames of the game's own current-element bookkeeping
+    /// (EditingManager.CurrentGlueElement.NamedObjects) - a duplicate entry here (as opposed to in
+    /// SpriteManager.ManagedPositionedObjects, the actual runtime objects) means a NamedObjectsToUpdate
+    /// push replaced the wrong entry or added a new one instead of replacing - see
+    /// EditingManager.ReplaceNamedObjectSave.
+    /// </summary>
+    public class GetCurrentElementNamedObjectsDto
+    {
+    }
+    #endregion
+
+    #region GetCurrentElementNamedObjectsResponse
+    public class GetCurrentElementNamedObjectsResponse
+    {
+        public List<string> InstanceNames { get; set; } = new List<string>();
     }
     #endregion
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -1674,6 +1674,18 @@ namespace GlueControl.Editing
             AppendLine($"Received {dtoTypeName}: {Describe(dto)}");
         }
 
+        // GlueControlManager.SendToGlue(object) is the single choke point every game->Glue message passes
+        // through (PrintOutput, Undo, ScreenLoadExceptionDto, ...), so logging there covers all of them
+        // for free - including diagnostic messages like EditingManager.GetObjectByName's "Tried to get
+        // object by name X but couldn't find anything", which previously only reached Glue's Output panel
+        // and never this buffer at all. That gap is what #2261 exposed: a reorder emits that exact
+        // message, but it never showed up in a pulled diagnostics log because nothing captured outbound
+        // traffic - only inbound (see LogDtoReceived/LogDtoResponse below).
+        public static void LogDtoSent(string dtoTypeName, object dto)
+        {
+            AppendLine($"Sent {dtoTypeName}: {Describe(dto)}");
+        }
+
         public static void LogDtoResponse(string dtoTypeName, object response)
         {
             if (dtoTypeName == nameof(GlueControl.Dtos.GetEmbeddedDiagnosticsLogDto))

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -1186,7 +1186,7 @@ namespace GlueControl.Editing
             CurrentNamedObjects.AddRange(newNamedObjects);
         }
 
-        public void ReplaceNamedObjectSave(NamedObjectSave nos, string glueElementName, string containerName)
+        public void ReplaceNamedObjectSave(NamedObjectSave nos, string glueElementName, string containerName, string oldInstanceName = null)
         {
             ///////////////////Early Out///////////////////
             if (CurrentGlueElement?.Name != glueElementName)
@@ -1195,7 +1195,11 @@ namespace GlueControl.Editing
             }
             ////////////////End Early Out//////////////////
 
-            var oldNos = CurrentGlueElement.AllNamedObjects.FirstOrDefault(item => item.InstanceName == nos.InstanceName);
+            // For a rename, nos.InstanceName is already the NEW name - the existing entry to replace is
+            // still under the old one (oldInstanceName, set only for this case - see
+            // NamedObjectWithElementName.OldInstanceName). Matching by nos.InstanceName here unconditionally
+            // would never find that entry and would add a second one instead of replacing it (#2261).
+            var oldNos = CurrentGlueElement.AllNamedObjects.FirstOrDefault(item => item.InstanceName == (oldInstanceName ?? nos.InstanceName));
             var oldContainer = CurrentGlueElement.AllNamedObjects.FirstOrDefault(item => item.ContainedObjects.Contains(oldNos));
 
             NamedObjectSave newContainer = null;

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/EditingManager.cs
@@ -1630,7 +1630,11 @@ namespace GlueControl.Editing
     /// longer to diagnose than they should have, since nothing recorded what led up to the failure. Not
     /// opt-in: a bug that already happened can't retroactively have logging turned on for it, so this
     /// always runs and a Glue-side "View Diagnostics Log" button fetches the current buffer on demand
-    /// (see GetEmbeddedDiagnosticsLogDto).
+    /// (see GetEmbeddedDiagnosticsLogDto). Also self-flushes to disk the moment any response reports a
+    /// failure (see FlushToDiskOnFailure) - the in-memory buffer alone doesn't survive
+    /// GlueViewSettingsViewModel.RestartOnFailedCommands killing and relaunching this process right after
+    /// a failed variable set, which would otherwise erase the only evidence of what just went wrong before
+    /// anyone could click that button.
     /// </summary>
     internal static class EmbeddedDiagnosticsLogger
     {
@@ -1678,6 +1682,88 @@ namespace GlueControl.Editing
             }
 
             AppendLine($"Response to {dtoTypeName}: {Describe(response)}");
+
+            if (HasReportedFailure(response))
+            {
+                FlushToDiskOnFailure(dtoTypeName);
+            }
+        }
+
+        /// <summary>
+        /// True if `response` (or any item in its `Data` list, for a *List response wrapper) carries a
+        /// non-empty Exception string - the shape every GlueVariableSetData response family uses to
+        /// report a failed lookup/assignment. Reflection-based rather than a per-DTO-type check so any
+        /// response with this shape is covered, including a batched GlueVariableSetDataResponseList
+        /// (one Exception per item).
+        /// </summary>
+        static bool HasReportedFailure(object response)
+        {
+            if (response == null)
+            {
+                return false;
+            }
+
+            var exceptionProperty = response.GetType().GetProperty("Exception");
+            if (exceptionProperty?.GetValue(response) is string exceptionText && !string.IsNullOrEmpty(exceptionText))
+            {
+                return true;
+            }
+
+            var dataProperty = response.GetType().GetProperty("Data");
+            if (dataProperty?.GetValue(response) is System.Collections.IEnumerable dataItems && !(dataItems is string))
+            {
+                foreach (var item in dataItems)
+                {
+                    if (HasReportedFailure(item))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Writes the current buffer to disk immediately, in the same folder/naming convention as the
+        /// Glue-side "View Diagnostics Log" button (MainCompilerPlugin.cs's
+        /// BuildTab_ViewEmbeddedDiagnosticsLog), so it lands somewhere the user already knows to look.
+        /// Exists because of #2261's diagnostics gap: on a failed variable set,
+        /// GlueViewSettingsViewModel.RestartOnFailedCommands (default true) kills and relaunches this
+        /// process - wiping this in-memory buffer - before anyone can click that button to fetch it.
+        /// Written game-side, synchronously, before the response goes back over the socket, so it lands
+        /// on disk regardless of how quickly Glue reacts to the failure.
+        /// </summary>
+        /// <summary>
+        /// Overrides where <see cref="FlushToDiskOnFailure"/> writes - set by
+        /// GlueUnitTests.TestSupport.LiveGameProcess (to a subfolder of its own disposable temp project
+        /// directory) so an automated LiveGame test never writes into the real developer's
+        /// %LocalAppData%\FlatRedBall\Glue\Diagnostics folder. Unset in production, where that real
+        /// folder is exactly where the user already knows to look (matches the "View Diagnostics Log"
+        /// button's own location).
+        /// </summary>
+        internal const string DirectoryOverrideEnvironmentVariable = "FRB_EMBEDDED_DIAGNOSTICS_DIRECTORY";
+
+        static void FlushToDiskOnFailure(string dtoTypeName)
+        {
+            try
+            {
+                var directory = Environment.GetEnvironmentVariable(DirectoryOverrideEnvironmentVariable);
+                if (string.IsNullOrEmpty(directory))
+                {
+                    directory = System.IO.Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "FlatRedBall", "Glue", "Diagnostics");
+                }
+                System.IO.Directory.CreateDirectory(directory);
+                var filePath = System.IO.Path.Combine(
+                    directory, $"communication-onfailure-{DateTime.Now:yyyyMMdd-HHmmss}-{dtoTypeName}.log");
+                System.IO.File.WriteAllText(filePath, GetLogText());
+            }
+            catch
+            {
+                // Best-effort - a failure to write this safety-net file should never fail the response itself.
+            }
         }
 
         public static void LogUnhandledException(string rawMessage, Exception exception)

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/VariableAssignmentLogic.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/Editing/VariableAssignmentLogic.cs
@@ -198,7 +198,15 @@ namespace GlueControl.Editing
                                 //screen.ApplyVariable(variableNameOnObjectInInstance, variableValue, item);
                             }
                         }
-                        response.WasVariableAssigned = true;
+                        // Only report success if none of the (possibly several, one per matching instance)
+                        // SetValueOnObjectInElement calls above already reported a failure - unconditionally
+                        // setting this to true stomped a real "could not find the object" failure into a
+                        // false success (#2261's contradictory WasVariableAssigned=true alongside a
+                        // populated Exception).
+                        if (response.Exception == null)
+                        {
+                            response.WasVariableAssigned = true;
+                        }
                     }
                 }
                 // See comment by setOnEntity about why we check for forcedItem.

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GlueControlManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Embedded/GlueControlManager.cs
@@ -414,6 +414,7 @@ namespace GlueControl
         {
             var type = dto.GetType().Name;
             var json = Newtonsoft.Json.JsonConvert.SerializeObject(dto);
+            EmbeddedDiagnosticsLogger.LogDtoSent(type, dto);
             return await SendCommandToGlue($"{type}:{json}");
         }
 

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
@@ -99,7 +99,17 @@ namespace GameCommunicationPlugin.GlueControl.Managers
             var gameScreenName = await CommandSender.Self.GetScreenName();
             var listOfVariables = GetNamedObjectValueChangedDtos(changedMember, oldValue, nos, assignOrRecordOnly, gameScreenName, forcedCurrentValue);
 
-            PushVariableChangesToGame(listOfVariables, new List<NamedObjectSave> { nos });
+            // A rename's NamedObjectSave already carries its NEW InstanceName, but
+            // EditingManager.ReplaceNamedObjectSave (invoked game-side via NamedObjectsToUpdate) matches
+            // the EXISTING entry to replace by that same InstanceName - for a rename it would never find
+            // the old entry (still under the old name) and would just add a duplicate. The variable-set
+            // DTO built above already renames the runtime object directly, so there's no NOS bookkeeping
+            // to push here.
+            var namedObjectsToUpdate = changedMember == nameof(NamedObjectSave.InstanceName)
+                ? new List<NamedObjectSave>()
+                : new List<NamedObjectSave> { nos };
+
+            PushVariableChangesToGame(listOfVariables, namedObjectsToUpdate);
         }
 
         public void PushVariableChangesToGame(List<GlueVariableSetData> listOfVariables, List<NamedObjectSave> namedObjectsToUpdate)
@@ -198,6 +208,33 @@ namespace GameCommunicationPlugin.GlueControl.Managers
         public List<GlueVariableSetData> GetNamedObjectValueChangedDtos(string changedMember, object oldValue, NamedObjectSave nos, AssignOrRecordOnly assignOrRecordOnly, string gameScreenName, object forcedCurrentValue = null)
         {
             List<GlueVariableSetData> toReturn = new List<GlueVariableSetData>();
+
+            // A rename doesn't fit the generic "NOS property changed" shape below: nos.InstanceName is
+            // already the NEW name by the time this runs (see GluxCommands.RenameNamedObjectSave), but the
+            // running game has never heard of that name - VariableName must address the OLD one. The
+            // property being assigned is also the special ".Name" (CommandReceiver.HandleDto(
+            // GlueVariableSetData)'s isAssigningName check), not the model-only "InstanceName" - there is
+            // no runtime "InstanceName" property to reflect over. #2261: without this, renaming a
+            // live-added object left it unreachable under its new name forever, since nothing ever told
+            // the running game the rename happened at all.
+            if (changedMember == nameof(NamedObjectSave.InstanceName))
+            {
+                var oldName = oldValue as string;
+                var renameElement = GlueState.Self.CurrentElement ?? ObjectFinder.Self.GetElementContaining(nos);
+                if (!string.IsNullOrEmpty(oldName) && renameElement != null)
+                {
+                    toReturn.Add(new GlueVariableSetData
+                    {
+                        AssignOrRecordOnly = assignOrRecordOnly,
+                        ElementNameGlue = renameElement.Name,
+                        VariableName = $"this.{oldName}.Name",
+                        VariableValue = nos.InstanceName,
+                        Type = "string",
+                    });
+                }
+
+                return toReturn;
+            }
 
             // If the value set is "ignored" that means we want to push a command to the game to only
             // re-run the command on screen change, but don't actually set the variable now.

--- a/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
+++ b/FRBDK/Glue/GameCommunicationPlugin/GlueControl/Managers/VariableSendingManager.cs
@@ -99,20 +99,12 @@ namespace GameCommunicationPlugin.GlueControl.Managers
             var gameScreenName = await CommandSender.Self.GetScreenName();
             var listOfVariables = GetNamedObjectValueChangedDtos(changedMember, oldValue, nos, assignOrRecordOnly, gameScreenName, forcedCurrentValue);
 
-            // A rename's NamedObjectSave already carries its NEW InstanceName, but
-            // EditingManager.ReplaceNamedObjectSave (invoked game-side via NamedObjectsToUpdate) matches
-            // the EXISTING entry to replace by that same InstanceName - for a rename it would never find
-            // the old entry (still under the old name) and would just add a duplicate. The variable-set
-            // DTO built above already renames the runtime object directly, so there's no NOS bookkeeping
-            // to push here.
-            var namedObjectsToUpdate = changedMember == nameof(NamedObjectSave.InstanceName)
-                ? new List<NamedObjectSave>()
-                : new List<NamedObjectSave> { nos };
+            var renamedFromInstanceName = changedMember == nameof(NamedObjectSave.InstanceName) ? oldValue as string : null;
 
-            PushVariableChangesToGame(listOfVariables, namedObjectsToUpdate);
+            PushVariableChangesToGame(listOfVariables, new List<NamedObjectSave> { nos }, renamedFromInstanceName);
         }
 
-        public void PushVariableChangesToGame(List<GlueVariableSetData> listOfVariables, List<NamedObjectSave> namedObjectsToUpdate)
+        public void PushVariableChangesToGame(List<GlueVariableSetData> listOfVariables, List<NamedObjectSave> namedObjectsToUpdate, string renamedNamedObjectOldInstanceName = null)
         {
             var dto = new GlueVariableSetDataList();
             dto.Data.AddRange(listOfVariables);
@@ -125,6 +117,9 @@ namespace GameCommunicationPlugin.GlueControl.Managers
                 namedObjectWithElement.GlueElementName = container?.Name;
                 var listNos = container?.NamedObjects.FirstOrDefault(item => item.ContainedObjects.Contains(nos));
                 namedObjectWithElement.ContainerName = listNos?.InstanceName;
+                // Only ever non-null for the single-NamedObjectSave rename push above - see
+                // NamedObjectWithElementName.OldInstanceName and EditingManager.ReplaceNamedObjectSave.
+                namedObjectWithElement.OldInstanceName = renamedNamedObjectOldInstanceName;
 
                 dto.NamedObjectsToUpdate.Add(namedObjectWithElement);
             }

--- a/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
+++ b/FRBDK/Glue/Glue/Plugins/ExportedImplementations/CommandInterfaces/GluxCommands.cs
@@ -1055,6 +1055,13 @@ public class GluxCommands : IGluxCommands
             namedObjectSave.InstanceName = newName;
             await EditorObjects.IoC.Container.Get<NamedObjectSetVariableLogic>().ReactToNamedObjectChangedInstanceName(namedObjectSave, oldName);
 
+            // Notifies a running game of the rename (GameCommunicationPlugin's VariableSendingManager
+            // turns this into a "this.<oldName>.Name" variable set, the shape CommandReceiver's
+            // HandleDto(GlueVariableSetData) already recognizes) - without this, a live-added object
+            // renamed here keeps its original runtime Name forever, since nothing else tells the game
+            // about the rename (issue #2261).
+            PluginManager.ReactToNamedObjectChangedValue(nameof(NamedObjectSave.InstanceName), oldName, namedObjectSave);
+
             if(performSaveAndGenerateCode)
             {
                 GlueCommands.Self.GluxCommands.SaveProjectAndElements(TaskExecutionPreference.AddOrMoveToEnd);

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.SaveClasses;
 using GameCommunicationPlugin.GlueControl.Dtos;
+using GameCommunicationPlugin.GlueControl.Managers;
 using GlueUnitTests.TestSupport;
 using Shouldly;
 using Xunit;
@@ -199,30 +200,32 @@ public class LiveGameProcessTests
         setResponse.Data.WasVariableAssigned.ShouldBeTrue();
     }
 
-    // #2261's actual root cause, pinned directly via the diagnostics log from a real repro: renaming a
-    // NamedObjectSave - GluxCommands.RenameNamedObjectSave (Glue/Plugins/ExportedImplementations/
-    // CommandInterfaces/GluxCommands.cs:1039) - only ever sets InstanceName on Glue's own model and
-    // regenerates code (NamedObjectSetVariableLogic.ReactToNamedObjectChangedInstanceName). Neither calls
-    // CommandSender.Self.Send - there is no DTO for "a named object was renamed" at all. So a live-added
-    // object renamed in Glue's tree/property grid keeps its ORIGINAL runtime Name forever, even though
-    // Glue's own model (and therefore every DTO addressing it from then on) uses the new one. There is
-    // nothing to replay here - the rename is a no-op on the wire - so this goes straight to the
-    // observable consequence: the running game still answers to the pre-rename name, not the name Glue
-    // now shows.
+    // #2261's actual root cause, fixed and pinned here: renaming a NamedObjectSave used to only update
+    // Glue's own model and regenerate code (GluxCommands.RenameNamedObjectSave) - nothing ever told a
+    // running game the rename happened, so a live-added object renamed in Glue's tree/property grid kept
+    // its ORIGINAL runtime Name forever, even though Glue's own model (and every DTO addressing it from
+    // then on) used the new one.
     //
-    // Measured (not just read) via a temporary Console.WriteLine probe: addressing "this.Head.X" resolves
-    // "Head" to nothing (no compiled member, no child by that name), falls back to
-    // Screen.GetInstanceRecursive("this.Head"), which - finding nothing there either - returns the
-    // SCREEN itself rather than null. VariableAssignmentLogic then tries to apply "X" to the screen,
-    // which has no such member, throwing a raw MemberAccessException that propagates out uncaught by
-    // SetValueOnObjectInElement. That is a DIFFERENT failure shape than the original issue's clean
-    // "Could not find an object named Head..." message with a contradictory WasVariableAssigned=true -
-    // this repro's exact variable ("X", a plain float) resolves through a different branch than the
-    // original's ("CurrentChainName" on a Sprite with AnimationChains set). Reproducing that exact
-    // contradictory shape would need the same variable/setup as the original log, not attempted here.
-    // Both shapes share the same root cause: the runtime object was never renamed.
+    // The fix has two parts: GluxCommands.RenameNamedObjectSave now calls
+    // PluginManager.ReactToNamedObjectChangedValue(nameof(NamedObjectSave.InstanceName), oldName, nos) -
+    // the same event GameCommunicationPlugin's MainCompilerPlugin already listens to for ordinary NOS
+    // property changes, so it reuses the existing, already-working notify-the-game pipeline rather than
+    // adding a new one. This test cannot exercise THAT half directly - MainCompilerPlugin's own StartUp
+    // isn't registered in this headless test host (it builds real WPF toolbars, like several plugins this
+    // harness's GlueTestBootstrap already skips for the same reason - see LiveGameProcess's own doc
+    // comment on MainCompilerPlugin not being safe to run here), so PluginManager has no subscriber to
+    // dispatch to. That one-line call follows the exact same PluginManager.ReactToNamedObjectChangedValue
+    // pattern already used (and exercised in real Glue every time a property-grid edit reaches the game)
+    // by many other call sites - ElementCommands.cs, GluxCommands.cs's other renames, SetPropertyManager.cs.
+    //
+    // What this test DOES pin, directly, is the actually-new logic: VariableSendingManager's InstanceName
+    // special case (GetNamedObjectValueChangedDtos) builds a "this.<oldName>.Name" variable-set DTO
+    // (addressing the OLD name - the only one the game has ever heard of), which VariableAssignmentLogic's
+    // existing generic reflection path turns into a real `.Name =` assignment on the live runtime object -
+    // by calling that manager the same way MainCompilerPlugin's event handler would, one level below the
+    // plugin-dispatch this host can't run.
     [StaFact]
-    public async Task EditorTest1_RenamedLiveAddedObject_IsStillFoundByItsOriginalRuntimeName()
+    public async Task EditorTest1_RenamingLiveAddedObject_NotifiesTheGame_SoItsReachableByItsNewName()
     {
         GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
 
@@ -260,6 +263,36 @@ public class LiveGameProcessTests
         addResponse.Succeeded.ShouldBeTrue(addResponse.Message);
         addResponse.Data.CreationResponse.Succeeded.ShouldBeTrue("the game should have created the live Sprite");
 
+        // Also added to Glue's own project model, exactly as a real "add object" flow would - so
+        // GetElementContaining(sprite) below can find its containing element the same way it would for a
+        // real live-added object.
+        entity.NamedObjects.Add(sprite);
+
+        var oldName = sprite.InstanceName;
+        sprite.InstanceName = "Head";
+
+        // Builds the DTO exactly the way MainCompilerPlugin's ReactToNamedObjectChangedValue handler
+        // would (RefreshManager.HandleNamedObjectVariableOrPropertyChanged ->
+        // VariableSendingManager.HandleNamedObjectVariableChanged), then sends it directly - that handler
+        // itself can't run in this test host (see doc comment above), and its own send is deliberately
+        // fire-and-forget in production, which would swallow this test's own assertions on the response.
+        var vsm = new VariableSendingManager(new RefreshManager((_, __) => Task.FromResult(""), (_, __) => { }));
+        var builtDtos = vsm.GetNamedObjectValueChangedDtos(
+            nameof(NamedObjectSave.InstanceName), oldName, sprite, AssignOrRecordOnly.Assign, gameScreenName: "");
+        builtDtos.Count.ShouldBe(1, $"expected exactly one rename DTO to be built (oldName={oldName})");
+        builtDtos[0].VariableName.ShouldBe($"this.{oldName}.Name");
+        builtDtos[0].VariableValue.ShouldBe("Head");
+        // A real Glue session's SetEditMode DTO (sent once, first, over the wire) is what normally
+        // populates the game's own ObjectFinder.Self.GlueProject; this harness never sends one, so
+        // without this the game's own CommandReceiver.HandleDto(GlueVariableSetData) NREs trying to load
+        // a project from a null path. Production code never needs this field on an ordinary NOS
+        // property-change DTO (see GetGlueVariableSetDataDto) for the same reason.
+        builtDtos[0].AbsoluteGlueProjectFilePath = Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj");
+
+        var renameResponse = await game.Send<GlueVariableSetDataResponse>(builtDtos[0]);
+        renameResponse.Succeeded.ShouldBeTrue(renameResponse.Message);
+        renameResponse.Data.Exception.ShouldBeNull(renameResponse.Data.Exception);
+
         GlueVariableSetData SetXDto(string instanceName) => new GlueVariableSetData
         {
             AssignOrRecordOnly = AssignOrRecordOnly.Assign,
@@ -271,21 +304,17 @@ public class LiveGameProcessTests
             AbsoluteGlueProjectFilePath = Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
         };
 
-        // Addressed by the name Glue's own model would use after a rename to "Head" - fails, because the
-        // runtime object is still named "LeftWingTest". See this test's doc comment for why the failure
-        // is a raw MemberAccessException here rather than the original issue's clean "Could not find an
-        // object named" message - different sub-path, same root cause.
+        // The rename reached the running game - addressed by the NEW name, the object is found.
         var byNewName = await game.Send<GlueVariableSetDataResponse>(SetXDto("Head"));
         byNewName.Succeeded.ShouldBeTrue(byNewName.Message);
-        byNewName.Data.Exception.ShouldNotBeNull("the runtime object was never renamed, so lookup by the new name should fail");
-        byNewName.Data.WasVariableAssigned.ShouldBeFalse();
+        byNewName.Data.Exception.ShouldBeNull(byNewName.Data.Exception);
+        byNewName.Data.WasVariableAssigned.ShouldBeTrue();
 
-        // Addressed by the name the game still actually uses - succeeds, proving the object was never
-        // lost, just never renamed.
+        // ...and the runtime object was actually renamed, not just found under a second alias - its old
+        // name no longer resolves.
         var byOriginalName = await game.Send<GlueVariableSetDataResponse>(SetXDto("LeftWingTest"));
         byOriginalName.Succeeded.ShouldBeTrue(byOriginalName.Message);
-        byOriginalName.Data.Exception.ShouldBeNull(byOriginalName.Data.Exception);
-        byOriginalName.Data.WasVariableAssigned.ShouldBeTrue();
+        byOriginalName.Data.Exception.ShouldNotBeNull("the object was renamed, so its old name should no longer resolve");
     }
 
     // #2261's diagnostics gap, found while reproducing the test above: GlueViewSettingsViewModel.
@@ -335,6 +364,56 @@ public class LiveGameProcessTests
         var flushedContent = File.ReadAllText(flushedFiles[0]);
         flushedContent.ShouldContain("Received GlueVariableSetData");
         flushedContent.ShouldContain("NoSuchObject2261");
+    }
+
+    // #2261's other diagnostics gap, found only because the user had to manually notice and report this
+    // message from Glue's Output panel: EditingManager.GetObjectByName's "Tried to get object by name X
+    // but couldn't find anything" (fired here by re-selecting a NamedObjectSave whose name Glue's model
+    // knows but the running game does not - exactly what the rename gap above leaves behind) is sent
+    // game->Glue as a PrintOutput call, a completely different channel than the DTO traffic
+    // LogDtoReceived/LogDtoResponse already captured - so it never reached the diagnostics log at all.
+    // GlueControlManager.SendToGlue is the single choke point for every such outbound call, so logging
+    // there (LogDtoSent) covers this message, and any other PrintOutput/Undo/etc. call, for free.
+    [StaFact]
+    public async Task EditorTest1_SelectingNamedObjectMissingAtRuntime_LogsOutboundGetObjectByNameFailure()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe");
+
+        var selectResponse = await game.SelectEntity("Entities\\Entity1");
+        selectResponse.Succeeded.ShouldBeTrue(selectResponse.Message);
+
+        var entity = ObjectFinder.Self.GetEntitySave("Entities\\Entity1");
+
+        // Simulates Glue's own model believing a NamedObjectSave named "Head" exists on this entity -
+        // exactly what a rename (which never notifies the running game - see the test above) leaves
+        // behind. No such object was ever added to the live game itself.
+        entity.NamedObjects.Add(new NamedObjectSave
+        {
+            InstanceName = "Head",
+            SourceType = SourceType.FlatRedBallType,
+            SourceClassType = "Sprite",
+        });
+
+        // EntitySave must be included so the game's own model (a separate process/copy - see
+        // CommandReceiver.HandleDto(SelectObjectDto)'s GlueElement != null branch) picks up the "Head"
+        // NamedObjectSave just added above; without it GetSelectedNamedObjects finds nothing and
+        // EditingManager.Select is never even called.
+        var selectHeadResponse = await game.Send(new SelectObjectDto
+        {
+            ElementNameGlue = "Entities\\Entity1",
+            EntitySave = entity,
+            NamedObjectNames = new List<string> { "Head" },
+        });
+        selectHeadResponse.Succeeded.ShouldBeTrue(selectHeadResponse.Message);
+
+        var logResponse = await game.Send<GetEmbeddedDiagnosticsLogResponse>(new GetEmbeddedDiagnosticsLogDto());
+        logResponse.Succeeded.ShouldBeTrue(logResponse.Message);
+        logResponse.Data.LogText.ShouldContain("Tried to get object by name Head but couldn't find anything");
     }
 
     // Pins the EmbeddedDiagnosticsLogger extension added for #2261: every DTO the game receives (and its

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FlatRedBall.Glue.Elements;
 using FlatRedBall.Glue.SaveClasses;
@@ -315,6 +316,92 @@ public class LiveGameProcessTests
         var byOriginalName = await game.Send<GlueVariableSetDataResponse>(SetXDto("LeftWingTest"));
         byOriginalName.Succeeded.ShouldBeTrue(byOriginalName.Message);
         byOriginalName.Data.Exception.ShouldNotBeNull("the object was renamed, so its old name should no longer resolve");
+    }
+
+    // Adjacent bug found (and fixed) while fixing #2261, in the game-side bookkeeping
+    // ReplaceNamedObjectSave pushes via NamedObjectsToUpdate keep in sync
+    // (EditingManager.CurrentGlueElement.NamedObjects - GetCurrentElementNamedObjectsDto, added to
+    // observe it, since it isn't visible over the wire any other way): ReplaceNamedObjectSave used to
+    // find the entry to replace by matching `item.InstanceName == nos.InstanceName` - fine when a NOS's
+    // own name never changes, but nos.InstanceName IS the new name for a rename, so it never found the
+    // old entry (still under the old name) and just added a second one instead of replacing it. Proven
+    // red before the fix: sending a rename's NamedObjectsToUpdate entry without OldInstanceName (the way
+    // this test builds it below) produced ["CircleInstance", "LeftWingTest", "Head"] - both names
+    // present. Fixed by NamedObjectWithElementName.OldInstanceName, which PushVariableChangesToGame now
+    // populates for exactly this case and ReplaceNamedObjectSave matches against instead.
+    [StaFact]
+    public async Task EditorTest1_RenamedLiveObjectPushedViaNamedObjectsToUpdate_ReplacesRatherThanDuplicatesBookkeeping()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe");
+
+        var selectResponse = await game.SelectEntity("Entities\\Entity1");
+        selectResponse.Succeeded.ShouldBeTrue(selectResponse.Message);
+
+        var entity = ObjectFinder.Self.GetEntitySave("Entities\\Entity1");
+
+        var sprite = new NamedObjectSave
+        {
+            InstanceName = "LeftWingTest",
+            SourceType = SourceType.FlatRedBallType,
+            SourceClassType = "Sprite",
+            AddToManagers = true,
+        };
+        var addObjectDto = new AddObjectDto
+        {
+            NamedObjectSave = sprite,
+            ElementNameGlue = "Entities\\Entity1",
+            EntitySave = entity,
+        };
+        addObjectDto.NamedObjectsToUpdate.Add(new NamedObjectWithElementName
+        {
+            NamedObjectSave = sprite,
+            GlueElementName = "Entities\\Entity1",
+        });
+        var addResponse = await game.Send<AddObjectDtoResponse>(addObjectDto);
+        addResponse.Succeeded.ShouldBeTrue(addResponse.Message);
+        addResponse.Data.CreationResponse.Succeeded.ShouldBeTrue("the game should have created the live Sprite");
+
+        var beforeRename = await game.Send<GetCurrentElementNamedObjectsResponse>(new GetCurrentElementNamedObjectsDto());
+        beforeRename.Succeeded.ShouldBeTrue(beforeRename.Message);
+        beforeRename.Data.InstanceNames.Count(n => n == "LeftWingTest").ShouldBe(1,
+            "sanity check: the live add itself should register exactly one bookkeeping entry");
+
+        entity.NamedObjects.Add(sprite);
+        var oldName = sprite.InstanceName;
+        sprite.InstanceName = "Head";
+
+        var vsm = new VariableSendingManager(new RefreshManager((_, __) => Task.FromResult(""), (_, __) => { }));
+        var renameDtos = vsm.GetNamedObjectValueChangedDtos(
+            nameof(NamedObjectSave.InstanceName), oldName, sprite, AssignOrRecordOnly.Assign, gameScreenName: "");
+        renameDtos[0].AbsoluteGlueProjectFilePath = Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj");
+
+        // Built by hand rather than via PushVariableChangesToGame (which now populates OldInstanceName
+        // itself for exactly this case) so the test can assert on the NamedObjectsToUpdate shape
+        // directly - OldInstanceName is what tells ReplaceNamedObjectSave which stale entry to replace.
+        var listDto = new GlueVariableSetDataList();
+        listDto.Data.AddRange(renameDtos);
+        listDto.NamedObjectsToUpdate.Add(new NamedObjectWithElementName
+        {
+            NamedObjectSave = sprite,
+            GlueElementName = "Entities\\Entity1",
+            OldInstanceName = oldName,
+        });
+
+        var pushResponse = await game.Send<GlueVariableSetDataResponseList>(listDto);
+        pushResponse.Succeeded.ShouldBeTrue(pushResponse.Message);
+
+        var afterRename = await game.Send<GetCurrentElementNamedObjectsResponse>(new GetCurrentElementNamedObjectsDto());
+        afterRename.Succeeded.ShouldBeTrue(afterRename.Message);
+        afterRename.Data.InstanceNames.ShouldContain("Head");
+        afterRename.Data.InstanceNames.ShouldNotContain("LeftWingTest",
+            "ReplaceNamedObjectSave should have replaced the stale old-named entry, not left it behind");
+        afterRename.Data.InstanceNames.Count(n => n == "Head").ShouldBe(1,
+            "ReplaceNamedObjectSave should not have added a second entry for the renamed object");
     }
 
     // #2261's diagnostics gap, found while reproducing the test above: GlueViewSettingsViewModel.

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
@@ -288,6 +288,55 @@ public class LiveGameProcessTests
         byOriginalName.Data.WasVariableAssigned.ShouldBeTrue();
     }
 
+    // #2261's diagnostics gap, found while reproducing the test above: GlueViewSettingsViewModel.
+    // RestartOnFailedCommands (default true) kills and relaunches the game the moment a variable-set
+    // response reports an Exception - wiping EmbeddedDiagnosticsLogger's in-memory buffer before anyone
+    // can click "View Diagnostics Log" to fetch it, so a second repro of the same bug produced a log with
+    // no trace of the failure at all. FlushToDiskOnFailure writes the buffer to disk synchronously, as
+    // part of producing the failing response, so it lands before any restart could possibly race it. This
+    // pins that it actually does.
+    [StaFact]
+    public async Task EditorTest1_FailedVariableSet_FlushesDiagnosticsLogToDiskBeforeAnyRestart()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe");
+
+        var selectResponse = await game.SelectEntity("Entities\\Entity1");
+        selectResponse.Succeeded.ShouldBeTrue(selectResponse.Message);
+
+        var entity = ObjectFinder.Self.GetEntitySave("Entities\\Entity1");
+
+        // Addresses an instance that was never added - guaranteed to fail the lookup and report an
+        // Exception, regardless of which internal sub-path it takes (see the rename test above for why
+        // that sub-path can vary).
+        var setVariableDto = new GlueVariableSetData
+        {
+            AssignOrRecordOnly = AssignOrRecordOnly.Assign,
+            ElementNameGlue = "Entities\\Entity1",
+            EntitySave = entity,
+            VariableName = "this.NoSuchObject2261.X",
+            VariableValue = "5",
+            Type = "float",
+            AbsoluteGlueProjectFilePath = Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        };
+
+        var setResponse = await game.Send<GlueVariableSetDataResponse>(setVariableDto);
+        setResponse.Succeeded.ShouldBeTrue(setResponse.Message);
+        setResponse.Data.Exception.ShouldNotBeNull("this test needs a failing variable set to exercise the flush");
+
+        Directory.Exists(game.EmbeddedDiagnosticsOnFailureDirectory).ShouldBeTrue(
+            "a failed variable-set response should have triggered EmbeddedDiagnosticsLogger's on-failure disk flush");
+        var flushedFiles = Directory.GetFiles(game.EmbeddedDiagnosticsOnFailureDirectory, "communication-onfailure-*.log");
+        flushedFiles.ShouldNotBeEmpty();
+        var flushedContent = File.ReadAllText(flushedFiles[0]);
+        flushedContent.ShouldContain("Received GlueVariableSetData");
+        flushedContent.ShouldContain("NoSuchObject2261");
+    }
+
     // Pins the EmbeddedDiagnosticsLogger extension added for #2261: every DTO the game receives (and its
     // response, when it sends one back) is recorded in memory, always on - no enable step needed - and
     // fetchable at any time via GetEmbeddedDiagnosticsLogDto. See CommandReceiver.Receive and

--- a/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Projects/LiveGameProcessTests.cs
@@ -199,6 +199,95 @@ public class LiveGameProcessTests
         setResponse.Data.WasVariableAssigned.ShouldBeTrue();
     }
 
+    // #2261's actual root cause, pinned directly via the diagnostics log from a real repro: renaming a
+    // NamedObjectSave - GluxCommands.RenameNamedObjectSave (Glue/Plugins/ExportedImplementations/
+    // CommandInterfaces/GluxCommands.cs:1039) - only ever sets InstanceName on Glue's own model and
+    // regenerates code (NamedObjectSetVariableLogic.ReactToNamedObjectChangedInstanceName). Neither calls
+    // CommandSender.Self.Send - there is no DTO for "a named object was renamed" at all. So a live-added
+    // object renamed in Glue's tree/property grid keeps its ORIGINAL runtime Name forever, even though
+    // Glue's own model (and therefore every DTO addressing it from then on) uses the new one. There is
+    // nothing to replay here - the rename is a no-op on the wire - so this goes straight to the
+    // observable consequence: the running game still answers to the pre-rename name, not the name Glue
+    // now shows.
+    //
+    // Measured (not just read) via a temporary Console.WriteLine probe: addressing "this.Head.X" resolves
+    // "Head" to nothing (no compiled member, no child by that name), falls back to
+    // Screen.GetInstanceRecursive("this.Head"), which - finding nothing there either - returns the
+    // SCREEN itself rather than null. VariableAssignmentLogic then tries to apply "X" to the screen,
+    // which has no such member, throwing a raw MemberAccessException that propagates out uncaught by
+    // SetValueOnObjectInElement. That is a DIFFERENT failure shape than the original issue's clean
+    // "Could not find an object named Head..." message with a contradictory WasVariableAssigned=true -
+    // this repro's exact variable ("X", a plain float) resolves through a different branch than the
+    // original's ("CurrentChainName" on a Sprite with AnimationChains set). Reproducing that exact
+    // contradictory shape would need the same variable/setup as the original log, not attempted here.
+    // Both shapes share the same root cause: the runtime object was never renamed.
+    [StaFact]
+    public async Task EditorTest1_RenamedLiveAddedObject_IsStillFoundByItsOriginalRuntimeName()
+    {
+        GlueTestBootstrap.EnsureGameProjectPluginsRegistered();
+
+        using var game = await LiveGameProcess.StartAsync(
+            "Samples/EditorTest1",
+            csprojRelativeToProjectRoot: "EditorTest1/EditorTest1.csproj",
+            exeRelativeToProjectRoot: "EditorTest1/bin/Debug/net9.0/EditorTest1.exe");
+
+        var selectResponse = await game.SelectEntity("Entities\\Entity1");
+        selectResponse.Succeeded.ShouldBeTrue(selectResponse.Message);
+        (await game.GetCurrentScreenName()).ShouldBe("GlueControl.Screens.EntityViewingScreen");
+
+        var entity = ObjectFinder.Self.GetEntitySave("Entities\\Entity1");
+
+        var sprite = new NamedObjectSave
+        {
+            InstanceName = "LeftWingTest",
+            SourceType = SourceType.FlatRedBallType,
+            SourceClassType = "Sprite",
+            AddToManagers = true,
+        };
+        var addObjectDto = new AddObjectDto
+        {
+            NamedObjectSave = sprite,
+            ElementNameGlue = "Entities\\Entity1",
+            EntitySave = entity,
+        };
+        addObjectDto.NamedObjectsToUpdate.Add(new NamedObjectWithElementName
+        {
+            NamedObjectSave = sprite,
+            GlueElementName = "Entities\\Entity1",
+        });
+
+        var addResponse = await game.Send<AddObjectDtoResponse>(addObjectDto);
+        addResponse.Succeeded.ShouldBeTrue(addResponse.Message);
+        addResponse.Data.CreationResponse.Succeeded.ShouldBeTrue("the game should have created the live Sprite");
+
+        GlueVariableSetData SetXDto(string instanceName) => new GlueVariableSetData
+        {
+            AssignOrRecordOnly = AssignOrRecordOnly.Assign,
+            ElementNameGlue = "Entities\\Entity1",
+            EntitySave = entity,
+            VariableName = $"this.{instanceName}.X",
+            VariableValue = "5",
+            Type = "float",
+            AbsoluteGlueProjectFilePath = Path.Combine(game.ProjectRoot, "EditorTest1", "EditorTest1.gluj"),
+        };
+
+        // Addressed by the name Glue's own model would use after a rename to "Head" - fails, because the
+        // runtime object is still named "LeftWingTest". See this test's doc comment for why the failure
+        // is a raw MemberAccessException here rather than the original issue's clean "Could not find an
+        // object named" message - different sub-path, same root cause.
+        var byNewName = await game.Send<GlueVariableSetDataResponse>(SetXDto("Head"));
+        byNewName.Succeeded.ShouldBeTrue(byNewName.Message);
+        byNewName.Data.Exception.ShouldNotBeNull("the runtime object was never renamed, so lookup by the new name should fail");
+        byNewName.Data.WasVariableAssigned.ShouldBeFalse();
+
+        // Addressed by the name the game still actually uses - succeeds, proving the object was never
+        // lost, just never renamed.
+        var byOriginalName = await game.Send<GlueVariableSetDataResponse>(SetXDto("LeftWingTest"));
+        byOriginalName.Succeeded.ShouldBeTrue(byOriginalName.Message);
+        byOriginalName.Data.Exception.ShouldBeNull(byOriginalName.Data.Exception);
+        byOriginalName.Data.WasVariableAssigned.ShouldBeTrue();
+    }
+
     // Pins the EmbeddedDiagnosticsLogger extension added for #2261: every DTO the game receives (and its
     // response, when it sends one back) is recorded in memory, always on - no enable step needed - and
     // fetchable at any time via GetEmbeddedDiagnosticsLogDto. See CommandReceiver.Receive and

--- a/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/TestSupport/LiveGameProcess.cs
@@ -41,6 +41,17 @@ internal sealed class LiveGameProcess : IDisposable
     internal const string OffscreenWindowEnvironmentVariable = "FRB_LIVE_GAME_TEST_OFFSCREEN";
 
     /// <summary>
+    /// Set on the launched process's environment, pointed at a subfolder of its own disposable
+    /// <see cref="project"/> temp directory - read by GlueControl.Editing.EmbeddedDiagnosticsLogger's
+    /// on-failure disk flush (see its own doc comment for why that flush exists) so a LiveGame test's
+    /// induced failures never write into the real developer's %LocalAppData%\FlatRedBall\Glue\Diagnostics
+    /// folder. Must stay identical to EmbeddedDiagnosticsLogger.DirectoryOverrideEnvironmentVariable -
+    /// same cross-compile-boundary constraint as OffscreenWindowEnvironmentVariable above, since that file
+    /// cannot reference this test assembly.
+    /// </summary>
+    internal const string EmbeddedDiagnosticsDirectoryEnvironmentVariable = "FRB_EMBEDDED_DIAGNOSTICS_DIRECTORY";
+
+    /// <summary>
     /// Set to a directory of OpenGL runtime DLLs (Mesa's llvmpipe build) to have them copied next to the
     /// game before it launches. A GPU-less CI runner resolves opengl32.dll to Windows' generic software
     /// implementation, which is OpenGL 1.1 and has no framebuffer objects, so MonoGame's GraphicsDevice
@@ -70,6 +81,13 @@ internal sealed class LiveGameProcess : IDisposable
     const double CommandResponseTimeoutInSeconds = 30;
 
     public string ProjectRoot => project.Root;
+
+    /// <summary>
+    /// Where EmbeddedDiagnosticsLogger's on-failure disk flush writes for this game process - see
+    /// <see cref="EmbeddedDiagnosticsDirectoryEnvironmentVariable"/>. Cleaned up automatically along with
+    /// the rest of <see cref="project"/> on <see cref="Dispose"/>.
+    /// </summary>
+    public string EmbeddedDiagnosticsOnFailureDirectory => Path.Combine(project.Root, "diagnostics-on-failure");
 
     LiveGameProcess(TempDir project, System.Diagnostics.Process process,
         GameJsonCommunicationPlugin.Common.GameConnectionManager connectionManager,
@@ -190,6 +208,8 @@ internal sealed class LiveGameProcess : IDisposable
                 }
             };
             process.StartInfo.Environment[OffscreenWindowEnvironmentVariable] = "1";
+            var embeddedDiagnosticsOnFailureDirectory = Path.Combine(project.Root, "diagnostics-on-failure");
+            process.StartInfo.Environment[EmbeddedDiagnosticsDirectoryEnvironmentVariable] = embeddedDiagnosticsOnFailureDirectory;
             // Async, event-based capture rather than ReadToEnd(): this process is long-lived (killed by
             // Dispose, not naturally exiting), so a blocking read would never return - see NestedDotnetCli's
             // doc comment for the same deadlock shape with dotnet build's child MSBuild nodes. This is what


### PR DESCRIPTION
Part of #2261.

## Summary
- Pins #2261's root cause with a real running-game test, then fixes it: renaming a live-added `NamedObjectSave` (`GluxCommands.RenameNamedObjectSave`) used to only update Glue's own model and regenerate code - nothing told the running game, so the object kept its original runtime `Name` forever. Fixed by routing the rename through `PluginManager.ReactToNamedObjectChangedValue` (the same event already used for ordinary NOS property changes) and teaching `VariableSendingManager` to build the `"this.<oldName>.Name"` variable-set DTO `CommandReceiver` already recognized but nothing sent.
- Fixes a related bug in the same code: `VariableAssignmentLogic`'s per-instance foreach unconditionally set `WasVariableAssigned = true` after the loop, masking a real "could not find the object" failure as a false success.
- Fixes a diagnostics gap found reproducing this a second time: `RestartOnFailedCommands` (default on) kills and relaunches the game on any failed variable set, wiping the in-memory diagnostics log before it could be fetched. Now flushed to disk synchronously as part of the failing response.
- Logs outbound game->Glue messages (`PrintOutput`, `Undo`, ...) to the diagnostics log too - previously invisible, so a "couldn't find object" print during a reorder never showed up in a pulled log.
- Fixes an adjacent bug found while implementing the rename fix: `EditingManager.ReplaceNamedObjectSave` (game-side bookkeeping for `NamedObjectsToUpdate` pushes) matched the entry to replace by the NamedObjectSave's *current* name - correct for ordinary pushes, but for a rename push that's already the *new* name, so the old entry was never found and a duplicate got added instead of a replacement.

## Test plan
- `EditorTest1_RenamingLiveAddedObject_NotifiesTheGame_SoItsReachableByItsNewName` - the rename now reaches the game; the object is reachable by its new name and not its old one.
- `EditorTest1_RenamedLiveObjectPushedViaNamedObjectsToUpdate_ReplacesRatherThanDuplicatesBookkeeping` - proven red first (duplicate bookkeeping entry), fixed, now green.
- `EditorTest1_FailedVariableSet_FlushesDiagnosticsLogToDiskBeforeAnyRestart` / `EditorTest1_SelectingNamedObjectMissingAtRuntime_LogsOutboundGetObjectByNameFailure` - diagnostics gaps.
- Full `Category=LiveGame` suite (23 tests) passes.

Manual test: not needed - engine/runtime + Glue-embedded behavior fully covered by the `LiveGame` tests above, which drive a real built game process over the real socket protocol. (Manually verified by the reporter against a real repro project too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8NTScYWtbsUigtFV7N8XA
