### PR TITLE
Fix StateCodeGenerator.Interpolation's enum default to compile against enum-typed locals

### DIFF
--- a/FRBDK/Glue/Glue/CodeGeneration/StateCodeGenerator.Interpolation.cs
+++ b/FRBDK/Glue/Glue/CodeGeneration/StateCodeGenerator.Interpolation.cs
@@ -563,7 +563,17 @@ namespace FlatRedBall.Glue.CodeGeneration
                                         if(string.IsNullOrEmpty(defaultStartingValue))
                                         {
                                             var type = customVariable.Type;
-                                            defaultStartingValue = TypeManager.GetDefaultForType(type);
+                                            // The AssetTypeInfo's own declared default for an enum, same as
+                                            // CustomVariableHelper.GetDefaultValueFor - this becomes a C#
+                                            // source literal below, so a bare numeric default won't compile
+                                            // against an enum-typed local (issue #2283).
+                                            var declaredDefault = nos?.GetAssetTypeInfo()?.VariableDefinitions
+                                                .FirstOrDefault(item => item.Name == customVariable.SourceObjectProperty)?.DefaultValue;
+
+                                            if (!TypeManager.TryGetVariableDefaultValueExpression(type, declaredDefault, out defaultStartingValue))
+                                            {
+                                                throw new ArgumentException("Could not find the value for type " + type);
+                                            }
                                         }
                                     }
                                 }

--- a/FRBDK/Glue/Glue/Parsing/TypeManager.cs
+++ b/FRBDK/Glue/Glue/Parsing/TypeManager.cs
@@ -783,6 +783,39 @@ namespace FlatRedBall.Glue.Parsing
             return TryGetDefaultForType(type, out defaultValue);
         }
 
+        /// <summary>
+        /// Like <see cref="TryGetVariableDefaultValue"/>, but for code-generation contexts where the default
+        /// becomes a C# source literal rather than a runtime-parsed string: for an enum this returns a
+        /// qualified member-name expression ("FlatRedBall.Graphics.MaxWidthBehavior.Chop") instead of the
+        /// numeric string the runtime path hands <c>VariableAssignmentLogic.ConvertStringToType</c>, since
+        /// assigning a bare int to an enum-typed local doesn't compile. Everything else forwards unchanged
+        /// to <see cref="TryGetVariableDefaultValue"/> (see issue #2283).
+        /// </summary>
+        public static bool TryGetVariableDefaultValueExpression(string type, string declaredDefault, out string expression)
+        {
+            var resolvedType = GetTypeFromString(type?.Trim());
+
+            if (resolvedType?.IsEnum == true)
+            {
+                var trimmedDeclaredDefault = declaredDefault?.Trim();
+
+                var memberName = !string.IsNullOrEmpty(trimmedDeclaredDefault) && Enum.IsDefined(resolvedType, trimmedDeclaredDefault)
+                    ? trimmedDeclaredDefault
+                    : Enum.GetName(resolvedType, Activator.CreateInstance(resolvedType));
+
+                if (memberName == null)
+                {
+                    expression = null;
+                    return false;
+                }
+
+                expression = resolvedType.FullName.Replace('+', '.') + "." + memberName;
+                return true;
+            }
+
+            return TryGetVariableDefaultValue(type, declaredDefault, out expression);
+        }
+
         public static object Parse(string typeName, string value) =>
             TypeConversion.Parse(typeName, value);
 

--- a/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.Interpolation.cs
+++ b/FRBDK/Glue/GumPlugin/GumPlugin/CodeGeneration/StateCodeGenerator.Interpolation.cs
@@ -319,7 +319,15 @@ public partial class StateCodeGenerator
                             }
                             else
                             {
-                                defaultStartingValue = FlatRedBall.Glue.Parsing.TypeManager.GetDefaultForType(variableSave.Type);
+                                // No declared AssetTypeInfo default is available in this Gum-side data model,
+                                // so this only resolves an enum's own CLR zero - fine here, since this value
+                                // is just a placeholder overwritten once both interpolation endpoints are set
+                                // (unlike TypeManager.GetDefaultForType, it also compiles for an enum type -
+                                // see issue #2283).
+                                if (!FlatRedBall.Glue.Parsing.TypeManager.TryGetVariableDefaultValueExpression(variableSave.Type, declaredDefault: null, out defaultStartingValue))
+                                {
+                                    throw new ArgumentException("Could not find the value for type " + variableSave.Type);
+                                }
                             }
                         }
                         catch

--- a/FRBDK/Glue/Tests/GlueUnitTests/Parsing/TypeManagerEnumValueTests.cs
+++ b/FRBDK/Glue/Tests/GlueUnitTests/Parsing/TypeManagerEnumValueTests.cs
@@ -98,4 +98,47 @@ public class TypeManagerEnumValueTests
         TypeManager.TryGetVariableDefaultValue("BitmapFont", null, out string value).ShouldBeFalse();
         value.ShouldBeNull();
     }
