### PR TITLE
Cache NuGet packages in pr-tests CI job

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -107,6 +107,11 @@ jobs:
         GALLIUM_DRIVER: llvmpipe   # force Mesa's software rasterizer, inherited by the game processes
       run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category=LiveGame" --blame-hang-timeout 15m
 
+    # Slowest step in the job by far: 69 tests, each copying a sample project out of the repo and loading it
+    # through a real headless editor. Needs the net9 SDK (installed above) and network for the first restore.
+    - name: Run new-project build smoke test
+      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category=BuildSmoke" --blame-hang-timeout 15m
+
     # Everything above this line covers the Glue editor only. The steps below cover the engine,
     # which otherwise gets compiled just once per release by Engine.yml -- long after the commit
     # that broke it.
@@ -129,46 +134,6 @@ jobs:
     # Samples\ is unbuilt by CI.
     - name: Build the MonoGame.Extended particle sample
       run: dotnet build 'FlatRedBall\Samples\MonoGameExtendedParticles\MonoGameExtendedParticles.sln' -c Debug
-
-  # Split out from the `test` job: at ~10 minutes this was the single slowest step in that job
-  # by far -- 69 tests, each copying a sample project out of the repo and loading it through a real
-  # headless editor -- so it was serializing after Build/unit-tests/live-game-tests instead of running
-  # alongside them. Its own job runs in parallel with `test` on a separate runner, at the cost of
-  # duplicating Checkout/Install .NET/Build here (~5 min) -- worth it since that duplicated setup is
-  # smaller than the wall-clock this unblocks. Needs the net9 SDK (installed below) and network access
-  # for the first NuGet restore.
-  smoke-test:
-    runs-on: windows-latest
-    steps:
-    - name: Checkout FRB
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
-        path: 'FlatRedBall'
-
-    - name: Checkout Gum
-      uses: actions/checkout@v4
-      with:
-        repository: ${{ github.repository_owner }}/Gum
-        fetch-depth: 1
-        path: 'Gum'
-
-    - name: Install .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: |
-          6.0.x
-          8.0.x
-          9.0.x
-
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
-
-    - name: Build
-      run: dotnet build -c Debug 'FlatRedBall\FRBDK\Glue\Glue with All.sln'
-
-    - name: Run new-project build smoke test
-      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category=BuildSmoke" --blame-hang-timeout 15m
 
   # GlueCommon (and anything landing alongside it, see #2276) is the one part of the Glue editor with
   # no Windows/WPF dependency, so it and its tests build and run on Linux too. A separate job, not a

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -107,11 +107,6 @@ jobs:
         GALLIUM_DRIVER: llvmpipe   # force Mesa's software rasterizer, inherited by the game processes
       run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category=LiveGame" --blame-hang-timeout 15m
 
-    # Slowest step in the job by far: 69 tests, each copying a sample project out of the repo and loading it
-    # through a real headless editor. Needs the net9 SDK (installed above) and network for the first restore.
-    - name: Run new-project build smoke test
-      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category=BuildSmoke" --blame-hang-timeout 15m
-
     # Everything above this line covers the Glue editor only. The steps below cover the engine,
     # which otherwise gets compiled just once per release by Engine.yml -- long after the commit
     # that broke it.
@@ -134,6 +129,46 @@ jobs:
     # Samples\ is unbuilt by CI.
     - name: Build the MonoGame.Extended particle sample
       run: dotnet build 'FlatRedBall\Samples\MonoGameExtendedParticles\MonoGameExtendedParticles.sln' -c Debug
+
+  # Split out from the `test` job: at ~10 minutes this was the single slowest step in that job
+  # by far -- 69 tests, each copying a sample project out of the repo and loading it through a real
+  # headless editor -- so it was serializing after Build/unit-tests/live-game-tests instead of running
+  # alongside them. Its own job runs in parallel with `test` on a separate runner, at the cost of
+  # duplicating Checkout/Install .NET/Build here (~5 min) -- worth it since that duplicated setup is
+  # smaller than the wall-clock this unblocks. Needs the net9 SDK (installed below) and network access
+  # for the first NuGet restore.
+  smoke-test:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout FRB
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        path: 'FlatRedBall'
+
+    - name: Checkout Gum
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository_owner }}/Gum
+        fetch-depth: 1
+        path: 'Gum'
+
+    - name: Install .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          6.0.x
+          8.0.x
+          9.0.x
+
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Build
+      run: dotnet build -c Debug 'FlatRedBall\FRBDK\Glue\Glue with All.sln'
+
+    - name: Run new-project build smoke test
+      run: dotnet test 'FlatRedBall\FRBDK\Glue\Glue with All.sln' -c Debug --filter "Category=BuildSmoke" --blame-hang-timeout 15m
 
   # GlueCommon (and anything landing alongside it, see #2276) is the one part of the Glue editor with
   # no Windows/WPF dependency, so it and its tests build and run on Linux too. A separate job, not a

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -38,6 +38,17 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
 
+    # No packages.lock.json files are checked in, so the cache key hashes the .csproj files directly
+    # (they're what pins package versions here). A miss just falls back to a normal restore and warms
+    # the cache for next time -- never a correctness risk, only a speed one.
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          nuget-${{ runner.os }}-
+
     - name: Build
       run: dotnet build -c Debug 'FlatRedBall\FRBDK\Glue\Glue with All.sln'
 


### PR DESCRIPTION
## Summary
- No `packages.lock.json` files are checked in, so every job restores from network cold, including once per template in the ~10min BuildSmoke test step.
- Caches `~/.nuget/packages` in the `test` job, keyed on `.csproj` hashes.
- Scoped to this one job only, isolated from other possible CI speedups, to measure this change's impact on its own before stacking anything else.

## Test plan
- [ ] Compare this branch's CI run time for the `test` job against the ~21min baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wbZKBuFWVofBh353NJcWb