+
+    // GitHub issue #2283: StateCodeGenerator.Interpolation.cs embeds this as a C# source literal, so a bare
+    // enum number (what TryGetVariableDefaultValue hands the runtime parser) doesn't compile - it needs a
+    // qualified member-name expression instead.
+    [Theory]
+    [InlineData("VerticalAlignment", "Center", "FlatRedBall.Graphics.VerticalAlignment.Center")]
+    [InlineData("ColorOperation", "ColorTextureAlpha", "FlatRedBall.Graphics.ColorOperation.ColorTextureAlpha")]
+    public void TryGetVariableDefaultValueExpression_ShouldReturnAQualifiedMemberExpression_WhenTheDeclaredDefaultResolves(
+        string type, string declaredDefault, string expected)
+    {
+        TypeManager.TryGetVariableDefaultValueExpression(type, declaredDefault, out string expression).ShouldBeTrue();
+        expression.ShouldBe(expected);
+    }
+
+    [Theory]
+    // No declared default, and a declared default that isn't a member of the enum: both fall back to the
+    // enum's own CLR zero member, same tiering as TryGetVariableDefaultValue - just as a name, not a number.
+    [InlineData("MaxWidthBehavior", null, "FlatRedBall.Graphics.MaxWidthBehavior.Chop")]
+    [InlineData("VerticalAlignment", "NotAMember", "FlatRedBall.Graphics.VerticalAlignment.Top")]
+    public void TryGetVariableDefaultValueExpression_ShouldFallBackToTheClrZeroMember_WhenNoDeclaredDefaultResolves(
+        string type, string declaredDefault, string expected)
+    {
+        TypeManager.TryGetVariableDefaultValueExpression(type, declaredDefault, out string expression).ShouldBeTrue();
+        expression.ShouldBe(expected);
+    }
+
+    [Theory]
+    // Non-enum types forward unchanged to TryGetVariableDefaultValue's own string result.
+    [InlineData("float", null, "0")]
+    [InlineData("bool", null, "false")]
+    public void TryGetVariableDefaultValueExpression_ShouldForwardToTryGetVariableDefaultValue_ForNonEnumTypes(
+        string type, string declaredDefault, string expected)
+    {
+        TypeManager.TryGetVariableDefaultValueExpression(type, declaredDefault, out string expression).ShouldBeTrue();
+        expression.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void TryGetVariableDefaultValueExpression_ShouldReturnFalse_ForAReferenceTypeWithNoKnownDefault()
+    {
+        TypeManager.TryGetVariableDefaultValueExpression("BitmapFont", null, out string expression).ShouldBeFalse();
+        expression.ShouldBeNull();
+    }
 }


### PR DESCRIPTION
Fixes #2283.

The third call site #2284 deferred: `StateCodeGenerator.Interpolation.cs` (FRB and Gum-plugin copies) called `TypeManager.GetDefaultForType(type)` directly for a non-state custom variable's interpolation starting value. Unlike `TryGetVariableDefaultValue`'s runtime-string context, this value is embedded as a C# source literal in generated code, so even the numeric default wouldn't compile against an enum-typed local.

Added `TypeManager.TryGetVariableDefaultValueExpression`: for an enum, resolves the declared default (or the enum's own CLR zero) to a qualified member-name expression (`FlatRedBall.Graphics.MaxWidthBehavior.Chop`); everything else forwards to `TryGetVariableDefaultValue` unchanged. Both call sites now use it instead of `GetDefaultForType`.

**Finding while fixing:** `CustomVariableHelper.GetInterpolationCharacteristic` (FRB) and `StateCodeGenerator.GetInterpolationCharacteristic` (Gum) both classify any enum-typed variable as `CantInterpolate` before this fallback is ever reached - so the line this PR fixes is currently unreachable for the five reported enum types in both copies, confirming the issue comment's own "unconfirmed... effectively dead" suspicion. Fixed anyway for correctness/consistency and to avoid the class of bug recurring if that gating logic ever changes. Given the path doesn't fire today, no forced integration test was written through the full generator machinery for it - the real logic (the new resolver) is pinned by `TypeManager`-level unit tests instead, extending `TypeManagerEnumValueTests` the same way #2284 did.

The issue's two "untested" coverage gaps (an `AssetTypeInfo` with no declared `DefaultValue`, and a non-`Text` object like `Sprite.ColorOperation`) were already covered by #2284's `CustomVariableHelperDefaultValueTests`/`TypeManagerEnumValueTests`.

Manual test: not needed - covered by the extended `TypeManagerEnumValueTests`, plus the full `GlueUnitTests` suite (979/980, excluding BuildSmoke/LiveGame; the one failure is `EmbeddedInputAllowedServiceTests`' real-cursor-position test, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wbZKBuFWVofBh353NJcWb
